### PR TITLE
f rel to parquet options

### DIFF
--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -180,6 +180,14 @@ rapi_rel_to_csv <- function(rel, file_name, options_sexps) {
   invisible(.Call(`_duckdb_rapi_rel_to_csv`, rel, file_name, options_sexps))
 }
 
+rapi_rel_to_table <- function(rel, schema_name, table_name, temporary) {
+  invisible(.Call(`_duckdb_rapi_rel_to_table`, rel, schema_name, table_name, temporary))
+}
+
+rapi_rel_insert <- function(rel, schema_name, table_name) {
+  invisible(.Call(`_duckdb_rapi_rel_insert`, rel, schema_name, table_name))
+}
+
 rapi_rel_to_altrep <- function(rel, allow_materialization) {
   .Call(`_duckdb_rapi_rel_to_altrep`, rel, allow_materialization)
 }

--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -176,6 +176,10 @@ rapi_rel_to_parquet <- function(rel, file_name, options_sexps) {
   invisible(.Call(`_duckdb_rapi_rel_to_parquet`, rel, file_name, options_sexps))
 }
 
+rapi_rel_to_csv <- function(rel, file_name, options_sexps) {
+  invisible(.Call(`_duckdb_rapi_rel_to_csv`, rel, file_name, options_sexps))
+}
+
 rapi_rel_to_altrep <- function(rel, allow_materialization) {
   .Call(`_duckdb_rapi_rel_to_altrep`, rel, allow_materialization)
 }

--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -172,8 +172,7 @@ rapi_rel_from_table_function <- function(con, function_name, positional_paramete
   .Call(`_duckdb_rapi_rel_from_table_function`, con, function_name, positional_parameters_sexps, named_parameters_sexps)
 }
 
-# allow_materialization = TRUE: compatibility with duckplyr <= 0.4.1
-rapi_rel_to_altrep <- function(rel, allow_materialization = TRUE) {
+rapi_rel_to_altrep <- function(rel, allow_materialization) {
   .Call(`_duckdb_rapi_rel_to_altrep`, rel, allow_materialization)
 }
 

--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -172,6 +172,10 @@ rapi_rel_from_table_function <- function(con, function_name, positional_paramete
   .Call(`_duckdb_rapi_rel_from_table_function`, con, function_name, positional_parameters_sexps, named_parameters_sexps)
 }
 
+rapi_rel_to_parquet <- function(rel, file_name, options_sexps) {
+  invisible(.Call(`_duckdb_rapi_rel_to_parquet`, rel, file_name, options_sexps))
+}
+
 rapi_rel_to_altrep <- function(rel, allow_materialization) {
   .Call(`_duckdb_rapi_rel_to_altrep`, rel, allow_materialization)
 }
@@ -218,10 +222,6 @@ rapi_record_batch <- function(qry_res, chunk_size) {
 
 rapi_execute <- function(stmt, arrow, integer64) {
   .Call(`_duckdb_rapi_execute`, stmt, arrow, integer64)
-}
-
-rapi_rel_to_parquet <- function(rel, file_name) {
-  invisible(.Call(`_duckdb_rapi_rel_to_parquet`, rel, file_name))
 }
 
 rapi_adbc_init_func <- function() {

--- a/R/cpp12.R
+++ b/R/cpp12.R
@@ -1,0 +1,4 @@
+# allow_materialization = TRUE: compatibility with duckplyr <= 0.4.1
+rapi_rel_to_altrep <- function(rel, allow_materialization = TRUE) {
+  .Call(`_duckdb_rapi_rel_to_altrep`, rel, allow_materialization)
+}

--- a/R/relational.R
+++ b/R/relational.R
@@ -492,8 +492,8 @@ rel_from_table_function <- function(con, function_name, positional_parameters = 
   rethrow_rapi_rel_from_table_function(con@conn_ref, function_name, positional_parameters, named_parameters)
 }
 
-rel_to_parquet <- function(rel, file_name) {
-  rethrow_rapi_rel_to_parquet(rel, file_name)
+rel_to_parquet <- function(rel, file_name, options = list()) {
+  rethrow_rapi_rel_to_parquet(rel, file_name, options)
 }
 
 rel_names <- function(rel) {

--- a/R/relational.R
+++ b/R/relational.R
@@ -496,6 +496,10 @@ rel_to_parquet <- function(rel, file_name, options = list()) {
   rethrow_rapi_rel_to_parquet(rel, file_name, options)
 }
 
+rel_to_csv <- function(rel, file_name, options = list()) {
+  rethrow_rapi_rel_to_csv(rel, file_name, options)
+}
+
 rel_names <- function(rel) {
   rethrow_rapi_rel_names(rel)
 }

--- a/R/rethrow-gen.R
+++ b/R/rethrow-gen.R
@@ -387,9 +387,8 @@ rethrow_rapi_rel_from_table_function <- function(con, function_name, positional_
   )
 }
 
-rethrow_rapi_rel_to_altrep <- function(rel, allow_materialization = TRUE, call = parent.frame(2)) {
+rethrow_rapi_rel_to_altrep <- function(rel, allow_materialization, call = parent.frame(2)) {
   rlang::try_fetch(
-    # duckplyr compat
     rapi_rel_to_altrep(rel, allow_materialization),
     error = function(e) {
       rethrow_error_from_rapi(e, call)

--- a/R/rethrow-gen.R
+++ b/R/rethrow-gen.R
@@ -396,6 +396,15 @@ rethrow_rapi_rel_to_parquet <- function(rel, file_name, options_sexps, call = pa
   )
 }
 
+rethrow_rapi_rel_to_csv <- function(rel, file_name, options_sexps, call = parent.frame(2)) {
+  rlang::try_fetch(
+    rapi_rel_to_csv(rel, file_name, options_sexps),
+    error = function(e) {
+      rethrow_error_from_rapi(e, call)
+    }
+  )
+}
+
 rethrow_rapi_rel_to_altrep <- function(rel, allow_materialization, call = parent.frame(2)) {
   rlang::try_fetch(
     rapi_rel_to_altrep(rel, allow_materialization),
@@ -576,6 +585,7 @@ rethrow_restore <- function() {
   rethrow_rapi_rel_from_table <<- rapi_rel_from_table
   rethrow_rapi_rel_from_table_function <<- rapi_rel_from_table_function
   rethrow_rapi_rel_to_parquet <<- rapi_rel_to_parquet
+  rethrow_rapi_rel_to_csv <<- rapi_rel_to_csv
   rethrow_rapi_rel_to_altrep <<- rapi_rel_to_altrep
   rethrow_rapi_rel_from_altrep_df <<- rapi_rel_from_altrep_df
   rethrow_rapi_release <<- rapi_release

--- a/R/rethrow-gen.R
+++ b/R/rethrow-gen.R
@@ -387,6 +387,15 @@ rethrow_rapi_rel_from_table_function <- function(con, function_name, positional_
   )
 }
 
+rethrow_rapi_rel_to_parquet <- function(rel, file_name, options_sexps, call = parent.frame(2)) {
+  rlang::try_fetch(
+    rapi_rel_to_parquet(rel, file_name, options_sexps),
+    error = function(e) {
+      rethrow_error_from_rapi(e, call)
+    }
+  )
+}
+
 rethrow_rapi_rel_to_altrep <- function(rel, allow_materialization, call = parent.frame(2)) {
   rlang::try_fetch(
     rapi_rel_to_altrep(rel, allow_materialization),
@@ -495,15 +504,6 @@ rethrow_rapi_execute <- function(stmt, arrow, integer64, call = parent.frame(2))
   )
 }
 
-rethrow_rapi_rel_to_parquet <- function(rel, file_name, call = parent.frame(2)) {
-  rlang::try_fetch(
-    rapi_rel_to_parquet(rel, file_name),
-    error = function(e) {
-      rethrow_error_from_rapi(e, call)
-    }
-  )
-}
-
 rethrow_rapi_adbc_init_func <- function(call = parent.frame(2)) {
   rlang::try_fetch(
     rapi_adbc_init_func(),
@@ -575,6 +575,7 @@ rethrow_restore <- function() {
   rethrow_rapi_rel_from_sql <<- rapi_rel_from_sql
   rethrow_rapi_rel_from_table <<- rapi_rel_from_table
   rethrow_rapi_rel_from_table_function <<- rapi_rel_from_table_function
+  rethrow_rapi_rel_to_parquet <<- rapi_rel_to_parquet
   rethrow_rapi_rel_to_altrep <<- rapi_rel_to_altrep
   rethrow_rapi_rel_from_altrep_df <<- rapi_rel_from_altrep_df
   rethrow_rapi_release <<- rapi_release
@@ -587,7 +588,6 @@ rethrow_restore <- function() {
   rethrow_rapi_execute_arrow <<- rapi_execute_arrow
   rethrow_rapi_record_batch <<- rapi_record_batch
   rethrow_rapi_execute <<- rapi_execute
-  rethrow_rapi_rel_to_parquet <<- rapi_rel_to_parquet
   rethrow_rapi_adbc_init_func <<- rapi_adbc_init_func
   rethrow_rapi_ptr_to_str <<- rapi_ptr_to_str
   rethrow_rapi_load_rfuns <<- rapi_load_rfuns

--- a/R/rethrow-gen.R
+++ b/R/rethrow-gen.R
@@ -405,6 +405,24 @@ rethrow_rapi_rel_to_csv <- function(rel, file_name, options_sexps, call = parent
   )
 }
 
+rethrow_rapi_rel_to_table <- function(rel, schema_name, table_name, temporary, call = parent.frame(2)) {
+  rlang::try_fetch(
+    rapi_rel_to_table(rel, schema_name, table_name, temporary),
+    error = function(e) {
+      rethrow_error_from_rapi(e, call)
+    }
+  )
+}
+
+rethrow_rapi_rel_insert <- function(rel, schema_name, table_name, call = parent.frame(2)) {
+  rlang::try_fetch(
+    rapi_rel_insert(rel, schema_name, table_name),
+    error = function(e) {
+      rethrow_error_from_rapi(e, call)
+    }
+  )
+}
+
 rethrow_rapi_rel_to_altrep <- function(rel, allow_materialization, call = parent.frame(2)) {
   rlang::try_fetch(
     rapi_rel_to_altrep(rel, allow_materialization),
@@ -586,6 +604,8 @@ rethrow_restore <- function() {
   rethrow_rapi_rel_from_table_function <<- rapi_rel_from_table_function
   rethrow_rapi_rel_to_parquet <<- rapi_rel_to_parquet
   rethrow_rapi_rel_to_csv <<- rapi_rel_to_csv
+  rethrow_rapi_rel_to_table <<- rapi_rel_to_table
+  rethrow_rapi_rel_insert <<- rapi_rel_insert
   rethrow_rapi_rel_to_altrep <<- rapi_rel_to_altrep
   rethrow_rapi_rel_from_altrep_df <<- rapi_rel_from_altrep_df
   rethrow_rapi_release <<- rapi_release

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -330,6 +330,22 @@ extern "C" SEXP _duckdb_rapi_rel_to_csv(SEXP rel, SEXP file_name, SEXP options_s
     return R_NilValue;
   END_CPP11
 }
+// relational.cpp
+void rapi_rel_to_table(duckdb::rel_extptr_t rel, std::string schema_name, std::string table_name, bool temporary);
+extern "C" SEXP _duckdb_rapi_rel_to_table(SEXP rel, SEXP schema_name, SEXP table_name, SEXP temporary) {
+  BEGIN_CPP11
+    rapi_rel_to_table(cpp11::as_cpp<cpp11::decay_t<duckdb::rel_extptr_t>>(rel), cpp11::as_cpp<cpp11::decay_t<std::string>>(schema_name), cpp11::as_cpp<cpp11::decay_t<std::string>>(table_name), cpp11::as_cpp<cpp11::decay_t<bool>>(temporary));
+    return R_NilValue;
+  END_CPP11
+}
+// relational.cpp
+void rapi_rel_insert(duckdb::rel_extptr_t rel, std::string schema_name, std::string table_name);
+extern "C" SEXP _duckdb_rapi_rel_insert(SEXP rel, SEXP schema_name, SEXP table_name) {
+  BEGIN_CPP11
+    rapi_rel_insert(cpp11::as_cpp<cpp11::decay_t<duckdb::rel_extptr_t>>(rel), cpp11::as_cpp<cpp11::decay_t<std::string>>(schema_name), cpp11::as_cpp<cpp11::decay_t<std::string>>(table_name));
+    return R_NilValue;
+  END_CPP11
+}
 // reltoaltrep.cpp
 SEXP rapi_rel_to_altrep(duckdb::rel_extptr_t rel, bool allow_materialization);
 extern "C" SEXP _duckdb_rapi_rel_to_altrep(SEXP rel, SEXP allow_materialization) {
@@ -477,6 +493,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_duckdb_rapi_rel_from_sql",            (DL_FUNC) &_duckdb_rapi_rel_from_sql,            2},
     {"_duckdb_rapi_rel_from_table",          (DL_FUNC) &_duckdb_rapi_rel_from_table,          3},
     {"_duckdb_rapi_rel_from_table_function", (DL_FUNC) &_duckdb_rapi_rel_from_table_function, 4},
+    {"_duckdb_rapi_rel_insert",              (DL_FUNC) &_duckdb_rapi_rel_insert,              3},
     {"_duckdb_rapi_rel_join",                (DL_FUNC) &_duckdb_rapi_rel_join,                5},
     {"_duckdb_rapi_rel_limit",               (DL_FUNC) &_duckdb_rapi_rel_limit,               2},
     {"_duckdb_rapi_rel_names",               (DL_FUNC) &_duckdb_rapi_rel_names,               1},
@@ -492,6 +509,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_duckdb_rapi_rel_to_df",               (DL_FUNC) &_duckdb_rapi_rel_to_df,               1},
     {"_duckdb_rapi_rel_to_parquet",          (DL_FUNC) &_duckdb_rapi_rel_to_parquet,          3},
     {"_duckdb_rapi_rel_to_sql",              (DL_FUNC) &_duckdb_rapi_rel_to_sql,              1},
+    {"_duckdb_rapi_rel_to_table",            (DL_FUNC) &_duckdb_rapi_rel_to_table,            4},
     {"_duckdb_rapi_rel_tostring",            (DL_FUNC) &_duckdb_rapi_rel_tostring,            2},
     {"_duckdb_rapi_rel_union_all",           (DL_FUNC) &_duckdb_rapi_rel_union_all,           2},
     {"_duckdb_rapi_release",                 (DL_FUNC) &_duckdb_rapi_release,                 1},

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -322,6 +322,14 @@ extern "C" SEXP _duckdb_rapi_rel_to_parquet(SEXP rel, SEXP file_name, SEXP optio
     return R_NilValue;
   END_CPP11
 }
+// relational.cpp
+void rapi_rel_to_csv(duckdb::rel_extptr_t rel, std::string file_name, list options_sexps);
+extern "C" SEXP _duckdb_rapi_rel_to_csv(SEXP rel, SEXP file_name, SEXP options_sexps) {
+  BEGIN_CPP11
+    rapi_rel_to_csv(cpp11::as_cpp<cpp11::decay_t<duckdb::rel_extptr_t>>(rel), cpp11::as_cpp<cpp11::decay_t<std::string>>(file_name), cpp11::as_cpp<cpp11::decay_t<list>>(options_sexps));
+    return R_NilValue;
+  END_CPP11
+}
 // reltoaltrep.cpp
 SEXP rapi_rel_to_altrep(duckdb::rel_extptr_t rel, bool allow_materialization);
 extern "C" SEXP _duckdb_rapi_rel_to_altrep(SEXP rel, SEXP allow_materialization) {
@@ -480,6 +488,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_duckdb_rapi_rel_set_symdiff",         (DL_FUNC) &_duckdb_rapi_rel_set_symdiff,         2},
     {"_duckdb_rapi_rel_sql",                 (DL_FUNC) &_duckdb_rapi_rel_sql,                 2},
     {"_duckdb_rapi_rel_to_altrep",           (DL_FUNC) &_duckdb_rapi_rel_to_altrep,           2},
+    {"_duckdb_rapi_rel_to_csv",              (DL_FUNC) &_duckdb_rapi_rel_to_csv,              3},
     {"_duckdb_rapi_rel_to_df",               (DL_FUNC) &_duckdb_rapi_rel_to_df,               1},
     {"_duckdb_rapi_rel_to_parquet",          (DL_FUNC) &_duckdb_rapi_rel_to_parquet,          3},
     {"_duckdb_rapi_rel_to_sql",              (DL_FUNC) &_duckdb_rapi_rel_to_sql,              1},

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -314,6 +314,14 @@ extern "C" SEXP _duckdb_rapi_rel_from_table_function(SEXP con, SEXP function_nam
     return cpp11::as_sexp(rapi_rel_from_table_function(cpp11::as_cpp<cpp11::decay_t<duckdb::conn_eptr_t>>(con), cpp11::as_cpp<cpp11::decay_t<const std::string>>(function_name), cpp11::as_cpp<cpp11::decay_t<list>>(positional_parameters_sexps), cpp11::as_cpp<cpp11::decay_t<list>>(named_parameters_sexps)));
   END_CPP11
 }
+// relational.cpp
+void rapi_rel_to_parquet(duckdb::rel_extptr_t rel, std::string file_name, list options_sexps);
+extern "C" SEXP _duckdb_rapi_rel_to_parquet(SEXP rel, SEXP file_name, SEXP options_sexps) {
+  BEGIN_CPP11
+    rapi_rel_to_parquet(cpp11::as_cpp<cpp11::decay_t<duckdb::rel_extptr_t>>(rel), cpp11::as_cpp<cpp11::decay_t<std::string>>(file_name), cpp11::as_cpp<cpp11::decay_t<list>>(options_sexps));
+    return R_NilValue;
+  END_CPP11
+}
 // reltoaltrep.cpp
 SEXP rapi_rel_to_altrep(duckdb::rel_extptr_t rel, bool allow_materialization);
 extern "C" SEXP _duckdb_rapi_rel_to_altrep(SEXP rel, SEXP allow_materialization) {
@@ -399,14 +407,6 @@ extern "C" SEXP _duckdb_rapi_execute(SEXP stmt, SEXP arrow, SEXP integer64) {
     return cpp11::as_sexp(rapi_execute(cpp11::as_cpp<cpp11::decay_t<duckdb::stmt_eptr_t>>(stmt), cpp11::as_cpp<cpp11::decay_t<bool>>(arrow), cpp11::as_cpp<cpp11::decay_t<bool>>(integer64)));
   END_CPP11
 }
-// statement.cpp
-void rapi_rel_to_parquet(duckdb::rel_extptr_t rel, std::string file_name);
-extern "C" SEXP _duckdb_rapi_rel_to_parquet(SEXP rel, SEXP file_name) {
-  BEGIN_CPP11
-    rapi_rel_to_parquet(cpp11::as_cpp<cpp11::decay_t<duckdb::rel_extptr_t>>(rel), cpp11::as_cpp<cpp11::decay_t<std::string>>(file_name));
-    return R_NilValue;
-  END_CPP11
-}
 // utils.cpp
 SEXP rapi_adbc_init_func();
 extern "C" SEXP _duckdb_rapi_adbc_init_func() {
@@ -481,7 +481,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_duckdb_rapi_rel_sql",                 (DL_FUNC) &_duckdb_rapi_rel_sql,                 2},
     {"_duckdb_rapi_rel_to_altrep",           (DL_FUNC) &_duckdb_rapi_rel_to_altrep,           2},
     {"_duckdb_rapi_rel_to_df",               (DL_FUNC) &_duckdb_rapi_rel_to_df,               1},
-    {"_duckdb_rapi_rel_to_parquet",          (DL_FUNC) &_duckdb_rapi_rel_to_parquet,          2},
+    {"_duckdb_rapi_rel_to_parquet",          (DL_FUNC) &_duckdb_rapi_rel_to_parquet,          3},
     {"_duckdb_rapi_rel_to_sql",              (DL_FUNC) &_duckdb_rapi_rel_to_sql,              1},
     {"_duckdb_rapi_rel_tostring",            (DL_FUNC) &_duckdb_rapi_rel_tostring,            2},
     {"_duckdb_rapi_rel_union_all",           (DL_FUNC) &_duckdb_rapi_rel_union_all,           2},

--- a/src/include/typesr.hpp
+++ b/src/include/typesr.hpp
@@ -206,3 +206,5 @@ struct RRawSexpType : public RSexpType {
 };
 
 } // namespace duckdb
+
+duckdb::case_insensitive_map_t<duckdb::vector<duckdb::Value>> ListToVectorOfValue(cpp11::list input_sexps);

--- a/src/relational.cpp
+++ b/src/relational.cpp
@@ -560,3 +560,7 @@ static SEXP result_to_df(duckdb::unique_ptr<QueryResult> res) {
 [[cpp11::register]] void rapi_rel_to_parquet(duckdb::rel_extptr_t rel, std::string file_name, list options_sexps) {
 	rel->rel->WriteParquet(file_name, ListToVectorOfValue(options_sexps));
 }
+
+[[cpp11::register]] void rapi_rel_to_csv(duckdb::rel_extptr_t rel, std::string file_name, list options_sexps) {
+	rel->rel->WriteCSV(file_name, ListToVectorOfValue(options_sexps));
+}

--- a/src/relational.cpp
+++ b/src/relational.cpp
@@ -556,3 +556,7 @@ static SEXP result_to_df(duckdb::unique_ptr<QueryResult> res) {
 	auto rel = con->conn->TableFunction(function_name, std::move(positional_parameters), std::move(named_parameters));
 	return make_external<RelationWrapper>("duckdb_relation", std::move(rel));
 }
+
+[[cpp11::register]] void rapi_rel_to_parquet(duckdb::rel_extptr_t rel, std::string file_name, list options_sexps) {
+	rel->rel->WriteParquet(file_name, ListToVectorOfValue(options_sexps));
+}

--- a/src/relational.cpp
+++ b/src/relational.cpp
@@ -564,3 +564,11 @@ static SEXP result_to_df(duckdb::unique_ptr<QueryResult> res) {
 [[cpp11::register]] void rapi_rel_to_csv(duckdb::rel_extptr_t rel, std::string file_name, list options_sexps) {
 	rel->rel->WriteCSV(file_name, ListToVectorOfValue(options_sexps));
 }
+
+[[cpp11::register]] void rapi_rel_to_table(duckdb::rel_extptr_t rel, std::string schema_name, std::string table_name, bool temporary) {
+	rel->rel->Create(table_name, schema_name, temporary);
+}
+
+[[cpp11::register]] void rapi_rel_insert(duckdb::rel_extptr_t rel, std::string schema_name, std::string table_name) {
+	rel->rel->Insert(table_name, schema_name);
+}

--- a/src/statement.cpp
+++ b/src/statement.cpp
@@ -384,7 +384,3 @@ bool FetchArrowChunk(ChunkScanState &scan_state, ClientProperties options, Appen
 		return out;
 	}
 }
-
-[[cpp11::register]] void rapi_rel_to_parquet(duckdb::rel_extptr_t rel, std::string file_name) {
-	rel->rel->WriteParquet(file_name);
-}


### PR DESCRIPTION
- **chore: Simplify workaround**
- **feat: Internal `rapi_rel_to_parquet()` gains `options` argument**
- **feat: New internal `rapi_rel_to_csv()`**
- **feat: New internal `rapi_rel_to_table()` and `rapi_rel_insert()`**
