### PR TITLE
fix: `DBI::dbQuoteIdentifier()` correctly quotes identifiers that start with a digit

### DIFF
--- a/R/dbQuoteIdentifier__duckdb_connection.R
+++ b/R/dbQuoteIdentifier__duckdb_connection.R
@@ -11,7 +11,7 @@ dbQuoteIdentifier__duckdb_connection <- function(conn, x, ...) {
   }
 
   x <- enc2utf8(x)
-  needs_escape <- !grepl("^[a-zA-Z0-9_]+$", x) | tolower(x) %in% reserved_words(conn)
+  needs_escape <- !grepl("^[a-zA-Z_][a-zA-Z0-9_]*$", x) | tolower(x) %in% reserved_words(conn)
   x[needs_escape] <- paste0('"', gsub('"', '""', x[needs_escape]), '"')
 
   SQL(x, names = names(x))

--- a/tests/testthat/test-dbQuoteIdentifier__duckdb_connection.R
+++ b/tests/testthat/test-dbQuoteIdentifier__duckdb_connection.R
@@ -3,8 +3,8 @@ test_that("only quotes where needed", {
   on.exit(dbDisconnect(con, shutdown = TRUE))
 
   expect_equal(
-    dbQuoteIdentifier(con, c("x y", "select", "SELECT", "x")),
-    SQL(c('"x y"', '"select"', '"SELECT"', "x"))
+    dbQuoteIdentifier(con, c("x y", "select", "SELECT", "x", "2nd")),
+    SQL(c('"x y"', '"select"', '"SELECT"', "x", '"2nd"'))
   )
 })
 


### PR DESCRIPTION
Closes #67.