### PR TITLE
feat: Limit automatic materialization by number of rows or number of cells

### DIFF
--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -188,8 +188,8 @@ rapi_rel_insert <- function(rel, schema_name, table_name) {
   invisible(.Call(`_duckdb_rapi_rel_insert`, rel, schema_name, table_name))
 }
 
-rapi_rel_to_altrep <- function(rel, allow_materialization) {
-  .Call(`_duckdb_rapi_rel_to_altrep`, rel, allow_materialization)
+rapi_rel_to_altrep <- function(rel, allow_materialization, n_rows, n_cells) {
+  .Call(`_duckdb_rapi_rel_to_altrep`, rel, allow_materialization, n_rows, n_cells)
 }
 
 rapi_rel_from_altrep_df <- function(df, strict, allow_materialized) {

--- a/R/cpp12.R
+++ b/R/cpp12.R
@@ -1,4 +1,4 @@
 # allow_materialization = TRUE: compatibility with duckplyr <= 0.4.1
-rapi_rel_to_altrep <- function(rel, allow_materialization = TRUE) {
-  .Call(`_duckdb_rapi_rel_to_altrep`, rel, allow_materialization)
+rapi_rel_to_altrep <- function(rel, allow_materialization = TRUE, n_row = Inf, n_cells = Inf) {
+  .Call(`_duckdb_rapi_rel_to_altrep`, rel, allow_materialization, n_row, n_cells)
 }

--- a/R/relational.R
+++ b/R/relational.R
@@ -412,8 +412,8 @@ rel_set_alias <- function(rel, alias) {
 #' con <- DBI::dbConnect(duckdb())
 #' rel <- rel_from_df(con, mtcars)
 #' print(rel_to_altrep(rel))
-rel_to_altrep <- function(rel, allow_materialization = TRUE) {
-  rethrow_rapi_rel_to_altrep(rel, allow_materialization)
+rel_to_altrep <- function(rel, allow_materialization = TRUE, n_rows = Inf, n_cells = Inf) {
+  rethrow_rapi_rel_to_altrep(rel, allow_materialization, n_rows = n_rows, n_cells = n_cells)
 }
 
 

--- a/R/rethrow-gen.R
+++ b/R/rethrow-gen.R
@@ -423,9 +423,9 @@ rethrow_rapi_rel_insert <- function(rel, schema_name, table_name, call = parent.
   )
 }
 
-rethrow_rapi_rel_to_altrep <- function(rel, allow_materialization, call = parent.frame(2)) {
+rethrow_rapi_rel_to_altrep <- function(rel, allow_materialization, n_rows, n_cells, call = parent.frame(2)) {
   rlang::try_fetch(
-    rapi_rel_to_altrep(rel, allow_materialization),
+    rapi_rel_to_altrep(rel, allow_materialization, n_rows, n_cells),
     error = function(e) {
       rethrow_error_from_rapi(e, call)
     }

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -347,10 +347,10 @@ extern "C" SEXP _duckdb_rapi_rel_insert(SEXP rel, SEXP schema_name, SEXP table_n
   END_CPP11
 }
 // reltoaltrep.cpp
-SEXP rapi_rel_to_altrep(duckdb::rel_extptr_t rel, bool allow_materialization);
-extern "C" SEXP _duckdb_rapi_rel_to_altrep(SEXP rel, SEXP allow_materialization) {
+SEXP rapi_rel_to_altrep(duckdb::rel_extptr_t rel, bool allow_materialization, double n_rows, double n_cells);
+extern "C" SEXP _duckdb_rapi_rel_to_altrep(SEXP rel, SEXP allow_materialization, SEXP n_rows, SEXP n_cells) {
   BEGIN_CPP11
-    return cpp11::as_sexp(rapi_rel_to_altrep(cpp11::as_cpp<cpp11::decay_t<duckdb::rel_extptr_t>>(rel), cpp11::as_cpp<cpp11::decay_t<bool>>(allow_materialization)));
+    return cpp11::as_sexp(rapi_rel_to_altrep(cpp11::as_cpp<cpp11::decay_t<duckdb::rel_extptr_t>>(rel), cpp11::as_cpp<cpp11::decay_t<bool>>(allow_materialization), cpp11::as_cpp<cpp11::decay_t<double>>(n_rows), cpp11::as_cpp<cpp11::decay_t<double>>(n_cells)));
   END_CPP11
 }
 // reltoaltrep.cpp
@@ -504,7 +504,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_duckdb_rapi_rel_set_intersect",       (DL_FUNC) &_duckdb_rapi_rel_set_intersect,       2},
     {"_duckdb_rapi_rel_set_symdiff",         (DL_FUNC) &_duckdb_rapi_rel_set_symdiff,         2},
     {"_duckdb_rapi_rel_sql",                 (DL_FUNC) &_duckdb_rapi_rel_sql,                 2},
-    {"_duckdb_rapi_rel_to_altrep",           (DL_FUNC) &_duckdb_rapi_rel_to_altrep,           2},
+    {"_duckdb_rapi_rel_to_altrep",           (DL_FUNC) &_duckdb_rapi_rel_to_altrep,           4},
     {"_duckdb_rapi_rel_to_csv",              (DL_FUNC) &_duckdb_rapi_rel_to_csv,              3},
     {"_duckdb_rapi_rel_to_df",               (DL_FUNC) &_duckdb_rapi_rel_to_df,               1},
     {"_duckdb_rapi_rel_to_parquet",          (DL_FUNC) &_duckdb_rapi_rel_to_parquet,          3},

--- a/src/reltoaltrep.cpp
+++ b/src/reltoaltrep.cpp
@@ -104,7 +104,7 @@ struct AltrepRelationWrapper {
 	MaterializedQueryResult *GetQueryResult() {
 		if (!res) {
 			if (!allow_materialization) {
-				cpp11::stop("Materialization is disabled, use collect() or as_tibble() to materialize");
+				cpp11::stop("Materialization is disabled, use collect() or as_tibble() to materialize.");
 			}
 
 			auto materialize_callback = Rf_GetOption(RStrings::get().materialize_callback_sym, R_BaseEnv);

--- a/src/reltoaltrep.cpp
+++ b/src/reltoaltrep.cpp
@@ -114,7 +114,7 @@ struct AltrepRelationWrapper {
 			}
 
 			auto materialize_message = Rf_GetOption(RStrings::get().materialize_message_sym, R_BaseEnv);
-		  if (Rf_isLogical(materialize_message) && Rf_length(materialize_message) == 1 && LOGICAL_ELT(materialize_message, 0) == true) {
+			if (Rf_isLogical(materialize_message) && Rf_length(materialize_message) == 1 && LOGICAL_ELT(materialize_message, 0) == true) {
 				// Legacy
 				Rprintf("duckplyr: materializing\n");
 			}

--- a/src/reltoaltrep.cpp
+++ b/src/reltoaltrep.cpp
@@ -153,7 +153,7 @@ struct AltrepRelationWrapper {
 		return (MaterializedQueryResult *)res.get();
 	}
 
-	bool allow_materialization;
+	const bool allow_materialization;
 
 	rel_extptr_t rel_eptr;
 	duckdb::shared_ptr<Relation> rel;

--- a/src/reltoaltrep.cpp
+++ b/src/reltoaltrep.cpp
@@ -11,6 +11,11 @@
 #include <cmath>
 #include <cstddef>
 
+#include "duckdb/common/unique_ptr.hpp"
+#include "duckdb/main/materialized_query_result.hpp"
+#include "duckdb/main/query_result.hpp"
+#include "duckdb/main/relation/limit_relation.hpp"
+
 #ifdef TRUE
 #undef TRUE
 #endif

--- a/tests/testthat/test-relational.R
+++ b/tests/testthat/test-relational.R
@@ -825,8 +825,7 @@ test_that("rel_project does not automatically quote upper-case column names", {
   ref <- expr_reference(names(df))
   exprs <- list(ref)
   proj <- rel_project(rel, exprs)
-  # FIXME: Change to rel_to_altrep() in 1.1.3
-  ans <- rapi_rel_to_altrep(proj)
+  ans <- rel_to_altrep(proj)
   expect_equal(df, ans)
 })
 
@@ -929,8 +928,7 @@ test_that("we don't crash with evaluation errors", {
     )
   )
 
-  # FIXME: Change to rel_to_altrep() in 1.1.3
-  ans <- rapi_rel_to_altrep(rel2)
+  ans <- rel_to_altrep(rel2)
 
   # This query is supposed to throw a runtime error.
   # If this succeeds, find a new query that throws a runtime error.
@@ -961,8 +959,7 @@ test_that("we don't crash with evaluation errors", {
     )
   )
 
-  # FIXME: Change to rel_to_altrep() in 1.1.3
-  ans <- rapi_rel_to_altrep(rel2)
+  ans <- rel_to_altrep(rel2)
 
   # This query is supposed to throw a runtime error.
   # If this succeeds, find a new query that throws a runtime error.


### PR DESCRIPTION
The purpose of this is to support automatic materialization up to a specific threshold (number of rows or number of cells). Is this perhaps built into the DuckDB library?

For review, the crucial part is https://github.com/duckdb/duckdb-r/pull/1017/files#diff-126b595d21fec2ecd861c9c0dbdb1434973d14eabf3fd0e16339e41070d74410R174-R176 : We add a limit relation with the maximum number of rows that we allow, plus one. If the result is larger, we throw an error.