### PR TITLE
feat: Add translation for `median()`

### DIFF
--- a/R/backend-dbplyr__duckdb_connection.R
+++ b/R/backend-dbplyr__duckdb_connection.R
@@ -356,6 +356,7 @@ sql_translation.duckdb_connection <- function(con) {
     sql_translator(
       .parent = base_agg,
       prod = sql_aggregate("PRODUCT"),
+      median = sql_aggregate("MEDIAN"),
       cor = sql_aggregate_2("CORR"),
       cov = sql_aggregate_2("COVAR_SAMP"),
       sd = sql_aggregate("STDDEV", "sd"),
@@ -370,6 +371,7 @@ sql_translation.duckdb_connection <- function(con) {
     sql_translator(
       .parent = base_win,
       prod = win_aggregate("PRODUCT"),
+      median = win_aggregate("MEDIAN"),
       cor = win_aggregate_2("CORR"),
       cov = win_aggregate_2("COVAR_SAMP"),
       sd = win_aggregate("STDDEV"),

--- a/tests/testthat/test-backend-dbplyr__duckdb_connection.R
+++ b/tests/testthat/test-backend-dbplyr__duckdb_connection.R
@@ -262,6 +262,10 @@ test_that("aggregators translated correctly", {
   expect_equal(translate(prod(x, na.rm = TRUE), window = FALSE), sql(r"{PRODUCT(x)}"))
   expect_equal(translate(prod(x, na.rm = TRUE), window = TRUE), sql(r"{PRODUCT(x) OVER ()}"))
 
+  expect_equal(translate(median(x), window = FALSE), sql(r"{MEDIAN(x)}"))
+  expect_equal(translate(median(x), window = TRUE), sql(r"{MEDIAN(x) OVER ()}"))
+  expect_equal(translate(median(x), window = TRUE, vars_group="z"), sql(r"{MEDIAN(x) OVER (PARTITION BY z)}"))
+
   expect_equal(translate(sd(x, na.rm = TRUE), window = FALSE), sql(r"{STDDEV(x)}"))
   expect_equal(translate(sd(x, na.rm = TRUE), window = TRUE), sql(r"{STDDEV(x) OVER ()}"))
 


### PR DESCRIPTION
Closes #993 

Adds translation for median aggregate and window functions.

Apparently aggregate function `median()` works without this translation as it is translated to `percentile_cont` ordered set aggregation function. However, the PR now includes a translation for the aggregation function also as I thought it'd be better to align the function calls. Any thoughts on this @krlmlr ?