### PR TITLE
expr_constant(NA)

### DIFF
--- a/src/relational.cpp
+++ b/src/relational.cpp
@@ -61,10 +61,13 @@ external_pointer<T> make_external_prot(const string &rclass, SEXP prot, ARGS &&.
 }
 
 [[cpp11::register]] SEXP rapi_expr_constant(sexp val) {
+	if (val == R_NilValue) {
+		return make_external<ConstantExpression>("duckdb_expr", Value(LogicalType::SQLNULL));
+	}
 	if (LENGTH(val) != 1) {
 		stop("expr_constant: Need value of length one");
 	}
-	return make_external<ConstantExpression>("duckdb_expr", RApiTypes::SexpToValue(val, 0, false));
+	return make_external<ConstantExpression>("duckdb_expr", RApiTypes::SexpToValue(val, 0, true));
 }
 
 [[cpp11::register]] SEXP rapi_expr_function(std::string name, list args, list order_bys, list filter_bys) {

--- a/tests/testthat/test-relational.R
+++ b/tests/testthat/test-relational.R
@@ -54,6 +54,7 @@ test_that("we can create various expressions and don't crash", {
   expect_error(expr_reference(""))
   expect_error(expr_reference(NULL))
 
+  expr_constant(NULL)
   expr_constant(TRUE)
   expr_constant(FALSE)
   expr_constant(NA)
@@ -62,9 +63,7 @@ test_that("we can create various expressions and don't crash", {
   const <- expr_constant("asdf")
   print(const)
 
-  expect_error(expr_constant(NULL))
   expect_error(expr_constant())
-
 
   expr_function("asdf", list())
 


### PR DESCRIPTION
Simpler (I believe) Alternative to #161 so that we can get a `LOGICAL NULL` constant with `expr_constant(NA)` and a `SQL NULL` from `expr_constant(NULL)`