### PR TITLE
fix: Make `./cleanup` script reentrant

### DIFF
--- a/cleanup
+++ b/cleanup
@@ -2,6 +2,12 @@
 
 set -ex
 
+# Check if the archive already exists
+if [ -f "duckdb.tar.xz" ]; then
+  echo "duckdb.tar.xz already exists. Skipping compression."
+  exit 0
+fi
+
 # For CI/CD: only compress if expansion is possible too
 if which xz > /dev/null; then
   if [ -d .git ]; then git clean -fdx src; fi


### PR DESCRIPTION
Skip cleanup if archive is already exists. 

Closes https://github.com/duckdb/duckdb-r/issues/612.