### PR TITLE
fix: `dplyr::tbl()` works again when a Parquet or CSV file is passed instead of a table name

### DIFF
--- a/R/backend-dbplyr__duckdb_connection.R
+++ b/R/backend-dbplyr__duckdb_connection.R
@@ -374,8 +374,9 @@ sql_escape_datetime.duckdb_connection <- function(con, x) {
 # @param from Table or parquet/csv -files to be registered
 # @param cache Enable object cache for parquet files
 tbl.duckdb_connection <- function(src, from, cache = FALSE, ...) {
-  ident_q <- pkg_method("ident_q", "dbplyr")
-  if (!inherits(from, "sql") & !DBI::dbExistsTable(src, from)) from <- ident_q(from)
+  if (!inherits(from, "sql") && !DBI::dbExistsTable(src, from)) {
+    from <- dbplyr::sql(paste0("FROM ", from))
+  }
   if (cache) DBI::dbExecute(src, "PRAGMA enable_object_cache")
   NextMethod("tbl")
 }


### PR DESCRIPTION
Closes #38.