### PR TITLE
feat: Add `temporary` argument to `duckdb_read_csv()`

### DIFF
--- a/R/csv.R
+++ b/R/csv.R
@@ -32,6 +32,7 @@
 duckdb_read_csv <- function(conn, name, files, ..., header = TRUE, na.strings = "", nrow.check = 500,
                             delim = ",", quote = "\"", col.names = NULL, lower.case.names = FALSE, sep = delim, transaction = TRUE, temporary = FALSE) {
   #
+  if (length(list(...))) warning("Arguments passed to ... are currently not used")
   if (length(na.strings) > 1) stop("na.strings must be of length 1")
   if (!missing(sep)) delim <- sep
 

--- a/R/csv.R
+++ b/R/csv.R
@@ -5,6 +5,7 @@
 #'
 #' @inheritParams duckdb_register
 #' @param files One or more CSV file names, should all have the same structure though
+#' @param ... Reserved for future extensions, must be empty.
 #' @param header Whether or not the CSV files have a separate header in the first line
 #' @param na.strings Which strings in the CSV files should be considered to be NULL
 #' @param nrow.check How many rows should be read from the CSV file to figure out data types
@@ -14,7 +15,7 @@
 #' @param lower.case.names Transform column names to lower case
 #' @param sep Alias for delim for compatibility
 #' @param transaction Should a transaction be used for the entire operation
-#' @param ... Passed on to [read.csv()]
+#' @param temporary Set to `TRUE` to create a temporary table
 #' @return The number of rows in the resulted table, invisibly.
 #' @export
 #' @examplesIf duckdb:::TEST_RE2
@@ -29,8 +30,22 @@
 #' dbReadTable(con, "data")
 #'
 #' dbDisconnect(con)
-duckdb_read_csv <- function(conn, name, files, ..., header = TRUE, na.strings = "", nrow.check = 500,
-                            delim = ",", quote = "\"", col.names = NULL, lower.case.names = FALSE, sep = delim, transaction = TRUE, temporary = FALSE) {
+duckdb_read_csv <- function(
+  conn,
+  name,
+  files,
+  ...,
+  header = TRUE,
+  na.strings = "",
+  nrow.check = 500,
+  delim = ",",
+  quote = "\"",
+  col.names = NULL,
+  lower.case.names = FALSE,
+  sep = delim,
+  transaction = TRUE,
+  temporary = FALSE
+) {
   # FIXME: Warning as of duckdb 1.1.1, turn this into an error later
   if (...length() > 0) warning("Arguments passed to ... are currently not used")
   if (length(na.strings) > 1) stop("na.strings must be of length 1")

--- a/R/csv.R
+++ b/R/csv.R
@@ -31,8 +31,8 @@
 #' dbDisconnect(con)
 duckdb_read_csv <- function(conn, name, files, ..., header = TRUE, na.strings = "", nrow.check = 500,
                             delim = ",", quote = "\"", col.names = NULL, lower.case.names = FALSE, sep = delim, transaction = TRUE, temporary = FALSE) {
-  #
-  if (length(list(...))) warning("Arguments passed to ... are currently not used")
+  # FIXME: Warning as of duckdb 1.1.1, turn this into an error later
+  if (...length() > 0) warning("Arguments passed to ... are currently not used")
   if (length(na.strings) > 1) stop("na.strings must be of length 1")
   if (!missing(sep)) delim <- sep
 

--- a/R/csv.R
+++ b/R/csv.R
@@ -29,8 +29,8 @@
 #' dbReadTable(con, "data")
 #'
 #' dbDisconnect(con)
-duckdb_read_csv <- function(conn, name, files, header = TRUE, na.strings = "", nrow.check = 500,
-                            delim = ",", quote = "\"", col.names = NULL, lower.case.names = FALSE, sep = delim, transaction = TRUE, ...) {
+duckdb_read_csv <- function(conn, name, files, ..., header = TRUE, na.strings = "", nrow.check = 500,
+                            delim = ",", quote = "\"", col.names = NULL, lower.case.names = FALSE, sep = delim, transaction = TRUE, temporary = FALSE) {
   #
   if (length(na.strings) > 1) stop("na.strings must be of length 1")
   if (!missing(sep)) delim <- sep
@@ -67,7 +67,7 @@ duckdb_read_csv <- function(conn, name, files, header = TRUE, na.strings = "", n
       }
       names(headers[[1]]) <- col.names
     }
-    dbWriteTable(conn, tablename, headers[[1]][FALSE, , drop = FALSE])
+    dbCreateTable(conn, tablename, headers[[1]], temporary = temporary)
   }
 
   for (i in seq_along(files)) {

--- a/man/duckdb_read_csv.Rd
+++ b/man/duckdb_read_csv.Rd
@@ -8,6 +8,7 @@ duckdb_read_csv(
   conn,
   name,
   files,
+  ...,
   header = TRUE,
   na.strings = "",
   nrow.check = 500,
@@ -17,7 +18,7 @@ duckdb_read_csv(
   lower.case.names = FALSE,
   sep = delim,
   transaction = TRUE,
-  ...
+  temporary = FALSE
 )
 }
 \arguments{
@@ -26,6 +27,8 @@ duckdb_read_csv(
 \item{name}{The name for the virtual table that is registered or unregistered}
 
 \item{files}{One or more CSV file names, should all have the same structure though}
+
+\item{...}{Reserved for future extensions, must be empty.}
 
 \item{header}{Whether or not the CSV files have a separate header in the first line}
 
@@ -45,7 +48,7 @@ duckdb_read_csv(
 
 \item{transaction}{Should a transaction be used for the entire operation}
 
-\item{...}{Passed on to \code{\link[=read.csv]{read.csv()}}}
+\item{temporary}{Set to \code{TRUE} to create a temporary table}
 }
 \value{
 The number of rows in the resulted table, invisibly.

--- a/tests/testthat/test-read.R
+++ b/tests/testthat/test-read.R
@@ -126,5 +126,17 @@ test_that("duckdb_read_csv() works as expected", {
     read.csv(tf3, na.strings = "-")
   )
 
+  # temporary table
+  # see https://github.com/duckdb/duckdb-r/issues/142
+  db <- tempfile()
+  con2 <- dbConnect(duckdb(), dbdir = db)
+  duckdb_read_csv(con2, "iris", tf, temporary = TRUE)
+  expect_true(length(dbListTables(con2)) == 1)
+  dbDisconnect(con2)
+
+  con2 <- dbConnect(duckdb(), dbdir = db)
+  expect_true(length(dbListTables(con2)) == 0)
+  dbDisconnect(con2)
+
   dbDisconnect(con, shutdown = TRUE)
 })


### PR DESCRIPTION
Here is a try for #142

@krlmlr: [You suggested](https://github.com/duckdb/duckdb-r/issues/142#issuecomment-2294792558) to modify the SQL and to use `tbl_function()`.

I do not understand why it is needed. Cannot we just pass temporary to `dbCreateTable()` like I did? Can you please clarify?

Warning: this example will overwrite `test.db` and `iris.csv` files on your disk if present.

```r
library(duckdb)
con <- dbConnect(duckdb(), dbdir = "test.db")

write.csv(iris, "iris.csv", row.names = FALSE)

duckdb_read_csv(con, "iris_temp_false", "iris.csv")
duckdb_read_csv(con, "iris_temp_true", "iris.csv", temporary = TRUE)

dbListTables(con)
# [1] "iris_temp_false" "iris_temp_true" 

dbReadTable(con, "iris_temp_false") |> head()
#   Sepal.Length Sepal.Width Petal.Length Petal.Width Species
# 1          5.1         3.5          1.4         0.2  setosa
# 2          4.9         3.0          1.4         0.2  setosa
# 3          4.7         3.2          1.3         0.2  setosa
# 4          4.6         3.1          1.5         0.2  setosa
# 5          5.0         3.6          1.4         0.2  setosa
# 6          5.4         3.9          1.7         0.4  setosa

dbReadTable(con, "iris_temp_true") |> head()
#   Sepal.Length Sepal.Width Petal.Length Petal.Width Species
# 1          5.1         3.5          1.4         0.2  setosa
# 2          4.9         3.0          1.4         0.2  setosa
# 3          4.7         3.2          1.3         0.2  setosa
# 4          4.6         3.1          1.5         0.2  setosa
# 5          5.0         3.6          1.4         0.2  setosa
# 6          5.4         3.9          1.7         0.4  setosa

dbDisconnect(con)
```

Check that the temporary table is gone:

```
con <- dbConnect(duckdb::duckdb(), dbdir = "test.db")

dbListTables(con)
# [1] "iris_temp_false"

dbDisconnect(con)
```