### PR TITLE
cran 1.1.3 2

### DIFF
--- a/.github/workflows/fledge.yaml
+++ b/.github/workflows/fledge.yaml
@@ -104,10 +104,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          set -x
-          gh pr create --base main --head fledge --fill-first
-          gh workflow run rcc -f ref=$(git rev-parse HEAD)
-          gh pr merge --squash --auto
+          set -ex
+          if [ -n "$(git diff main --numstat)" ]; then
+            gh pr create --base main --head fledge --fill-first
+            gh workflow run rcc -f ref=$(git rev-parse HEAD)
+            gh pr merge --squash --auto
+          else
+            echo "No changes."
+          fi
         shell: bash
 
       - name: Check release

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: duckdb
 Title: DBI Package for the DuckDB Database Management System
-Version: 1.1.3-1
+Version: 1.1.3.9017
 Authors@R: c(
     person("Hannes", "Mühleisen", , "hannes@cwi.nl", role = "aut",
            comment = c(ORCID = "0000-0001-8552-0029")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: duckdb
 Title: DBI Package for the DuckDB Database Management System
-Version: 1.1.3.9017
+Version: 1.1.3-2
 Authors@R: c(
     person("Hannes", "Mühleisen", , "hannes@cwi.nl", role = "aut",
            comment = c(ORCID = "0000-0001-8552-0029")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,27 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
+
+# duckdb 1.1.3-2
+
+## Bug fixes
+
+- Make `cleanup` truly idempotent (#612, #940).
+
+## Chore
+
+- Sync vendoring script with igraph (#936).
+
+## Features
+
+- New internal `rapi_rel_to_csv()`,`rapi_rel_to_table()`, and `rapi_rel_insert()`; `rapi_rel_to_parquet()` gains `options` argument (#867).
+
+## Testing
+
+- Skip tests that are about to fail.
+
+- Sync tests.
+
+
 # duckdb 1.1.3-1
 
 ## Features

--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -172,8 +172,23 @@ rapi_rel_from_table_function <- function(con, function_name, positional_paramete
   .Call(`_duckdb_rapi_rel_from_table_function`, con, function_name, positional_parameters_sexps, named_parameters_sexps)
 }
 
-# allow_materialization = TRUE: compatibility with duckplyr <= 0.4.1
-rapi_rel_to_altrep <- function(rel, allow_materialization = TRUE) {
+rapi_rel_to_parquet <- function(rel, file_name, options_sexps) {
+  invisible(.Call(`_duckdb_rapi_rel_to_parquet`, rel, file_name, options_sexps))
+}
+
+rapi_rel_to_csv <- function(rel, file_name, options_sexps) {
+  invisible(.Call(`_duckdb_rapi_rel_to_csv`, rel, file_name, options_sexps))
+}
+
+rapi_rel_to_table <- function(rel, schema_name, table_name, temporary) {
+  invisible(.Call(`_duckdb_rapi_rel_to_table`, rel, schema_name, table_name, temporary))
+}
+
+rapi_rel_insert <- function(rel, schema_name, table_name) {
+  invisible(.Call(`_duckdb_rapi_rel_insert`, rel, schema_name, table_name))
+}
+
+rapi_rel_to_altrep <- function(rel, allow_materialization) {
   .Call(`_duckdb_rapi_rel_to_altrep`, rel, allow_materialization)
 }
 
@@ -219,10 +234,6 @@ rapi_record_batch <- function(qry_res, chunk_size) {
 
 rapi_execute <- function(stmt, arrow, integer64) {
   .Call(`_duckdb_rapi_execute`, stmt, arrow, integer64)
-}
-
-rapi_rel_to_parquet <- function(rel, file_name) {
-  invisible(.Call(`_duckdb_rapi_rel_to_parquet`, rel, file_name))
 }
 
 rapi_adbc_init_func <- function() {

--- a/R/cpp12.R
+++ b/R/cpp12.R
@@ -1,0 +1,4 @@
+# allow_materialization = TRUE: compatibility with duckplyr <= 0.4.1
+rapi_rel_to_altrep <- function(rel, allow_materialization = TRUE) {
+  .Call(`_duckdb_rapi_rel_to_altrep`, rel, allow_materialization)
+}

--- a/R/relational.R
+++ b/R/relational.R
@@ -492,8 +492,12 @@ rel_from_table_function <- function(con, function_name, positional_parameters = 
   rethrow_rapi_rel_from_table_function(con@conn_ref, function_name, positional_parameters, named_parameters)
 }
 
-rel_to_parquet <- function(rel, file_name) {
-  rethrow_rapi_rel_to_parquet(rel, file_name)
+rel_to_parquet <- function(rel, file_name, options = list()) {
+  rethrow_rapi_rel_to_parquet(rel, file_name, options)
+}
+
+rel_to_csv <- function(rel, file_name, options = list()) {
+  rethrow_rapi_rel_to_csv(rel, file_name, options)
 }
 
 rel_names <- function(rel) {

--- a/R/relational.R
+++ b/R/relational.R
@@ -500,6 +500,14 @@ rel_to_csv <- function(rel, file_name, options = list()) {
   rethrow_rapi_rel_to_csv(rel, file_name, options)
 }
 
+rel_to_table <- function(rel, schema_name, table_name, temporary) {
+  rethrow_rapi_rel_to_table(rel, schema_name, table_name, temporary)
+}
+
+rel_insert <- function(rel, schema_name, table_name) {
+  rethrow_rapi_rel_insert(rel, schema_name, table_name)
+}
+
 rel_names <- function(rel) {
   rethrow_rapi_rel_names(rel)
 }

--- a/R/rethrow-gen.R
+++ b/R/rethrow-gen.R
@@ -387,9 +387,44 @@ rethrow_rapi_rel_from_table_function <- function(con, function_name, positional_
   )
 }
 
-rethrow_rapi_rel_to_altrep <- function(rel, allow_materialization = TRUE, call = parent.frame(2)) {
+rethrow_rapi_rel_to_parquet <- function(rel, file_name, options_sexps, call = parent.frame(2)) {
   rlang::try_fetch(
-    # duckplyr compat
+    rapi_rel_to_parquet(rel, file_name, options_sexps),
+    error = function(e) {
+      rethrow_error_from_rapi(e, call)
+    }
+  )
+}
+
+rethrow_rapi_rel_to_csv <- function(rel, file_name, options_sexps, call = parent.frame(2)) {
+  rlang::try_fetch(
+    rapi_rel_to_csv(rel, file_name, options_sexps),
+    error = function(e) {
+      rethrow_error_from_rapi(e, call)
+    }
+  )
+}
+
+rethrow_rapi_rel_to_table <- function(rel, schema_name, table_name, temporary, call = parent.frame(2)) {
+  rlang::try_fetch(
+    rapi_rel_to_table(rel, schema_name, table_name, temporary),
+    error = function(e) {
+      rethrow_error_from_rapi(e, call)
+    }
+  )
+}
+
+rethrow_rapi_rel_insert <- function(rel, schema_name, table_name, call = parent.frame(2)) {
+  rlang::try_fetch(
+    rapi_rel_insert(rel, schema_name, table_name),
+    error = function(e) {
+      rethrow_error_from_rapi(e, call)
+    }
+  )
+}
+
+rethrow_rapi_rel_to_altrep <- function(rel, allow_materialization, call = parent.frame(2)) {
+  rlang::try_fetch(
     rapi_rel_to_altrep(rel, allow_materialization),
     error = function(e) {
       rethrow_error_from_rapi(e, call)
@@ -496,15 +531,6 @@ rethrow_rapi_execute <- function(stmt, arrow, integer64, call = parent.frame(2))
   )
 }
 
-rethrow_rapi_rel_to_parquet <- function(rel, file_name, call = parent.frame(2)) {
-  rlang::try_fetch(
-    rapi_rel_to_parquet(rel, file_name),
-    error = function(e) {
-      rethrow_error_from_rapi(e, call)
-    }
-  )
-}
-
 rethrow_rapi_adbc_init_func <- function(call = parent.frame(2)) {
   rlang::try_fetch(
     rapi_adbc_init_func(),
@@ -576,6 +602,10 @@ rethrow_restore <- function() {
   rethrow_rapi_rel_from_sql <<- rapi_rel_from_sql
   rethrow_rapi_rel_from_table <<- rapi_rel_from_table
   rethrow_rapi_rel_from_table_function <<- rapi_rel_from_table_function
+  rethrow_rapi_rel_to_parquet <<- rapi_rel_to_parquet
+  rethrow_rapi_rel_to_csv <<- rapi_rel_to_csv
+  rethrow_rapi_rel_to_table <<- rapi_rel_to_table
+  rethrow_rapi_rel_insert <<- rapi_rel_insert
   rethrow_rapi_rel_to_altrep <<- rapi_rel_to_altrep
   rethrow_rapi_rel_from_altrep_df <<- rapi_rel_from_altrep_df
   rethrow_rapi_release <<- rapi_release
@@ -588,7 +618,6 @@ rethrow_restore <- function() {
   rethrow_rapi_execute_arrow <<- rapi_execute_arrow
   rethrow_rapi_record_batch <<- rapi_record_batch
   rethrow_rapi_execute <<- rapi_execute
-  rethrow_rapi_rel_to_parquet <<- rapi_rel_to_parquet
   rethrow_rapi_adbc_init_func <<- rapi_adbc_init_func
   rethrow_rapi_ptr_to_str <<- rapi_ptr_to_str
   rethrow_rapi_load_rfuns <<- rapi_load_rfuns

--- a/cleanup
+++ b/cleanup
@@ -3,7 +3,7 @@
 set -ex
 
 # Check if the archive already exists
-if [ -f "duckdb.tar.xz" ]; then
+if [ -f "src/duckdb.tar.xz" ]; then
   echo "duckdb.tar.xz already exists. Skipping compression."
   exit 0
 fi

--- a/duckdb.Rproj
+++ b/duckdb.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: d9f7e98d-d76d-4f44-8083-febca8f351bc
 
 RestoreWorkspace: No
 SaveWorkspace: No

--- a/src/Makevars
+++ b/src/Makevars
@@ -6,7 +6,8 @@
 #
 # The symbols.rds file helps troubleshoot issues with forbidden symbols
 # such as abort.
-all: duckdb.tar symbols.rds $(SHLIB)
+# Set UserNM=true to speed up compilation during development.
+all: symbols.rds $(SHLIB)
 
 include include/sources.mk
 

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -6,7 +6,8 @@
 #
 # The symbols.rds file helps troubleshoot issues with forbidden symbols
 # such as abort.
-all: duckdb.tar symbols.rds $(SHLIB)
+# Set UserNM=true to speed up compilation during development.
+all: symbols.rds $(SHLIB)
 
 include include/sources.mk
 

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -6,7 +6,8 @@
 #
 # The symbols.rds file helps troubleshoot issues with forbidden symbols
 # such as abort.
-all: duckdb.tar symbols.rds $(SHLIB)
+# Set UserNM=true to speed up compilation during development.
+all: symbols.rds $(SHLIB)
 
 include include/sources.mk
 

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -314,6 +314,38 @@ extern "C" SEXP _duckdb_rapi_rel_from_table_function(SEXP con, SEXP function_nam
     return cpp11::as_sexp(rapi_rel_from_table_function(cpp11::as_cpp<cpp11::decay_t<duckdb::conn_eptr_t>>(con), cpp11::as_cpp<cpp11::decay_t<const std::string>>(function_name), cpp11::as_cpp<cpp11::decay_t<list>>(positional_parameters_sexps), cpp11::as_cpp<cpp11::decay_t<list>>(named_parameters_sexps)));
   END_CPP11
 }
+// relational.cpp
+void rapi_rel_to_parquet(duckdb::rel_extptr_t rel, std::string file_name, list options_sexps);
+extern "C" SEXP _duckdb_rapi_rel_to_parquet(SEXP rel, SEXP file_name, SEXP options_sexps) {
+  BEGIN_CPP11
+    rapi_rel_to_parquet(cpp11::as_cpp<cpp11::decay_t<duckdb::rel_extptr_t>>(rel), cpp11::as_cpp<cpp11::decay_t<std::string>>(file_name), cpp11::as_cpp<cpp11::decay_t<list>>(options_sexps));
+    return R_NilValue;
+  END_CPP11
+}
+// relational.cpp
+void rapi_rel_to_csv(duckdb::rel_extptr_t rel, std::string file_name, list options_sexps);
+extern "C" SEXP _duckdb_rapi_rel_to_csv(SEXP rel, SEXP file_name, SEXP options_sexps) {
+  BEGIN_CPP11
+    rapi_rel_to_csv(cpp11::as_cpp<cpp11::decay_t<duckdb::rel_extptr_t>>(rel), cpp11::as_cpp<cpp11::decay_t<std::string>>(file_name), cpp11::as_cpp<cpp11::decay_t<list>>(options_sexps));
+    return R_NilValue;
+  END_CPP11
+}
+// relational.cpp
+void rapi_rel_to_table(duckdb::rel_extptr_t rel, std::string schema_name, std::string table_name, bool temporary);
+extern "C" SEXP _duckdb_rapi_rel_to_table(SEXP rel, SEXP schema_name, SEXP table_name, SEXP temporary) {
+  BEGIN_CPP11
+    rapi_rel_to_table(cpp11::as_cpp<cpp11::decay_t<duckdb::rel_extptr_t>>(rel), cpp11::as_cpp<cpp11::decay_t<std::string>>(schema_name), cpp11::as_cpp<cpp11::decay_t<std::string>>(table_name), cpp11::as_cpp<cpp11::decay_t<bool>>(temporary));
+    return R_NilValue;
+  END_CPP11
+}
+// relational.cpp
+void rapi_rel_insert(duckdb::rel_extptr_t rel, std::string schema_name, std::string table_name);
+extern "C" SEXP _duckdb_rapi_rel_insert(SEXP rel, SEXP schema_name, SEXP table_name) {
+  BEGIN_CPP11
+    rapi_rel_insert(cpp11::as_cpp<cpp11::decay_t<duckdb::rel_extptr_t>>(rel), cpp11::as_cpp<cpp11::decay_t<std::string>>(schema_name), cpp11::as_cpp<cpp11::decay_t<std::string>>(table_name));
+    return R_NilValue;
+  END_CPP11
+}
 // reltoaltrep.cpp
 SEXP rapi_rel_to_altrep(duckdb::rel_extptr_t rel, bool allow_materialization);
 extern "C" SEXP _duckdb_rapi_rel_to_altrep(SEXP rel, SEXP allow_materialization) {
@@ -399,14 +431,6 @@ extern "C" SEXP _duckdb_rapi_execute(SEXP stmt, SEXP arrow, SEXP integer64) {
     return cpp11::as_sexp(rapi_execute(cpp11::as_cpp<cpp11::decay_t<duckdb::stmt_eptr_t>>(stmt), cpp11::as_cpp<cpp11::decay_t<bool>>(arrow), cpp11::as_cpp<cpp11::decay_t<bool>>(integer64)));
   END_CPP11
 }
-// statement.cpp
-void rapi_rel_to_parquet(duckdb::rel_extptr_t rel, std::string file_name);
-extern "C" SEXP _duckdb_rapi_rel_to_parquet(SEXP rel, SEXP file_name) {
-  BEGIN_CPP11
-    rapi_rel_to_parquet(cpp11::as_cpp<cpp11::decay_t<duckdb::rel_extptr_t>>(rel), cpp11::as_cpp<cpp11::decay_t<std::string>>(file_name));
-    return R_NilValue;
-  END_CPP11
-}
 // utils.cpp
 SEXP rapi_adbc_init_func();
 extern "C" SEXP _duckdb_rapi_adbc_init_func() {
@@ -469,6 +493,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_duckdb_rapi_rel_from_sql",            (DL_FUNC) &_duckdb_rapi_rel_from_sql,            2},
     {"_duckdb_rapi_rel_from_table",          (DL_FUNC) &_duckdb_rapi_rel_from_table,          3},
     {"_duckdb_rapi_rel_from_table_function", (DL_FUNC) &_duckdb_rapi_rel_from_table_function, 4},
+    {"_duckdb_rapi_rel_insert",              (DL_FUNC) &_duckdb_rapi_rel_insert,              3},
     {"_duckdb_rapi_rel_join",                (DL_FUNC) &_duckdb_rapi_rel_join,                5},
     {"_duckdb_rapi_rel_limit",               (DL_FUNC) &_duckdb_rapi_rel_limit,               2},
     {"_duckdb_rapi_rel_names",               (DL_FUNC) &_duckdb_rapi_rel_names,               1},
@@ -480,9 +505,11 @@ static const R_CallMethodDef CallEntries[] = {
     {"_duckdb_rapi_rel_set_symdiff",         (DL_FUNC) &_duckdb_rapi_rel_set_symdiff,         2},
     {"_duckdb_rapi_rel_sql",                 (DL_FUNC) &_duckdb_rapi_rel_sql,                 2},
     {"_duckdb_rapi_rel_to_altrep",           (DL_FUNC) &_duckdb_rapi_rel_to_altrep,           2},
+    {"_duckdb_rapi_rel_to_csv",              (DL_FUNC) &_duckdb_rapi_rel_to_csv,              3},
     {"_duckdb_rapi_rel_to_df",               (DL_FUNC) &_duckdb_rapi_rel_to_df,               1},
-    {"_duckdb_rapi_rel_to_parquet",          (DL_FUNC) &_duckdb_rapi_rel_to_parquet,          2},
+    {"_duckdb_rapi_rel_to_parquet",          (DL_FUNC) &_duckdb_rapi_rel_to_parquet,          3},
     {"_duckdb_rapi_rel_to_sql",              (DL_FUNC) &_duckdb_rapi_rel_to_sql,              1},
+    {"_duckdb_rapi_rel_to_table",            (DL_FUNC) &_duckdb_rapi_rel_to_table,            4},
     {"_duckdb_rapi_rel_tostring",            (DL_FUNC) &_duckdb_rapi_rel_tostring,            2},
     {"_duckdb_rapi_rel_union_all",           (DL_FUNC) &_duckdb_rapi_rel_union_all,           2},
     {"_duckdb_rapi_release",                 (DL_FUNC) &_duckdb_rapi_release,                 1},

--- a/src/include/from-tar.mk
+++ b/src/include/from-tar.mk
@@ -2,6 +2,7 @@
 # to an existing file.
 # We print details on the object files already extracted in the configure script
 # for diagnostic purposes.
+all: duckdb.tar
 duckdb.tar: $(DUCKDB_R_PREBUILT_ARCHIVE)
 	ls -lR
 	# Ensure the file is recreated in the next run

--- a/src/include/to-tar-win.mk
+++ b/src/include/to-tar-win.mk
@@ -1,6 +1,7 @@
 # This file is used from Makevars if $DUCKDB_R_PREBUILT_ARCHIVE is empty
 # or does not point to an existing file.
 # In the latter case, we create the file after the object files have been built.
+all: duckdb.tar
 duckdb.tar: $(SOURCES)
 	if [ -n "$(DUCKDB_R_PREBUILT_ARCHIVE)" ]; then tar -cv --force-local -f "$(DUCKDB_R_PREBUILT_ARCHIVE)" $(SOURCES); fi
 	rm -f Makevars.duckdb

--- a/src/include/to-tar.mk
+++ b/src/include/to-tar.mk
@@ -1,6 +1,7 @@
 # This file is used from Makevars if $DUCKDB_R_PREBUILT_ARCHIVE is empty
 # or does not point to an existing file.
 # In the latter case, we create the file after the object files have been built.
+all: duckdb.tar
 duckdb.tar: $(SOURCES)
 	if [ -n "$(DUCKDB_R_PREBUILT_ARCHIVE)" ]; then tar -cv -f "$(DUCKDB_R_PREBUILT_ARCHIVE)" $(SOURCES); fi
 	rm -f Makevars.duckdb

--- a/src/include/typesr.hpp
+++ b/src/include/typesr.hpp
@@ -206,3 +206,5 @@ struct RRawSexpType : public RSexpType {
 };
 
 } // namespace duckdb
+
+duckdb::case_insensitive_map_t<duckdb::vector<duckdb::Value>> ListToVectorOfValue(cpp11::list input_sexps);

--- a/src/relational.cpp
+++ b/src/relational.cpp
@@ -566,9 +566,9 @@ static SEXP result_to_df(duckdb::unique_ptr<QueryResult> res) {
 }
 
 [[cpp11::register]] void rapi_rel_to_table(duckdb::rel_extptr_t rel, std::string schema_name, std::string table_name, bool temporary) {
-	rel->rel->Create(table_name, schema_name, temporary);
+	rel->rel->Create(schema_name, table_name, temporary);
 }
 
 [[cpp11::register]] void rapi_rel_insert(duckdb::rel_extptr_t rel, std::string schema_name, std::string table_name) {
-	rel->rel->Insert(table_name, schema_name);
+	rel->rel->Insert(schema_name, table_name);
 }

--- a/src/relational.cpp
+++ b/src/relational.cpp
@@ -556,3 +556,19 @@ static SEXP result_to_df(duckdb::unique_ptr<QueryResult> res) {
 	auto rel = con->conn->TableFunction(function_name, std::move(positional_parameters), std::move(named_parameters));
 	return make_external<RelationWrapper>("duckdb_relation", std::move(rel));
 }
+
+[[cpp11::register]] void rapi_rel_to_parquet(duckdb::rel_extptr_t rel, std::string file_name, list options_sexps) {
+	rel->rel->WriteParquet(file_name, ListToVectorOfValue(options_sexps));
+}
+
+[[cpp11::register]] void rapi_rel_to_csv(duckdb::rel_extptr_t rel, std::string file_name, list options_sexps) {
+	rel->rel->WriteCSV(file_name, ListToVectorOfValue(options_sexps));
+}
+
+[[cpp11::register]] void rapi_rel_to_table(duckdb::rel_extptr_t rel, std::string schema_name, std::string table_name, bool temporary) {
+	rel->rel->Create(table_name, schema_name, temporary);
+}
+
+[[cpp11::register]] void rapi_rel_insert(duckdb::rel_extptr_t rel, std::string schema_name, std::string table_name) {
+	rel->rel->Insert(table_name, schema_name);
+}

--- a/src/statement.cpp
+++ b/src/statement.cpp
@@ -384,7 +384,3 @@ bool FetchArrowChunk(ChunkScanState &scan_state, ClientProperties options, Appen
 		return out;
 	}
 }
-
-[[cpp11::register]] void rapi_rel_to_parquet(duckdb::rel_extptr_t rel, std::string file_name) {
-	rel->rel->WriteParquet(file_name);
-}

--- a/tests/testthat/test-DBItest.R
+++ b/tests/testthat/test-DBItest.R
@@ -203,6 +203,11 @@ if (rlang::is_installed("DBItest")) DBItest::test_all(c(
   "arrow_write_table_arrow_roundtrip_timestamp_extended", # precision
   "arrow_append_table_arrow_roundtrip_timestamp_extended", # precision
 
+  # https://github.com/duckdb/duckdb/pull/15125
+  "data_date_current_typed",
+  "data_time_current",
+  "data_date_current",
+
   if (!rlang::is_installed("vctrs")) {
     c(
       "arrow_append_table_arrow_roundtrip_blob",

--- a/tests/testthat/test-rel_api.R
+++ b/tests/testthat/test-rel_api.R
@@ -10,13 +10,13 @@ test_that("relational anti_join(join_by(a)) order-preserving", {
   invisible(
     dbExecute(con, 'CREATE MACRO "___eq_na_matches_na"(x, y) AS (x IS NOT DISTINCT FROM y)')
   )
-  df1 <- data.frame(a = 1:4, b = rep(2, 4L))
+  df1 <- data.frame(a = 1:4, b = 2)
 
   "anti_join"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
   "anti_join"
   rel2 <- rel_set_alias(rel1, "lhs")
-  df2 <- data.frame(a = 2:5, b = rep(2, 4L))
+  df2 <- data.frame(a = 2:5, b = 2)
 
   "anti_join"
   rel3 <- rel_from_df(con, df2, experimental = experimental)
@@ -89,13 +89,13 @@ test_that("relational anti_join(join_by(a)) order-enforcing", {
   invisible(
     dbExecute(con, 'CREATE MACRO "___eq_na_matches_na"(x, y) AS (x IS NOT DISTINCT FROM y)')
   )
-  df1 <- data.frame(a = 1:4, b = rep(2, 4L))
+  df1 <- data.frame(a = 1:4, b = 2)
 
   "anti_join"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
   "anti_join"
   rel2 <- rel_set_alias(rel1, "lhs")
-  df2 <- data.frame(a = 2:5, b = rep(2, 4L))
+  df2 <- data.frame(a = 2:5, b = 2)
 
   "anti_join"
   rel3 <- rel_from_df(con, df2, experimental = experimental)
@@ -128,7 +128,7 @@ test_that("relational arrange() order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "arrange"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -136,7 +136,7 @@ test_that("relational arrange() order-preserving", {
   out <- rel_to_altrep(rel1)
   expect_identical(
     out,
-    data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+    data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -146,7 +146,7 @@ test_that("relational arrange(a) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "arrange"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -203,7 +203,7 @@ test_that("relational arrange(a) order-preserving", {
   out <- rel_to_altrep(rel4)
   expect_identical(
     out,
-    data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+    data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -213,7 +213,7 @@ test_that("relational arrange(g) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "arrange"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -270,7 +270,7 @@ test_that("relational arrange(g) order-preserving", {
   out <- rel_to_altrep(rel4)
   expect_identical(
     out,
-    data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+    data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -280,7 +280,7 @@ test_that("relational arrange(g, a) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "arrange"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -340,7 +340,7 @@ test_that("relational arrange(g, a) order-preserving", {
   out <- rel_to_altrep(rel4)
   expect_identical(
     out,
-    data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+    data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -350,7 +350,7 @@ test_that("relational arrange(a, g) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "arrange"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -410,7 +410,7 @@ test_that("relational arrange(a, g) order-preserving", {
   out <- rel_to_altrep(rel4)
   expect_identical(
     out,
-    data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+    data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -422,7 +422,7 @@ test_that("relational arrange() order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "arrange"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -437,7 +437,7 @@ test_that("relational arrange() order-enforcing", {
   out <- rel_to_altrep(rel3)
   expect_identical(
     out,
-    data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+    data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -447,7 +447,7 @@ test_that("relational arrange(a) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "arrange"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -462,7 +462,7 @@ test_that("relational arrange(a) order-enforcing", {
   out <- rel_to_altrep(rel3)
   expect_identical(
     out,
-    data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+    data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -472,7 +472,7 @@ test_that("relational arrange(g) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "arrange"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -487,7 +487,7 @@ test_that("relational arrange(g) order-enforcing", {
   out <- rel_to_altrep(rel3)
   expect_identical(
     out,
-    data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+    data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -497,7 +497,7 @@ test_that("relational arrange(g, a) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "arrange"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -512,7 +512,7 @@ test_that("relational arrange(g, a) order-enforcing", {
   out <- rel_to_altrep(rel3)
   expect_identical(
     out,
-    data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+    data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -522,7 +522,7 @@ test_that("relational arrange(a, g) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "arrange"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -537,7 +537,7 @@ test_that("relational arrange(a, g) order-enforcing", {
   out <- rel_to_altrep(rel3)
   expect_identical(
     out,
-    data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+    data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -550,7 +550,7 @@ test_that("relational count() order-preserving", {
   con <- dbConnect(drv)
   experimental <- FALSE
   invisible(dbExecute(con, 'CREATE MACRO "n"() AS CAST(COUNT(*) AS int32)'))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "count"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -581,7 +581,7 @@ test_that("relational count(a) order-preserving", {
   con <- dbConnect(drv)
   experimental <- FALSE
   invisible(dbExecute(con, 'CREATE MACRO "n"() AS CAST(COUNT(*) AS int32)'))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "count"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -618,7 +618,7 @@ test_that("relational count(a) order-preserving", {
   out <- rel_to_altrep(rel3)
   expect_identical(
     out,
-    data.frame(a = seq(1, 6, by = 1), n = rep(1L, 6L))
+    data.frame(a = seq(1, 6, by = 1), n = 1L)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -629,7 +629,7 @@ test_that("relational count(b) order-preserving", {
   con <- dbConnect(drv)
   experimental <- FALSE
   invisible(dbExecute(con, 'CREATE MACRO "n"() AS CAST(COUNT(*) AS int32)'))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "count"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -677,7 +677,7 @@ test_that("relational count(g) order-preserving", {
   con <- dbConnect(drv)
   experimental <- FALSE
   invisible(dbExecute(con, 'CREATE MACRO "n"() AS CAST(COUNT(*) AS int32)'))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "count"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -725,7 +725,7 @@ test_that("relational count(g, a) order-preserving", {
   con <- dbConnect(drv)
   experimental <- FALSE
   invisible(dbExecute(con, 'CREATE MACRO "n"() AS CAST(COUNT(*) AS int32)'))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "count"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -772,7 +772,7 @@ test_that("relational count(g, a) order-preserving", {
   out <- rel_to_altrep(rel3)
   expect_identical(
     out,
-    data.frame(g = c(1L, 2L, 2L, 3L, 3L, 3L), a = seq(1, 6, by = 1), n = rep(1L, 6L))
+    data.frame(g = c(1L, 2L, 2L, 3L, 3L, 3L), a = seq(1, 6, by = 1), n = 1L)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -783,7 +783,7 @@ test_that("relational count(b, g) order-preserving", {
   con <- dbConnect(drv)
   experimental <- FALSE
   invisible(dbExecute(con, 'CREATE MACRO "n"() AS CAST(COUNT(*) AS int32)'))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "count"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -830,7 +830,7 @@ test_that("relational count(b, g) order-preserving", {
   out <- rel_to_altrep(rel3)
   expect_identical(
     out,
-    data.frame(b = rep(2, 3L), g = 1:3, n = 1:3)
+    data.frame(b = 2, g = 1:3, n = 1:3)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -843,7 +843,7 @@ test_that("relational count() order-enforcing", {
   con <- dbConnect(drv)
   experimental <- FALSE
   invisible(dbExecute(con, 'CREATE MACRO "n"() AS CAST(COUNT(*) AS int32)'))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "count"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -876,7 +876,7 @@ test_that("relational count(a) order-enforcing", {
   con <- dbConnect(drv)
   experimental <- FALSE
   invisible(dbExecute(con, 'CREATE MACRO "n"() AS CAST(COUNT(*) AS int32)'))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "count"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -915,7 +915,7 @@ test_that("relational count(a) order-enforcing", {
   out <- rel_to_altrep(rel4)
   expect_identical(
     out,
-    data.frame(a = seq(1, 6, by = 1), n = rep(1L, 6L))
+    data.frame(a = seq(1, 6, by = 1), n = 1L)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -926,7 +926,7 @@ test_that("relational count(b) order-enforcing", {
   con <- dbConnect(drv)
   experimental <- FALSE
   invisible(dbExecute(con, 'CREATE MACRO "n"() AS CAST(COUNT(*) AS int32)'))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "count"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -976,7 +976,7 @@ test_that("relational count(g) order-enforcing", {
   con <- dbConnect(drv)
   experimental <- FALSE
   invisible(dbExecute(con, 'CREATE MACRO "n"() AS CAST(COUNT(*) AS int32)'))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "count"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -1026,7 +1026,7 @@ test_that("relational count(g, a) order-enforcing", {
   con <- dbConnect(drv)
   experimental <- FALSE
   invisible(dbExecute(con, 'CREATE MACRO "n"() AS CAST(COUNT(*) AS int32)'))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "count"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -1078,7 +1078,7 @@ test_that("relational count(g, a) order-enforcing", {
   out <- rel_to_altrep(rel4)
   expect_identical(
     out,
-    data.frame(g = c(1L, 2L, 2L, 3L, 3L, 3L), a = seq(1, 6, by = 1), n = rep(1L, 6L))
+    data.frame(g = c(1L, 2L, 2L, 3L, 3L, 3L), a = seq(1, 6, by = 1), n = 1L)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -1089,7 +1089,7 @@ test_that("relational count(b, g) order-enforcing", {
   con <- dbConnect(drv)
   experimental <- FALSE
   invisible(dbExecute(con, 'CREATE MACRO "n"() AS CAST(COUNT(*) AS int32)'))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "count"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -1141,7 +1141,7 @@ test_that("relational count(b, g) order-enforcing", {
   out <- rel_to_altrep(rel4)
   expect_identical(
     out,
-    data.frame(b = rep(2, 3L), g = 1:3, n = 1:3)
+    data.frame(b = 2, g = 1:3, n = 1:3)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -1153,8 +1153,7 @@ test_that("relational distinct() order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  invisible(rapi_load_rfuns(drv@database_ref))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "distinct"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -1237,8 +1236,8 @@ test_that("relational distinct() order-preserving", {
   rel4 <- rel_filter(
     rel3,
     list(
-      expr_function(
-        "r_base::==",
+      expr_comparison(
+        "==",
         list(
           expr_reference("___row_number_by"),
           if ("experimental" %in% names(formals(expr_constant))) {
@@ -1277,7 +1276,7 @@ test_that("relational distinct() order-preserving", {
   out <- rel_to_altrep(rel6)
   expect_identical(
     out,
-    data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+    data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -1287,8 +1286,7 @@ test_that("relational distinct(a) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  invisible(rapi_load_rfuns(drv@database_ref))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "distinct"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -1351,8 +1349,8 @@ test_that("relational distinct(a) order-preserving", {
   rel4 <- rel_filter(
     rel3,
     list(
-      expr_function(
-        "r_base::==",
+      expr_comparison(
+        "==",
         list(
           expr_reference("___row_number_by"),
           if ("experimental" %in% names(formals(expr_constant))) {
@@ -1391,8 +1389,7 @@ test_that("relational distinct(a, b) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  invisible(rapi_load_rfuns(drv@database_ref))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "distinct"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -1465,8 +1462,8 @@ test_that("relational distinct(a, b) order-preserving", {
   rel4 <- rel_filter(
     rel3,
     list(
-      expr_function(
-        "r_base::==",
+      expr_comparison(
+        "==",
         list(
           expr_reference("___row_number_by"),
           if ("experimental" %in% names(formals(expr_constant))) {
@@ -1500,7 +1497,7 @@ test_that("relational distinct(a, b) order-preserving", {
   out <- rel_to_altrep(rel6)
   expect_identical(
     out,
-    data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L))
+    data.frame(a = seq(1, 6, by = 1), b = 2)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -1510,8 +1507,7 @@ test_that("relational distinct(b, b) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  invisible(rapi_load_rfuns(drv@database_ref))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "distinct"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -1574,8 +1570,8 @@ test_that("relational distinct(b, b) order-preserving", {
   rel4 <- rel_filter(
     rel3,
     list(
-      expr_function(
-        "r_base::==",
+      expr_comparison(
+        "==",
         list(
           expr_reference("___row_number_by"),
           if ("experimental" %in% names(formals(expr_constant))) {
@@ -1614,8 +1610,7 @@ test_that("relational distinct(g) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  invisible(rapi_load_rfuns(drv@database_ref))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "distinct"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -1678,8 +1673,8 @@ test_that("relational distinct(g) order-preserving", {
   rel4 <- rel_filter(
     rel3,
     list(
-      expr_function(
-        "r_base::==",
+      expr_comparison(
+        "==",
         list(
           expr_reference("___row_number_by"),
           if ("experimental" %in% names(formals(expr_constant))) {
@@ -1718,8 +1713,7 @@ test_that("relational union_all(data.frame(a = 1L, b = 3, g = 2L)) %>% distinct(
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  invisible(rapi_load_rfuns(drv@database_ref))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "union_all"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -1884,8 +1878,8 @@ test_that("relational union_all(data.frame(a = 1L, b = 3, g = 2L)) %>% distinct(
   rel10 <- rel_filter(
     rel9,
     list(
-      expr_function(
-        "r_base::==",
+      expr_comparison(
+        "==",
         list(
           expr_reference("___row_number_by"),
           if ("experimental" %in% names(formals(expr_constant))) {
@@ -1924,8 +1918,7 @@ test_that("relational union_all(data.frame(a = 1L, b = 4, g = 2L)) %>% distinct(
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  invisible(rapi_load_rfuns(drv@database_ref))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "union_all"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -2090,8 +2083,8 @@ test_that("relational union_all(data.frame(a = 1L, b = 4, g = 2L)) %>% distinct(
   rel10 <- rel_filter(
     rel9,
     list(
-      expr_function(
-        "r_base::==",
+      expr_comparison(
+        "==",
         list(
           expr_reference("___row_number_by"),
           if ("experimental" %in% names(formals(expr_constant))) {
@@ -2130,8 +2123,7 @@ test_that("relational union_all(data.frame(a = 1L, b = 5, g = 2L)) %>% distinct(
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  invisible(rapi_load_rfuns(drv@database_ref))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "union_all"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -2296,8 +2288,8 @@ test_that("relational union_all(data.frame(a = 1L, b = 5, g = 2L)) %>% distinct(
   rel10 <- rel_filter(
     rel9,
     list(
-      expr_function(
-        "r_base::==",
+      expr_comparison(
+        "==",
         list(
           expr_reference("___row_number_by"),
           if ("experimental" %in% names(formals(expr_constant))) {
@@ -2336,8 +2328,7 @@ test_that("relational union_all(data.frame(a = 1L, b = 6, g = 2L)) %>% distinct(
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  invisible(rapi_load_rfuns(drv@database_ref))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "union_all"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -2502,8 +2493,8 @@ test_that("relational union_all(data.frame(a = 1L, b = 6, g = 2L)) %>% distinct(
   rel10 <- rel_filter(
     rel9,
     list(
-      expr_function(
-        "r_base::==",
+      expr_comparison(
+        "==",
         list(
           expr_reference("___row_number_by"),
           if ("experimental" %in% names(formals(expr_constant))) {
@@ -2542,8 +2533,7 @@ test_that("relational union_all(data.frame(a = 1L, b = 7, g = 2L)) %>% distinct(
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  invisible(rapi_load_rfuns(drv@database_ref))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "union_all"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -2708,8 +2698,8 @@ test_that("relational union_all(data.frame(a = 1L, b = 7, g = 2L)) %>% distinct(
   rel10 <- rel_filter(
     rel9,
     list(
-      expr_function(
-        "r_base::==",
+      expr_comparison(
+        "==",
         list(
           expr_reference("___row_number_by"),
           if ("experimental" %in% names(formals(expr_constant))) {
@@ -2748,8 +2738,7 @@ test_that("relational distinct(g, .keep_all = TRUE) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  invisible(rapi_load_rfuns(drv@database_ref))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "distinct"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -2822,8 +2811,8 @@ test_that("relational distinct(g, .keep_all = TRUE) order-preserving", {
   rel4 <- rel_filter(
     rel3,
     list(
-      expr_function(
-        "r_base::==",
+      expr_comparison(
+        "==",
         list(
           expr_reference("___row_number_by"),
           if ("experimental" %in% names(formals(expr_constant))) {
@@ -2862,7 +2851,7 @@ test_that("relational distinct(g, .keep_all = TRUE) order-preserving", {
   out <- rel_to_altrep(rel6)
   expect_identical(
     out,
-    data.frame(a = c(1, 2, 4), b = rep(2, 3L), g = 1:3)
+    data.frame(a = c(1, 2, 4), b = 2, g = 1:3)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -2874,7 +2863,7 @@ test_that("relational distinct() order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "distinct"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -2889,7 +2878,7 @@ test_that("relational distinct() order-enforcing", {
   out <- rel_to_altrep(rel3)
   expect_identical(
     out,
-    data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+    data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -2899,7 +2888,7 @@ test_that("relational distinct(a) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "distinct"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -2932,7 +2921,7 @@ test_that("relational distinct(a, b) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "distinct"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -2960,7 +2949,7 @@ test_that("relational distinct(a, b) order-enforcing", {
   out <- rel_to_altrep(rel4)
   expect_identical(
     out,
-    data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L))
+    data.frame(a = seq(1, 6, by = 1), b = 2)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -2970,7 +2959,7 @@ test_that("relational distinct(b, b) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "distinct"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -3003,7 +2992,7 @@ test_that("relational distinct(g) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "distinct"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -3036,7 +3025,7 @@ test_that("relational union_all(data.frame(a = 1L, b = 3, g = 2L)) %>% distinct(
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "union_all"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -3075,7 +3064,7 @@ test_that("relational union_all(data.frame(a = 1L, b = 4, g = 2L)) %>% distinct(
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "union_all"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -3114,7 +3103,7 @@ test_that("relational union_all(data.frame(a = 1L, b = 5, g = 2L)) %>% distinct(
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "union_all"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -3153,7 +3142,7 @@ test_that("relational union_all(data.frame(a = 1L, b = 6, g = 2L)) %>% distinct(
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "union_all"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -3192,7 +3181,7 @@ test_that("relational union_all(data.frame(a = 1L, b = 7, g = 2L)) %>% distinct(
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "union_all"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -3231,8 +3220,7 @@ test_that("relational distinct(g, .keep_all = TRUE) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  invisible(rapi_load_rfuns(drv@database_ref))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "distinct"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -3305,8 +3293,8 @@ test_that("relational distinct(g, .keep_all = TRUE) order-enforcing", {
   rel4 <- rel_filter(
     rel3,
     list(
-      expr_function(
-        "r_base::==",
+      expr_comparison(
+        "==",
         list(
           expr_reference("___row_number_by"),
           if ("experimental" %in% names(formals(expr_constant))) {
@@ -3350,7 +3338,7 @@ test_that("relational distinct(g, .keep_all = TRUE) order-enforcing", {
   out <- rel_to_altrep(rel7)
   expect_identical(
     out,
-    data.frame(a = c(1, 2, 4), b = rep(2, 3L), g = 1:3)
+    data.frame(a = c(1, 2, 4), b = 2, g = 1:3)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -3362,8 +3350,7 @@ test_that("relational filter(a == 1) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  invisible(rapi_load_rfuns(drv@database_ref))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "filter"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -3397,8 +3384,8 @@ test_that("relational filter(a == 1) order-preserving", {
   rel3 <- rel_filter(
     rel2,
     list(
-      expr_function(
-        "r_base::==",
+      expr_comparison(
+        "==",
         list(
           expr_reference("a"),
           if ("experimental" %in% names(formals(expr_constant))) {
@@ -3450,7 +3437,7 @@ test_that("relational filter(a %in% 2:3, g == 2) order-preserving", {
   invisible(rapi_load_rfuns(drv@database_ref))
   invisible(dbExecute(con, 'CREATE MACRO "___coalesce"(x, y) AS COALESCE(x, y)'))
   invisible(dbExecute(con, 'CREATE MACRO "|"(x, y) AS (x OR y)'))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "filter"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -3521,8 +3508,8 @@ test_that("relational filter(a %in% 2:3, g == 2) order-preserving", {
           }
         )
       ),
-      expr_function(
-        "r_base::==",
+      expr_comparison(
+        "==",
         list(
           expr_reference("g"),
           if ("experimental" %in% names(formals(expr_constant))) {
@@ -3561,7 +3548,7 @@ test_that("relational filter(a %in% 2:3, g == 2) order-preserving", {
   out <- rel_to_altrep(rel5)
   expect_identical(
     out,
-    data.frame(a = c(2, 3), b = c(2, 2), g = c(2L, 2L))
+    data.frame(a = c(2, 3), b = 2, g = 2L)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -3575,7 +3562,7 @@ test_that("relational filter(a %in% 2:3 & g == 2) order-preserving", {
   invisible(dbExecute(con, 'CREATE MACRO "&"(x, y) AS (x AND y)'))
   invisible(dbExecute(con, 'CREATE MACRO "___coalesce"(x, y) AS COALESCE(x, y)'))
   invisible(dbExecute(con, 'CREATE MACRO "|"(x, y) AS (x OR y)'))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "filter"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -3649,8 +3636,8 @@ test_that("relational filter(a %in% 2:3 & g == 2) order-preserving", {
               }
             )
           ),
-          expr_function(
-            "r_base::==",
+          expr_comparison(
+            "==",
             list(
               expr_reference("g"),
               if ("experimental" %in% names(formals(expr_constant))) {
@@ -3691,7 +3678,7 @@ test_that("relational filter(a %in% 2:3 & g == 2) order-preserving", {
   out <- rel_to_altrep(rel5)
   expect_identical(
     out,
-    data.frame(a = c(2, 3), b = c(2, 2), g = c(2L, 2L))
+    data.frame(a = c(2, 3), b = 2, g = 2L)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -3703,7 +3690,7 @@ test_that("relational filter(a != 2 | g != 2) order-preserving", {
   experimental <- FALSE
   invisible(rapi_load_rfuns(drv@database_ref))
   invisible(dbExecute(con, 'CREATE MACRO "|"(x, y) AS (x OR y)'))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "filter"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -3793,7 +3780,7 @@ test_that("relational filter(a != 2 | g != 2) order-preserving", {
   out <- rel_to_altrep(rel5)
   expect_identical(
     out,
-    data.frame(a = c(1, 3, 4, 5, 6), b = rep(2, 5L), g = c(1L, 2L, 3L, 3L, 3L))
+    data.frame(a = c(1, 3, 4, 5, 6), b = 2, g = c(1L, 2L, 3L, 3L, 3L))
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -3805,8 +3792,7 @@ test_that("relational filter(a == 1) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  invisible(rapi_load_rfuns(drv@database_ref))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "filter"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -3814,8 +3800,8 @@ test_that("relational filter(a == 1) order-enforcing", {
   rel2 <- rel_filter(
     rel1,
     list(
-      expr_function(
-        "r_base::==",
+      expr_comparison(
+        "==",
         list(
           expr_reference("a"),
           if ("experimental" %in% names(formals(expr_constant))) {
@@ -3849,7 +3835,7 @@ test_that("relational filter(a %in% 2:3, g == 2) order-enforcing", {
   invisible(rapi_load_rfuns(drv@database_ref))
   invisible(dbExecute(con, 'CREATE MACRO "___coalesce"(x, y) AS COALESCE(x, y)'))
   invisible(dbExecute(con, 'CREATE MACRO "|"(x, y) AS (x OR y)'))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "filter"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -3894,8 +3880,8 @@ test_that("relational filter(a %in% 2:3, g == 2) order-enforcing", {
           }
         )
       ),
-      expr_function(
-        "r_base::==",
+      expr_comparison(
+        "==",
         list(
           expr_reference("g"),
           if ("experimental" %in% names(formals(expr_constant))) {
@@ -3916,7 +3902,7 @@ test_that("relational filter(a %in% 2:3, g == 2) order-enforcing", {
   out <- rel_to_altrep(rel3)
   expect_identical(
     out,
-    data.frame(a = c(2, 3), b = c(2, 2), g = c(2L, 2L))
+    data.frame(a = c(2, 3), b = 2, g = 2L)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -3930,7 +3916,7 @@ test_that("relational filter(a %in% 2:3 & g == 2) order-enforcing", {
   invisible(dbExecute(con, 'CREATE MACRO "&"(x, y) AS (x AND y)'))
   invisible(dbExecute(con, 'CREATE MACRO "___coalesce"(x, y) AS COALESCE(x, y)'))
   invisible(dbExecute(con, 'CREATE MACRO "|"(x, y) AS (x OR y)'))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "filter"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -3978,8 +3964,8 @@ test_that("relational filter(a %in% 2:3 & g == 2) order-enforcing", {
               }
             )
           ),
-          expr_function(
-            "r_base::==",
+          expr_comparison(
+            "==",
             list(
               expr_reference("g"),
               if ("experimental" %in% names(formals(expr_constant))) {
@@ -4002,7 +3988,7 @@ test_that("relational filter(a %in% 2:3 & g == 2) order-enforcing", {
   out <- rel_to_altrep(rel3)
   expect_identical(
     out,
-    data.frame(a = c(2, 3), b = c(2, 2), g = c(2L, 2L))
+    data.frame(a = c(2, 3), b = 2, g = 2L)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -4014,7 +4000,7 @@ test_that("relational filter(a != 2 | g != 2) order-enforcing", {
   experimental <- FALSE
   invisible(rapi_load_rfuns(drv@database_ref))
   invisible(dbExecute(con, 'CREATE MACRO "|"(x, y) AS (x OR y)'))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "filter"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -4060,7 +4046,7 @@ test_that("relational filter(a != 2 | g != 2) order-enforcing", {
   out <- rel_to_altrep(rel3)
   expect_identical(
     out,
-    data.frame(a = c(1, 3, 4, 5, 6), b = rep(2, 5L), g = c(1L, 2L, 3L, 3L, 3L))
+    data.frame(a = c(1, 3, 4, 5, 6), b = 2, g = c(1L, 2L, 3L, 3L, 3L))
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -4076,13 +4062,13 @@ test_that("relational full_join(join_by(a)) order-preserving", {
     dbExecute(con, 'CREATE MACRO "___eq_na_matches_na"(x, y) AS (x IS NOT DISTINCT FROM y)')
   )
   invisible(dbExecute(con, 'CREATE MACRO "___coalesce"(x, y) AS COALESCE(x, y)'))
-  df1 <- data.frame(a = 1:4, b = rep(2, 4L))
+  df1 <- data.frame(a = 1:4, b = 2)
 
   "full_join"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
   "full_join"
   rel2 <- rel_set_alias(rel1, "lhs")
-  df2 <- data.frame(a = 2:5, b = rep(2, 4L))
+  df2 <- data.frame(a = 2:5, b = 2)
 
   "full_join"
   rel3 <- rel_from_df(con, df2, experimental = experimental)
@@ -4217,13 +4203,13 @@ test_that("relational full_join(join_by(a)) order-enforcing", {
     dbExecute(con, 'CREATE MACRO "___eq_na_matches_na"(x, y) AS (x IS NOT DISTINCT FROM y)')
   )
   invisible(dbExecute(con, 'CREATE MACRO "___coalesce"(x, y) AS COALESCE(x, y)'))
-  df1 <- data.frame(a = 1:4, b = rep(2, 4L))
+  df1 <- data.frame(a = 1:4, b = 2)
 
   "full_join"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
   "full_join"
   rel2 <- rel_set_alias(rel1, "lhs")
-  df2 <- data.frame(a = 2:5, b = rep(2, 4L))
+  df2 <- data.frame(a = 2:5, b = 2)
 
   "full_join"
   rel3 <- rel_from_df(con, df2, experimental = experimental)
@@ -4316,13 +4302,13 @@ test_that("relational inner_join(join_by(a)) order-preserving", {
     dbExecute(con, 'CREATE MACRO "___eq_na_matches_na"(x, y) AS (x IS NOT DISTINCT FROM y)')
   )
   invisible(dbExecute(con, 'CREATE MACRO "___coalesce"(x, y) AS COALESCE(x, y)'))
-  df1 <- data.frame(a = 1:4, b = rep(2, 4L))
+  df1 <- data.frame(a = 1:4, b = 2)
 
   "inner_join"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
   "inner_join"
   rel2 <- rel_set_alias(rel1, "lhs")
-  df2 <- data.frame(a = 2:5, b = rep(2, 4L))
+  df2 <- data.frame(a = 2:5, b = 2)
 
   "inner_join"
   rel3 <- rel_from_df(con, df2, experimental = experimental)
@@ -4441,7 +4427,7 @@ test_that("relational inner_join(join_by(a)) order-preserving", {
   out <- rel_to_altrep(rel11)
   expect_identical(
     out,
-    data.frame(a = 2:4, b.x = rep(2, 3L), b.y = rep(2, 3L))
+    data.frame(a = 2:4, b.x = 2, b.y = 2)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -4457,13 +4443,13 @@ test_that("relational inner_join(join_by(a)) order-enforcing", {
     dbExecute(con, 'CREATE MACRO "___eq_na_matches_na"(x, y) AS (x IS NOT DISTINCT FROM y)')
   )
   invisible(dbExecute(con, 'CREATE MACRO "___coalesce"(x, y) AS COALESCE(x, y)'))
-  df1 <- data.frame(a = 1:4, b = rep(2, 4L))
+  df1 <- data.frame(a = 1:4, b = 2)
 
   "inner_join"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
   "inner_join"
   rel2 <- rel_set_alias(rel1, "lhs")
-  df2 <- data.frame(a = 2:5, b = rep(2, 4L))
+  df2 <- data.frame(a = 2:5, b = 2)
 
   "inner_join"
   rel3 <- rel_from_df(con, df2, experimental = experimental)
@@ -4540,7 +4526,7 @@ test_that("relational inner_join(join_by(a)) order-enforcing", {
   out <- rel_to_altrep(rel9)
   expect_identical(
     out,
-    data.frame(a = 2:4, b.x = rep(2, 3L), b.y = rep(2, 3L))
+    data.frame(a = 2:4, b.x = 2, b.y = 2)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -4555,14 +4541,13 @@ test_that("relational intersect() order-preserving", {
   invisible(
     dbExecute(con, 'CREATE MACRO "___eq_na_matches_na"(x, y) AS (x IS NOT DISTINCT FROM y)')
   )
-  invisible(rapi_load_rfuns(drv@database_ref))
-  df1 <- data.frame(a = 1:4, b = rep(2, 4L))
+  df1 <- data.frame(a = 1:4, b = 2)
 
   "semi_join"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
   "semi_join"
   rel2 <- rel_set_alias(rel1, "lhs")
-  df2 <- data.frame(a = 2:5, b = rep(2, 4L))
+  df2 <- data.frame(a = 2:5, b = 2)
 
   "semi_join"
   rel3 <- rel_from_df(con, df2, experimental = experimental)
@@ -4681,8 +4666,8 @@ test_that("relational intersect() order-preserving", {
   rel11 <- rel_filter(
     rel10,
     list(
-      expr_function(
-        "r_base::==",
+      expr_comparison(
+        "==",
         list(
           expr_reference("___row_number_by"),
           if ("experimental" %in% names(formals(expr_constant))) {
@@ -4716,7 +4701,7 @@ test_that("relational intersect() order-preserving", {
   out <- rel_to_altrep(rel13)
   expect_identical(
     out,
-    data.frame(a = 2:4, b = rep(2, 3L))
+    data.frame(a = 2:4, b = 2)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -4728,11 +4713,11 @@ test_that("relational intersect() order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = 1:4, b = rep(2, 4L))
+  df1 <- data.frame(a = 1:4, b = 2)
 
   "intersect"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
-  df2 <- data.frame(a = 2:5, b = rep(2, 4L))
+  df2 <- data.frame(a = 2:5, b = 2)
 
   "intersect"
   rel2 <- rel_from_df(con, df2, experimental = experimental)
@@ -4744,7 +4729,7 @@ test_that("relational intersect() order-enforcing", {
   out <- rel_to_altrep(rel4)
   expect_identical(
     out,
-    data.frame(a = 2:4, b = rep(2, 3L))
+    data.frame(a = 2:4, b = 2)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -4760,13 +4745,13 @@ test_that("relational left_join(join_by(a)) order-preserving", {
     dbExecute(con, 'CREATE MACRO "___eq_na_matches_na"(x, y) AS (x IS NOT DISTINCT FROM y)')
   )
   invisible(dbExecute(con, 'CREATE MACRO "___coalesce"(x, y) AS COALESCE(x, y)'))
-  df1 <- data.frame(a = 1:4, b = rep(2, 4L))
+  df1 <- data.frame(a = 1:4, b = 2)
 
   "left_join"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
   "left_join"
   rel2 <- rel_set_alias(rel1, "lhs")
-  df2 <- data.frame(a = 2:5, b = rep(2, 4L))
+  df2 <- data.frame(a = 2:5, b = 2)
 
   "left_join"
   rel3 <- rel_from_df(con, df2, experimental = experimental)
@@ -4885,7 +4870,7 @@ test_that("relational left_join(join_by(a)) order-preserving", {
   out <- rel_to_altrep(rel11)
   expect_identical(
     out,
-    data.frame(a = 1:4, b.x = rep(2, 4L), b.y = c(NA, 2, 2, 2))
+    data.frame(a = 1:4, b.x = 2, b.y = c(NA, 2, 2, 2))
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -4901,13 +4886,13 @@ test_that("relational left_join(join_by(a)) order-enforcing", {
     dbExecute(con, 'CREATE MACRO "___eq_na_matches_na"(x, y) AS (x IS NOT DISTINCT FROM y)')
   )
   invisible(dbExecute(con, 'CREATE MACRO "___coalesce"(x, y) AS COALESCE(x, y)'))
-  df1 <- data.frame(a = 1:4, b = rep(2, 4L))
+  df1 <- data.frame(a = 1:4, b = 2)
 
   "left_join"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
   "left_join"
   rel2 <- rel_set_alias(rel1, "lhs")
-  df2 <- data.frame(a = 2:5, b = rep(2, 4L))
+  df2 <- data.frame(a = 2:5, b = 2)
 
   "left_join"
   rel3 <- rel_from_df(con, df2, experimental = experimental)
@@ -4984,7 +4969,7 @@ test_that("relational left_join(join_by(a)) order-enforcing", {
   out <- rel_to_altrep(rel9)
   expect_identical(
     out,
-    data.frame(a = 1:4, b.x = rep(2, 4L), b.y = c(NA, 2, 2, 2))
+    data.frame(a = 1:4, b.x = 2, b.y = c(NA, 2, 2, 2))
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -4996,7 +4981,7 @@ test_that("relational mutate() order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -5004,7 +4989,7 @@ test_that("relational mutate() order-preserving", {
   out <- rel_to_altrep(rel1)
   expect_identical(
     out,
-    data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+    data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -5014,7 +4999,7 @@ test_that("relational mutate(a + 1) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -5060,7 +5045,7 @@ test_that("relational mutate(a + 1) order-preserving", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `a + 1` = seq(2, 7, by = 1),
       check.names = FALSE
@@ -5074,7 +5059,7 @@ test_that("relational mutate(a + 1, .by = g) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -5179,7 +5164,7 @@ test_that("relational mutate(a + 1, .by = g) order-preserving", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `a + 1` = seq(2, 7, by = 1),
       check.names = FALSE
@@ -5193,7 +5178,7 @@ test_that("relational mutate(c = a + 1) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -5239,7 +5224,7 @@ test_that("relational mutate(c = a + 1) order-preserving", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       c = seq(2, 7, by = 1)
     )
@@ -5252,7 +5237,7 @@ test_that("relational mutate(`if` = a + 1) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -5298,7 +5283,7 @@ test_that("relational mutate(`if` = a + 1) order-preserving", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `if` = seq(2, 7, by = 1),
       check.names = FALSE
@@ -5312,7 +5297,7 @@ test_that("relational mutate(sum(a)) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -5348,9 +5333,9 @@ test_that("relational mutate(sum(a)) order-preserving", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      `sum(a)` = rep(21, 6L),
+      `sum(a)` = 21,
       check.names = FALSE
     )
   )
@@ -5362,7 +5347,7 @@ test_that("relational mutate(sum(a), .by = g) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -5457,7 +5442,7 @@ test_that("relational mutate(sum(a), .by = g) order-preserving", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `sum(a)` = c(1, 5, 5, 15, 15, 15),
       check.names = FALSE
@@ -5471,7 +5456,7 @@ test_that("relational mutate(mean(a)) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -5507,9 +5492,9 @@ test_that("relational mutate(mean(a)) order-preserving", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      `mean(a)` = rep(3.5, 6L),
+      `mean(a)` = 3.5,
       check.names = FALSE
     )
   )
@@ -5521,7 +5506,7 @@ test_that("relational mutate(mean(a), .by = g) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -5616,7 +5601,7 @@ test_that("relational mutate(mean(a), .by = g) order-preserving", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `mean(a)` = c(1, 2.5, 2.5, 5, 5, 5),
       check.names = FALSE
@@ -5630,7 +5615,7 @@ test_that("relational mutate(sd(a)) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -5666,9 +5651,9 @@ test_that("relational mutate(sd(a)) order-preserving", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      `sd(a)` = rep(0x1.deeea11683f49p+0, 6L),
+      `sd(a)` = 0x1.deeea11683f49p+0,
       check.names = FALSE
     )
   )
@@ -5680,7 +5665,7 @@ test_that("relational mutate(sd(a), .by = g) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -5775,7 +5760,7 @@ test_that("relational mutate(sd(a), .by = g) order-preserving", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `sd(a)` = c(NA, 0.7071067811865476, 0.7071067811865476, 1, 1, 1),
       check.names = FALSE
@@ -5789,7 +5774,7 @@ test_that("relational mutate(lag(a)) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -5835,7 +5820,7 @@ test_that("relational mutate(lag(a)) order-preserving", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `lag(a)` = c(NA, 1, 2, 3, 4, 5),
       check.names = FALSE
@@ -5849,7 +5834,7 @@ test_that("relational mutate(lag(a), .by = g) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -5954,7 +5939,7 @@ test_that("relational mutate(lag(a), .by = g) order-preserving", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `lag(a)` = c(NA, NA, 2, NA, 4, 5),
       check.names = FALSE
@@ -5968,7 +5953,7 @@ test_that("relational mutate(lead(a)) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -6014,7 +5999,7 @@ test_that("relational mutate(lead(a)) order-preserving", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `lead(a)` = c(2, 3, 4, 5, 6, NA),
       check.names = FALSE
@@ -6028,7 +6013,7 @@ test_that("relational mutate(lead(a), .by = g) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -6133,7 +6118,7 @@ test_that("relational mutate(lead(a), .by = g) order-preserving", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `lead(a)` = c(NA, 3, NA, 5, 6, NA),
       check.names = FALSE
@@ -6147,7 +6132,7 @@ test_that("relational mutate(lag(a, 2)) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -6193,7 +6178,7 @@ test_that("relational mutate(lag(a, 2)) order-preserving", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `lag(a, 2)` = c(NA, NA, 1, 2, 3, 4),
       check.names = FALSE
@@ -6207,7 +6192,7 @@ test_that("relational mutate(lag(a, 2), .by = g) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -6312,7 +6297,7 @@ test_that("relational mutate(lag(a, 2), .by = g) order-preserving", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `lag(a, 2)` = rep(c(NA, 4), c(5L, 1L)),
       check.names = FALSE
@@ -6326,7 +6311,7 @@ test_that("relational mutate(lead(a, 2)) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -6372,7 +6357,7 @@ test_that("relational mutate(lead(a, 2)) order-preserving", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `lead(a, 2)` = c(3, 4, 5, 6, NA, NA),
       check.names = FALSE
@@ -6386,7 +6371,7 @@ test_that("relational mutate(lead(a, 2), .by = g) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -6491,7 +6476,7 @@ test_that("relational mutate(lead(a, 2), .by = g) order-preserving", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `lead(a, 2)` = c(NA, NA, NA, 6, NA, NA),
       check.names = FALSE
@@ -6505,7 +6490,7 @@ test_that("relational mutate(lag(a, 4)) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -6551,7 +6536,7 @@ test_that("relational mutate(lag(a, 4)) order-preserving", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `lag(a, 4)` = c(NA, NA, NA, NA, 1, 2),
       check.names = FALSE
@@ -6565,7 +6550,7 @@ test_that("relational mutate(lag(a, 4), .by = g) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -6670,9 +6655,9 @@ test_that("relational mutate(lag(a, 4), .by = g) order-preserving", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      `lag(a, 4)` = rep(NA_real_, 6L),
+      `lag(a, 4)` = NA_real_,
       check.names = FALSE
     )
   )
@@ -6684,7 +6669,7 @@ test_that("relational mutate(lead(a, 4)) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -6730,7 +6715,7 @@ test_that("relational mutate(lead(a, 4)) order-preserving", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `lead(a, 4)` = c(5, 6, NA, NA, NA, NA),
       check.names = FALSE
@@ -6744,7 +6729,7 @@ test_that("relational mutate(lead(a, 4), .by = g) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -6849,9 +6834,9 @@ test_that("relational mutate(lead(a, 4), .by = g) order-preserving", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      `lead(a, 4)` = rep(NA_real_, 6L),
+      `lead(a, 4)` = NA_real_,
       check.names = FALSE
     )
   )
@@ -6863,7 +6848,7 @@ test_that("relational mutate(lag(a, default = 0)) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -6913,7 +6898,7 @@ test_that("relational mutate(lag(a, default = 0)) order-preserving", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `lag(a, default = 0)` = seq(0, 5, by = 1),
       check.names = FALSE
@@ -6927,7 +6912,7 @@ test_that("relational mutate(lag(a, default = 0), .by = g) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -7036,7 +7021,7 @@ test_that("relational mutate(lag(a, default = 0), .by = g) order-preserving", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `lag(a, default = 0)` = c(0, 0, 2, 0, 4, 5),
       check.names = FALSE
@@ -7050,7 +7035,7 @@ test_that("relational mutate(lead(a, default = 1000)) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -7100,7 +7085,7 @@ test_that("relational mutate(lead(a, default = 1000)) order-preserving", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `lead(a, default = 1000)` = c(2, 3, 4, 5, 6, 1000),
       check.names = FALSE
@@ -7114,7 +7099,7 @@ test_that("relational mutate(lead(a, default = 1000), .by = g) order-preserving"
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -7223,7 +7208,7 @@ test_that("relational mutate(lead(a, default = 1000), .by = g) order-preserving"
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `lead(a, default = 1000)` = c(1000, 3, 1000, 5, 6, 1000),
       check.names = FALSE
@@ -7237,7 +7222,7 @@ test_that("relational mutate(min(a)) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -7273,9 +7258,9 @@ test_that("relational mutate(min(a)) order-preserving", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      `min(a)` = rep(1, 6L),
+      `min(a)` = 1,
       check.names = FALSE
     )
   )
@@ -7287,7 +7272,7 @@ test_that("relational mutate(min(a), .by = g) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -7382,7 +7367,7 @@ test_that("relational mutate(min(a), .by = g) order-preserving", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `min(a)` = c(1, 2, 2, 4, 4, 4),
       check.names = FALSE
@@ -7396,7 +7381,7 @@ test_that("relational mutate(max(a)) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -7432,9 +7417,9 @@ test_that("relational mutate(max(a)) order-preserving", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      `max(a)` = rep(6, 6L),
+      `max(a)` = 6,
       check.names = FALSE
     )
   )
@@ -7446,7 +7431,7 @@ test_that("relational mutate(max(a), .by = g) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -7541,7 +7526,7 @@ test_that("relational mutate(max(a), .by = g) order-preserving", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `max(a)` = c(1, 3, 3, 6, 6, 6),
       check.names = FALSE
@@ -7555,7 +7540,7 @@ test_that("relational mutate(first(a)) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -7591,9 +7576,9 @@ test_that("relational mutate(first(a)) order-preserving", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      `first(a)` = rep(1, 6L),
+      `first(a)` = 1,
       check.names = FALSE
     )
   )
@@ -7605,7 +7590,7 @@ test_that("relational mutate(first(a), .by = g) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -7700,7 +7685,7 @@ test_that("relational mutate(first(a), .by = g) order-preserving", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `first(a)` = c(1, 2, 2, 4, 4, 4),
       check.names = FALSE
@@ -7714,7 +7699,7 @@ test_that("relational mutate(last(a)) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -7750,9 +7735,9 @@ test_that("relational mutate(last(a)) order-preserving", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      `last(a)` = rep(6, 6L),
+      `last(a)` = 6,
       check.names = FALSE
     )
   )
@@ -7764,7 +7749,7 @@ test_that("relational mutate(last(a), .by = g) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -7859,7 +7844,7 @@ test_that("relational mutate(last(a), .by = g) order-preserving", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `last(a)` = c(1, 3, 3, 6, 6, 6),
       check.names = FALSE
@@ -7873,7 +7858,7 @@ test_that("relational mutate(nth(a, 2)) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -7925,9 +7910,9 @@ test_that("relational mutate(nth(a, 2)) order-preserving", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      `nth(a, 2)` = rep(2, 6L),
+      `nth(a, 2)` = 2,
       check.names = FALSE
     )
   )
@@ -7939,7 +7924,7 @@ test_that("relational mutate(nth(a, 2), .by = g) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -8050,7 +8035,7 @@ test_that("relational mutate(nth(a, 2), .by = g) order-preserving", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `nth(a, 2)` = c(NA, 3, 3, 5, 5, 5),
       check.names = FALSE
@@ -8070,7 +8055,7 @@ test_that("relational mutate(a / b) order-preserving", {
       r"[CREATE MACRO "___divide"(x, y) AS CASE WHEN y = 0 THEN CASE WHEN x = 0 THEN CAST('NaN' AS double) WHEN x > 0 THEN CAST('+Infinity' AS double) ELSE CAST('-Infinity' AS double) END ELSE CAST(x AS double) / y END]"
     )
   )
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -8106,7 +8091,7 @@ test_that("relational mutate(a / b) order-preserving", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `a/b` = seq(0.5, 3, by = 0.5),
       check.names = FALSE
@@ -8126,7 +8111,7 @@ test_that("relational mutate(d = 0, e = 1 / d, f = 0 / d, g = -1 / d) order-pres
       r"[CREATE MACRO "___divide"(x, y) AS CASE WHEN y = 0 THEN CASE WHEN x = 0 THEN CAST('NaN' AS double) WHEN x > 0 THEN CAST('+Infinity' AS double) ELSE CAST('-Infinity' AS double) END ELSE CAST(x AS double) / y END]"
     )
   )
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -8302,14 +8287,7 @@ test_that("relational mutate(d = 0, e = 1 / d, f = 0 / d, g = -1 / d) order-pres
   out <- rel_to_altrep(rel5)
   expect_identical(
     out,
-    data.frame(
-      a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
-      g = rep(-Inf, 6L),
-      d = numeric(6),
-      e = rep(Inf, 6L),
-      f = rep(NaN, 6L)
-    )
+    data.frame(a = seq(1, 6, by = 1), b = 2, g = -Inf, d = 0, e = Inf, f = NaN)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -8326,7 +8304,7 @@ test_that("relational mutate(c = 0, d = -1, e = log(c), f = suppressWarnings(log
     )
   )
   invisible(dbExecute(con, 'CREATE MACRO "suppressWarnings"(x) AS (x)'))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -8483,12 +8461,12 @@ test_that("relational mutate(c = 0, d = -1, e = log(c), f = suppressWarnings(log
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      c = numeric(6),
-      d = rep(-1, 6L),
-      e = rep(-Inf, 6L),
-      f = rep(NaN, 6L)
+      c = 0,
+      d = -1,
+      e = -Inf,
+      f = NaN
     )
   )
   dbDisconnect(con, shutdown = TRUE)
@@ -8506,7 +8484,7 @@ test_that("relational mutate(c = 0, d = -1, e = log10(c), f = suppressWarnings(l
     )
   )
   invisible(dbExecute(con, 'CREATE MACRO "suppressWarnings"(x) AS (x)'))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -8663,12 +8641,12 @@ test_that("relational mutate(c = 0, d = -1, e = log10(c), f = suppressWarnings(l
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      c = numeric(6),
-      d = rep(-1, 6L),
-      e = rep(-Inf, 6L),
-      f = rep(NaN, 6L)
+      c = 0,
+      d = -1,
+      e = -Inf,
+      f = NaN
     )
   )
   dbDisconnect(con, shutdown = TRUE)
@@ -8685,7 +8663,7 @@ test_that("relational mutate(c = 10, d = log(c)) order-preserving", {
       r"[CREATE MACRO "___log"(x) AS CASE WHEN x < 0 THEN CAST('NaN' AS double) WHEN x = 0 THEN CAST('-Inf' AS double) ELSE ln(x) END]"
     )
   )
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -8756,10 +8734,10 @@ test_that("relational mutate(c = 10, d = log(c)) order-preserving", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      c = rep(10, 6L),
-      d = rep(2.302585092994046, 6L)
+      c = 10,
+      d = 2.302585092994046
     )
   )
   dbDisconnect(con, shutdown = TRUE)
@@ -8776,7 +8754,7 @@ test_that("relational mutate(c = 10, d = log10(c)) order-preserving", {
       r"[CREATE MACRO "___log10"(x) AS CASE WHEN x < 0 THEN CAST('NaN' AS double) WHEN x = 0 THEN CAST('-Inf' AS double) ELSE log10(x) END]"
     )
   )
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -8845,20 +8823,12 @@ test_that("relational mutate(c = 10, d = log10(c)) order-preserving", {
   out <- rel_to_altrep(rel3)
   expect_identical(
     out,
-    data.frame(
-      a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
-      g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      c = rep(10, 6L),
-      d = rep(1, 6L)
-    )
+    data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L), c = 10, d = 1)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
 
 test_that("relational mutate(c = NA_character_, d = grepl('.', c)) order-preserving", {
-  skip_if_not(TEST_RE2)
-
   # Autogenerated
   drv <- duckdb()
   con <- dbConnect(drv)
@@ -8869,7 +8839,7 @@ test_that("relational mutate(c = NA_character_, d = grepl('.', c)) order-preserv
       'CREATE MACRO "grepl"(pattern, x) AS (CASE WHEN x IS NULL THEN FALSE ELSE regexp_matches(x, pattern) END)'
     )
   )
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -8950,10 +8920,10 @@ test_that("relational mutate(c = NA_character_, d = grepl('.', c)) order-preserv
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      c = rep(NA_character_, 6L),
-      d = logical(6)
+      c = NA_character_,
+      d = FALSE
     )
   )
   dbDisconnect(con, shutdown = TRUE)
@@ -8965,7 +8935,7 @@ test_that("relational mutate(d = a %in% NA_real_) order-preserving", {
   con <- dbConnect(drv)
   experimental <- FALSE
   invisible(dbExecute(con, 'CREATE MACRO "is.na"(x) AS (x IS NULL OR isnan(x))'))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -8999,12 +8969,7 @@ test_that("relational mutate(d = a %in% NA_real_) order-preserving", {
   out <- rel_to_altrep(rel2)
   expect_identical(
     out,
-    data.frame(
-      a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
-      g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      d = logical(6)
-    )
+    data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L), d = FALSE)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -9014,7 +8979,7 @@ test_that("relational mutate(d = a %in% NULL) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -9052,12 +9017,7 @@ test_that("relational mutate(d = a %in% NULL) order-preserving", {
   out <- rel_to_altrep(rel2)
   expect_identical(
     out,
-    data.frame(
-      a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
-      g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      d = logical(6)
-    )
+    data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L), d = FALSE)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -9067,7 +9027,7 @@ test_that("relational mutate(d = a %in% integer()) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -9105,12 +9065,7 @@ test_that("relational mutate(d = a %in% integer()) order-preserving", {
   out <- rel_to_altrep(rel2)
   expect_identical(
     out,
-    data.frame(
-      a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
-      g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      d = logical(6)
-    )
+    data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L), d = FALSE)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -9121,7 +9076,7 @@ test_that("relational mutate(d = NA_real_, e = is.na(d)) order-preserving", {
   con <- dbConnect(drv)
   experimental <- FALSE
   invisible(dbExecute(con, 'CREATE MACRO "is.na"(x) AS (x IS NULL OR isnan(x))'))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -9192,10 +9147,10 @@ test_that("relational mutate(d = NA_real_, e = is.na(d)) order-preserving", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      d = rep(NA_real_, 6L),
-      e = rep(TRUE, 6L)
+      d = NA_real_,
+      e = TRUE
     )
   )
   dbDisconnect(con, shutdown = TRUE)
@@ -9207,7 +9162,7 @@ test_that("relational mutate(d = NaN, e = is.na(d)) order-preserving", {
   con <- dbConnect(drv)
   experimental <- FALSE
   invisible(dbExecute(con, 'CREATE MACRO "is.na"(x) AS (x IS NULL OR isnan(x))'))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -9276,13 +9231,7 @@ test_that("relational mutate(d = NaN, e = is.na(d)) order-preserving", {
   out <- rel_to_altrep(rel3)
   expect_identical(
     out,
-    data.frame(
-      a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
-      g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      d = rep(NaN, 6L),
-      e = rep(TRUE, 6L)
-    )
+    data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L), d = NaN, e = TRUE)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -9293,7 +9242,7 @@ test_that("relational mutate(d = row_number()) order-preserving", {
   con <- dbConnect(drv)
   experimental <- FALSE
   invisible(rapi_load_rfuns(drv@database_ref))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -9332,7 +9281,7 @@ test_that("relational mutate(d = row_number()) order-preserving", {
   out <- rel_to_altrep(rel2)
   expect_identical(
     out,
-    data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L), d = 1:6)
+    data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L), d = 1:6)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -9343,7 +9292,7 @@ test_that("relational mutate(d = row_number(), .by = g) order-preserving", {
   con <- dbConnect(drv)
   experimental <- FALSE
   invisible(rapi_load_rfuns(drv@database_ref))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -9443,7 +9392,7 @@ test_that("relational mutate(d = row_number(), .by = g) order-preserving", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       d = c(1L, 1L, 2L, 1L, 2L, 3L)
     )
@@ -9456,7 +9405,7 @@ test_that("relational mutate(c = .data$b) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -9490,12 +9439,7 @@ test_that("relational mutate(c = .data$b) order-preserving", {
   out <- rel_to_altrep(rel2)
   expect_identical(
     out,
-    data.frame(
-      a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
-      g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      c = rep(2, 6L)
-    )
+    data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L), c = 2)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -9506,7 +9450,7 @@ test_that("relational mutate(d = NA) order-preserving", {
   con <- dbConnect(drv)
   experimental <- FALSE
   invisible(dbExecute(con, 'CREATE MACRO "___null"() AS CAST(NULL AS BOOLEAN)'))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -9540,12 +9484,7 @@ test_that("relational mutate(d = NA) order-preserving", {
   out <- rel_to_altrep(rel2)
   expect_identical(
     out,
-    data.frame(
-      a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
-      g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      d = rep(NA, 6L)
-    )
+    data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L), d = NA)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -9555,7 +9494,7 @@ test_that("relational mutate(d = NA_integer_) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -9593,12 +9532,7 @@ test_that("relational mutate(d = NA_integer_) order-preserving", {
   out <- rel_to_altrep(rel2)
   expect_identical(
     out,
-    data.frame(
-      a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
-      g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      d = rep(NA_integer_, 6L)
-    )
+    data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L), d = NA_integer_)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -9608,7 +9542,7 @@ test_that("relational mutate(d = NA_real_) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -9646,12 +9580,7 @@ test_that("relational mutate(d = NA_real_) order-preserving", {
   out <- rel_to_altrep(rel2)
   expect_identical(
     out,
-    data.frame(
-      a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
-      g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      d = rep(NA_real_, 6L)
-    )
+    data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L), d = NA_real_)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -9661,7 +9590,7 @@ test_that("relational mutate(d = NA_character_) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -9699,12 +9628,7 @@ test_that("relational mutate(d = NA_character_) order-preserving", {
   out <- rel_to_altrep(rel2)
   expect_identical(
     out,
-    data.frame(
-      a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
-      g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      d = rep(NA_character_, 6L)
-    )
+    data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L), d = NA_character_)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -9714,14 +9638,13 @@ test_that("relational mutate(d = if_else(a > 1, \"ok\", NA)) order-preserving", 
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  invisible(rapi_load_rfuns(drv@database_ref))
   invisible(
     dbExecute(
       con,
       'CREATE MACRO "if_else"(test, yes, no) AS (CASE WHEN test IS NULL THEN NULL ELSE CASE WHEN test THEN yes ELSE no END END)'
     )
   )
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -9748,8 +9671,8 @@ test_that("relational mutate(d = if_else(a > 1, \"ok\", NA)) order-preserving", 
         tmp_expr <- expr_function(
           "if_else",
           list(
-            expr_function(
-              "r_base::>",
+            expr_comparison(
+              ">",
               list(
                 expr_reference("a"),
                 if ("experimental" %in% names(formals(expr_constant))) {
@@ -9782,7 +9705,7 @@ test_that("relational mutate(d = if_else(a > 1, \"ok\", NA)) order-preserving", 
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       d = rep(c(NA, "ok"), c(1L, 5L))
     )
@@ -9797,7 +9720,7 @@ test_that("relational mutate() order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -9810,7 +9733,7 @@ test_that("relational mutate() order-enforcing", {
   out <- rel_to_altrep(rel2)
   expect_identical(
     out,
-    data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+    data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -9820,7 +9743,7 @@ test_that("relational mutate(a + 1) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -9871,7 +9794,7 @@ test_that("relational mutate(a + 1) order-enforcing", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `a + 1` = seq(2, 7, by = 1),
       check.names = FALSE
@@ -9885,7 +9808,7 @@ test_that("relational mutate(a + 1, .by = g) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -9936,7 +9859,7 @@ test_that("relational mutate(a + 1, .by = g) order-enforcing", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `a + 1` = seq(2, 7, by = 1),
       check.names = FALSE
@@ -9950,7 +9873,7 @@ test_that("relational mutate(c = a + 1) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -10001,7 +9924,7 @@ test_that("relational mutate(c = a + 1) order-enforcing", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       c = seq(2, 7, by = 1)
     )
@@ -10014,7 +9937,7 @@ test_that("relational mutate(`if` = a + 1) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -10065,7 +9988,7 @@ test_that("relational mutate(`if` = a + 1) order-enforcing", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `if` = seq(2, 7, by = 1),
       check.names = FALSE
@@ -10079,7 +10002,7 @@ test_that("relational mutate(sum(a)) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -10120,9 +10043,9 @@ test_that("relational mutate(sum(a)) order-enforcing", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      `sum(a)` = rep(21, 6L),
+      `sum(a)` = 21,
       check.names = FALSE
     )
   )
@@ -10134,7 +10057,7 @@ test_that("relational mutate(sum(a), .by = g) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -10175,7 +10098,7 @@ test_that("relational mutate(sum(a), .by = g) order-enforcing", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `sum(a)` = c(1, 5, 5, 15, 15, 15),
       check.names = FALSE
@@ -10189,7 +10112,7 @@ test_that("relational mutate(mean(a)) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -10230,9 +10153,9 @@ test_that("relational mutate(mean(a)) order-enforcing", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      `mean(a)` = rep(3.5, 6L),
+      `mean(a)` = 3.5,
       check.names = FALSE
     )
   )
@@ -10244,7 +10167,7 @@ test_that("relational mutate(mean(a), .by = g) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -10285,7 +10208,7 @@ test_that("relational mutate(mean(a), .by = g) order-enforcing", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `mean(a)` = c(1, 2.5, 2.5, 5, 5, 5),
       check.names = FALSE
@@ -10299,7 +10222,7 @@ test_that("relational mutate(sd(a)) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -10340,9 +10263,9 @@ test_that("relational mutate(sd(a)) order-enforcing", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      `sd(a)` = rep(0x1.deeea11683f49p+0, 6L),
+      `sd(a)` = 0x1.deeea11683f49p+0,
       check.names = FALSE
     )
   )
@@ -10354,7 +10277,7 @@ test_that("relational mutate(sd(a), .by = g) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -10395,7 +10318,7 @@ test_that("relational mutate(sd(a), .by = g) order-enforcing", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `sd(a)` = c(NA, 0.7071067811865476, 0.7071067811865476, 1, 1, 1),
       check.names = FALSE
@@ -10409,7 +10332,7 @@ test_that("relational mutate(lag(a)) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -10460,7 +10383,7 @@ test_that("relational mutate(lag(a)) order-enforcing", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `lag(a)` = c(NA, 1, 2, 3, 4, 5),
       check.names = FALSE
@@ -10474,7 +10397,7 @@ test_that("relational mutate(lag(a), .by = g) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -10525,7 +10448,7 @@ test_that("relational mutate(lag(a), .by = g) order-enforcing", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `lag(a)` = c(NA, NA, 2, NA, 4, 5),
       check.names = FALSE
@@ -10539,7 +10462,7 @@ test_that("relational mutate(lead(a)) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -10590,7 +10513,7 @@ test_that("relational mutate(lead(a)) order-enforcing", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `lead(a)` = c(2, 3, 4, 5, 6, NA),
       check.names = FALSE
@@ -10604,7 +10527,7 @@ test_that("relational mutate(lead(a), .by = g) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -10655,7 +10578,7 @@ test_that("relational mutate(lead(a), .by = g) order-enforcing", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `lead(a)` = c(NA, 3, NA, 5, 6, NA),
       check.names = FALSE
@@ -10669,7 +10592,7 @@ test_that("relational mutate(lag(a, 2)) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -10720,7 +10643,7 @@ test_that("relational mutate(lag(a, 2)) order-enforcing", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `lag(a, 2)` = c(NA, NA, 1, 2, 3, 4),
       check.names = FALSE
@@ -10734,7 +10657,7 @@ test_that("relational mutate(lag(a, 2), .by = g) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -10785,7 +10708,7 @@ test_that("relational mutate(lag(a, 2), .by = g) order-enforcing", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `lag(a, 2)` = rep(c(NA, 4), c(5L, 1L)),
       check.names = FALSE
@@ -10799,7 +10722,7 @@ test_that("relational mutate(lead(a, 2)) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -10850,7 +10773,7 @@ test_that("relational mutate(lead(a, 2)) order-enforcing", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `lead(a, 2)` = c(3, 4, 5, 6, NA, NA),
       check.names = FALSE
@@ -10864,7 +10787,7 @@ test_that("relational mutate(lead(a, 2), .by = g) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -10915,7 +10838,7 @@ test_that("relational mutate(lead(a, 2), .by = g) order-enforcing", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `lead(a, 2)` = c(NA, NA, NA, 6, NA, NA),
       check.names = FALSE
@@ -10929,7 +10852,7 @@ test_that("relational mutate(lag(a, 4)) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -10980,7 +10903,7 @@ test_that("relational mutate(lag(a, 4)) order-enforcing", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `lag(a, 4)` = c(NA, NA, NA, NA, 1, 2),
       check.names = FALSE
@@ -10994,7 +10917,7 @@ test_that("relational mutate(lag(a, 4), .by = g) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -11045,9 +10968,9 @@ test_that("relational mutate(lag(a, 4), .by = g) order-enforcing", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      `lag(a, 4)` = rep(NA_real_, 6L),
+      `lag(a, 4)` = NA_real_,
       check.names = FALSE
     )
   )
@@ -11059,7 +10982,7 @@ test_that("relational mutate(lead(a, 4)) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -11110,7 +11033,7 @@ test_that("relational mutate(lead(a, 4)) order-enforcing", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `lead(a, 4)` = c(5, 6, NA, NA, NA, NA),
       check.names = FALSE
@@ -11124,7 +11047,7 @@ test_that("relational mutate(lead(a, 4), .by = g) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -11175,9 +11098,9 @@ test_that("relational mutate(lead(a, 4), .by = g) order-enforcing", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      `lead(a, 4)` = rep(NA_real_, 6L),
+      `lead(a, 4)` = NA_real_,
       check.names = FALSE
     )
   )
@@ -11189,7 +11112,7 @@ test_that("relational mutate(lag(a, default = 0)) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -11244,7 +11167,7 @@ test_that("relational mutate(lag(a, default = 0)) order-enforcing", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `lag(a, default = 0)` = seq(0, 5, by = 1),
       check.names = FALSE
@@ -11258,7 +11181,7 @@ test_that("relational mutate(lag(a, default = 0), .by = g) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -11313,7 +11236,7 @@ test_that("relational mutate(lag(a, default = 0), .by = g) order-enforcing", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `lag(a, default = 0)` = c(0, 0, 2, 0, 4, 5),
       check.names = FALSE
@@ -11327,7 +11250,7 @@ test_that("relational mutate(lead(a, default = 1000)) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -11382,7 +11305,7 @@ test_that("relational mutate(lead(a, default = 1000)) order-enforcing", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `lead(a, default = 1000)` = c(2, 3, 4, 5, 6, 1000),
       check.names = FALSE
@@ -11396,7 +11319,7 @@ test_that("relational mutate(lead(a, default = 1000), .by = g) order-enforcing",
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -11451,7 +11374,7 @@ test_that("relational mutate(lead(a, default = 1000), .by = g) order-enforcing",
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `lead(a, default = 1000)` = c(1000, 3, 1000, 5, 6, 1000),
       check.names = FALSE
@@ -11465,7 +11388,7 @@ test_that("relational mutate(min(a)) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -11506,9 +11429,9 @@ test_that("relational mutate(min(a)) order-enforcing", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      `min(a)` = rep(1, 6L),
+      `min(a)` = 1,
       check.names = FALSE
     )
   )
@@ -11520,7 +11443,7 @@ test_that("relational mutate(min(a), .by = g) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -11561,7 +11484,7 @@ test_that("relational mutate(min(a), .by = g) order-enforcing", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `min(a)` = c(1, 2, 2, 4, 4, 4),
       check.names = FALSE
@@ -11575,7 +11498,7 @@ test_that("relational mutate(max(a)) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -11616,9 +11539,9 @@ test_that("relational mutate(max(a)) order-enforcing", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      `max(a)` = rep(6, 6L),
+      `max(a)` = 6,
       check.names = FALSE
     )
   )
@@ -11630,7 +11553,7 @@ test_that("relational mutate(max(a), .by = g) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -11671,7 +11594,7 @@ test_that("relational mutate(max(a), .by = g) order-enforcing", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `max(a)` = c(1, 3, 3, 6, 6, 6),
       check.names = FALSE
@@ -11685,7 +11608,7 @@ test_that("relational mutate(first(a)) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -11726,9 +11649,9 @@ test_that("relational mutate(first(a)) order-enforcing", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      `first(a)` = rep(1, 6L),
+      `first(a)` = 1,
       check.names = FALSE
     )
   )
@@ -11740,7 +11663,7 @@ test_that("relational mutate(first(a), .by = g) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -11781,7 +11704,7 @@ test_that("relational mutate(first(a), .by = g) order-enforcing", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `first(a)` = c(1, 2, 2, 4, 4, 4),
       check.names = FALSE
@@ -11795,7 +11718,7 @@ test_that("relational mutate(last(a)) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -11836,9 +11759,9 @@ test_that("relational mutate(last(a)) order-enforcing", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      `last(a)` = rep(6, 6L),
+      `last(a)` = 6,
       check.names = FALSE
     )
   )
@@ -11850,7 +11773,7 @@ test_that("relational mutate(last(a), .by = g) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -11891,7 +11814,7 @@ test_that("relational mutate(last(a), .by = g) order-enforcing", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `last(a)` = c(1, 3, 3, 6, 6, 6),
       check.names = FALSE
@@ -11905,7 +11828,7 @@ test_that("relational mutate(nth(a, 2)) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -11962,9 +11885,9 @@ test_that("relational mutate(nth(a, 2)) order-enforcing", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      `nth(a, 2)` = rep(2, 6L),
+      `nth(a, 2)` = 2,
       check.names = FALSE
     )
   )
@@ -11976,7 +11899,7 @@ test_that("relational mutate(nth(a, 2), .by = g) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -12033,7 +11956,7 @@ test_that("relational mutate(nth(a, 2), .by = g) order-enforcing", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `nth(a, 2)` = c(NA, 3, 3, 5, 5, 5),
       check.names = FALSE
@@ -12053,7 +11976,7 @@ test_that("relational mutate(a / b) order-enforcing", {
       r"[CREATE MACRO "___divide"(x, y) AS CASE WHEN y = 0 THEN CASE WHEN x = 0 THEN CAST('NaN' AS double) WHEN x > 0 THEN CAST('+Infinity' AS double) ELSE CAST('-Infinity' AS double) END ELSE CAST(x AS double) / y END]"
     )
   )
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -12094,7 +12017,7 @@ test_that("relational mutate(a / b) order-enforcing", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       `a/b` = seq(0.5, 3, by = 0.5),
       check.names = FALSE
@@ -12114,7 +12037,7 @@ test_that("relational mutate(d = 0, e = 1 / d, f = 0 / d, g = -1 / d) order-enfo
       r"[CREATE MACRO "___divide"(x, y) AS CASE WHEN y = 0 THEN CASE WHEN x = 0 THEN CAST('NaN' AS double) WHEN x > 0 THEN CAST('+Infinity' AS double) ELSE CAST('-Infinity' AS double) END ELSE CAST(x AS double) / y END]"
     )
   )
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -12295,14 +12218,7 @@ test_that("relational mutate(d = 0, e = 1 / d, f = 0 / d, g = -1 / d) order-enfo
   out <- rel_to_altrep(rel6)
   expect_identical(
     out,
-    data.frame(
-      a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
-      g = rep(-Inf, 6L),
-      d = numeric(6),
-      e = rep(Inf, 6L),
-      f = rep(NaN, 6L)
-    )
+    data.frame(a = seq(1, 6, by = 1), b = 2, g = -Inf, d = 0, e = Inf, f = NaN)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -12319,7 +12235,7 @@ test_that("relational mutate(c = 0, d = -1, e = log(c), f = suppressWarnings(log
     )
   )
   invisible(dbExecute(con, 'CREATE MACRO "suppressWarnings"(x) AS (x)'))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -12481,12 +12397,12 @@ test_that("relational mutate(c = 0, d = -1, e = log(c), f = suppressWarnings(log
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      c = numeric(6),
-      d = rep(-1, 6L),
-      e = rep(-Inf, 6L),
-      f = rep(NaN, 6L)
+      c = 0,
+      d = -1,
+      e = -Inf,
+      f = NaN
     )
   )
   dbDisconnect(con, shutdown = TRUE)
@@ -12504,7 +12420,7 @@ test_that("relational mutate(c = 0, d = -1, e = log10(c), f = suppressWarnings(l
     )
   )
   invisible(dbExecute(con, 'CREATE MACRO "suppressWarnings"(x) AS (x)'))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -12666,12 +12582,12 @@ test_that("relational mutate(c = 0, d = -1, e = log10(c), f = suppressWarnings(l
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      c = numeric(6),
-      d = rep(-1, 6L),
-      e = rep(-Inf, 6L),
-      f = rep(NaN, 6L)
+      c = 0,
+      d = -1,
+      e = -Inf,
+      f = NaN
     )
   )
   dbDisconnect(con, shutdown = TRUE)
@@ -12688,7 +12604,7 @@ test_that("relational mutate(c = 10, d = log(c)) order-enforcing", {
       r"[CREATE MACRO "___log"(x) AS CASE WHEN x < 0 THEN CAST('NaN' AS double) WHEN x = 0 THEN CAST('-Inf' AS double) ELSE ln(x) END]"
     )
   )
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -12764,10 +12680,10 @@ test_that("relational mutate(c = 10, d = log(c)) order-enforcing", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      c = rep(10, 6L),
-      d = rep(2.302585092994046, 6L)
+      c = 10,
+      d = 2.302585092994046
     )
   )
   dbDisconnect(con, shutdown = TRUE)
@@ -12784,7 +12700,7 @@ test_that("relational mutate(c = 10, d = log10(c)) order-enforcing", {
       r"[CREATE MACRO "___log10"(x) AS CASE WHEN x < 0 THEN CAST('NaN' AS double) WHEN x = 0 THEN CAST('-Inf' AS double) ELSE log10(x) END]"
     )
   )
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -12858,20 +12774,12 @@ test_that("relational mutate(c = 10, d = log10(c)) order-enforcing", {
   out <- rel_to_altrep(rel4)
   expect_identical(
     out,
-    data.frame(
-      a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
-      g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      c = rep(10, 6L),
-      d = rep(1, 6L)
-    )
+    data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L), c = 10, d = 1)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
 
 test_that("relational mutate(c = NA_character_, d = grepl('.', c)) order-enforcing", {
-  skip_if_not(TEST_RE2)
-
   # Autogenerated
   drv <- duckdb()
   con <- dbConnect(drv)
@@ -12882,7 +12790,7 @@ test_that("relational mutate(c = NA_character_, d = grepl('.', c)) order-enforci
       'CREATE MACRO "grepl"(pattern, x) AS (CASE WHEN x IS NULL THEN FALSE ELSE regexp_matches(x, pattern) END)'
     )
   )
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -12968,10 +12876,10 @@ test_that("relational mutate(c = NA_character_, d = grepl('.', c)) order-enforci
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      c = rep(NA_character_, 6L),
-      d = logical(6)
+      c = NA_character_,
+      d = FALSE
     )
   )
   dbDisconnect(con, shutdown = TRUE)
@@ -12983,7 +12891,7 @@ test_that("relational mutate(d = a %in% NA_real_) order-enforcing", {
   con <- dbConnect(drv)
   experimental <- FALSE
   invisible(dbExecute(con, 'CREATE MACRO "is.na"(x) AS (x IS NULL OR isnan(x))'))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -13022,12 +12930,7 @@ test_that("relational mutate(d = a %in% NA_real_) order-enforcing", {
   out <- rel_to_altrep(rel3)
   expect_identical(
     out,
-    data.frame(
-      a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
-      g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      d = logical(6)
-    )
+    data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L), d = FALSE)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -13037,7 +12940,7 @@ test_that("relational mutate(d = a %in% NULL) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -13080,12 +12983,7 @@ test_that("relational mutate(d = a %in% NULL) order-enforcing", {
   out <- rel_to_altrep(rel3)
   expect_identical(
     out,
-    data.frame(
-      a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
-      g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      d = logical(6)
-    )
+    data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L), d = FALSE)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -13095,7 +12993,7 @@ test_that("relational mutate(d = a %in% integer()) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -13138,12 +13036,7 @@ test_that("relational mutate(d = a %in% integer()) order-enforcing", {
   out <- rel_to_altrep(rel3)
   expect_identical(
     out,
-    data.frame(
-      a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
-      g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      d = logical(6)
-    )
+    data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L), d = FALSE)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -13154,7 +13047,7 @@ test_that("relational mutate(d = NA_real_, e = is.na(d)) order-enforcing", {
   con <- dbConnect(drv)
   experimental <- FALSE
   invisible(dbExecute(con, 'CREATE MACRO "is.na"(x) AS (x IS NULL OR isnan(x))'))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -13230,10 +13123,10 @@ test_that("relational mutate(d = NA_real_, e = is.na(d)) order-enforcing", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      d = rep(NA_real_, 6L),
-      e = rep(TRUE, 6L)
+      d = NA_real_,
+      e = TRUE
     )
   )
   dbDisconnect(con, shutdown = TRUE)
@@ -13245,7 +13138,7 @@ test_that("relational mutate(d = NaN, e = is.na(d)) order-enforcing", {
   con <- dbConnect(drv)
   experimental <- FALSE
   invisible(dbExecute(con, 'CREATE MACRO "is.na"(x) AS (x IS NULL OR isnan(x))'))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -13319,13 +13212,7 @@ test_that("relational mutate(d = NaN, e = is.na(d)) order-enforcing", {
   out <- rel_to_altrep(rel4)
   expect_identical(
     out,
-    data.frame(
-      a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
-      g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      d = rep(NaN, 6L),
-      e = rep(TRUE, 6L)
-    )
+    data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L), d = NaN, e = TRUE)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -13336,7 +13223,7 @@ test_that("relational mutate(d = row_number()) order-enforcing", {
   con <- dbConnect(drv)
   experimental <- FALSE
   invisible(rapi_load_rfuns(drv@database_ref))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -13380,7 +13267,7 @@ test_that("relational mutate(d = row_number()) order-enforcing", {
   out <- rel_to_altrep(rel3)
   expect_identical(
     out,
-    data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L), d = 1:6)
+    data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L), d = 1:6)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -13391,7 +13278,7 @@ test_that("relational mutate(d = row_number(), .by = g) order-enforcing", {
   con <- dbConnect(drv)
   experimental <- FALSE
   invisible(rapi_load_rfuns(drv@database_ref))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -13437,7 +13324,7 @@ test_that("relational mutate(d = row_number(), .by = g) order-enforcing", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       d = c(1L, 1L, 2L, 1L, 2L, 3L)
     )
@@ -13450,7 +13337,7 @@ test_that("relational mutate(c = .data$b) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -13489,12 +13376,7 @@ test_that("relational mutate(c = .data$b) order-enforcing", {
   out <- rel_to_altrep(rel3)
   expect_identical(
     out,
-    data.frame(
-      a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
-      g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      c = rep(2, 6L)
-    )
+    data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L), c = 2)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -13505,7 +13387,7 @@ test_that("relational mutate(d = NA) order-enforcing", {
   con <- dbConnect(drv)
   experimental <- FALSE
   invisible(dbExecute(con, 'CREATE MACRO "___null"() AS CAST(NULL AS BOOLEAN)'))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -13544,12 +13426,7 @@ test_that("relational mutate(d = NA) order-enforcing", {
   out <- rel_to_altrep(rel3)
   expect_identical(
     out,
-    data.frame(
-      a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
-      g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      d = rep(NA, 6L)
-    )
+    data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L), d = NA)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -13559,7 +13436,7 @@ test_that("relational mutate(d = NA_integer_) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -13602,12 +13479,7 @@ test_that("relational mutate(d = NA_integer_) order-enforcing", {
   out <- rel_to_altrep(rel3)
   expect_identical(
     out,
-    data.frame(
-      a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
-      g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      d = rep(NA_integer_, 6L)
-    )
+    data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L), d = NA_integer_)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -13617,7 +13489,7 @@ test_that("relational mutate(d = NA_real_) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -13660,12 +13532,7 @@ test_that("relational mutate(d = NA_real_) order-enforcing", {
   out <- rel_to_altrep(rel3)
   expect_identical(
     out,
-    data.frame(
-      a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
-      g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      d = rep(NA_real_, 6L)
-    )
+    data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L), d = NA_real_)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -13675,7 +13542,7 @@ test_that("relational mutate(d = NA_character_) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -13718,12 +13585,7 @@ test_that("relational mutate(d = NA_character_) order-enforcing", {
   out <- rel_to_altrep(rel3)
   expect_identical(
     out,
-    data.frame(
-      a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
-      g = c(1L, 2L, 2L, 3L, 3L, 3L),
-      d = rep(NA_character_, 6L)
-    )
+    data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L), d = NA_character_)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -13733,14 +13595,13 @@ test_that("relational mutate(d = if_else(a > 1, \"ok\", NA)) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  invisible(rapi_load_rfuns(drv@database_ref))
   invisible(
     dbExecute(
       con,
       'CREATE MACRO "if_else"(test, yes, no) AS (CASE WHEN test IS NULL THEN NULL ELSE CASE WHEN test THEN yes ELSE no END END)'
     )
   )
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "mutate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -13767,8 +13628,8 @@ test_that("relational mutate(d = if_else(a > 1, \"ok\", NA)) order-enforcing", {
         tmp_expr <- expr_function(
           "if_else",
           list(
-            expr_function(
-              "r_base::>",
+            expr_comparison(
+              ">",
               list(
                 expr_reference("a"),
                 if ("experimental" %in% names(formals(expr_constant))) {
@@ -13806,7 +13667,7 @@ test_that("relational mutate(d = if_else(a > 1, \"ok\", NA)) order-enforcing", {
     out,
     data.frame(
       a = seq(1, 6, by = 1),
-      b = rep(2, 6L),
+      b = 2,
       g = c(1L, 2L, 2L, 3L, 3L, 3L),
       d = rep(c(NA, "ok"), c(1L, 5L))
     )
@@ -13821,7 +13682,7 @@ test_that("relational relocate(g) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "relocate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -13850,7 +13711,7 @@ test_that("relational relocate(g) order-preserving", {
   out <- rel_to_altrep(rel2)
   expect_identical(
     out,
-    data.frame(g = c(1L, 2L, 2L, 3L, 3L, 3L), a = seq(1, 6, by = 1), b = rep(2, 6L))
+    data.frame(g = c(1L, 2L, 2L, 3L, 3L, 3L), a = seq(1, 6, by = 1), b = 2)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -13860,7 +13721,7 @@ test_that("relational relocate(a) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "relocate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -13889,7 +13750,7 @@ test_that("relational relocate(a) order-preserving", {
   out <- rel_to_altrep(rel2)
   expect_identical(
     out,
-    data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+    data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -13899,7 +13760,7 @@ test_that("relational relocate(g, .before = b) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "relocate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -13928,7 +13789,7 @@ test_that("relational relocate(g, .before = b) order-preserving", {
   out <- rel_to_altrep(rel2)
   expect_identical(
     out,
-    data.frame(a = seq(1, 6, by = 1), g = c(1L, 2L, 2L, 3L, 3L, 3L), b = rep(2, 6L))
+    data.frame(a = seq(1, 6, by = 1), g = c(1L, 2L, 2L, 3L, 3L, 3L), b = 2)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -13938,7 +13799,7 @@ test_that("relational relocate(a:b, .after = g) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "relocate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -13967,7 +13828,7 @@ test_that("relational relocate(a:b, .after = g) order-preserving", {
   out <- rel_to_altrep(rel2)
   expect_identical(
     out,
-    data.frame(g = c(1L, 2L, 2L, 3L, 3L, 3L), a = seq(1, 6, by = 1), b = rep(2, 6L))
+    data.frame(g = c(1L, 2L, 2L, 3L, 3L, 3L), a = seq(1, 6, by = 1), b = 2)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -13979,7 +13840,7 @@ test_that("relational relocate(g) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "relocate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -14013,7 +13874,7 @@ test_that("relational relocate(g) order-enforcing", {
   out <- rel_to_altrep(rel3)
   expect_identical(
     out,
-    data.frame(g = c(1L, 2L, 2L, 3L, 3L, 3L), a = seq(1, 6, by = 1), b = rep(2, 6L))
+    data.frame(g = c(1L, 2L, 2L, 3L, 3L, 3L), a = seq(1, 6, by = 1), b = 2)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -14023,7 +13884,7 @@ test_that("relational relocate(a) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "relocate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -14057,7 +13918,7 @@ test_that("relational relocate(a) order-enforcing", {
   out <- rel_to_altrep(rel3)
   expect_identical(
     out,
-    data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+    data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -14067,7 +13928,7 @@ test_that("relational relocate(g, .before = b) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "relocate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -14101,7 +13962,7 @@ test_that("relational relocate(g, .before = b) order-enforcing", {
   out <- rel_to_altrep(rel3)
   expect_identical(
     out,
-    data.frame(a = seq(1, 6, by = 1), g = c(1L, 2L, 2L, 3L, 3L, 3L), b = rep(2, 6L))
+    data.frame(a = seq(1, 6, by = 1), g = c(1L, 2L, 2L, 3L, 3L, 3L), b = 2)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -14111,7 +13972,7 @@ test_that("relational relocate(a:b, .after = g) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "relocate"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -14145,7 +14006,7 @@ test_that("relational relocate(a:b, .after = g) order-enforcing", {
   out <- rel_to_altrep(rel3)
   expect_identical(
     out,
-    data.frame(g = c(1L, 2L, 2L, 3L, 3L, 3L), a = seq(1, 6, by = 1), b = rep(2, 6L))
+    data.frame(g = c(1L, 2L, 2L, 3L, 3L, 3L), a = seq(1, 6, by = 1), b = 2)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -14157,7 +14018,7 @@ test_that("relational rename() order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "rename"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -14186,7 +14047,7 @@ test_that("relational rename() order-preserving", {
   out <- rel_to_altrep(rel2)
   expect_identical(
     out,
-    data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+    data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -14196,7 +14057,7 @@ test_that("relational rename(c = a) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "rename"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -14225,7 +14086,7 @@ test_that("relational rename(c = a) order-preserving", {
   out <- rel_to_altrep(rel2)
   expect_identical(
     out,
-    data.frame(c = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+    data.frame(c = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -14237,7 +14098,7 @@ test_that("relational rename() order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "rename"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -14271,7 +14132,7 @@ test_that("relational rename() order-enforcing", {
   out <- rel_to_altrep(rel3)
   expect_identical(
     out,
-    data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+    data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -14281,7 +14142,7 @@ test_that("relational rename(c = a) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "rename"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -14315,7 +14176,7 @@ test_that("relational rename(c = a) order-enforcing", {
   out <- rel_to_altrep(rel3)
   expect_identical(
     out,
-    data.frame(c = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+    data.frame(c = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -14330,13 +14191,13 @@ test_that("relational right_join(join_by(a)) order-preserving", {
   invisible(
     dbExecute(con, 'CREATE MACRO "___eq_na_matches_na"(x, y) AS (x IS NOT DISTINCT FROM y)')
   )
-  df1 <- data.frame(a = 1:4, b = rep(2, 4L))
+  df1 <- data.frame(a = 1:4, b = 2)
 
   "right_join"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
   "right_join"
   rel2 <- rel_set_alias(rel1, "lhs")
-  df2 <- data.frame(a = 2:5, b = rep(2, 4L))
+  df2 <- data.frame(a = 2:5, b = 2)
 
   "right_join"
   rel3 <- rel_from_df(con, df2, experimental = experimental)
@@ -14455,7 +14316,7 @@ test_that("relational right_join(join_by(a)) order-preserving", {
   out <- rel_to_altrep(rel11)
   expect_identical(
     out,
-    data.frame(a = 2:5, b.x = c(2, 2, 2, NA), b.y = rep(2, 4L))
+    data.frame(a = 2:5, b.x = c(2, 2, 2, NA), b.y = 2)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -14470,13 +14331,13 @@ test_that("relational right_join(join_by(a)) order-enforcing", {
   invisible(
     dbExecute(con, 'CREATE MACRO "___eq_na_matches_na"(x, y) AS (x IS NOT DISTINCT FROM y)')
   )
-  df1 <- data.frame(a = 1:4, b = rep(2, 4L))
+  df1 <- data.frame(a = 1:4, b = 2)
 
   "right_join"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
   "right_join"
   rel2 <- rel_set_alias(rel1, "lhs")
-  df2 <- data.frame(a = 2:5, b = rep(2, 4L))
+  df2 <- data.frame(a = 2:5, b = 2)
 
   "right_join"
   rel3 <- rel_from_df(con, df2, experimental = experimental)
@@ -14553,7 +14414,7 @@ test_that("relational right_join(join_by(a)) order-enforcing", {
   out <- rel_to_altrep(rel9)
   expect_identical(
     out,
-    data.frame(a = 2:5, b.x = c(2, 2, 2, NA), b.y = rep(2, 4L))
+    data.frame(a = 2:5, b.x = c(2, 2, 2, NA), b.y = 2)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -14565,7 +14426,7 @@ test_that("relational select(a) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "select"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -14594,7 +14455,7 @@ test_that("relational select(-g) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "select"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -14618,7 +14479,7 @@ test_that("relational select(-g) order-preserving", {
   out <- rel_to_altrep(rel2)
   expect_identical(
     out,
-    data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L))
+    data.frame(a = seq(1, 6, by = 1), b = 2)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -14628,7 +14489,7 @@ test_that("relational select(everything()) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "select"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -14657,7 +14518,7 @@ test_that("relational select(everything()) order-preserving", {
   out <- rel_to_altrep(rel2)
   expect_identical(
     out,
-    data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+    data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -14669,7 +14530,7 @@ test_that("relational select(a) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "select"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -14700,7 +14561,7 @@ test_that("relational select(-g) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "select"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -14726,7 +14587,7 @@ test_that("relational select(-g) order-enforcing", {
   out <- rel_to_altrep(rel3)
   expect_identical(
     out,
-    data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L))
+    data.frame(a = seq(1, 6, by = 1), b = 2)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -14736,7 +14597,7 @@ test_that("relational select(everything()) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "select"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -14770,7 +14631,7 @@ test_that("relational select(everything()) order-enforcing", {
   out <- rel_to_altrep(rel3)
   expect_identical(
     out,
-    data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+    data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -14785,13 +14646,13 @@ test_that("relational semi_join(join_by(a)) order-preserving", {
   invisible(
     dbExecute(con, 'CREATE MACRO "___eq_na_matches_na"(x, y) AS (x IS NOT DISTINCT FROM y)')
   )
-  df1 <- data.frame(a = 1:4, b = rep(2, 4L))
+  df1 <- data.frame(a = 1:4, b = 2)
 
   "semi_join"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
   "semi_join"
   rel2 <- rel_set_alias(rel1, "lhs")
-  df2 <- data.frame(a = 2:5, b = rep(2, 4L))
+  df2 <- data.frame(a = 2:5, b = 2)
 
   "semi_join"
   rel3 <- rel_from_df(con, df2, experimental = experimental)
@@ -14849,7 +14710,7 @@ test_that("relational semi_join(join_by(a)) order-preserving", {
   out <- rel_to_altrep(rel8)
   expect_identical(
     out,
-    data.frame(a = 2:4, b = rep(2, 3L))
+    data.frame(a = 2:4, b = 2)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -14864,13 +14725,13 @@ test_that("relational semi_join(join_by(a)) order-enforcing", {
   invisible(
     dbExecute(con, 'CREATE MACRO "___eq_na_matches_na"(x, y) AS (x IS NOT DISTINCT FROM y)')
   )
-  df1 <- data.frame(a = 1:4, b = rep(2, 4L))
+  df1 <- data.frame(a = 1:4, b = 2)
 
   "semi_join"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
   "semi_join"
   rel2 <- rel_set_alias(rel1, "lhs")
-  df2 <- data.frame(a = 2:5, b = rep(2, 4L))
+  df2 <- data.frame(a = 2:5, b = 2)
 
   "semi_join"
   rel3 <- rel_from_df(con, df2, experimental = experimental)
@@ -14891,7 +14752,7 @@ test_that("relational semi_join(join_by(a)) order-enforcing", {
   out <- rel_to_altrep(rel6)
   expect_identical(
     out,
-    data.frame(a = 2:4, b = rep(2, 3L))
+    data.frame(a = 2:4, b = 2)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -14906,14 +14767,13 @@ test_that("relational setdiff() order-preserving", {
   invisible(
     dbExecute(con, 'CREATE MACRO "___eq_na_matches_na"(x, y) AS (x IS NOT DISTINCT FROM y)')
   )
-  invisible(rapi_load_rfuns(drv@database_ref))
-  df1 <- data.frame(a = 1:4, b = rep(2, 4L))
+  df1 <- data.frame(a = 1:4, b = 2)
 
   "anti_join"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
   "anti_join"
   rel2 <- rel_set_alias(rel1, "lhs")
-  df2 <- data.frame(a = 2:5, b = rep(2, 4L))
+  df2 <- data.frame(a = 2:5, b = 2)
 
   "anti_join"
   rel3 <- rel_from_df(con, df2, experimental = experimental)
@@ -15032,8 +14892,8 @@ test_that("relational setdiff() order-preserving", {
   rel11 <- rel_filter(
     rel10,
     list(
-      expr_function(
-        "r_base::==",
+      expr_comparison(
+        "==",
         list(
           expr_reference("___row_number_by"),
           if ("experimental" %in% names(formals(expr_constant))) {
@@ -15079,11 +14939,11 @@ test_that("relational setdiff() order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = 1:4, b = rep(2, 4L))
+  df1 <- data.frame(a = 1:4, b = 2)
 
   "setdiff"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
-  df2 <- data.frame(a = 2:5, b = rep(2, 4L))
+  df2 <- data.frame(a = 2:5, b = 2)
 
   "setdiff"
   rel2 <- rel_from_df(con, df2, experimental = experimental)
@@ -15107,7 +14967,7 @@ test_that("relational summarise(c = mean(a)) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "summarise"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -15139,7 +14999,7 @@ test_that("relational summarise(c = mean(a), .by = b) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "summarise"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -15218,7 +15078,7 @@ test_that("relational summarise(c = mean(a), .by = g) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "summarise"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -15297,7 +15157,7 @@ test_that("relational summarise(c = 1) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "summarise"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -15333,7 +15193,7 @@ test_that("relational summarise(c = 1, .by = g) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "summarise"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -15406,7 +15266,7 @@ test_that("relational summarise(c = 1, .by = g) order-preserving", {
   out <- rel_to_altrep(rel5)
   expect_identical(
     out,
-    data.frame(g = 1:3, c = rep(1, 3L))
+    data.frame(g = 1:3, c = 1)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -15417,7 +15277,7 @@ test_that("relational summarise(n = n(), n = n() + 1L, .by = g) order-preserving
   con <- dbConnect(drv)
   experimental <- FALSE
   invisible(dbExecute(con, 'CREATE MACRO "n"() AS CAST(COUNT(*) AS int32)'))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "summarise"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -15507,7 +15367,7 @@ test_that("relational summarise(n = n(), n = n() + 1L) order-preserving", {
   con <- dbConnect(drv)
   experimental <- FALSE
   invisible(dbExecute(con, 'CREATE MACRO "n"() AS CAST(COUNT(*) AS int32)'))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "summarise"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -15551,7 +15411,7 @@ test_that("relational summarise(c = mean(a)) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "summarise"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -15585,7 +15445,7 @@ test_that("relational summarise(c = mean(a), .by = b) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "summarise"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -15617,7 +15477,7 @@ test_that("relational summarise(c = mean(a), .by = g) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "summarise"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -15649,7 +15509,7 @@ test_that("relational summarise(c = 1) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "summarise"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -15687,7 +15547,7 @@ test_that("relational summarise(c = 1, .by = g) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "summarise"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -15713,7 +15573,7 @@ test_that("relational summarise(c = 1, .by = g) order-enforcing", {
   out <- rel_to_altrep(rel3)
   expect_identical(
     out,
-    data.frame(g = 1:3, c = rep(1, 3L))
+    data.frame(g = 1:3, c = 1)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -15724,7 +15584,7 @@ test_that("relational summarise(n = n(), n = n() + 1L, .by = g) order-enforcing"
   con <- dbConnect(drv)
   experimental <- FALSE
   invisible(dbExecute(con, 'CREATE MACRO "n"() AS CAST(COUNT(*) AS int32)'))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "summarise"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -15767,7 +15627,7 @@ test_that("relational summarise(n = n(), n = n() + 1L) order-enforcing", {
   con <- dbConnect(drv)
   experimental <- FALSE
   invisible(dbExecute(con, 'CREATE MACRO "n"() AS CAST(COUNT(*) AS int32)'))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "summarise"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -15816,14 +15676,13 @@ test_that("relational symdiff() order-preserving", {
   invisible(
     dbExecute(con, 'CREATE MACRO "___eq_na_matches_na"(x, y) AS (x IS NOT DISTINCT FROM y)')
   )
-  invisible(rapi_load_rfuns(drv@database_ref))
-  df1 <- data.frame(a = 1:4, b = rep(2, 4L))
+  df1 <- data.frame(a = 1:4, b = 2)
 
   "anti_join"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
   "anti_join"
   rel2 <- rel_set_alias(rel1, "lhs")
-  df2 <- data.frame(a = 2:5, b = rep(2, 4L))
+  df2 <- data.frame(a = 2:5, b = 2)
 
   "anti_join"
   rel3 <- rel_from_df(con, df2, experimental = experimental)
@@ -15878,14 +15737,40 @@ test_that("relational symdiff() order-preserving", {
       }
     )
   )
-  df3 <- data.frame(a = 1L, b = 2)
+  df3 <- data.frame(a = 5L, b = 2)
 
   "union_all"
   rel9 <- rel_from_df(con, df3, experimental = experimental)
-  df4 <- data.frame(a = 5L, b = 2)
-
   "union_all"
-  rel10 <- rel_from_df(con, df4, experimental = experimental)
+  rel10 <- rel_project(
+    rel8,
+    list(
+      {
+        tmp_expr <- expr_reference("a")
+        expr_set_alias(tmp_expr, "a")
+        tmp_expr
+      },
+      {
+        tmp_expr <- expr_reference("b")
+        expr_set_alias(tmp_expr, "b")
+        tmp_expr
+      },
+      {
+        tmp_expr <- expr_window(expr_function("row_number", list()), list(), list(), offset_expr = NULL, default_expr = NULL)
+        expr_set_alias(tmp_expr, "___row_number_x")
+        tmp_expr
+      },
+      {
+        tmp_expr <- if ("experimental" %in% names(formals(expr_constant))) {
+          expr_constant(NA_integer_, experimental = experimental)
+        } else {
+          expr_constant(NA_integer_)
+        }
+        expr_set_alias(tmp_expr, "___row_number_y")
+        tmp_expr
+      }
+    )
+  )
   "union_all"
   rel11 <- rel_project(
     rel9,
@@ -15901,36 +15786,6 @@ test_that("relational symdiff() order-preserving", {
         tmp_expr
       },
       {
-        tmp_expr <- expr_window(expr_function("row_number", list()), list(), list(), offset_expr = NULL, default_expr = NULL)
-        expr_set_alias(tmp_expr, "___row_number_x")
-        tmp_expr
-      },
-      {
-        tmp_expr <- if ("experimental" %in% names(formals(expr_constant))) {
-          expr_constant(NA_integer_, experimental = experimental)
-        } else {
-          expr_constant(NA_integer_)
-        }
-        expr_set_alias(tmp_expr, "___row_number_y")
-        tmp_expr
-      }
-    )
-  )
-  "union_all"
-  rel12 <- rel_project(
-    rel10,
-    list(
-      {
-        tmp_expr <- expr_reference("a")
-        expr_set_alias(tmp_expr, "a")
-        tmp_expr
-      },
-      {
-        tmp_expr <- expr_reference("b")
-        expr_set_alias(tmp_expr, "b")
-        tmp_expr
-      },
-      {
         tmp_expr <- if ("experimental" %in% names(formals(expr_constant))) {
           expr_constant(NA_integer_, experimental = experimental)
         } else {
@@ -15947,15 +15802,15 @@ test_that("relational symdiff() order-preserving", {
     )
   )
   "union_all"
-  rel13 <- rel_union_all(rel11, rel12)
+  rel12 <- rel_union_all(rel10, rel11)
   "union_all"
-  rel14 <- rel_order(
-    rel13,
+  rel13 <- rel_order(
+    rel12,
     list(expr_reference("___row_number_x"), expr_reference("___row_number_y"))
   )
   "union_all"
-  rel15 <- rel_project(
-    rel14,
+  rel14 <- rel_project(
+    rel13,
     list(
       {
         tmp_expr <- expr_reference("a")
@@ -15970,8 +15825,8 @@ test_that("relational symdiff() order-preserving", {
     )
   )
   "distinct"
-  rel16 <- rel_project(
-    rel15,
+  rel15 <- rel_project(
+    rel14,
     list(
       {
         tmp_expr <- expr_reference("a")
@@ -15991,8 +15846,8 @@ test_that("relational symdiff() order-preserving", {
     )
   )
   "distinct"
-  rel17 <- rel_project(
-    rel16,
+  rel16 <- rel_project(
+    rel15,
     list(
       {
         tmp_expr <- expr_reference("a")
@@ -16030,11 +15885,11 @@ test_that("relational symdiff() order-preserving", {
     )
   )
   "distinct"
-  rel18 <- rel_filter(
-    rel17,
+  rel17 <- rel_filter(
+    rel16,
     list(
-      expr_function(
-        "r_base::==",
+      expr_comparison(
+        "==",
         list(
           expr_reference("___row_number_by"),
           if ("experimental" %in% names(formals(expr_constant))) {
@@ -16047,10 +15902,10 @@ test_that("relational symdiff() order-preserving", {
     )
   )
   "distinct"
-  rel19 <- rel_order(rel18, list(expr_reference("___row_number")))
+  rel18 <- rel_order(rel17, list(expr_reference("___row_number")))
   "distinct"
-  rel20 <- rel_project(
-    rel19,
+  rel19 <- rel_project(
+    rel18,
     list(
       {
         tmp_expr <- expr_reference("a")
@@ -16064,11 +15919,11 @@ test_that("relational symdiff() order-preserving", {
       }
     )
   )
-  rel20
-  out <- rel_to_altrep(rel20)
+  rel19
+  out <- rel_to_altrep(rel19)
   expect_identical(
     out,
-    data.frame(a = c(1L, 5L), b = c(2, 2))
+    data.frame(a = c(1L, 5L), b = 2)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -16080,11 +15935,11 @@ test_that("relational symdiff() order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = 1:4, b = rep(2, 4L))
+  df1 <- data.frame(a = 1:4, b = 2)
 
   "symdiff"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
-  df2 <- data.frame(a = 2:5, b = rep(2, 4L))
+  df2 <- data.frame(a = 2:5, b = 2)
 
   "symdiff"
   rel2 <- rel_from_df(con, df2, experimental = experimental)
@@ -16096,7 +15951,7 @@ test_that("relational symdiff() order-enforcing", {
   out <- rel_to_altrep(rel4)
   expect_identical(
     out,
-    data.frame(a = c(1L, 5L), b = c(2, 2))
+    data.frame(a = c(1L, 5L), b = 2)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -16109,7 +15964,7 @@ test_that("relational tally() order-preserving", {
   con <- dbConnect(drv)
   experimental <- FALSE
   invisible(dbExecute(con, 'CREATE MACRO "n"() AS CAST(COUNT(*) AS int32)'))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "summarise"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -16144,7 +15999,7 @@ test_that("relational tally() order-enforcing", {
   con <- dbConnect(drv)
   experimental <- FALSE
   invisible(dbExecute(con, 'CREATE MACRO "n"() AS CAST(COUNT(*) AS int32)'))
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "summarise"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -16180,7 +16035,7 @@ test_that("relational transmute(c = a + 1) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "transmute"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -16219,7 +16074,7 @@ test_that("relational transmute(row = a) order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "transmute"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -16250,7 +16105,7 @@ test_that("relational transmute(c = a + 1) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "transmute"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -16291,7 +16146,7 @@ test_that("relational transmute(row = a) order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = seq(1, 6, by = 1), b = rep(2, 6L), g = c(1L, 2L, 2L, 3L, 3L, 3L))
+  df1 <- data.frame(a = seq(1, 6, by = 1), b = 2, g = c(1L, 2L, 2L, 3L, 3L, 3L))
 
   "transmute"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
@@ -16324,12 +16179,11 @@ test_that("relational union() order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  invisible(rapi_load_rfuns(drv@database_ref))
-  df1 <- data.frame(a = 1:4, b = rep(2, 4L))
+  df1 <- data.frame(a = 1:4, b = 2)
 
   "union_all"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
-  df2 <- data.frame(a = 2:5, b = rep(2, 4L))
+  df2 <- data.frame(a = 2:5, b = 2)
 
   "union_all"
   rel2 <- rel_from_df(con, df2, experimental = experimental)
@@ -16480,8 +16334,8 @@ test_that("relational union() order-preserving", {
   rel10 <- rel_filter(
     rel9,
     list(
-      expr_function(
-        "r_base::==",
+      expr_comparison(
+        "==",
         list(
           expr_reference("___row_number_by"),
           if ("experimental" %in% names(formals(expr_constant))) {
@@ -16515,7 +16369,7 @@ test_that("relational union() order-preserving", {
   out <- rel_to_altrep(rel12)
   expect_identical(
     out,
-    data.frame(a = 1:5, b = rep(2, 5L))
+    data.frame(a = 1:5, b = 2)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -16527,11 +16381,11 @@ test_that("relational union() order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = 1:4, b = rep(2, 4L))
+  df1 <- data.frame(a = 1:4, b = 2)
 
   "union_all"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
-  df2 <- data.frame(a = 2:5, b = rep(2, 4L))
+  df2 <- data.frame(a = 2:5, b = 2)
 
   "union_all"
   rel2 <- rel_from_df(con, df2, experimental = experimental)
@@ -16545,7 +16399,7 @@ test_that("relational union() order-enforcing", {
   out <- rel_to_altrep(rel5)
   expect_identical(
     out,
-    data.frame(a = 1:5, b = rep(2, 5L))
+    data.frame(a = 1:5, b = 2)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -16557,11 +16411,11 @@ test_that("relational union_all() order-preserving", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = 1:4, b = rep(2, 4L))
+  df1 <- data.frame(a = 1:4, b = 2)
 
   "union_all"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
-  df2 <- data.frame(a = 2:5, b = rep(2, 4L))
+  df2 <- data.frame(a = 2:5, b = 2)
 
   "union_all"
   rel2 <- rel_from_df(con, df2, experimental = experimental)
@@ -16652,7 +16506,7 @@ test_that("relational union_all() order-preserving", {
   out <- rel_to_altrep(rel7)
   expect_identical(
     out,
-    data.frame(a = c(1L, 2L, 3L, 4L, 2L, 3L, 4L, 5L), b = rep(2, 8L))
+    data.frame(a = c(1L, 2L, 3L, 4L, 2L, 3L, 4L, 5L), b = 2)
   )
   dbDisconnect(con, shutdown = TRUE)
 })
@@ -16664,11 +16518,11 @@ test_that("relational union_all() order-enforcing", {
   drv <- duckdb()
   con <- dbConnect(drv)
   experimental <- FALSE
-  df1 <- data.frame(a = 1:4, b = rep(2, 4L))
+  df1 <- data.frame(a = 1:4, b = 2)
 
   "union_all"
   rel1 <- rel_from_df(con, df1, experimental = experimental)
-  df2 <- data.frame(a = 2:5, b = rep(2, 4L))
+  df2 <- data.frame(a = 2:5, b = 2)
 
   "union_all"
   rel2 <- rel_from_df(con, df2, experimental = experimental)
@@ -16680,7 +16534,7 @@ test_that("relational union_all() order-enforcing", {
   out <- rel_to_altrep(rel4)
   expect_identical(
     out,
-    data.frame(a = c(1L, 2L, 2L, 3L, 3L, 4L, 4L, 5L), b = rep(2, 8L))
+    data.frame(a = c(1L, 2L, 2L, 3L, 3L, 4L, 4L, 5L), b = 2)
   )
   dbDisconnect(con, shutdown = TRUE)
 })


### PR DESCRIPTION
- **fledge: Bump**
- **ci: Avoid failure in fledge workflow if no changes (#639)**
- **test: Sync tests**
- **chore: IDE**
- **test: Skip tests that are about to fail**
- **feat: New internal `rapi_rel_to_csv()`,`rapi_rel_to_table()`, and `rapi_rel_insert()`; `rapi_rel_to_parquet()` gains `options` argument (#867)**
- **chore: `rethrow_()` variants**
- **fix: Argument order**
- **fix: Make `cleanup` truly idempotent (#940)**
- **chore: Move internal `duckdb.tar` dependency (#1013)**
- **NEWS**
