### PR TITLE
fix: Avoid `R CMD check` warning regarding `SETLENGTH()` and `SET_TRUELENGTH()`

### DIFF
--- a/inst/include/cpp11/r_vector.hpp
+++ b/inst/include/cpp11/r_vector.hpp
@@ -890,13 +890,8 @@ inline void r_vector<T>::clear() {
 }
 
 inline SEXP truncate(SEXP x, R_xlen_t length, R_xlen_t capacity) {
-#if R_VERSION >= R_Version(3, 4, 0)
-  SETLENGTH(x, length);
-  SET_TRUELENGTH(x, capacity);
-  SET_GROWABLE_BIT(x);
-#else
+  // Avoid SETLENGTH() and SET_TRUELENGTH() which trigger a warning on R-devel 4.5
   x = safe[Rf_lengthgets](x, length);
-#endif
   return x;
 }
 

--- a/src/reltoaltrep.cpp
+++ b/src/reltoaltrep.cpp
@@ -299,21 +299,11 @@ static R_altrep_class_t LogicalTypeToAltrepType(const LogicalType &type) {
 	auto drel = rel->rel;
 	auto ncols = drel->Columns().size();
 
-	cpp11::writable::list data_frame(NEW_LIST(ncols));
-	data_frame.attr(R_ClassSymbol) = RStrings::get().dataframe_str;
 	auto relation_wrapper = make_shared<AltrepRelationWrapper>(drel);
 
-	cpp11::external_pointer<AltrepRownamesWrapper> ptr(new AltrepRownamesWrapper(relation_wrapper));
-	R_SetExternalPtrTag(ptr, RStrings::get().duckdb_row_names_sym);
+	cpp11::writable::list data_frame;
+	data_frame.reserve(ncols);
 
-	cpp11::sexp row_names_sexp = R_new_altrep(RelToAltrep::rownames_class, ptr, rel);
-	install_new_attrib(data_frame, R_RowNamesSymbol, row_names_sexp);
-	vector<string> names;
-	for (auto &col : drel->Columns()) {
-		names.push_back(col.Name());
-	}
-
-	SET_NAMES(data_frame, StringsToSexp(names));
 	for (size_t col_idx = 0; col_idx < ncols; col_idx++) {
 		auto &column_type = drel->Columns()[col_idx].Type();
 		cpp11::external_pointer<AltrepVectorWrapper> ptr(new AltrepVectorWrapper(relation_wrapper, col_idx));
@@ -321,8 +311,28 @@ static R_altrep_class_t LogicalTypeToAltrepType(const LogicalType &type) {
 
 		cpp11::sexp vector_sexp = R_new_altrep(LogicalTypeToAltrepType(column_type), ptr, rel);
 		duckdb_r_decorate(column_type, vector_sexp, false);
-		SET_VECTOR_ELT(data_frame, col_idx, vector_sexp);
+		data_frame.push_back(vector_sexp);
 	}
+
+	// convert to SEXP, with potential side effect of truncation and removal of attributes
+	(void)(SEXP)data_frame;
+
+	// Names
+	vector<string> names;
+	for (auto &col : drel->Columns()) {
+		names.push_back(col.Name());
+	}
+	SET_NAMES(data_frame, StringsToSexp(names));
+
+	// Row names
+	cpp11::external_pointer<AltrepRownamesWrapper> ptr(new AltrepRownamesWrapper(relation_wrapper));
+	R_SetExternalPtrTag(ptr, RStrings::get().duckdb_row_names_sym);
+	cpp11::sexp row_names_sexp = R_new_altrep(RelToAltrep::rownames_class, ptr, rel);
+	install_new_attrib(data_frame, R_RowNamesSymbol, row_names_sexp);
+
+	// Class
+	data_frame.attr(R_ClassSymbol) = RStrings::get().dataframe_str;
+
 	return data_frame;
 }
 

--- a/src/scan.cpp
+++ b/src/scan.cpp
@@ -37,12 +37,12 @@ data_ptr_t GetColDataPtr(const RType &rtype, SEXP coldata) {
 		return (data_ptr_t)INTEGER_POINTER(coldata);
 	case RType::DATE:
 		if (!IS_NUMERIC(coldata)) {
-			cpp11::stop("DATE should really be integer");
+			cpp11::stop("DATE should be of numeric type");
 		}
 		return (data_ptr_t)NUMERIC_POINTER(coldata);
 	case RType::DATE_INTEGER:
 		if (!IS_INTEGER(coldata)) {
-			cpp11::stop("DATE_INTEGER should really be integer");
+			cpp11::stop("DATE_INTEGER should be of integer type");
 		}
 		return (data_ptr_t)INTEGER_POINTER(coldata);
 	case RType::LIST_OF_NULLS:

--- a/src/statement.cpp
+++ b/src/statement.cpp
@@ -213,16 +213,21 @@ SEXP duckdb::duckdb_execute_R_impl(MaterializedQueryResult *result, bool integer
 	// Note we cannot use cpp11's data frame here as it tries to calculate the number of rows itself,
 	// but gives the wrong answer if the first column is another data frame. So we set the necessary
 	// attributes manually.
-	cpp11::writable::list data_frame(NEW_LIST(ncols));
-	data_frame.attr(R_ClassSymbol) = RStrings::get().dataframe_str;
-	data_frame.attr(R_RowNamesSymbol) = {NA_INTEGER, -static_cast<int>(nrows)};
-	SET_NAMES(data_frame, StringsToSexp(result->names));
+	cpp11::writable::list data_frame;
+	data_frame.reserve(ncols);
 
 	for (size_t col_idx = 0; col_idx < ncols; col_idx++) {
 		cpp11::sexp varvalue = duckdb_r_allocate(result->types[col_idx], nrows);
 		duckdb_r_decorate(result->types[col_idx], varvalue, integer64);
-		SET_VECTOR_ELT(data_frame, col_idx, varvalue);
+		data_frame.push_back(varvalue);
 	}
+
+	// Convert to SEXP, finalize length
+	(void)(SEXP)data_frame;
+
+	data_frame.attr(R_ClassSymbol) = RStrings::get().dataframe_str;
+	data_frame.attr(R_RowNamesSymbol) = {NA_INTEGER, -static_cast<int>(nrows)};
+	SET_NAMES(data_frame, StringsToSexp(result->names));
 
 	// at this point data_frame is fully allocated and the only protected SEXP
 

--- a/src/statement.cpp
+++ b/src/statement.cpp
@@ -63,7 +63,7 @@ using namespace cpp11::literals;
 
 static cpp11::list construct_retlist(duckdb::unique_ptr<PreparedStatement> stmt, const string &query, idx_t n_param) {
 	cpp11::writable::list retlist;
-	retlist.reserve(6);
+	retlist.reserve(7);
 	retlist.push_back({"str"_nm = query});
 
 	auto stmtholder = new RStatement();

--- a/src/transform.cpp
+++ b/src/transform.cpp
@@ -51,6 +51,7 @@ SEXP duckdb_r_allocate(const LogicalType &type, idx_t nrows) {
 		return NEW_LIST(nrows);
 	case LogicalTypeId::STRUCT: {
 		cpp11::writable::list dest_list;
+		dest_list.reserve(StructType::GetChildTypes(type).size());
 
 		for (const auto &child : StructType::GetChildTypes(type)) {
 			const auto &name = child.first;
@@ -59,6 +60,9 @@ SEXP duckdb_r_allocate(const LogicalType &type, idx_t nrows) {
 			cpp11::sexp dest_child = duckdb_r_allocate(child_type, nrows);
 			dest_list.push_back(cpp11::named_arg(name.c_str()) = std::move(dest_child));
 		}
+
+		// convert to SEXP, with potential side effect of truncation
+		(void)(SEXP)dest_list;
 
 		// Note we cannot use cpp11's data frame here as it tries to calculate the number of rows itself,
 		// but gives the wrong answer if the first column is another data frame or the struct is empty.


### PR DESCRIPTION
Timings for running all tests didn't change too much. Need more investigation if this actually harms performance, will await user reports.

## This PR

R -q -e 'testthat::test_local()'  12.58s user 1.87s system 95% cpu 15.192 total

## Parent

R -q -e 'testthat::test_local()'  13.12s user 1.99s system 96% cpu 15.644 total

