### PR TITLE
fledge: CRAN release v1.2.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: duckdb
 Title: DBI Package for the DuckDB Database Management System
-Version: 1.2.0.9006
+Version: 1.2.1
 Authors@R: c(
     person("Hannes", "Mühleisen", , "hannes@cwi.nl", role = "aut",
            comment = c(ORCID = "0000-0001-8552-0029")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,161 +2,29 @@
 
 # duckdb 1.2.1
 
+## Features
+
+- Update to duckdb v1.2.1, see <https://github.com/duckdb/duckdb/releases/tag/v1.2.1> for details.
+
 ## Bug fixes
 
 - `dbExecute(con, "CALL ...")` no longer attempts to access the resulting data frame. Use `dbGetQuery(con, "CALL ...")` to access the data (#1062, #1080).
 
 - Fix support for the connections pane in RStudio and Positron (@dfalbel, #1063).
 
-## Features
+## Internal
 
-- New `rel_to_view() (`\#1075\`{=html}).
+- New `rel_to_view()` (\#1075).
 
 - New internal `AltrepDataframeRelation`, used with `rel_from_altrep_df(wrap = TRUE)` (#949, #1072).
 
-- Try materialization only once (#1066).
+- Try relational materialization only once (#1066).
 
 ## Chore
-
-- Tweak error message.
-
-- Fix error if `NULL` is passed as environment for sessions with `duckdb(environment_scan = TRUE)` (#1076).
-
-- Fix clang 20 compatibility (#1071).
 
 - Update vendored cpp11 to 0.5.2 (#1068).
 
 - Avoid calls to non-API R functions.
-
-- More careful cleanup.
-
-- Clean up after failed vendoring.
-
-- Prepare removal of `allow_materialization` (#1057).
-
-## Testing
-
-- Adapt malformed test.
-
-## Uncategorized
-
-- PLACEHOLDER https://github.com/duckdb/duckdb-r/pull/1074 (#1074).
-
-- Vendor: Update vendored sources (tag v1.2.1) to duckdb/duckdb@8e52ec43959ab363643d63cb78ee214577111da4.
-
-- Vendor: Update vendored sources to duckdb/duckdb@ef253eea8eb6f97244578c4df3ef0c72dc72ca65.
-
-- Vendor: Update vendored sources to duckdb/duckdb@fba0ffea7e034d2601b8ec5c7afb508245bbec93.
-
-- Vendor: Update vendored sources to duckdb/duckdb@28b8a398a493f2e845cecb367f1ac04892c9edab.
-
-- Vendor: Update vendored sources to duckdb/duckdb@a0b525cb6dcc847d20405487478fd26142801a9b.
-
-- Vendor: Update vendored sources to duckdb/duckdb@318e783c48f295e44d8d4ca613cbf10c28d68c09.
-
-- Vendor: Update vendored sources to duckdb/duckdb@5e6f23a220a73a965fb118f56a306d2b728df48d.
-
-- Vendor: Update vendored sources to duckdb/duckdb@4c370a7fe0e2b10642b4638f2dd8385eaf5260d4.
-
-- Vendor: Update vendored sources to duckdb/duckdb@9f42783b00e80c2c21121781b3ea53dc0f517769.
-
-- Vendor: Update vendored sources to duckdb/duckdb@ddee4c445f385dca7869115e5e2f3c513d73bf1a.
-
-- Vendor: Update vendored sources to duckdb/duckdb@718e9f1396aaf77a6afea6e5d1b26a60d815fefb.
-
-- Vendor: Update vendored sources to duckdb/duckdb@b6d9eabb8f0aa61acc1b2f7a7c286640efcdd198.
-
-- Vendor: Update vendored sources to duckdb/duckdb@3050447575d18bb48bbd5177fdc5e2ea2f06b70e.
-
-- Vendor: Update vendored sources to duckdb/duckdb@96b9742bc6b3d8e931ecb8c63791182c87f5d349.
-
-- Vendor: Update vendored sources to duckdb/duckdb@e9a3cec452a5e18d018783c4af4bb54bad8ef538.
-
-- Vendor: Update vendored sources to duckdb/duckdb@f99871b64c46229f3a51b0f5e26cc417da300a3b.
-
-- Vendor: Update vendored sources to duckdb/duckdb@a87b39a56889a72ff4a63e305064b2f4dc0914de.
-
-- Vendor: Update vendored sources to duckdb/duckdb@77a4b9873d6ffc1ce7a78fe92891a3ff9079563d.
-
-- Vendor: Update vendored sources to duckdb/duckdb@bd9f49043d1ece7573a0625f7aa08542348a9365.
-
-- Vendor: Update vendored sources to duckdb/duckdb@ff41058fc983e252b773089e6075c4bebd21c6ab.
-
-- Vendor: Update vendored sources to duckdb/duckdb@d8387736a9cd84774f68b6a19531673aa0cce585.
-
-- Vendor: Update vendored sources to duckdb/duckdb@c79f529696f137eda88c46923c6d7972a155b449.
-
-- Vendor: Update vendored sources to duckdb/duckdb@023633611fe3fc0a6feee833a1de1a353877b7a7.
-
-- Vendor: Update vendored sources to duckdb/duckdb@227d9d36bc7e980af7fc51677b35fa3e4edec85b.
-
-- Vendor: Update vendored sources to duckdb/duckdb@dac2f866d7ed3fc942fe12171efa6e2d030ddab1.
-
-- Vendor: Update vendored sources to duckdb/duckdb@e8889b7a0e7fb9bf08d312e0397271b0c09b5876.
-
-- Vendor: Update vendored sources to duckdb/duckdb@ef50246314b2f80dcf6a8132db45a80dab7dd162.
-
-- Vendor: Update vendored sources to duckdb/duckdb@317dc5ba5a9cee309425f8ca770c680c9fb475d9.
-
-- Vendor: Update vendored sources to duckdb/duckdb@5ea07fd6a49e89e95de18470b7b8a146e1b09cbe.
-
-- Vendor: Update vendored sources to duckdb/duckdb@cabb9db877c6f69fe5c4e814a28bb42d9a8eda27.
-
-- Vendor: Update vendored sources to duckdb/duckdb@24d18d02e7dc2fad8f95e923baeab9effdd70e7e.
-
-- Vendor: Update vendored sources to duckdb/duckdb@5509eb4516b27b83b0b8101a50632090df5cb6e6.
-
-- Vendor: Update vendored sources to duckdb/duckdb@9c9823db406bd51b6f23f500790eb36dd780e9be.
-
-- Vendor: Update vendored sources to duckdb/duckdb@c19a7fed49a5bbca50c7417c38e2e619a77bffdf.
-
-- Vendor: Update vendored sources to duckdb/duckdb@6415640753e28d21ca5fb340d28a2bf435bab313.
-
-- Vendor: Update vendored sources to duckdb/duckdb@6f2447e01e94f4a80c22e035cadf9534a8092aa1.
-
-- Vendor: Update vendored sources to duckdb/duckdb@42859d220dfc9f74619ee126d460b8cbb8fb7597.
-
-- Vendor: Update vendored sources to duckdb/duckdb@e1d11312b279bf271ae3b282661cd2c5ffa56505.
-
-- Vendor: Update vendored sources to duckdb/duckdb@d1062f154ead67b3af76902d25a9502e2c597548.
-
-- Vendor: Update vendored sources to duckdb/duckdb@cfafb10bb2863b6f8706af66c8cd6d19c167de51.
-
-- Vendor: Update vendored sources to duckdb/duckdb@4c8d1f9192a008ca384e01059cc5cb93e6f06f6e.
-
-- Vendor: Update vendored sources to duckdb/duckdb@2ba2b654620c39ce9b32deb54e910ecdd9baafcc.
-
-- Vendor: Update vendored sources to duckdb/duckdb@df68ebd5f32da54b9954b0e54f14747544a5c5cf.
-
-- Vendor: Update vendored sources to duckdb/duckdb@c27c0529b13f8f20acf3164affa3bb618577e3d4.
-
-- Vendor: Update vendored sources to duckdb/duckdb@52811a9d197d8c4e98d291b4144a0d1724cefbda.
-
-- Vendor: Update vendored sources to duckdb/duckdb@2b873268957ce115b6314ca72ca31e0f4ebf6fa6.
-
-- Vendor: Update vendored sources to duckdb/duckdb@dfdd6a5e2d3bd31fa3c25d11b43608f0ad9b18b5.
-
-- Vendor: Update vendored sources to duckdb/duckdb@d2cec3e5fbd6c158a3b8965f93abb7f692185a1f.
-
-- Vendor: Update vendored sources to duckdb/duckdb@9b8fff6fa2fab30e44ee196b59a57c08af84492a.
-
-- Vendor: Update vendored sources to duckdb/duckdb@5b8f3542dd62ec1c9f18a96f64088367d770f4bc.
-
-- Vendor: Update vendored sources to duckdb/duckdb@a86eb125b77f49ee123889c995e6b8c2079bbefe.
-
-- Vendor: Update vendored sources to duckdb/duckdb@989e6536005325be9e8b9dc2d351aba3cf731d50.
-
-- Vendor: Update vendored sources to duckdb/duckdb@8b582bcabd995a9bd657c3740737af9f4c833f4c.
-
-- Vendor: Update vendored sources to duckdb/duckdb@f667296c3df4694a79253bf7ba2ed9f8e71c17ba.
-
-- Vendor: Update vendored sources to duckdb/duckdb@4f8064425d24da27ec8403927809f55ff4fdbe02.
-
-- Vendor: Update vendored sources to duckdb/duckdb@f7637a9b9be4c8fb199e47d8f1011f5eee0a9b4e.
-
-- Vendor: Update vendored sources (tag v1.2.0) to duckdb/duckdb@5f5512b827df6397afd31daedb4bbdee76520019.
-
-- Vendor: Update vendored sources to duckdb/duckdb@0e844786417d80226851f5fc375060b47d3b65e0.
 
 
 # duckdb 1.2.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,14 +1,20 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# duckdb 1.2.0.9006
+# duckdb 1.2.1
 
 ## Bug fixes
 
 - `dbExecute(con, "CALL ...")` no longer attempts to access the resulting data frame. Use `dbGetQuery(con, "CALL ...")` to access the data (#1062, #1080).
 
+- Fix support for the connections pane in RStudio and Positron (@dfalbel, #1063).
+
 ## Features
 
 - New `rel_to_view() (`\#1075\`{=html}).
+
+- New internal `AltrepDataframeRelation`, used with `rel_from_altrep_df(wrap = TRUE)` (#949, #1072).
+
+- Try materialization only once (#1066).
 
 ## Chore
 
@@ -16,49 +22,25 @@
 
 - Fix error if `NULL` is passed as environment for sessions with `duckdb(environment_scan = TRUE)` (#1076).
 
-## Uncategorized
-
-- PLACEHOLDER https://github.com/duckdb/duckdb-r/pull/1074 (#1074).
-
-
-# duckdb 1.2.0.9005
-
-## Features
-
-- New internal `AltrepDataframeRelation`, used with `rel_from_altrep_df(wrap = TRUE)` (#949, #1072).
-
-## Chore
-
 - Fix clang 20 compatibility (#1071).
-
-
-# duckdb 1.2.0.9004
-
-## Bug fixes
-
-- Fix support for the connections pane in RStudio and Positron (@dfalbel, #1063).
-
-
-# duckdb 1.2.0.9003
-
-## Chore
 
 - Update vendored cpp11 to 0.5.2 (#1068).
 
 - Avoid calls to non-API R functions.
 
+- More careful cleanup.
 
-# duckdb 1.2.0.9002
+- Clean up after failed vendoring.
 
-## Features
-
-- Try materialization only once (#1066).
+- Prepare removal of `allow_materialization` (#1057).
 
 ## Testing
 
 - Adapt malformed test.
 
 ## Uncategorized
+
+- PLACEHOLDER https://github.com/duckdb/duckdb-r/pull/1074 (#1074).
 
 - Vendor: Update vendored sources (tag v1.2.1) to duckdb/duckdb@8e52ec43959ab363643d63cb78ee214577111da4.
 
@@ -174,25 +156,7 @@
 
 - Vendor: Update vendored sources (tag v1.2.0) to duckdb/duckdb@5f5512b827df6397afd31daedb4bbdee76520019.
 
-
-# duckdb 1.2.0.9001
-
-## Chore
-
-- More careful cleanup.
-
-- Clean up after failed vendoring.
-
-## Uncategorized
-
 - Vendor: Update vendored sources to duckdb/duckdb@0e844786417d80226851f5fc375060b47d3b65e0.
-
-
-# duckdb 1.2.0.9000
-
-## Chore
-
-- Prepare removal of `allow_materialization` (#1057).
 
 
 # duckdb 1.2.0

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,4 +1,4 @@
-duckdb 1.2.0
+duckdb 1.2.1
 
 ## Cran Repository Policy
 

--- a/patch/0015-UMA-1.patch
+++ b/patch/0015-UMA-1.patch
@@ -1,27 +1,26 @@
-From bde583340d571dca2af1693375964161a37bea6d Mon Sep 17 00:00:00 2001
+From ced20e495b349ecb43664e6c8fba71b033e4835d Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Kirill=20M=C3=BCller?= <kirill@cynkra.com>
-Date: Fri, 14 Mar 2025 07:38:54 +0100
-Subject: [PATCH 15/17] UMA 1
+Date: Fri, 14 Mar 2025 08:02:53 +0100
+Subject: [PATCH] UMA 1
 
 ---
- .../include/core_functions/aggregate/quantile_state.hpp       | 4 ++++
- 1 file changed, 4 insertions(+)
+ .../include/core_functions/aggregate/quantile_state.hpp        | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
 
 diff --git a/src/duckdb/extension/core_functions/include/core_functions/aggregate/quantile_state.hpp b/src/duckdb/extension/core_functions/include/core_functions/aggregate/quantile_state.hpp
-index 00f4baf77..49ac31861 100644
+index 49ac31861..cdf242ae9 100644
 --- a/src/duckdb/extension/core_functions/include/core_functions/aggregate/quantile_state.hpp
 +++ b/src/duckdb/extension/core_functions/include/core_functions/aggregate/quantile_state.hpp
-@@ -208,6 +208,10 @@ struct WindowQuantileState {
+@@ -207,8 +207,7 @@ struct WindowQuantileState {
+ 				dest[0] = skips[0].second;
  				if (skips.size() > 1) {
  					dest[1] = skips[1].second;
+-				}
+-				else {
++				} else {
+ 					// Avoid UMA
+ 					dest[1] = skips[0].second;
  				}
-+				else {
-+					// Avoid UMA
-+					dest[1] = skips[0].second;
-+				}
- 				return interp.template Extract<INPUT_TYPE, RESULT_TYPE>(dest.data(), result);
- 			} catch (const duckdb_skiplistlib::skip_list::IndexError &idx_err) {
- 				throw InternalException(idx_err.message());
 -- 
 2.48.1
 

--- a/patch/0015-UMA-1.patch
+++ b/patch/0015-UMA-1.patch
@@ -1,0 +1,27 @@
+From bde583340d571dca2af1693375964161a37bea6d Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Kirill=20M=C3=BCller?= <kirill@cynkra.com>
+Date: Fri, 14 Mar 2025 07:38:54 +0100
+Subject: [PATCH 15/17] UMA 1
+
+---
+ .../include/core_functions/aggregate/quantile_state.hpp       | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/duckdb/extension/core_functions/include/core_functions/aggregate/quantile_state.hpp b/src/duckdb/extension/core_functions/include/core_functions/aggregate/quantile_state.hpp
+index 00f4baf77..49ac31861 100644
+--- a/src/duckdb/extension/core_functions/include/core_functions/aggregate/quantile_state.hpp
++++ b/src/duckdb/extension/core_functions/include/core_functions/aggregate/quantile_state.hpp
+@@ -208,6 +208,10 @@ struct WindowQuantileState {
+ 				if (skips.size() > 1) {
+ 					dest[1] = skips[1].second;
+ 				}
++				else {
++					// Avoid UMA
++					dest[1] = skips[0].second;
++				}
+ 				return interp.template Extract<INPUT_TYPE, RESULT_TYPE>(dest.data(), result);
+ 			} catch (const duckdb_skiplistlib::skip_list::IndexError &idx_err) {
+ 				throw InternalException(idx_err.message());
+-- 
+2.48.1
+

--- a/patch/0016-UMA-2.patch
+++ b/patch/0016-UMA-2.patch
@@ -1,0 +1,50 @@
+From 5f581bc0fed9f21d9d6701bd585e1e1262a65da2 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Kirill=20M=C3=BCller?= <kirill@cynkra.com>
+Date: Fri, 14 Mar 2025 07:39:14 +0100
+Subject: [PATCH 16/17] UMA 2
+
+---
+ .../common/types/row/tuple_data_segment.cpp   | 20 +++++++++----------
+ 1 file changed, 10 insertions(+), 10 deletions(-)
+
+diff --git a/src/duckdb/src/common/types/row/tuple_data_segment.cpp b/src/duckdb/src/common/types/row/tuple_data_segment.cpp
+index d14c0e0ba..c3383f3cb 100644
+--- a/src/duckdb/src/common/types/row/tuple_data_segment.cpp
++++ b/src/duckdb/src/common/types/row/tuple_data_segment.cpp
+@@ -15,23 +15,23 @@ void TupleDataChunkPart::SetHeapEmpty() {
+ 	base_heap_ptr = nullptr;
+ }
+ 
+-void SwapTupleDataChunkPart(TupleDataChunkPart &a, TupleDataChunkPart &b) {
+-	std::swap(a.row_block_index, b.row_block_index);
+-	std::swap(a.row_block_offset, b.row_block_offset);
+-	std::swap(a.heap_block_index, b.heap_block_index);
+-	std::swap(a.heap_block_offset, b.heap_block_offset);
+-	std::swap(a.base_heap_ptr, b.base_heap_ptr);
+-	std::swap(a.total_heap_size, b.total_heap_size);
+-	std::swap(a.count, b.count);
++void MoveTupleDataChunkPart(TupleDataChunkPart &a, TupleDataChunkPart &b) {
++	a.row_block_index = b.row_block_index;
++	a.row_block_offset = b.row_block_offset;
++	a.heap_block_index = b.heap_block_index;
++	a.heap_block_offset = b.heap_block_offset;
++	a.base_heap_ptr = b.base_heap_ptr;
++	a.total_heap_size = b.total_heap_size;
++	a.count = b.count;
+ 	std::swap(a.lock, b.lock);
+ }
+ 
+ TupleDataChunkPart::TupleDataChunkPart(TupleDataChunkPart &&other) noexcept : lock((other.lock)) {
+-	SwapTupleDataChunkPart(*this, other);
++	MoveTupleDataChunkPart(*this, other);
+ }
+ 
+ TupleDataChunkPart &TupleDataChunkPart::operator=(TupleDataChunkPart &&other) noexcept {
+-	SwapTupleDataChunkPart(*this, other);
++	MoveTupleDataChunkPart(*this, other);
+ 	return *this;
+ }
+ 
+-- 
+2.48.1
+

--- a/patch/0017-UMA-3.patch
+++ b/patch/0017-UMA-3.patch
@@ -1,0 +1,25 @@
+From 84748fe7691c5da448b315ad526ec4f183a82091 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Kirill=20M=C3=BCller?= <kirill@cynkra.com>
+Date: Fri, 14 Mar 2025 07:39:20 +0100
+Subject: [PATCH 17/17] UMA 3
+
+---
+ .../operator/csv_scanner/scanner/string_value_scanner.cpp       | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/duckdb/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp b/src/duckdb/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
+index 725f442d4..db945be76 100644
+--- a/src/duckdb/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
++++ b/src/duckdb/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
+@@ -690,7 +690,7 @@ bool LineError::HandleErrors(StringValueResult &result) {
+ 			break;
+ 		case CAST_ERROR: {
+ 			string column_name;
+-			LogicalTypeId type_id;
++			LogicalTypeId type_id = LogicalTypeId::INVALID;
+ 			if (cur_error.col_idx < result.names.size()) {
+ 				column_name = result.names[cur_error.col_idx];
+ 			}
+-- 
+2.48.1
+

--- a/src/duckdb/extension/core_functions/include/core_functions/aggregate/quantile_state.hpp
+++ b/src/duckdb/extension/core_functions/include/core_functions/aggregate/quantile_state.hpp
@@ -208,6 +208,10 @@ struct WindowQuantileState {
 				if (skips.size() > 1) {
 					dest[1] = skips[1].second;
 				}
+				else {
+					// Avoid UMA
+					dest[1] = skips[0].second;
+				}
 				return interp.template Extract<INPUT_TYPE, RESULT_TYPE>(dest.data(), result);
 			} catch (const duckdb_skiplistlib::skip_list::IndexError &idx_err) {
 				throw InternalException(idx_err.message());

--- a/src/duckdb/extension/core_functions/include/core_functions/aggregate/quantile_state.hpp
+++ b/src/duckdb/extension/core_functions/include/core_functions/aggregate/quantile_state.hpp
@@ -207,8 +207,7 @@ struct WindowQuantileState {
 				dest[0] = skips[0].second;
 				if (skips.size() > 1) {
 					dest[1] = skips[1].second;
-				}
-				else {
+				} else {
 					// Avoid UMA
 					dest[1] = skips[0].second;
 				}

--- a/src/duckdb/src/common/types/row/tuple_data_segment.cpp
+++ b/src/duckdb/src/common/types/row/tuple_data_segment.cpp
@@ -15,23 +15,23 @@ void TupleDataChunkPart::SetHeapEmpty() {
 	base_heap_ptr = nullptr;
 }
 
-void SwapTupleDataChunkPart(TupleDataChunkPart &a, TupleDataChunkPart &b) {
-	std::swap(a.row_block_index, b.row_block_index);
-	std::swap(a.row_block_offset, b.row_block_offset);
-	std::swap(a.heap_block_index, b.heap_block_index);
-	std::swap(a.heap_block_offset, b.heap_block_offset);
-	std::swap(a.base_heap_ptr, b.base_heap_ptr);
-	std::swap(a.total_heap_size, b.total_heap_size);
-	std::swap(a.count, b.count);
+void MoveTupleDataChunkPart(TupleDataChunkPart &a, TupleDataChunkPart &b) {
+	a.row_block_index = b.row_block_index;
+	a.row_block_offset = b.row_block_offset;
+	a.heap_block_index = b.heap_block_index;
+	a.heap_block_offset = b.heap_block_offset;
+	a.base_heap_ptr = b.base_heap_ptr;
+	a.total_heap_size = b.total_heap_size;
+	a.count = b.count;
 	std::swap(a.lock, b.lock);
 }
 
 TupleDataChunkPart::TupleDataChunkPart(TupleDataChunkPart &&other) noexcept : lock((other.lock)) {
-	SwapTupleDataChunkPart(*this, other);
+	MoveTupleDataChunkPart(*this, other);
 }
 
 TupleDataChunkPart &TupleDataChunkPart::operator=(TupleDataChunkPart &&other) noexcept {
-	SwapTupleDataChunkPart(*this, other);
+	MoveTupleDataChunkPart(*this, other);
 	return *this;
 }
 

--- a/src/duckdb/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
+++ b/src/duckdb/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
@@ -690,7 +690,7 @@ bool LineError::HandleErrors(StringValueResult &result) {
 			break;
 		case CAST_ERROR: {
 			string column_name;
-			LogicalTypeId type_id;
+			LogicalTypeId type_id = LogicalTypeId::INVALID;
 			if (cur_error.col_idx < result.names.size()) {
 				column_name = result.names[cur_error.col_idx];
 			}


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2025-03-13, problems found: https://cran.r-project.org/web/checks/check_results_duckdb.html
- [ ] WARN: r-devel-linux-x86_64-debian-clang
     Found the following significant warnings:
     ../inst/include/cpp11/R.hpp:54:31: warning: identifier '_xl' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
     ../inst/include/cpp11/named_arg.hpp:44:29: warning: identifier '_nm' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
     duckdb/third_party/httplib/httplib.hpp:3422:43: warning: identifier '_t' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
     duckdb/third_party/httplib/httplib.hpp:3437:26: warning: identifier '_t' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
     duckdb/third_party/httplib/httplib.hpp:3495:26: warning: identifier '_t' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
     duckdb/third_party/fmt/include/fmt/format.h:551:33: warning: identifier '_u' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
     duckdb/third_party/fmt/include/fmt/format.h:3345:56: warning: identifier '_format' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
     duckdb/third_party/fmt/include/fmt/format.h:3349:59: warning: identifier '_format' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
     duckdb/third_party/fmt/include/fmt/format.h:3365:50: warning: identifier '_a' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
     duckdb/third_party/fmt/include/fmt/format.h:3369:53: warning: identifier '_a' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
     See ‘/home/hornik/tmp/R.check/r-devel-clang/Work/PKGS/duckdb.Rcheck/00install.out’ for details.
     * used C++ compiler
- [ ] NOTE: r-devel-linux-x86_64-debian-clang, r-devel-linux-x86_64-debian-gcc, r-devel-linux-x86_64-fedora-clang, r-devel-linux-x86_64-fedora-gcc
     File ‘duckdb/libs/duckdb.so’:
     Found non-API calls to R: ‘DATAPTR’, ‘Rf_GetOption’
     
     Compiled code should not call non-API entry points in R.
     
     See ‘Writing portable packages’ in the ‘Writing R Extensions’ manual,
     and section ‘Moving into C API compliance’ for issues with the use of
     non-API entry points.
- [ ] WARN: r-devel-linux-x86_64-fedora-clang
     Found the following significant warnings:
     ../inst/include/cpp11/R.hpp:54:31: warning: identifier '_xl' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
     ../inst/include/cpp11/named_arg.hpp:44:29: warning: identifier '_nm' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
     duckdb/third_party/httplib/httplib.hpp:3422:43: warning: identifier '_t' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
     duckdb/third_party/httplib/httplib.hpp:3437:26: warning: identifier '_t' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
     duckdb/third_party/httplib/httplib.hpp:3495:26: warning: identifier '_t' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
     duckdb/third_party/fmt/include/fmt/format.h:551:33: warning: identifier '_u' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
     duckdb/third_party/fmt/include/fmt/format.h:3345:56: warning: identifier '_format' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
     duckdb/third_party/fmt/include/fmt/format.h:3349:59: warning: identifier '_format' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
     duckdb/third_party/fmt/include/fmt/format.h:3365:50: warning: identifier '_a' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
     duckdb/third_party/fmt/include/fmt/format.h:3369:53: warning: identifier '_a' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
     See ‘/data/gannet/ripley/R/packages/tests-clang/duckdb.Rcheck/00install.out’ for details.
     * used C++ compiler: ‘cla
- [ ] WARN: r-devel-windows-x86_64
     Found the following significant warnings:
     D:/rtools45/x86_64-w64-mingw32.static.posix/lib/gcc/x86_64-w64-mingw32.static.posix/14.2.0/include/c++/bits/move.h:221:11: warning: '*(__vector(4) unsigned int*)this' is used uninitialized [-Wuninitialized]
     D:/rtools45/x86_64-w64-mingw32.static.posix/lib/gcc/x86_64-w64-mingw32.static.posix/14.2.0/include/c++/bits/move.h:221:11: warning: '((unsigned char**)this)[2]' is used uninitialized [-Wuninitialized]
     D:/rtools45/x86_64-w64-mingw32.static.posix/lib/gcc/x86_64-w64-mingw32.static.posix/14.2.0/include/c++/bits/move.h:221:11: warning: '((__vector(2) unsigned int*)this)[3]' is used uninitialized [-Wuninitialized]
     See 'd:/Rcompile/CRANpkg/local/4.5/duckdb.Rcheck/00install.out' for details.
     * used C++ compiler: 'g++.exe (GCC) 14.2.0'

Check results at: https://cran.r-project.org/web/checks/check_results_duckdb.html

## Action items

- [ ] Review PR
- [ ] Await successful CI/CD run
- [ ] Run `fledge::release()`
- [ ] When the package is accepted on CRAN, run `fledge::post_release()`