### PR TITLE
tidy up dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,11 +43,10 @@ License: MIT + file LICENSE
 URL: https://duckdb.org/, https://github.com/duckdb/duckdb-r
 BugReports: https://github.com/duckdb/duckdb-r/issues
 Depends:
-    DBI,
     R (>= 3.6.0)
 Imports:
     methods,
-    utils
+    DBI
 Suggests:
     arrow (>= 13.0.0),
     bit64,

--- a/R/csv.R
+++ b/R/csv.R
@@ -18,6 +18,7 @@
 #' @return The number of rows in the resulted table, invisibly.
 #' @export
 #' @examples
+#' library(DBI)
 #' con <- dbConnect(duckdb())
 #'
 #' data <- data.frame(a = 1:3, b = letters[1:3])

--- a/R/dbConnect__duckdb_driver.R
+++ b/R/dbConnect__duckdb_driver.R
@@ -26,6 +26,7 @@
 #'
 #' @rdname duckdb
 #' @examples
+#' library(DBI)
 #' drv <- duckdb()
 #' con <- dbConnect(drv)
 #'

--- a/R/register.R
+++ b/R/register.R
@@ -32,6 +32,7 @@ encode_values <- function(value) {
 #' @return These functions are called for their side effect.
 #' @export
 #' @examples
+#' library(DBI)
 #' con <- dbConnect(duckdb())
 #'
 #' data <- data.frame(a = 1:3, b = letters[1:3])

--- a/man/duckdb.Rd
+++ b/man/duckdb.Rd
@@ -99,6 +99,7 @@ with_adbc(db <- adbc_database_init(duckdb_adbc()), {
   as.data.frame(read_adbc(db, "SELECT 1 as one;"))
 })
 \dontshow{\}) # examplesIf}
+library(DBI)
 drv <- duckdb()
 con <- dbConnect(drv)
 

--- a/man/duckdb_read_csv.Rd
+++ b/man/duckdb_read_csv.Rd
@@ -55,6 +55,7 @@ Directly reads a CSV file into DuckDB, tries to detect and create the correct sc
 This usually is much faster than reading the data into R and writing it to DuckDB.
 }
 \examples{
+library(DBI)
 con <- dbConnect(duckdb())
 
 data <- data.frame(a = 1:3, b = letters[1:3])

--- a/man/duckdb_register.Rd
+++ b/man/duckdb_register.Rd
@@ -32,6 +32,7 @@ No data is copied.
 \code{duckdb_unregister()} unregisters a previously registered data frame.
 }
 \examples{
+library(DBI)
 con <- dbConnect(duckdb())
 
 data <- data.frame(a = 1:3, b = letters[1:3])

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,4 +1,4 @@
-if (!requireNamespace("testthat", quietly=TRUE)) {
+if (requireNamespace("testthat", quietly=TRUE)) {
   library("testthat")
   library("DBI")
   test_check("duckdb")

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,4 +1,7 @@
-library("testthat")
-library("DBI")
-
-test_check("duckdb")
+if (!requireNamespace("testthat", quietly=TRUE)) {
+  library("testthat")
+  library("DBI")
+  test_check("duckdb")
+} else {
+  cat("Unit tests has been skipped. Install 'testthat' package and retry.\n")
+}


### PR DESCRIPTION
PR includes following changes:

- move DBI from Depends to Imports in DCF:
It is good practice to avoid Depends when possible in favor of Imports. Side effect is that we need to explicitly load DBI namespace if we want to use functions from it in examples
- utils removed from DCF:
No need to specify it. It is enough if it is in NAMESPACE
- removed importFrom DBI in NAMESPACE:
DBI was imported completely already in NAMESPACE so this line is redundant
- test script correctly escapes suggested package:
as per recommendation in [WRE](https://cran.r-project.org/doc/manuals/r-release/R-exts.html) "...recommendation to use suggested packages conditionally in tests does also apply to packages used to manage test suites: a notorious example was testthat..."