### PR TITLE
fix: Support new `I()` syntax from dbplyr

### DIFF
--- a/R/dbExistsTable__duckdb_connection_ANY.R
+++ b/R/dbExistsTable__duckdb_connection_ANY.R
@@ -1,7 +1,7 @@
 #' @rdname duckdb_connection-class
 #' @inheritParams DBI::dbExistsTable
 #' @usage NULL
-dbExistsTable__duckdb_connection_character <- function(conn, name, ...) {
+dbExistsTable__duckdb_connection_ANY <- function(conn, name, ...) {
   if (!dbIsValid(conn)) {
     stop("Invalid connection")
   }
@@ -29,4 +29,4 @@ dbExistsTable__duckdb_connection_character <- function(conn, name, ...) {
 
 #' @rdname duckdb_connection-class
 #' @export
-setMethod("dbExistsTable", c("duckdb_connection", "character"), dbExistsTable__duckdb_connection_character)
+setMethod("dbExistsTable", c("duckdb_connection", "ANY"), dbExistsTable__duckdb_connection_ANY)

--- a/man/duckdb_connection-class.Rd
+++ b/man/duckdb_connection-class.Rd
@@ -25,8 +25,8 @@
 \alias{dbCommit,duckdb_connection-method}
 \alias{dbDataType__duckdb_connection}
 \alias{dbDataType,duckdb_connection-method}
-\alias{dbExistsTable__duckdb_connection_character}
-\alias{dbExistsTable,duckdb_connection,character-method}
+\alias{dbExistsTable__duckdb_connection_ANY}
+\alias{dbExistsTable,duckdb_connection,ANY-method}
 \alias{dbGetInfo__duckdb_connection}
 \alias{dbGetInfo,duckdb_connection-method}
 \alias{dbIsValid__duckdb_connection}
@@ -61,7 +61,7 @@
 
 \S4method{dbDataType}{duckdb_connection}(dbObj, obj, ...)
 
-\S4method{dbExistsTable}{duckdb_connection,character}(conn, name, ...)
+\S4method{dbExistsTable}{duckdb_connection,ANY}(conn, name, ...)
 
 \S4method{dbGetInfo}{duckdb_connection}(dbObj, ...)
 


### PR DESCRIPTION
- **CRAN release 1.0.0-1**
- **fix: Support new `I()` syntax from dbplyr**
