### PR TITLE
feat: Initial ALTREP support for `LIST` logical type

### DIFF
--- a/src/include/rapi.hpp
+++ b/src/include/rapi.hpp
@@ -4,12 +4,17 @@
 
 #include <Rdefines.h>
 #include <R_ext/Altrep.h>
+#include <Rversion.h>
 
 #include "duckdb.hpp"
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/common/unordered_map.hpp"
 #include "duckdb/parser/tableref/table_function_ref.hpp"
 #include "duckdb/common/mutex.hpp"
+
+#if defined(R_VERSION) && R_VERSION >= R_Version(4, 3, 0)
+#define R_HAS_ALTLIST
+#endif
 
 namespace duckdb {
 

--- a/src/include/reltoaltrep.hpp
+++ b/src/include/reltoaltrep.hpp
@@ -15,12 +15,16 @@ struct RelToAltrep {
 	static Rboolean RelInspect(SEXP x, int pre, int deep, int pvec, void (*inspect_subtree)(SEXP, int, int, int));
 
 	static SEXP VectorStringElt(SEXP x, R_xlen_t i);
-	static SEXP VectorListElt(SEXP x, R_xlen_t i);
 
 	static R_altrep_class_t rownames_class;
 	static R_altrep_class_t logical_class;
 	static R_altrep_class_t int_class;
 	static R_altrep_class_t real_class;
 	static R_altrep_class_t string_class;
+
+#if defined(R_HAS_ALTLIST)
+	static SEXP VectorListElt(SEXP x, R_xlen_t i);
 	static R_altrep_class_t list_class;
+#endif
+
 };

--- a/src/include/reltoaltrep.hpp
+++ b/src/include/reltoaltrep.hpp
@@ -15,10 +15,12 @@ struct RelToAltrep {
 	static Rboolean RelInspect(SEXP x, int pre, int deep, int pvec, void (*inspect_subtree)(SEXP, int, int, int));
 
 	static SEXP VectorStringElt(SEXP x, R_xlen_t i);
+	static SEXP VectorListElt(SEXP x, R_xlen_t i);
 
 	static R_altrep_class_t rownames_class;
 	static R_altrep_class_t logical_class;
 	static R_altrep_class_t int_class;
 	static R_altrep_class_t real_class;
 	static R_altrep_class_t string_class;
+	static R_altrep_class_t list_class;
 };

--- a/src/reltoaltrep.cpp
+++ b/src/reltoaltrep.cpp
@@ -10,6 +10,7 @@ R_altrep_class_t RelToAltrep::logical_class;
 R_altrep_class_t RelToAltrep::int_class;
 R_altrep_class_t RelToAltrep::real_class;
 R_altrep_class_t RelToAltrep::string_class;
+R_altrep_class_t RelToAltrep::list_class;
 
 void RelToAltrep::Initialize(DllInfo *dll) {
 	// this is a string so setting row names will not lead to materialization
@@ -18,28 +19,33 @@ void RelToAltrep::Initialize(DllInfo *dll) {
 	int_class = R_make_altinteger_class("reltoaltrep_int_class", "duckdb", dll);
 	real_class = R_make_altreal_class("reltoaltrep_real_class", "duckdb", dll);
 	string_class = R_make_altstring_class("reltoaltrep_string_class", "duckdb", dll);
+	list_class = R_make_altlist_class("reltoaltrep_list_class", "duckdb", dll);
 
 	R_set_altrep_Inspect_method(rownames_class, RownamesInspect);
 	R_set_altrep_Inspect_method(logical_class, RelInspect);
 	R_set_altrep_Inspect_method(int_class, RelInspect);
 	R_set_altrep_Inspect_method(real_class, RelInspect);
 	R_set_altrep_Inspect_method(string_class, RelInspect);
+	R_set_altrep_Inspect_method(list_class, RelInspect);
 
 	R_set_altrep_Length_method(rownames_class, RownamesLength);
 	R_set_altrep_Length_method(logical_class, VectorLength);
 	R_set_altrep_Length_method(int_class, VectorLength);
 	R_set_altrep_Length_method(real_class, VectorLength);
 	R_set_altrep_Length_method(string_class, VectorLength);
+	R_set_altrep_Length_method(list_class, VectorLength);
 
 	R_set_altvec_Dataptr_method(rownames_class, RownamesDataptr);
 	R_set_altvec_Dataptr_method(logical_class, VectorDataptr);
 	R_set_altvec_Dataptr_method(int_class, VectorDataptr);
 	R_set_altvec_Dataptr_method(real_class, VectorDataptr);
 	R_set_altvec_Dataptr_method(string_class, VectorDataptr);
+	R_set_altvec_Dataptr_method(list_class, VectorDataptr);
 
 	R_set_altvec_Dataptr_or_null_method(rownames_class, RownamesDataptrOrNull);
 
 	R_set_altstring_Elt_method(string_class, VectorStringElt);
+	R_set_altlist_Elt_method(list_class, VectorListElt);
 }
 
 template <class T>
@@ -231,6 +237,12 @@ SEXP RelToAltrep::VectorStringElt(SEXP x, R_xlen_t i) {
 	END_CPP11
 }
 
+SEXP RelToAltrep::VectorListElt(SEXP x, R_xlen_t i) {
+	BEGIN_CPP11
+	return VECTOR_ELT(AltrepVectorWrapper::Get(x)->Vector(), i);
+	END_CPP11
+}
+
 static R_altrep_class_t LogicalTypeToAltrepType(const LogicalType &type) {
 	switch (type.id()) {
 	case LogicalTypeId::BOOLEAN:
@@ -261,13 +273,15 @@ static R_altrep_class_t LogicalTypeToAltrepType(const LogicalType &type) {
 	case LogicalTypeId::VARCHAR:
 	case LogicalTypeId::UUID:
 		return RelToAltrep::string_class;
+	case LogicalTypeId::LIST:
+		return RelToAltrep::list_class;
 	default:
 		cpp11::stop("rel_to_altrep: Unknown column type for altrep: %s", type.ToString().c_str());
 	}
 }
 
 [[cpp11::register]] SEXP rapi_rel_to_altrep(duckdb::rel_extptr_t rel) {
-	D_ASSERT(rel && rel->rel);
+  	D_ASSERT(rel && rel->rel);
 	auto drel = rel->rel;
 	auto ncols = drel->Columns().size();
 

--- a/src/reltoaltrep.cpp
+++ b/src/reltoaltrep.cpp
@@ -281,7 +281,7 @@ static R_altrep_class_t LogicalTypeToAltrepType(const LogicalType &type) {
 }
 
 [[cpp11::register]] SEXP rapi_rel_to_altrep(duckdb::rel_extptr_t rel) {
-  	D_ASSERT(rel && rel->rel);
+  D_ASSERT(rel && rel->rel);
 	auto drel = rel->rel;
 	auto ncols = drel->Columns().size();
 

--- a/src/reltoaltrep.cpp
+++ b/src/reltoaltrep.cpp
@@ -294,7 +294,7 @@ static R_altrep_class_t LogicalTypeToAltrepType(const LogicalType &type) {
 }
 
 [[cpp11::register]] SEXP rapi_rel_to_altrep(duckdb::rel_extptr_t rel) {
-  D_ASSERT(rel && rel->rel);
+	D_ASSERT(rel && rel->rel);
 	auto drel = rel->rel;
 	auto ncols = drel->Columns().size();
 

--- a/tests/testthat/test_list.R
+++ b/tests/testthat/test_list.R
@@ -28,6 +28,8 @@ test_that("one-level lists can be read", {
 })
 
 test_that("rel_filter() handles LIST logical type", {
+  skip_if_not(getRversion() >= "4.3.0")
+
   con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
 

--- a/tests/testthat/test_list.R
+++ b/tests/testthat/test_list.R
@@ -26,3 +26,16 @@ test_that("one-level lists can be read", {
   res <- dbGetQuery(con, "SELECT ['Hello', 'World'] a union all select ['There']")$a
   expect_equal(res, list(c("Hello", "World"), c("There")))
 })
+
+test_that("rel_filter() handles LIST logical type", {
+  con <- dbConnect(duckdb())
+  on.exit(dbDisconnect(con, shutdown = TRUE))
+
+  df1 <- tibble::tibble(a = list(1, c(1,2)))
+
+  rel1 <- rel_from_df(con, df1)
+  rel2 <- rel_filter(rel1, list(expr_constant(TRUE)))
+
+  df2 <- rel_to_altrep(rel2)
+  expect_equal(df1$a, df2$a)
+})


### PR DESCRIPTION
This uses the same approach as with alters strings, i.e. `Elt()` materialise all with `VECTOR_ELT(AltrepVectorWrapper::Get(x)->Vector(), i);` 

there is probably a better way involving not forcing materialisation, i.e. an `Elt()` method that would just call `duckdb_r_transform(chunk.data[column_index], dest, dest_offset, chunk.size(), false);`  