### PR TITLE
Bind `NULL` to `NA` (logical)

### DIFF
--- a/src/duckdb/src/planner/expression_binder.cpp
+++ b/src/duckdb/src/planner/expression_binder.cpp
@@ -210,7 +210,7 @@ bool ExpressionBinder::ContainsNullType(const LogicalType &type) {
 }
 
 LogicalType ExpressionBinder::ExchangeNullType(const LogicalType &type) {
-	return ExchangeType(type, LogicalTypeId::SQLNULL, LogicalType::INTEGER);
+	return ExchangeType(type, LogicalTypeId::SQLNULL, LogicalType::BOOLEAN);
 }
 
 unique_ptr<Expression> ExpressionBinder::Bind(unique_ptr<ParsedExpression> &expr, optional_ptr<LogicalType> result_type,


### PR DESCRIPTION
Closes #155.

We'd need to either upstream this, or patch here. Unclear about the consequences.

``` r
duckdb <- asNamespace("duckdb")
drv <- duckdb::duckdb()
con <- DBI::dbConnect(drv)
experimental <- FALSE
df1 <- tibble::tibble(a = 1)

rel1 <- duckdb$rel_from_df(con, df1, experimental = experimental)
rel2 <- duckdb$rel_project(
  rel1,
  list(
    {
      tmp_expr <- duckdb$expr_reference("a")
      duckdb$expr_set_alias(tmp_expr, "a")
      tmp_expr
    },
    {
      tmp_expr <- if ("experimental" %in% names(formals(duckdb$expr_constant))) {
        duckdb$expr_constant(NA, experimental = experimental)
      } else {
        duckdb$expr_constant(NA)
      }
      duckdb$expr_set_alias(tmp_expr, "b")
      tmp_expr
    }
  )
)
rel2
#> DuckDB Relation: 
#> ---------------------
#> --- Relation Tree ---
#> ---------------------
#> Projection [a as a, NULL as b]
#>   r_dataframe_scan(0x138dfe8e8)
#> 
#> ---------------------
#> -- Result Columns  --
#> ---------------------
#> - a (DOUBLE)
#> - b (BOOLEAN)
dput(duckdb$rel_to_altrep(rel2))
#> structure(list(a = 1, b = NA), row.names = c(NA, -1L), class = "data.frame")

DBI::dbDisconnect(con)
```

<sup>Created on 2024-05-04 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>