### PR TITLE
fix vendor script

### DIFF
--- a/vendor.sh
+++ b/vendor.sh
@@ -5,7 +5,11 @@ set -x
 
 cd `dirname $0`
 
-duckdir=../duckdb-main
+if [ -z "$1" ]; then
+  duckdir=../duckdb
+else
+  duckdir=../$1
+fi
 
 if [ -n "$(git status --porcelain)" ]; then
   echo "Error: working directory not clean"
@@ -23,5 +27,6 @@ echo "Importing commit $commit"
 echo "R: configure"
 python3 rconfigure.py
 
+git checkout vendor.sh
 git add .
 git commit -m "Update vendored sources to duckdb/duckdb@$commit"


### PR DESCRIPTION
seems like the last update vendor script changed last time the vendor script ran https://github.com/duckdb/duckdb-r/commit/16d50d4bd2e38b454390ffe951e6561f21944f01#diff-5207f4376418838c90f2fbb73b803096a1b41cae984e1c78af0726977a9331c6. Probably because everything gets added and committed, so the change is silently commited.

Now you can pass the surname of the duckdb repo, but the default is duckdb. 
Also, if someone does change the vendor script, the changes are erased when the script is executed to avoid this happening again.

This will fix the broke R scripts on duckdb-main

https://github.com/duckdb/duckdb/actions/runs/6323197765/job/17170295075
