### PR TITLE
Fixes usage of `bigint` parameter when using `dbConnect`. 

### DIFF
--- a/R/Driver.R
+++ b/R/Driver.R
@@ -27,18 +27,7 @@ drv_to_string <- function(drv) {
 #' @export
 duckdb <- function(dbdir = DBDIR_MEMORY, read_only = FALSE, bigint = "numeric", config = list()) {
   check_flag(read_only)
-
-  switch(bigint,
-    numeric = {
-      # fine
-    },
-    integer64 = {
-      if (!is_installed("bit64")) {
-        stop("bit64 package is required for integer64 support")
-      }
-    },
-    stop(paste("Unsupported bigint configuration", bigint))
-  )
+  check_bigint(bigint)
 
   # R packages are not allowed to write extensions into home directory, so use R_user_dir instead
   if (!("extension_directory" %in% names(config))) {
@@ -135,4 +124,18 @@ check_tz <- function(timezone) {
   }
 
   timezone
+}
+
+check_bigint <- function(bigint_type) {
+  switch(bigint_type,
+    numeric = {
+      # fine
+    },
+    integer64 = {
+      if (!is_installed("bit64")) {
+        stop("bit64 package is required for integer64 support")
+      }
+    },
+    stop(paste("Unsupported bigint configuration", bigint_type))
+  )
 }

--- a/R/dbConnect__duckdb_driver.R
+++ b/R/dbConnect__duckdb_driver.R
@@ -47,6 +47,8 @@ dbConnect__duckdb_driver <- function(drv, dbdir = DBDIR_MEMORY, ...,
   check_flag(debug)
   timezone_out <- check_tz(timezone_out)
   tz_out_convert <- match.arg(tz_out_convert)
+  check_bigint(bigint)
+
 
   missing_dbdir <- missing(dbdir)
   dbdir <- path.expand(as.character(dbdir))
@@ -56,12 +58,13 @@ dbConnect__duckdb_driver <- function(drv, dbdir = DBDIR_MEMORY, ...,
     drv <- duckdb(dbdir, read_only, bigint, config)
   }
 
+
   conn <- duckdb_connection(drv, debug = debug)
   on.exit(dbDisconnect(conn))
 
   conn@timezone_out <- timezone_out
   conn@tz_out_convert <- tz_out_convert
-
+  conn@driver@bigint <- bigint
   on.exit(NULL)
 
   rs_on_connection_opened(conn)

--- a/man/duckdb.Rd
+++ b/man/duckdb.Rd
@@ -31,7 +31,7 @@ duckdb_adbc()
   timezone_out = "UTC",
   tz_out_convert = c("with", "force"),
   config = list(),
-  bigint = "numeric"
+  bigint = NULL
 )
 
 \S4method{dbDisconnect}{duckdb_connection}(conn, ..., shutdown = FALSE)
@@ -43,7 +43,9 @@ data is kept in RAM}
 
 \item{read_only}{Set to \code{TRUE} for read-only operation}
 
-\item{bigint}{How 64-bit integers should be returned, default is double/numeric. Set to integer64 for bit64 encoding.}
+\item{bigint}{How 64-bit integers should be returned. There are two options: \verb{"numeric}" and \verb{"integer64}".
+If \verb{"numeric}" is selected, bigint integers will be treated as double/numeric.
+If \verb{"integer64}" is selected, bigint integers will be set to bit64 encoding.}
 
 \item{config}{Named list with DuckDB configuration flags}
 
@@ -84,7 +86,7 @@ An object of class "adbc_driver"
 
 \code{duckdb_shutdown()} shuts down a database instance.
 
-Return an \code{\link[adbcdrivermanager:adbc_driver_void]{adbcdrivermanager::adbc_driver()}} for use with Arrow Database
+Return an \code{\link[adbcdrivermanager:adbc_driver]{adbcdrivermanager::adbc_driver()}} for use with Arrow Database
 Connectivity via the adbcdrivermanager package.
 
 \code{dbConnect()} connects to a database instance.

--- a/tests/testthat/test_integer64.R
+++ b/tests/testthat/test_integer64.R
@@ -1,7 +1,7 @@
 # this tests both retrieval and scans
 test_that("we can roundtrip an integer64", {
   skip_if_not_installed("bit64")
-
+  # ! tiago, test is here
   con <- dbConnect(duckdb(bigint = "integer64"))
   on.exit(dbDisconnect(con, shutdown = TRUE))
   df <- data.frame(a = bit64::as.integer64(42), b = bit64::as.integer64(-42), c = bit64::as.integer64(NA))

--- a/tests/testthat/test_integer64.R
+++ b/tests/testthat/test_integer64.R
@@ -1,8 +1,19 @@
 # this tests both retrieval and scans
-test_that("we can roundtrip an integer64", {
+test_that("we can roundtrip an integer64 via driver", {
   skip_if_not_installed("bit64")
-  # ! tiago, test is here
   con <- dbConnect(duckdb(bigint = "integer64"))
+  on.exit(dbDisconnect(con, shutdown = TRUE))
+  df <- data.frame(a = bit64::as.integer64(42), b = bit64::as.integer64(-42), c = bit64::as.integer64(NA))
+
+  duckdb_register(con, "df", df)
+
+  res <- dbReadTable(con, "df")
+  expect_identical(df, res)
+})
+
+test_that("we can roundtrip an integer64 via dbConnect", {
+  skip_if_not_installed("bit64")
+  con <- dbConnect(duckdb(), bigint = "integer64")
   on.exit(dbDisconnect(con, shutdown = TRUE))
   df <- data.frame(a = bit64::as.integer64(42), b = bit64::as.integer64(-42), c = bit64::as.integer64(NA))
 


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb-r/issues/6. 

Thanks for all the work on this package 👍 