### PR TITLE
feat: Implement `n_distinct()` for multiple arguments using duckdb structs

### DIFF
--- a/R/backend-dbplyr__duckdb_connection.R
+++ b/R/backend-dbplyr__duckdb_connection.R
@@ -80,7 +80,7 @@ duckdb_grepl <- function(pattern, x, ignore.case = FALSE, perl = FALSE, fixed = 
 duckdb_n_distinct <- function(..., na.rm = FALSE) {
   sql <- pkg_method("sql", "dbplyr")
 
-  if (identical(na.rm, TRUE)) {
+  if (!identical(na.rm, FALSE)) {
     stop("Parameter `na.rm = TRUE` in n_distinct() is currently not supported in DuckDB backend.", call. = FALSE)
   }
 

--- a/R/backend-dbplyr__duckdb_connection.R
+++ b/R/backend-dbplyr__duckdb_connection.R
@@ -78,25 +78,16 @@ duckdb_grepl <- function(pattern, x, ignore.case = FALSE, perl = FALSE, fixed = 
 }
 
 duckdb_n_distinct <- function(..., na.rm = FALSE) {
-  glue_sql2 <- pkg_method("glue_sql2", "dbplyr")
+  sql <- pkg_method("sql", "dbplyr")
 
   if (identical(na.rm, TRUE)) {
     cli::cli_abort("`na.rm = TRUE` not implemented.")
   }
 
-  vars <- list(...)
-  str_struct <-
-    paste0("{", paste0(
-      lapply(
-        seq_along(vars),
-        \(i) glue::glue("'v{i}' : {vars[[i]]}")
-      ),
-      collapse = ", "
-    ), "}")
-  glue_sql2(
-    sql_current_con(),
-    "COUNT(DISTINCT {str_struct})"
-  )
+  # https://duckdb.org/docs/sql/data_types/struct.html#creating-structs-with-the-row-function
+  str_struct <- paste0("row(", paste0(list(...), collapse = ", "), ")")
+
+  sql(paste0("COUNT(DISTINCT ", str_struct, ")"))
 }
 
 # Customized translation functions for DuckDB SQL

--- a/R/backend-dbplyr__duckdb_connection.R
+++ b/R/backend-dbplyr__duckdb_connection.R
@@ -81,7 +81,7 @@ duckdb_n_distinct <- function(..., na.rm = FALSE) {
   sql <- pkg_method("sql", "dbplyr")
 
   if (identical(na.rm, TRUE)) {
-    cli::cli_abort("`na.rm = TRUE` not implemented.")
+    stop("Parameter `na.rm = TRUE` in n_distinct() is currently not supported in DuckDB backend.", call. = FALSE)
   }
 
   # https://duckdb.org/docs/sql/data_types/struct.html#creating-structs-with-the-row-function

--- a/R/backend-dbplyr__duckdb_connection.R
+++ b/R/backend-dbplyr__duckdb_connection.R
@@ -78,10 +78,11 @@ duckdb_grepl <- function(pattern, x, ignore.case = FALSE, perl = FALSE, fixed = 
 }
 
 duckdb_n_distinct <- function(..., na.rm = FALSE) {
-  check_na_rm <- pkg_method("check_na_rm", "dbplyr")
   glue_sql2 <- pkg_method("glue_sql2", "dbplyr")
 
-  check_na_rm(na.rm)
+  if (identical(na.rm, TRUE)) {
+    cli::cli_abort("`na.rm = TRUE` not implemented.")
+  }
 
   vars <- list(...)
   str_struct <-

--- a/tests/testthat/test-backend-dbplyr__duckdb_connection.R
+++ b/tests/testthat/test-backend-dbplyr__duckdb_connection.R
@@ -236,44 +236,36 @@ test_that("n_distinct() computations are correct", {
   summarize <- dplyr::summarize
   pull <- dplyr::pull
 
-  duckdb_register(con, "df1", data.frame(x = c(1, 1, 2)))
-  duckdb_register(con, "df1_na", data.frame(x = c(1, 1, 2, NA)))
-  duckdb_register(con, "df2", data.frame(x = c(1, 1, 2, 2), y = c(1, 2, 2, 2)))
-  duckdb_register(con, "df2_na", data.frame(x = c(1, 1, 2, NA, NA), y = c(1, 2, NA, 2, NA)))
+  duckdb_register(con, "df", data.frame(x = c(1, 1, 2, 2), y = c(1, 2, 2, 2)))
+  duckdb_register(con, "df_na", data.frame(x = c(1, 1, 2, NA, NA), y = c(1, 2, NA, 2, NA)))
+
+  df <- tbl(con, "df")
+  df_na <- tbl(con, "df_na")
 
   expect_error(
-    tbl(con, "df1") |>
-      summarize(n = n_distinct(x, na.rm = TRUE)) |>
-      pull(n)
+    pull(summarize(df, n = n_distinct(x, na.rm = TRUE)), n)
   )
 
   # single column is working as usual
   expect_equal(
-    tbl(con, "df1") |>
-      summarize(n = n_distinct(x)) |>
-      pull(n),
+    pull(summarize(df, n = n_distinct(x)), n),
     2
   )
+
   expect_equal(
-    tbl(con, "df1_na") |>
-      summarize(n = n_distinct(x)) |>
-      pull(n),
+    pull(summarize(df_na, n = n_distinct(x)), n),
     3
   )
 
   # two columns return correct results
   expect_equal(
-    tbl(con, "df2") |>
-      summarize(n = n_distinct(x, y)) |>
-      pull(n),
+    pull(summarize(df, n = n_distinct(x, y)), n),
     3
   )
 
   # two columns containing NAs return correct results
   expect_equal(
-    tbl(con, "df2_na") |>
-      summarize(n = n_distinct(x, y)) |>
-      pull(n),
+    pull(summarize(df_na, n = n_distinct(x, y)), n),
     5
   )
 })

--- a/tests/testthat/test-backend-dbplyr__duckdb_connection.R
+++ b/tests/testthat/test-backend-dbplyr__duckdb_connection.R
@@ -207,8 +207,8 @@ test_that("aggregators translated correctly", {
   expect_equal(translate(str_flatten(x, ","), window = FALSE), sql(r"{STRING_AGG(x, ',')}"))
   expect_equal(translate(str_flatten(x, ","), window = TRUE), sql(r"{STRING_AGG(x, ',') OVER ()}"))
 
-  expect_equal(translate(n_distinct(x, na.rm = TRUE), window = FALSE), sql(r"{COUNT(DISTINCT {'v1' : x})}"))
-  expect_equal(translate(n_distinct(x, na.rm = TRUE), window = TRUE), sql(r"{COUNT(DISTINCT {'v1' : x}) OVER ()}"))
+  expect_equal(translate(n_distinct(x), window = FALSE), sql(r"{COUNT(DISTINCT {'v1' : x})}"))
+  expect_equal(translate(n_distinct(x), window = TRUE), sql(r"{COUNT(DISTINCT {'v1' : x}) OVER ()}"))
 })
 
 test_that("two variable aggregates are translated correctly", {
@@ -222,8 +222,8 @@ test_that("two variable aggregates are translated correctly", {
   expect_equal(translate(cor(x, y), window = FALSE), sql(r"{CORR(x, y)}"))
   expect_equal(translate(cor(x, y), window = TRUE), sql(r"{CORR(x, y) OVER ()}"))
 
-  expect_equal(translate(n_distinct(x, y, na.rm = TRUE), window = FALSE), sql(r"{COUNT(DISTINCT {'v1' : x, 'v2' : y})}"))
-  expect_equal(translate(n_distinct(x, y, na.rm = TRUE), window = TRUE), sql(r"{COUNT(DISTINCT {'v1' : x, 'v2' : y}) OVER ()}"))
+  expect_equal(translate(n_distinct(x, y), window = FALSE), sql(r"{COUNT(DISTINCT {'v1' : x, 'v2' : y})}"))
+  expect_equal(translate(n_distinct(x, y), window = TRUE), sql(r"{COUNT(DISTINCT {'v1' : x, 'v2' : y}) OVER ()}"))
 })
 
 

--- a/tests/testthat/test-backend-dbplyr__duckdb_connection.R
+++ b/tests/testthat/test-backend-dbplyr__duckdb_connection.R
@@ -207,8 +207,8 @@ test_that("aggregators translated correctly", {
   expect_equal(translate(str_flatten(x, ","), window = FALSE), sql(r"{STRING_AGG(x, ',')}"))
   expect_equal(translate(str_flatten(x, ","), window = TRUE), sql(r"{STRING_AGG(x, ',') OVER ()}"))
 
-  expect_equal(translate(n_distinct(x), window = FALSE), sql(r"{COUNT(DISTINCT {'v1' : x})}"))
-  expect_equal(translate(n_distinct(x), window = TRUE), sql(r"{COUNT(DISTINCT {'v1' : x}) OVER ()}"))
+  expect_equal(translate(n_distinct(x), window = FALSE), sql(r"{COUNT(DISTINCT row(x))}"))
+  expect_equal(translate(n_distinct(x), window = TRUE), sql(r"{COUNT(DISTINCT row(x)) OVER ()}"))
 })
 
 test_that("two variable aggregates are translated correctly", {
@@ -222,8 +222,8 @@ test_that("two variable aggregates are translated correctly", {
   expect_equal(translate(cor(x, y), window = FALSE), sql(r"{CORR(x, y)}"))
   expect_equal(translate(cor(x, y), window = TRUE), sql(r"{CORR(x, y) OVER ()}"))
 
-  expect_equal(translate(n_distinct(x, y), window = FALSE), sql(r"{COUNT(DISTINCT {'v1' : x, 'v2' : y})}"))
-  expect_equal(translate(n_distinct(x, y), window = TRUE), sql(r"{COUNT(DISTINCT {'v1' : x, 'v2' : y}) OVER ()}"))
+  expect_equal(translate(n_distinct(x, y), window = FALSE), sql(r"{COUNT(DISTINCT row(x, y))}"))
+  expect_equal(translate(n_distinct(x, y), window = TRUE), sql(r"{COUNT(DISTINCT row(x, y)) OVER ()}"))
 })
 
 test_that("n_distinct() computations are correct", {

--- a/tests/testthat/test-backend-dbplyr__duckdb_connection.R
+++ b/tests/testthat/test-backend-dbplyr__duckdb_connection.R
@@ -206,6 +206,9 @@ test_that("aggregators translated correctly", {
 
   expect_equal(translate(str_flatten(x, ","), window = FALSE), sql(r"{STRING_AGG(x, ',')}"))
   expect_equal(translate(str_flatten(x, ","), window = TRUE), sql(r"{STRING_AGG(x, ',') OVER ()}"))
+
+  expect_equal(translate(n_distinct(x, na.rm = TRUE), window = FALSE), sql(r"{COUNT(DISTINCT {'v1' : x})}"))
+  expect_equal(translate(n_distinct(x, na.rm = TRUE), window = TRUE), sql(r"{COUNT(DISTINCT {'v1' : x}) OVER ()}"))
 })
 
 test_that("two variable aggregates are translated correctly", {
@@ -218,6 +221,9 @@ test_that("two variable aggregates are translated correctly", {
 
   expect_equal(translate(cor(x, y), window = FALSE), sql(r"{CORR(x, y)}"))
   expect_equal(translate(cor(x, y), window = TRUE), sql(r"{CORR(x, y) OVER ()}"))
+
+  expect_equal(translate(n_distinct(x, y, na.rm = TRUE), window = FALSE), sql(r"{COUNT(DISTINCT {'v1' : x, 'v2' : y})}"))
+  expect_equal(translate(n_distinct(x, y, na.rm = TRUE), window = TRUE), sql(r"{COUNT(DISTINCT {'v1' : x, 'v2' : y}) OVER ()}"))
 })
 
 


### PR DESCRIPTION
This PR attempts to adress #110, implementing `n_distinct()` making use of duckdb's [structs](https://duckdb.org/docs/sql/data_types/struct).

I don't have any experience in writing dbplyr SQL translations, in particular I have no idea of the 'best practices', but I tried to mimic as much from the already existing code as I could.

A couple of notes:

- duckdb's struct fields need to be named. In this case, the naming is irrelevant and I chose to name them 'v1', 'v2', 'v3', ... and so on, depending on the number of arguments passed to `n_distinct()`. If there is an alternative prefered way to do it, please let me know.
- I was making use of `glue::glue()`. Although dbplyr depends on glue, and in this function we are assuming that dbplyr is installed, I am not sure if I am allowed to assume that this function exists. Maybe I should not make use of it?
- I also added unit tests at places where I thought they make sense. Let me know if I should change them or relocate them, etc..

Thanks! :)

Closes #110 