### PR TITLE
feat: Add dbplyr translations for `clock::add_days()`, `clock::add_years()`, `clock::get_day()`, `clock::get_month()`, and `clock::get_year()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,6 +51,7 @@ Suggests:
     arrow (>= 13.0.0),
     bit64,
     callr,
+    clock,
     DBItest,
     dbplyr,
     dplyr,

--- a/R/backend-dbplyr__duckdb_connection.R
+++ b/R/backend-dbplyr__duckdb_connection.R
@@ -274,6 +274,15 @@ sql_translation.duckdb_connection <- function(con) {
       add_years = function(x, n, ...) {
         build_sql("date_add(", !!x, ", INTERVAL '", n ," year')")
       },
+      get_year = function(x) {
+        sql_expr(date_part('year', !!x))
+      },
+      get_month = function(x) {
+        sql_expr(date_part('month', !!x))
+      },
+      get_day = function(x) {
+        sql_expr(date_part('day', !!x))
+      },
 
       # stringr functions
       str_c = sql_paste(""),

--- a/R/backend-dbplyr__duckdb_connection.R
+++ b/R/backend-dbplyr__duckdb_connection.R
@@ -267,6 +267,16 @@ sql_translation.duckdb_connection <- function(con) {
       paste = sql_paste(" "),
       paste0 = sql_paste(""),
 
+      # clock
+      add_days = function(x, n, ...) {
+        check_dots_empty()
+        glue_sql2(sql_current_con(), "({.col x} + {.val n}*INTERVAL'1 day')")
+      },
+      add_years = function(x, n, ...) {
+        check_dots_empty()
+        glue_sql2(sql_current_con(), "({.col x} + {.val n}*INTERVAL'1 year')")
+      },
+
       # stringr functions
       str_c = sql_paste(""),
       str_detect = function(string, pattern, negate = FALSE) {

--- a/R/backend-dbplyr__duckdb_connection.R
+++ b/R/backend-dbplyr__duckdb_connection.R
@@ -272,16 +272,16 @@ sql_translation.duckdb_connection <- function(con) {
         build_sql("date_add(", !!x, ", INTERVAL '", n ," day')")
       },
       add_years = function(x, n, ...) {
-        build_sql("date_add(", !!x, ", INTERVAL '", n ," year')")
+        build_sql("DATE_ADD(", !!x, ", INTERVAL '", n ," year')")
       },
       get_year = function(x) {
-        sql_expr(date_part('year', !!x))
+        sql_expr(DATE_PART('year', !!x))
       },
       get_month = function(x) {
-        sql_expr(date_part('month', !!x))
+        sql_expr(DATE_PART('month', !!x))
       },
       get_day = function(x) {
-        sql_expr(date_part('day', !!x))
+        sql_expr(DATE_PART('day', !!x))
       },
 
       # stringr functions

--- a/R/backend-dbplyr__duckdb_connection.R
+++ b/R/backend-dbplyr__duckdb_connection.R
@@ -275,13 +275,13 @@ sql_translation.duckdb_connection <- function(con) {
         build_sql("DATE_ADD(", !!x, ", INTERVAL '", n ," year')")
       },
       get_year = function(x) {
-        sql_expr(DATE_PART('year', !!x))
+        build_sql("DATE_PART('year', ", !!x, ")")
       },
       get_month = function(x) {
-        sql_expr(DATE_PART('month', !!x))
+        build_sql("DATE_PART('month', ", !!x, ")")
       },
       get_day = function(x) {
-        sql_expr(DATE_PART('day', !!x))
+        build_sql("DATE_PART('day', ", !!x, ")")
       },
 
       # stringr functions

--- a/R/backend-dbplyr__duckdb_connection.R
+++ b/R/backend-dbplyr__duckdb_connection.R
@@ -269,11 +269,9 @@ sql_translation.duckdb_connection <- function(con) {
 
       # clock
       add_days = function(x, n, ...) {
-        check_dots_empty()
         glue_sql2(sql_current_con(), "({.col x} + {.val n}*INTERVAL'1 day')")
       },
       add_years = function(x, n, ...) {
-        check_dots_empty()
         glue_sql2(sql_current_con(), "({.col x} + {.val n}*INTERVAL'1 year')")
       },
 

--- a/R/backend-dbplyr__duckdb_connection.R
+++ b/R/backend-dbplyr__duckdb_connection.R
@@ -269,7 +269,7 @@ sql_translation.duckdb_connection <- function(con) {
 
       # clock
       add_days = function(x, n, ...) {
-        glue_sql2(sql_current_con(), "({.col x} + {.val n}*INTERVAL'1 day')")
+        build_sql("date_add(", !!x, " + INTERVAL '", n ," day')")
       },
       add_years = function(x, n, ...) {
         glue_sql2(sql_current_con(), "({.col x} + {.val n}*INTERVAL'1 year')")

--- a/R/backend-dbplyr__duckdb_connection.R
+++ b/R/backend-dbplyr__duckdb_connection.R
@@ -269,10 +269,10 @@ sql_translation.duckdb_connection <- function(con) {
 
       # clock
       add_days = function(x, n, ...) {
-        build_sql("date_add(", !!x, " + INTERVAL '", n ," day')")
+        build_sql("date_add(", !!x, ", INTERVAL '", n ," day')")
       },
       add_years = function(x, n, ...) {
-        glue_sql2(sql_current_con(), "({.col x} + {.val n}*INTERVAL'1 year')")
+        build_sql("date_add(", !!x, ", INTERVAL '", n ," year')")
       },
 
       # stringr functions

--- a/R/backend-dbplyr__duckdb_connection.R
+++ b/R/backend-dbplyr__duckdb_connection.R
@@ -269,7 +269,7 @@ sql_translation.duckdb_connection <- function(con) {
 
       # clock
       add_days = function(x, n, ...) {
-        build_sql("date_add(", !!x, ", INTERVAL '", n ," day')")
+        build_sql("DATE_ADD(", !!x, ", INTERVAL '", n ," day')")
       },
       add_years = function(x, n, ...) {
         build_sql("DATE_ADD(", !!x, ", INTERVAL '", n ," year')")

--- a/tests/testthat/test-backend-dbplyr__duckdb_connection.R
+++ b/tests/testthat/test-backend-dbplyr__duckdb_connection.R
@@ -129,6 +129,22 @@ test_that("custom lubridate functions translated correctly", {
   expect_equal(translate(floor_date(x, "week", week_start = 4)), sql(r"{CAST(x AS DATE) - CAST(EXTRACT('dow' FROM CAST(x AS DATE) + 3) AS INTEGER)}"))
 })
 
+# clock functions
+test_that("custom clock functions translated correctly", {
+  skip_if_no_R4()
+  skip_if_not_installed("dbplyr")
+  con <- dbConnect(duckdb())
+  on.exit(dbDisconnect(con, shutdown = TRUE))
+  translate <- function(...) dbplyr::translate_sql(..., con = con)
+  sql <- function(...) dbplyr::sql(...)
+
+  expect_equal(translate(add_days(x, 1L)), sql(r"{date_add(x, INTERVAL '1 day')}"))
+  expect_equal(translate(add_years(x, 2L)), sql(r"{date_add(x, INTERVAL '2 day')}"))
+
+  expect_equal(translate(add_years(x, 1L)), sql(r"{date_add(x, INTERVAL '1 year')}"))
+  expect_equal(translate(add_years(x, 2L)), sql(r"{date_add(x, INTERVAL '2 year')}"))
+})
+
 # stringr functions
 
 test_that("custom stringr functions translated correctly", {

--- a/tests/testthat/test-backend-dbplyr__duckdb_connection.R
+++ b/tests/testthat/test-backend-dbplyr__duckdb_connection.R
@@ -143,6 +143,28 @@ test_that("custom clock functions translated correctly", {
 
   expect_equal(translate(add_years(x, 1L)), sql(r"{date_add(x, INTERVAL '1 year')}"))
   expect_equal(translate(add_years(x, 2L)), sql(r"{date_add(x, INTERVAL '2 year')}"))
+
+  test_data <- data.frame(
+    person = 1L,
+    date_1 = as.Date("2000-01-01")
+  )
+  test_data <- test_data |>
+    mutate(date_plus_two_days  = clock::add_days(date_1, 2),
+           date_plus_two_years = clock::add_years(date_1, 2),
+           date_minus_two_days  = clock::add_days(date_1, -2),
+           date_minus_two_years = clock::add_years(date_1, -2)) |>
+    dplyr::glimpse()
+  db_test_data <- copy_to(con, test_data, overwrite = TRUE)
+  db_test_data <- db_test_data |>
+    mutate(date_plus_two_days  = as.Date(clock::add_days(date_1, 2)),
+           date_plus_two_years = as.Date(clock::add_years(date_1, 2)),
+           date_minus_two_days  = as.Date(clock::add_days(date_1, -2)),
+           date_minus_two_years = as.Date(clock::add_years(date_1, -2))) |>
+    dplyr::collect()
+
+  expect_equal(unclass(test_data), unclass(db_test_data))
+
+
 })
 
 # stringr functions

--- a/tests/testthat/test-backend-dbplyr__duckdb_connection.R
+++ b/tests/testthat/test-backend-dbplyr__duckdb_connection.R
@@ -138,28 +138,39 @@ test_that("custom clock functions translated correctly", {
   translate <- function(...) dbplyr::translate_sql(..., con = con)
   sql <- function(...) dbplyr::sql(...)
 
-  expect_equal(translate(add_days(x, 1L)), sql(r"{date_add(x, INTERVAL '1 day')}"))
-  expect_equal(translate(add_days(x, 2L)), sql(r"{date_add(x, INTERVAL '2 day')}"))
+  expect_equal(translate(add_days(x, 1L)), sql(r"{DATE_ADD(x, INTERVAL '1 day')}"))
+  expect_equal(translate(add_days(x, 2L)), sql(r"{DATE_ADD(x, INTERVAL '2 day')}"))
 
-  expect_equal(translate(add_years(x, 1L)), sql(r"{date_add(x, INTERVAL '1 year')}"))
-  expect_equal(translate(add_years(x, 2L)), sql(r"{date_add(x, INTERVAL '2 year')}"))
+  expect_equal(translate(add_years(x, 1L)), sql(r"{DATE_ADD(x, INTERVAL '1 year')}"))
+  expect_equal(translate(add_years(x, 2L)), sql(r"{DATE_ADD(x, INTERVAL '2 year')}"))
+
+  expect_equal(translate(get_day(x)), sql(r"{DATE_PART('day', x)}"))
+  expect_equal(translate(get_month(x)), sql(r"{DATE_PART('month', x)}"))
+  expect_equal(translate(get_year(x)), sql(r"{DATE_PART('year', x)}"))
 
   test_data <- data.frame(
     person = 1L,
     date_1 = as.Date("2000-01-01")
   )
   test_data <- test_data |>
-    mutate(date_plus_two_days  = clock::add_days(date_1, 2),
+    dplyr::mutate(date_plus_two_days  = clock::add_days(date_1, 2),
            date_plus_two_years = clock::add_years(date_1, 2),
            date_minus_two_days  = clock::add_days(date_1, -2),
-           date_minus_two_years = clock::add_years(date_1, -2)) |>
+           date_minus_two_years = clock::add_years(date_1, -2),
+           day = clock::get_day(date_1),
+           month = clock::get_month(date_1),
+           year = clock::get_year(date_1)
+           ) |>
     dplyr::glimpse()
-  db_test_data <- copy_to(con, test_data, overwrite = TRUE)
+  db_test_data <- dplyr::copy_to(con, test_data, overwrite = TRUE)
   db_test_data <- db_test_data |>
-    mutate(date_plus_two_days  = as.Date(clock::add_days(date_1, 2)),
+    dplyr::mutate(date_plus_two_days  = as.Date(clock::add_days(date_1, 2)),
            date_plus_two_years = as.Date(clock::add_years(date_1, 2)),
            date_minus_two_days  = as.Date(clock::add_days(date_1, -2)),
-           date_minus_two_years = as.Date(clock::add_years(date_1, -2))) |>
+           date_minus_two_years = as.Date(clock::add_years(date_1, -2)),
+           day = clock::get_day(date_1),
+           month = clock::get_month(date_1),
+           year = clock::get_year(date_1)) |>
     dplyr::collect()
 
   expect_equal(unclass(test_data), unclass(db_test_data))

--- a/tests/testthat/test-backend-dbplyr__duckdb_connection.R
+++ b/tests/testthat/test-backend-dbplyr__duckdb_connection.R
@@ -133,6 +133,7 @@ test_that("custom lubridate functions translated correctly", {
 test_that("custom clock functions translated correctly", {
   skip_if_no_R4()
   skip_if_not_installed("dbplyr")
+  skip_if_not_installed("clock")
   con <- dbConnect(duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))
   translate <- function(...) dbplyr::translate_sql(..., con = con)

--- a/tests/testthat/test-backend-dbplyr__duckdb_connection.R
+++ b/tests/testthat/test-backend-dbplyr__duckdb_connection.R
@@ -139,7 +139,7 @@ test_that("custom clock functions translated correctly", {
   sql <- function(...) dbplyr::sql(...)
 
   expect_equal(translate(add_days(x, 1L)), sql(r"{date_add(x, INTERVAL '1 day')}"))
-  expect_equal(translate(add_years(x, 2L)), sql(r"{date_add(x, INTERVAL '2 day')}"))
+  expect_equal(translate(add_days(x, 2L)), sql(r"{date_add(x, INTERVAL '2 day')}"))
 
   expect_equal(translate(add_years(x, 1L)), sql(r"{date_add(x, INTERVAL '1 year')}"))
   expect_equal(translate(add_years(x, 2L)), sql(r"{date_add(x, INTERVAL '2 year')}"))


### PR DESCRIPTION
For isssue #116 
- add translations for clock::add_days() and clock::add_years()
- add associated tests