### PR TITLE
Change conversion for difftime to INTERVAL, not TIME

### DIFF
--- a/R/dbQuoteLiteral__duckdb_connection.R
+++ b/R/dbQuoteLiteral__duckdb_connection.R
@@ -43,8 +43,13 @@ dbQuoteLiteral__duckdb_connection <- function(conn, x, ...) {
       return(SQL(character()))
     }
 
-    out <- callNextMethod()
-    return(SQL(paste0(out, "::time")))
+    units(x) <- "secs"
+    value <- round(as.numeric(x) * 1000000)
+    value[!is.finite(x)] <- NA
+
+    out <- paste0("to_microseconds(", formatC(value, format = "f", digits = 0), ")")
+    out[is.na(value)] <- "NULL"
+    return(SQL(out))
   }
 
   if (is.list(x)) {

--- a/src/include/typesr.hpp
+++ b/src/include/typesr.hpp
@@ -26,16 +26,16 @@ enum class RTypeId {
 	DATE,
 	DATE_INTEGER,
 	TIMESTAMP,
-	TIME_SECONDS,
-	TIME_MINUTES,
-	TIME_HOURS,
-	TIME_DAYS,
-	TIME_WEEKS,
-	TIME_SECONDS_INTEGER,
-	TIME_MINUTES_INTEGER,
-	TIME_HOURS_INTEGER,
-	TIME_DAYS_INTEGER,
-	TIME_WEEKS_INTEGER,
+	INTERVAL_SECONDS,
+	INTERVAL_MINUTES,
+	INTERVAL_HOURS,
+	INTERVAL_DAYS,
+	INTERVAL_WEEKS,
+	INTERVAL_SECONDS_INTEGER,
+	INTERVAL_MINUTES_INTEGER,
+	INTERVAL_HOURS_INTEGER,
+	INTERVAL_DAYS_INTEGER,
+	INTERVAL_WEEKS_INTEGER,
 	INTEGER64,
 	LIST_OF_NULLS,
 	BLOB,
@@ -80,16 +80,16 @@ struct RType {
 	static constexpr const RTypeId DATE = RTypeId::DATE;
 	static constexpr const RTypeId DATE_INTEGER = RTypeId::DATE_INTEGER;
 	static constexpr const RTypeId TIMESTAMP = RTypeId::TIMESTAMP;
-	static constexpr const RTypeId TIME_SECONDS = RTypeId::TIME_SECONDS;
-	static constexpr const RTypeId TIME_MINUTES = RTypeId::TIME_MINUTES;
-	static constexpr const RTypeId TIME_HOURS = RTypeId::TIME_HOURS;
-	static constexpr const RTypeId TIME_DAYS = RTypeId::TIME_DAYS;
-	static constexpr const RTypeId TIME_WEEKS = RTypeId::TIME_WEEKS;
-	static constexpr const RTypeId TIME_SECONDS_INTEGER = RTypeId::TIME_SECONDS_INTEGER;
-	static constexpr const RTypeId TIME_MINUTES_INTEGER = RTypeId::TIME_MINUTES_INTEGER;
-	static constexpr const RTypeId TIME_HOURS_INTEGER = RTypeId::TIME_HOURS_INTEGER;
-	static constexpr const RTypeId TIME_DAYS_INTEGER = RTypeId::TIME_DAYS_INTEGER;
-	static constexpr const RTypeId TIME_WEEKS_INTEGER = RTypeId::TIME_WEEKS_INTEGER;
+	static constexpr const RTypeId INTERVAL_SECONDS = RTypeId::INTERVAL_SECONDS;
+	static constexpr const RTypeId INTERVAL_MINUTES = RTypeId::INTERVAL_MINUTES;
+	static constexpr const RTypeId INTERVAL_HOURS = RTypeId::INTERVAL_HOURS;
+	static constexpr const RTypeId INTERVAL_DAYS = RTypeId::INTERVAL_DAYS;
+	static constexpr const RTypeId INTERVAL_WEEKS = RTypeId::INTERVAL_WEEKS;
+	static constexpr const RTypeId INTERVAL_SECONDS_INTEGER = RTypeId::INTERVAL_SECONDS_INTEGER;
+	static constexpr const RTypeId INTERVAL_MINUTES_INTEGER = RTypeId::INTERVAL_MINUTES_INTEGER;
+	static constexpr const RTypeId INTERVAL_HOURS_INTEGER = RTypeId::INTERVAL_HOURS_INTEGER;
+	static constexpr const RTypeId INTERVAL_DAYS_INTEGER = RTypeId::INTERVAL_DAYS_INTEGER;
+	static constexpr const RTypeId INTERVAL_WEEKS_INTEGER = RTypeId::INTERVAL_WEEKS_INTEGER;
 	static constexpr const RTypeId INTEGER64 = RTypeId::INTEGER64;
 	static constexpr const RTypeId LIST_OF_NULLS = RTypeId::LIST_OF_NULLS;
 	static constexpr const RTypeId BLOB = RTypeId::BLOB;
@@ -153,24 +153,24 @@ struct RTimestampType : public RDoubleType {
 	static timestamp_t Convert(double val);
 };
 
-struct RTimeSecondsType : public RDoubleType {
-	static dtime_t Convert(double val);
+struct RIntervalSecondsType : public RDoubleType {
+	static interval_t Convert(double val);
 };
 
-struct RTimeMinutesType : public RDoubleType {
-	static dtime_t Convert(double val);
+struct RIntervalMinutesType : public RDoubleType {
+	static interval_t Convert(double val);
 };
 
-struct RTimeHoursType : public RDoubleType {
-	static dtime_t Convert(double val);
+struct RIntervalHoursType : public RDoubleType {
+	static interval_t Convert(double val);
 };
 
-struct RTimeDaysType : public RDoubleType {
-	static dtime_t Convert(double val);
+struct RIntervalDaysType : public RDoubleType {
+	static interval_t Convert(double val);
 };
 
-struct RTimeWeeksType : public RDoubleType {
-	static dtime_t Convert(double val);
+struct RIntervalWeeksType : public RDoubleType {
+	static interval_t Convert(double val);
 };
 
 struct RIntegerType {

--- a/src/scan.cpp
+++ b/src/scan.cpp
@@ -23,17 +23,17 @@ data_ptr_t GetColDataPtr(const RType &rtype, SEXP coldata) {
 		return (data_ptr_t)DATAPTR_RO(coldata);
 	case RType::TIMESTAMP:
 		return (data_ptr_t)NUMERIC_POINTER(coldata);
-	case RType::TIME_SECONDS:
-	case RType::TIME_MINUTES:
-	case RType::TIME_HOURS:
-	case RType::TIME_DAYS:
-	case RType::TIME_WEEKS:
+	case RType::INTERVAL_SECONDS:
+	case RType::INTERVAL_MINUTES:
+	case RType::INTERVAL_HOURS:
+	case RType::INTERVAL_DAYS:
+	case RType::INTERVAL_WEEKS:
 		return (data_ptr_t)NUMERIC_POINTER(coldata);
-	case RType::TIME_SECONDS_INTEGER:
-	case RType::TIME_MINUTES_INTEGER:
-	case RType::TIME_HOURS_INTEGER:
-	case RType::TIME_DAYS_INTEGER:
-	case RType::TIME_WEEKS_INTEGER:
+	case RType::INTERVAL_SECONDS_INTEGER:
+	case RType::INTERVAL_MINUTES_INTEGER:
+	case RType::INTERVAL_HOURS_INTEGER:
+	case RType::INTERVAL_DAYS_INTEGER:
+	case RType::INTERVAL_WEEKS_INTEGER:
 		return (data_ptr_t)INTEGER_POINTER(coldata);
 	case RType::DATE:
 		if (!IS_NUMERIC(coldata)) {
@@ -181,54 +181,54 @@ void AppendAnyColumnSegment(const RType &rtype, bool experimental, data_ptr_t co
 		AppendColumnSegment<double, timestamp_t, RTimestampType>(data_ptr, sexp_offset, v, this_count);
 		break;
 	}
-	case RType::TIME_SECONDS: {
+	case RType::INTERVAL_SECONDS: {
 		auto data_ptr = (double *)coldata_ptr;
-		AppendColumnSegment<double, dtime_t, RTimeSecondsType>(data_ptr, sexp_offset, v, this_count);
+		AppendColumnSegment<double, interval_t, RIntervalSecondsType>(data_ptr, sexp_offset, v, this_count);
 		break;
 	}
-	case RType::TIME_MINUTES: {
+	case RType::INTERVAL_MINUTES: {
 		auto data_ptr = (double *)coldata_ptr;
-		AppendColumnSegment<double, dtime_t, RTimeMinutesType>(data_ptr, sexp_offset, v, this_count);
+		AppendColumnSegment<double, interval_t, RIntervalMinutesType>(data_ptr, sexp_offset, v, this_count);
 		break;
 	}
-	case RType::TIME_HOURS: {
+	case RType::INTERVAL_HOURS: {
 		auto data_ptr = (double *)coldata_ptr;
-		AppendColumnSegment<double, dtime_t, RTimeHoursType>(data_ptr, sexp_offset, v, this_count);
+		AppendColumnSegment<double, interval_t, RIntervalHoursType>(data_ptr, sexp_offset, v, this_count);
 		break;
 	}
-	case RType::TIME_DAYS: {
+	case RType::INTERVAL_DAYS: {
 		auto data_ptr = (double *)coldata_ptr;
-		AppendColumnSegment<double, dtime_t, RTimeDaysType>(data_ptr, sexp_offset, v, this_count);
+		AppendColumnSegment<double, interval_t, RIntervalDaysType>(data_ptr, sexp_offset, v, this_count);
 		break;
 	}
-	case RType::TIME_WEEKS: {
+	case RType::INTERVAL_WEEKS: {
 		auto data_ptr = (double *)coldata_ptr;
-		AppendColumnSegment<double, dtime_t, RTimeWeeksType>(data_ptr, sexp_offset, v, this_count);
+		AppendColumnSegment<double, interval_t, RIntervalWeeksType>(data_ptr, sexp_offset, v, this_count);
 		break;
 	}
-	case RType::TIME_SECONDS_INTEGER: {
+	case RType::INTERVAL_SECONDS_INTEGER: {
 		auto data_ptr = (int *)coldata_ptr;
-		AppendColumnSegment<int, dtime_t, RTimeSecondsType>(data_ptr, sexp_offset, v, this_count);
+		AppendColumnSegment<int, interval_t, RIntervalSecondsType>(data_ptr, sexp_offset, v, this_count);
 		break;
 	}
-	case RType::TIME_MINUTES_INTEGER: {
+	case RType::INTERVAL_MINUTES_INTEGER: {
 		auto data_ptr = (int *)coldata_ptr;
-		AppendColumnSegment<int, dtime_t, RTimeMinutesType>(data_ptr, sexp_offset, v, this_count);
+		AppendColumnSegment<int, interval_t, RIntervalMinutesType>(data_ptr, sexp_offset, v, this_count);
 		break;
 	}
-	case RType::TIME_HOURS_INTEGER: {
+	case RType::INTERVAL_HOURS_INTEGER: {
 		auto data_ptr = (int *)coldata_ptr;
-		AppendColumnSegment<int, dtime_t, RTimeHoursType>(data_ptr, sexp_offset, v, this_count);
+		AppendColumnSegment<int, interval_t, RIntervalHoursType>(data_ptr, sexp_offset, v, this_count);
 		break;
 	}
-	case RType::TIME_DAYS_INTEGER: {
+	case RType::INTERVAL_DAYS_INTEGER: {
 		auto data_ptr = (int *)coldata_ptr;
-		AppendColumnSegment<int, dtime_t, RTimeDaysType>(data_ptr, sexp_offset, v, this_count);
+		AppendColumnSegment<int, interval_t, RIntervalDaysType>(data_ptr, sexp_offset, v, this_count);
 		break;
 	}
-	case RType::TIME_WEEKS_INTEGER: {
+	case RType::INTERVAL_WEEKS_INTEGER: {
 		auto data_ptr = (int *)coldata_ptr;
-		AppendColumnSegment<int, dtime_t, RTimeWeeksType>(data_ptr, sexp_offset, v, this_count);
+		AppendColumnSegment<int, interval_t, RIntervalWeeksType>(data_ptr, sexp_offset, v, this_count);
 		break;
 	}
 	case RType::DATE: {
@@ -405,7 +405,6 @@ static void DataFrameScanFunc(ClientContext &context, TableFunctionInput &data, 
 		auto rtype = bind_data.rtypes[src_df_col_idx];
 		AppendAnyColumnSegment(rtype, bind_data.experimental, coldata_ptr, sexp_offset, v, this_count);
 	}
-
 	operator_data.position += this_count;
 }
 

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -99,15 +99,15 @@ RType RApiTypes::DetectRType(SEXP v, bool integer64) {
 		}
 		SEXP units0 = STRING_ELT(units, 0);
 		if (units0 == RStrings::get().secs) {
-			return RType::TIME_SECONDS;
+			return RType::INTERVAL_SECONDS;
 		} else if (units0 == RStrings::get().mins) {
-			return RType::TIME_MINUTES;
+			return RType::INTERVAL_MINUTES;
 		} else if (units0 == RStrings::get().hours) {
-			return RType::TIME_HOURS;
+			return RType::INTERVAL_HOURS;
 		} else if (units0 == RStrings::get().days) {
-			return RType::TIME_DAYS;
+			return RType::INTERVAL_DAYS;
 		} else if (units0 == RStrings::get().weeks) {
-			return RType::TIME_WEEKS;
+			return RType::INTERVAL_WEEKS;
 		} else {
 			return RType::UNKNOWN;
 		}
@@ -118,15 +118,15 @@ RType RApiTypes::DetectRType(SEXP v, bool integer64) {
 		}
 		SEXP units0 = STRING_ELT(units, 0);
 		if (units0 == RStrings::get().secs) {
-			return RType::TIME_SECONDS_INTEGER;
+			return RType::INTERVAL_SECONDS_INTEGER;
 		} else if (units0 == RStrings::get().mins) {
-			return RType::TIME_MINUTES_INTEGER;
+			return RType::INTERVAL_MINUTES_INTEGER;
 		} else if (units0 == RStrings::get().hours) {
-			return RType::TIME_HOURS_INTEGER;
+			return RType::INTERVAL_HOURS_INTEGER;
 		} else if (units0 == RStrings::get().days) {
-			return RType::TIME_DAYS_INTEGER;
+			return RType::INTERVAL_DAYS_INTEGER;
 		} else if (units0 == RStrings::get().weeks) {
-			return RType::TIME_WEEKS_INTEGER;
+			return RType::INTERVAL_WEEKS_INTEGER;
 		} else {
 			return RType::UNKNOWN;
 		}
@@ -223,18 +223,17 @@ LogicalType RApiTypes::LogicalTypeFromRType(const RType &rtype, bool experimenta
 		break;
 	case RType::TIMESTAMP:
 		return LogicalType::TIMESTAMP;
-	case RType::TIME_SECONDS:
-	case RType::TIME_MINUTES:
-	case RType::TIME_HOURS:
-	case RType::TIME_DAYS:
-	case RType::TIME_WEEKS:
-		return LogicalType::TIME;
-	case RType::TIME_SECONDS_INTEGER:
-	case RType::TIME_MINUTES_INTEGER:
-	case RType::TIME_HOURS_INTEGER:
-	case RType::TIME_DAYS_INTEGER:
-	case RType::TIME_WEEKS_INTEGER:
-		return LogicalType::TIME;
+	case RType::INTERVAL_SECONDS:
+	case RType::INTERVAL_MINUTES:
+	case RType::INTERVAL_HOURS:
+	case RType::INTERVAL_DAYS:
+	case RType::INTERVAL_WEEKS:
+	case RType::INTERVAL_SECONDS_INTEGER:
+	case RType::INTERVAL_MINUTES_INTEGER:
+	case RType::INTERVAL_HOURS_INTEGER:
+	case RType::INTERVAL_DAYS_INTEGER:
+	case RType::INTERVAL_WEEKS_INTEGER:
+		return LogicalType::INTERVAL;
 	case RType::DATE:
 		return LogicalType::DATE;
 	case RType::DATE_INTEGER:
@@ -332,24 +331,24 @@ timestamp_t RTimestampType::Convert(double val) {
 	return Timestamp::FromEpochMicroSeconds(round(val * Interval::MICROS_PER_SEC));
 }
 
-dtime_t RTimeSecondsType::Convert(double val) {
-	return dtime_t(int64_t(val * Interval::MICROS_PER_SEC));
+interval_t RIntervalSecondsType::Convert(double val) {
+	return Interval::FromMicro(int64_t(val * Interval::MICROS_PER_SEC));
 }
 
-dtime_t RTimeMinutesType::Convert(double val) {
-	return dtime_t(int64_t(val * Interval::MICROS_PER_MINUTE));
+interval_t RIntervalMinutesType::Convert(double val) {
+	return Interval::FromMicro(int64_t(val * Interval::MICROS_PER_MINUTE));
 }
 
-dtime_t RTimeHoursType::Convert(double val) {
-	return dtime_t(int64_t(val * Interval::MICROS_PER_HOUR));
+interval_t RIntervalHoursType::Convert(double val) {
+	return Interval::FromMicro(int64_t(val * Interval::MICROS_PER_HOUR));
 }
 
-dtime_t RTimeDaysType::Convert(double val) {
-	return dtime_t(int64_t(val * Interval::MICROS_PER_DAY));
+interval_t RIntervalDaysType::Convert(double val) {
+	return Interval::FromMicro(int64_t(val * Interval::MICROS_PER_DAY));
 }
 
-dtime_t RTimeWeeksType::Convert(double val) {
-	return dtime_t(int64_t(val * (Interval::MICROS_PER_DAY * Interval::DAYS_PER_WEEK)));
+interval_t RIntervalWeeksType::Convert(double val) {
+	return Interval::FromMicro(int64_t(val * (Interval::MICROS_PER_DAY * Interval::DAYS_PER_WEEK)));
 }
 
 bool RIntegerType::IsNull(int val) {

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -332,23 +332,23 @@ timestamp_t RTimestampType::Convert(double val) {
 }
 
 interval_t RIntervalSecondsType::Convert(double val) {
-	return Interval::FromMicro(int64_t(val * Interval::MICROS_PER_SEC));
+	return Interval::FromMicro(int64_t(round(val * Interval::MICROS_PER_SEC)));
 }
 
 interval_t RIntervalMinutesType::Convert(double val) {
-	return Interval::FromMicro(int64_t(val * Interval::MICROS_PER_MINUTE));
+	return Interval::FromMicro(int64_t(round(val * Interval::MICROS_PER_MINUTE)));
 }
 
 interval_t RIntervalHoursType::Convert(double val) {
-	return Interval::FromMicro(int64_t(val * Interval::MICROS_PER_HOUR));
+	return Interval::FromMicro(int64_t(round(val * Interval::MICROS_PER_HOUR)));
 }
 
 interval_t RIntervalDaysType::Convert(double val) {
-	return Interval::FromMicro(int64_t(val * Interval::MICROS_PER_DAY));
+	return Interval::FromMicro(int64_t(round(val * Interval::MICROS_PER_DAY)));
 }
 
 interval_t RIntervalWeeksType::Convert(double val) {
-	return Interval::FromMicro(int64_t(val * (Interval::MICROS_PER_DAY * Interval::DAYS_PER_WEEK)));
+	return Interval::FromMicro(int64_t(round(val * (Interval::MICROS_PER_DAY * Interval::DAYS_PER_WEEK))));
 }
 
 bool RIntegerType::IsNull(int val) {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -160,47 +160,47 @@ Value RApiTypes::SexpToValue(SEXP valsexp, R_len_t idx, bool typed_logical_null)
 		auto d_val = INTEGER_POINTER(valsexp)[idx];
 		return RIntegerType::IsNull(d_val) ? Value(LogicalType::DATE) : Value::DATE(RDateType::Convert(d_val));
 	}
-	case RType::TIME_SECONDS: {
+	case RType::INTERVAL_SECONDS: {
 		auto ts_val = NUMERIC_POINTER(valsexp)[idx];
-		return RTimeSecondsType::IsNull(ts_val) ? Value(LogicalType::TIME)
-		                                        : Value::TIME(RTimeSecondsType::Convert(ts_val));
+		return RIntervalSecondsType::IsNull(ts_val) ? Value(LogicalType::INTERVAL)
+		                                        : Value::INTERVAL(RIntervalSecondsType::Convert(ts_val));
 	}
-	case RType::TIME_MINUTES: {
+	case RType::INTERVAL_MINUTES: {
 		auto ts_val = NUMERIC_POINTER(valsexp)[idx];
-		return RTimeMinutesType::IsNull(ts_val) ? Value(LogicalType::TIME)
-		                                        : Value::TIME(RTimeMinutesType::Convert(ts_val));
+		return RIntervalMinutesType::IsNull(ts_val) ? Value(LogicalType::INTERVAL)
+		                                        : Value::INTERVAL(RIntervalMinutesType::Convert(ts_val));
 	}
-	case RType::TIME_HOURS: {
+	case RType::INTERVAL_HOURS: {
 		auto ts_val = NUMERIC_POINTER(valsexp)[idx];
-		return RTimeHoursType::IsNull(ts_val) ? Value(LogicalType::TIME) : Value::TIME(RTimeHoursType::Convert(ts_val));
+		return RIntervalHoursType::IsNull(ts_val) ? Value(LogicalType::INTERVAL) : Value::INTERVAL(RIntervalHoursType::Convert(ts_val));
 	}
-	case RType::TIME_DAYS: {
+	case RType::INTERVAL_DAYS: {
 		auto ts_val = NUMERIC_POINTER(valsexp)[idx];
-		return RTimeDaysType::IsNull(ts_val) ? Value(LogicalType::TIME) : Value::TIME(RTimeDaysType::Convert(ts_val));
+		return RIntervalDaysType::IsNull(ts_val) ? Value(LogicalType::INTERVAL) : Value::INTERVAL(RIntervalDaysType::Convert(ts_val));
 	}
-	case RType::TIME_WEEKS: {
+	case RType::INTERVAL_WEEKS: {
 		auto ts_val = NUMERIC_POINTER(valsexp)[idx];
-		return RTimeWeeksType::IsNull(ts_val) ? Value(LogicalType::TIME) : Value::TIME(RTimeWeeksType::Convert(ts_val));
+		return RIntervalWeeksType::IsNull(ts_val) ? Value(LogicalType::INTERVAL) : Value::INTERVAL(RIntervalWeeksType::Convert(ts_val));
 	}
-	case RType::TIME_SECONDS_INTEGER: {
+	case RType::INTERVAL_SECONDS_INTEGER: {
 		auto ts_val = INTEGER_POINTER(valsexp)[idx];
-		return RIntegerType::IsNull(ts_val) ? Value(LogicalType::TIME) : Value::TIME(RTimeSecondsType::Convert(ts_val));
+		return RIntegerType::IsNull(ts_val) ? Value(LogicalType::INTERVAL) : Value::INTERVAL(RIntervalSecondsType::Convert(ts_val));
 	}
-	case RType::TIME_MINUTES_INTEGER: {
+	case RType::INTERVAL_MINUTES_INTEGER: {
 		auto ts_val = INTEGER_POINTER(valsexp)[idx];
-		return RIntegerType::IsNull(ts_val) ? Value(LogicalType::TIME) : Value::TIME(RTimeMinutesType::Convert(ts_val));
+		return RIntegerType::IsNull(ts_val) ? Value(LogicalType::INTERVAL) : Value::INTERVAL(RIntervalMinutesType::Convert(ts_val));
 	}
-	case RType::TIME_HOURS_INTEGER: {
+	case RType::INTERVAL_HOURS_INTEGER: {
 		auto ts_val = INTEGER_POINTER(valsexp)[idx];
-		return RIntegerType::IsNull(ts_val) ? Value(LogicalType::TIME) : Value::TIME(RTimeHoursType::Convert(ts_val));
+		return RIntegerType::IsNull(ts_val) ? Value(LogicalType::INTERVAL) : Value::INTERVAL(RIntervalHoursType::Convert(ts_val));
 	}
-	case RType::TIME_DAYS_INTEGER: {
+	case RType::INTERVAL_DAYS_INTEGER: {
 		auto ts_val = INTEGER_POINTER(valsexp)[idx];
-		return RIntegerType::IsNull(ts_val) ? Value(LogicalType::TIME) : Value::TIME(RTimeDaysType::Convert(ts_val));
+		return RIntegerType::IsNull(ts_val) ? Value(LogicalType::INTERVAL) : Value::INTERVAL(RIntervalDaysType::Convert(ts_val));
 	}
-	case RType::TIME_WEEKS_INTEGER: {
+	case RType::INTERVAL_WEEKS_INTEGER: {
 		auto ts_val = INTEGER_POINTER(valsexp)[idx];
-		return RIntegerType::IsNull(ts_val) ? Value(LogicalType::TIME) : Value::TIME(RTimeWeeksType::Convert(ts_val));
+		return RIntegerType::IsNull(ts_val) ? Value(LogicalType::INTERVAL) : Value::INTERVAL(RIntervalWeeksType::Convert(ts_val));
 	}
 	case RType::LIST_OF_NULLS:
 		// Performance shortcut: this corresponds to the RType::BLOB case,


### PR DESCRIPTION
This PR changes the DuckDB representation of `difftime` R objects from `TIME` to `INTERVAL`. The reasoning here is that R's difftime can represent way larger time differences than single days, which is what `TIME` is for. This goes wrong if the difftime is longer than one day and one tries for example casting the value to a string.

Here is an example that demonstrates the problem

```R
con <- DBI::dbConnect(duckdb::duckdb())
duckdb::duckdb_register(con, "difftime", data.frame(difftime=structure(710, units = "days", class = "difftime")))
print(DBI::dbGetQuery(con, 'select difftime, difftime::varchar difftime_string from difftime'))
```

Currently, this returns random garbage for the string
```
       difftime difftime_string
1 61344000 secs  \xd2\034:00:00
``` 

and triggers an assertion when built in debug mode.

With this PR, it returns
```
       difftime difftime_string
1 61344000 secs        710 days
```