### PR TITLE
Tweaks for building on Windows/aarch64 with LLVM 17.

### DIFF
--- a/src/duckdb/third_party/fast_float/fast_float/fast_float.h
+++ b/src/duckdb/third_party/fast_float/fast_float/fast_float.h
@@ -242,7 +242,7 @@ fastfloat_really_inline uint64_t _umul128(uint64_t ab, uint64_t cd,
 fastfloat_really_inline value128 full_multiplication(uint64_t a,
                                                      uint64_t b) {
   value128 answer;
-#ifdef _M_ARM64
+#if defined(FASTFLOAT_VISUAL_STUDIO) && defined(_M_ARM64)
   // ARM64 has native support for 64-bit multiplications, no need to emulate
   answer.high = __umulh(a, b);
   answer.low = a * b;

--- a/src/duckdb/third_party/thrift/thrift/thrift-config.h
+++ b/src/duckdb/third_party/thrift/thrift/thrift-config.h
@@ -22,7 +22,7 @@
 
 
 #ifdef _WIN32
-#if defined(_M_IX86) || defined(_M_X64)
+#if defined(_M_IX86) || defined(_M_X64) || defined(_M_ARM64)
 #define ARITHMETIC_RIGHT_SHIFT 1
 #define SIGNED_RIGHT_SHIFT_IS 1
 #endif


### PR DESCRIPTION
__umulh is a Microsoft intrinsic not supported by clang (LLVM17) with mingw target. This patch makes it used only with Visual studio.

thrift-config.h had to be updated to assert that the platform has an arithmetic right shift - on Windows (unlike other platforms), it asserted that only with x86/x86_64. I have ran the upstream thrift configure test, which concluded that the right shift is arithmetic on Windows/aarch64.

With the patch applied, the (CRAN version of the) package builds fine on my Windows/aarch64.