### PR TITLE
Add install.libs script to remove debug symbols

### DIFF
--- a/src/install.libs.R
+++ b/src/install.libs.R
@@ -1,0 +1,7 @@
+files <- Sys.glob(paste0("*", SHLIB_EXT))
+dest <- file.path(R_PACKAGE_DIR, paste0('libs', R_ARCH))
+dir.create(dest, recursive = TRUE, showWarnings = FALSE)
+file.copy(files, dest, overwrite = TRUE)
+if (file.exists("symbols.rds")) {
+  file.copy("symbols.rds", dest, overwrite = TRUE)
+}


### PR DESCRIPTION
Custom install script, somehow makes CRAN not ship debug symbols ^^
thanks @gaborcsardi