### PR TITLE
Fix invalid regex in .Rbuildignore

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -33,4 +33,4 @@ RELEASE.md
 ^pkgdown$
 ^docker$
 ^docker-compose\.yml$
-^*_files$
+^.*_files$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -33,4 +33,4 @@ RELEASE.md
 ^pkgdown$
 ^docker$
 ^docker-compose\.yml$
-^.*_files$
+_files$


### PR DESCRIPTION
An invalid regex in the .RbuildIgnore is causing many CI failures. A `*` regex character cannot match the `^` character 0 or more times. 
I've changed it to `.*` but I'm not sure if the original intention is to match everything with the suffix `_files`