### PR TITLE
Remove std:: from unordered_map

### DIFF
--- a/src/register.cpp
+++ b/src/register.cpp
@@ -163,7 +163,7 @@ private:
 		return conjunction_sexp;
 	}
 
-	static SEXP TransformFilter(TableFilterSet &filter_collection, std::unordered_map<idx_t, string> &columns,
+	static SEXP TransformFilter(TableFilterSet &filter_collection, unordered_map<idx_t, string> &columns,
 	                            SEXP functions, string &timezone_config) {
 		auto fit = filter_collection.filters.begin();
 		cpp11::sexp res = TransformFilterExpression(*fit->second, columns[fit->first], functions, timezone_config);


### PR DESCRIPTION
We're using namespace `duckdb` which uses it so it should be fine. I plan to make changes to `duckdb::unordered` map in a separate PR to the duckdb repo. I hope this fixes my CI!