### PR TITLE
fledge: CRAN release v1.1.3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: duckdb
 Title: DBI Package for the DuckDB Database Management System
-Version: 1.1.2.9904
+Version: 1.1.3
 Authors@R: c(
     person("Hannes", "Mühleisen", , "hannes@cwi.nl", role = "aut",
            comment = c(ORCID = "0000-0001-8552-0029")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,31 +2,25 @@
 
 # duckdb 1.1.3
 
-## Bug fixes
-
-- Avoid compiler warning related to `Rboolean` (#594).
-  - fix: Avoid compiler warning related to `Rboolean`
-  - Don't use xz if not available
-
 ## Features
 
 - Update to duckdb v1.1.3, see <https://github.com/duckdb/duckdb/releases/tag/v1.1.3> for details.
+
 - New `duckdb.materialize_callback` option, supersedes `get_last_rel()` (#589).
+
 - New `rel_explain_df()` and `rel_tostring()` (#587).
+
 - Handle empty child values for list constants (#186, @romainfrancois).
 
 ## Chore
 
 - Undef `TRUE` and `FALSE` (#595).
+
 - Remove `enable_materialization` argument to `rel_from_altrep_df()` in favor of creating a new data frame when needed (#588).
+
 - Flip argument order for `expr_comparison()` (#585).
+
 - Keep `cleanup` files to accommodate different build scenarios (#536).
-
-## Testing
-
-- Sync tests with duckplyr (#596).
-  - test: Sync tests with duckplyr
-  - Skip
 
 
 # duckdb 1.1.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,47 +1,33 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# duckdb 1.1.2.9904
+# duckdb 1.1.3
 
 ## Bug fixes
 
 - Avoid compiler warning related to `Rboolean` (#594).
-
   - fix: Avoid compiler warning related to `Rboolean`
-
   - Don't use xz if not available
-
-## Chore
-
-- Undef `TRUE` and `FALSE` (#595).
-
-## Testing
-
-- Sync tests with duckplyr (#596).
-
-  - test: Sync tests with duckplyr
-
-  - Skip
-
-
-# duckdb 1.1.2.9903
 
 ## Features
 
 - Update to duckdb v1.1.3, see <https://github.com/duckdb/duckdb/releases/tag/v1.1.3> for details.
-
 - New `duckdb.materialize_callback` option, supersedes `get_last_rel()` (#589).
-
 - New `rel_explain_df()` and `rel_tostring()` (#587).
-
 - Handle empty child values for list constants (#186, @romainfrancois).
 
 ## Chore
 
+- Undef `TRUE` and `FALSE` (#595).
 - Remove `enable_materialization` argument to `rel_from_altrep_df()` in favor of creating a new data frame when needed (#588).
-
 - Flip argument order for `expr_comparison()` (#585).
-
 - Keep `cleanup` files to accommodate different build scenarios (#536).
+
+## Testing
+
+- Sync tests with duckplyr (#596).
+  - test: Sync tests with duckplyr
+  - Skip
+
 
 # duckdb 1.1.2
 

--- a/cleanup
+++ b/cleanup
@@ -4,7 +4,7 @@ set -ex
 
 # For CI/CD: only compress if expansion is possible too
 if which xz > /dev/null; then
-  git clean -fdx src
+  if [ -d .git ]; then git clean -fdx src; fi
   cd src
   tar cvJf duckdb.tar.xz duckdb
   rm -rf duckdb

--- a/cleanup.win
+++ b/cleanup.win
@@ -4,7 +4,7 @@ set -ex
 
 # For CI/CD: only compress if expansion is possible too
 if which xz > /dev/null; then
-  git clean -fdx src
+  if [ -d .git ]; then git clean -fdx src; fi
   cd src
   find duckdb -type f | egrep '[.](cc|cpp|h|hpp)$' | xargs dos2unix
   tar cvJf duckdb.tar.xz duckdb

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,4 +1,4 @@
-duckdb 1.1.2.9903
+duckdb 1.1.3
 
 ## Cran Repository Policy
 


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2024-11-21, problems found: https://cran.r-project.org/web/checks/check_results_duckdb.html
- [ ] WARN: r-devel-linux-x86_64-debian-gcc
     Found the following significant warnings:
     /usr/include/c++/14/bits/move.h:222:11: warning: ‘((void (**)(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >))this)[2]’ is used uninitialized [-Wuninitialized]
     See ‘/home/hornik/tmp/R.check/r-devel-gcc/Work/PKGS/duckdb.Rcheck/00install.out’ for details.
     * used C++ compiler: ‘g++-14 (Debian 14.2.0-8) 14.2.0’

Check results at: https://cran.r-project.org/web/checks/check_results_duckdb.html

## Action items

- [ ] Review PR
- [ ] Await successful CI/CD run
- [ ] Run `fledge::release()`
- [ ] When the package is accepted on CRAN, run `fledge::post_release()`