### PR TITLE
feat: Catch and add query context for statement extraction

### DIFF
--- a/src/statement.cpp
+++ b/src/statement.cpp
@@ -131,7 +131,14 @@ static cpp11::list construct_retlist(duckdb::unique_ptr<PreparedStatement> stmt,
 		cpp11::stop("rapi_prepare: Invalid connection");
 	}
 
-	auto statements = conn->conn->ExtractStatements(query.c_str());
+	vector<unique_ptr<SQLStatement>> statements;
+	try {
+		statements = conn->conn->ExtractStatements(query.c_str());
+	} catch (std::exception &ex) {
+		ErrorData error(ex);
+		error.AddErrorLocation(query);
+		cpp11::stop("rapi_prepare: Failed to extract statements:\n%s", error.Message().c_str());
+	}
 	if (statements.empty()) {
 		// no statements to execute
 		cpp11::stop("rapi_prepare: No statements to execute");


### PR DESCRIPTION
Closes https://github.com/tidyverse/duckplyr/issues/219.

``` r
library(DBI)

drv <- duckdb::duckdb()
con <- dbConnect(drv)

sql <- "SELECT count(*), date FROM SELECT CAST(time AS date), count(*) GROUP by date;"
dbGetQuery(con, sql)
#> Error: rapi_prepare: Failed to extract statements:
#> Parser Error: syntax error at or near "SELECT"
#> LINE 1: SELECT count(*), date FROM SELECT CAST(time AS date), count(*) GRO...
#>                                    ^
```

<sup>Created on 2024-10-26 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>