### PR TITLE
fledge: CRAN pre-release v1.2.1.9902

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,235 +2,35 @@
 
 # duckdb 1.2.1.9902
 
-## Bug fixes
+## Features
 
-- Avoid setting empty tzone attribute.
+- Update to duckdb v1.2.2, see <https://github.com/duckdb/duckdb/releases/tag/v1.2.2> for details.
 
-- Correctly check unclassed vectors.
-
-- Use vctrs to construct funny data frames.
-
-- Windows builds.
+- Add support for duckdb arrays in R (@joakimlinde, #102, #1090). To enable, connect with `dbConnect(duckdb(), array = "matrix")` (@joakimlinde, #1125).
 
 - Support fractional seconds in `TIME` and `INTERVAL` data (#1109).
 
-## Features
-
-- Store `convert_opts` for relations (#1140).
-
-- Store `convert_opts` with the connection in C++ land (#1139).
-
 - The `autoload_known_extensions` configuration option is now enabled by default (#582, #1084, #1134).
-
-- Support `STRUCT` in ALTREP data frames.
-
-- Add `dbConnect(array = "none")`, pass `array = "matrix"` to enable conversion of array columns (@joakimlinde, #1125).
-
-- Perform optional checks for ALTREP compatibility in `rel_from_df()` and `expr_constant()` (#1117).
-
-- Types exposed through ALTREP are the same as through DBI (#1111).
 
 - Mention column name for conversion errors (#1108).
 
-- Rework data frame creation (#1103).
-
-- Add optional alias argument to all functions returning an expression (#1100).
-
-- Add support for duckdb arrays in R (@joakimlinde, #102, #1090).
-
 ## Chore
-
-- Remove lints.
-
-- Delete empty constructor (#1137).
-
-- Delete empty constructor (#1136).
-
-- Delete empty constructor (#1138).
-
-- Delete empty constructors.
-
-- Reorder.
 
 - Require R \>= 4.1 (#1087, #1133).
 
-- Move naming of structs to `duckdb_r_decorate()`.
+- Types exposed through ALTREP are the same as through DBI (#1111), including `STRUCT`. This enables support more types in upcoming duckplyr versions.
 
-- `duckdb_r_df_decorate()`.
-
-- Move computation of row names.
-
-- `get_attrib()`.
+- Perform optional checks for ALTREP compatibility in `rel_from_df()` and `expr_constant()` (#1117).
 
 - Perform time zone conversion in the C++ layer where possible, to support ALTREP (#1130).
 
-- Fix `pkgload::load_all()` (#1128).
+- Improve developer experience: `pkgload::load_all()` now works, source files are rebuilt if header files change, configure clangd (#1128).
 
-- Fix build.
-
-- Backticks in error message.
-
-- Remove lints (#1116).
-
-- Add dots (#1115).
-
-- Adapt tests to use data frames without row names (#1113).
-
-- Satisfy lintr.
-
-- `ConvertOpts` is a struct (#1110).
-
-- Configure clangd.
-
-- Avoid passing bitmask through data frame scan function (#1105).
+- Add dots with checks to unexported functions (#1115).
 
 - Clean up edge case for fetching zero rows (#1104).
 
-- Remove unused attribute.
-
 - Avoid test for timings on CRAN (#1101).
-
-- Fix path.
-
-- Move scripts.
-
-- Reorganize scripts.
-
-- Increase window.
-
-## Continuous integration
-
-- Fix detection for running without suggested.
-
-- Allow NOTEs if suggested packages are missing.
-
-- Only fail covr builds if token is given (#1131).
-
-- Tweak permissions.
-
-- Lints.
-
-- Always use `_R_CHECK_FORCE_SUGGESTS_=false` (#1129).
-
-- Correct installation of xml2 (#1123).
-
-- Explain (#1121).
-
-- Add xml2 for covr, print testthat results (#1120).
-
-- Sync (#1119).
-
-- More accurate determination if no-suggests tests need to run.
-
-- Ignore arrow for R \< 4.2.
-
-- Fix script location.
-
-## Testing
-
-- Support relational datetime with time zones.
-
-- Skip tests using `grep()` or `sub()` on CRAN.
-
-- Skip test if vctrs not installed.
-
-- Skip ALTVEC for old R versions.
-
-- Add tests.
-
-- Sync tests.
-
-## Uncategorized
-
-- Vendor: Update vendored sources (tag v1.2.2) to duckdb/duckdb@7c039464e452ddc3330e2691d3fa6d305521d09b.
-
-- Vendor: Update vendored sources to duckdb/duckdb@4d7180d13e8988c73d565f97a29855ff425ed340.
-
-- Vendor: Update vendored sources to duckdb/duckdb@4de79a0fcb1e260ce2543fb40d1a6977d7c1750a.
-
-- Vendor: Update vendored sources to duckdb/duckdb@5e26d7ad8277e48248f75181c5e79b44a6e178ad.
-
-- Vendor: Update vendored sources to duckdb/duckdb@099fba2a4b5563dd40b5a462fd6fac0594560a4c.
-
-- Vendor: Update vendored sources to duckdb/duckdb@78379ad797f8e5aa4b10f4ff0a95be3f13b4b47a.
-
-- Vendor: Update vendored sources to duckdb/duckdb@929daf42d9425720c658e64e5d6bd8d3c55c9509.
-
-- Vendor: Update vendored sources to duckdb/duckdb@c11e85537e5b9f296e976fcf0762c0c27dbc189d.
-
-- Vendor: Update vendored sources to duckdb/duckdb@40c13c407044b6be8cbac4f0e78670a9fdb8721e.
-
-- Vendor: Update vendored sources to duckdb/duckdb@c26196e7141699beddeacf51214f36f25a49485d.
-
-- Vendor: Update vendored sources to duckdb/duckdb@5920da2406ffa651d7c79493c9188518de5229f4.
-
-- Vendor: Update vendored sources to duckdb/duckdb@c353171bc5e06f217a96ae4eb515847bd9ca3a52.
-
-- Vendor: Update vendored sources to duckdb/duckdb@21301415e58c8a18110c80b0cc7f8d3aa4e56c16.
-
-- Vendor: Update vendored sources to duckdb/duckdb@a4380e7c0895ebdb879bf1c32616004643834ff8.
-
-- Vendor: Update vendored sources to duckdb/duckdb@ca8f3a76699dde5b03bd56a2ab737edb066d955f.
-
-- Vendor: Update vendored sources to duckdb/duckdb@72cf6467725a4eaeb39c02c115a5952f800eea7d.
-
-- Vendor: Update vendored sources to duckdb/duckdb@882980aa420dd52fead9c23c2bc82f9c8bea043c.
-
-- Vendor: Update vendored sources to duckdb/duckdb@3c9d9ddc6056a565d4320024b6ca0221854cb6be.
-
-- Vendor: Update vendored sources to duckdb/duckdb@3fa4b872b3936ff4e373d0b4aaf1434dcc79bfa8.
-
-- Vendor: Update vendored sources to duckdb/duckdb@91e67a22bf4533afb7abf9636aa8d369a4555d45.
-
-- Vendor: Update vendored sources to duckdb/duckdb@75fb0d7cdf0c1f7fdcce1058b84c83affa0c7185.
-
-- Vendor: Update vendored sources to duckdb/duckdb@0c09b40666abb58df1ac1ae601af17eb14f5ff59.
-
-- Vendor: Update vendored sources to duckdb/duckdb@d0ac2f2929e7230ac168de568d35dcde94b089c4.
-
-- Vendor: Update vendored sources to duckdb/duckdb@ede55e1564fbfb10e10058810681cb5972fa534e.
-
-- Vendor: Update vendored sources to duckdb/duckdb@249a4218be632ce96008568608c347b97c3d45bb.
-
-- Vendor: Update vendored sources to duckdb/duckdb@0d2f28c10415550b0b1aaba0aa55618856be1d22.
-
-- Vendor: Update vendored sources to duckdb/duckdb@09bf1d736d031fb7c49a56201a436a390545c16e.
-
-- Vendor: Update vendored sources to duckdb/duckdb@7b5e2b7373c2be02affb1771f45a606ed8e711b3.
-
-- Vendor: Update vendored sources to duckdb/duckdb@40eac1c115ed8b70145375687c80cedf88590b76.
-
-- Vendor: Update vendored sources to duckdb/duckdb@6610bc9122f0b091bf0ff074fd8854091b33cc24.
-
-- Vendor: Update vendored sources to duckdb/duckdb@745bc7877ffe5b9b1eae9ee4c4cb31784b201820.
-
-- Vendor: Update vendored sources to duckdb/duckdb@1378dccaf052255dd37e4076e8adf84249fca12f.
-
-- Vendor: Update vendored sources to duckdb/duckdb@1f7c2c958097612d506f08e8e9e96554341bec42.
-
-- Vendor: Update vendored sources to duckdb/duckdb@d76de45caa58c69f04ff8a2e16270d324ecf3559.
-
-- Vendor: Update vendored sources to duckdb/duckdb@2243dd860b990bb1947dd46e87513c497ff627ca.
-
-- Vendor: Update vendored sources to duckdb/duckdb@64351c2bba6e905892711998101a8bcf00218467.
-
-- Vendor: Update vendored sources to duckdb/duckdb@ba4a4482d3b1854d20ca1749f6d0fc46c96aaab2.
-
-- Vendor: Update vendored sources to duckdb/duckdb@65061f58d439cc021db4c1a74218f118886a2fd4.
-
-- Vendor: Update vendored sources to duckdb/duckdb@ce38435fe300aae35a142838b6d64318275a5a0b.
-
-- Vendor: Update vendored sources to duckdb/duckdb@7d9d4fc60d1b51e1f18763f4f8f4e3c91112bb37.
-
-- Vendor: Update vendored sources to duckdb/duckdb@34b9403c4def6a88c87410741e7071a84177f220.
-
-- Vendor: Update vendored sources to duckdb/duckdb@c577724b2c1a21ac0f5d67a447f9e69956457ba8.
-
-- Vendor: Update vendored sources to duckdb/duckdb@52a9e8faee041ec226c4720b853b777bb08dd914.
-
-- Same as previous version.
-
-- Switching to development version.
 
 
 # duckdb 1.2.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,11 +2,41 @@
 
 # duckdb 1.2.1.9902
 
+## Bug fixes
+
+- Avoid setting empty tzone attribute.
+
+- Correctly check unclassed vectors.
+
+- Use vctrs to construct funny data frames.
+
+- Windows builds.
+
+- Support fractional seconds in `TIME` and `INTERVAL` data (#1109).
+
 ## Features
 
 - Store `convert_opts` for relations (#1140).
 
 - Store `convert_opts` with the connection in C++ land (#1139).
+
+- The `autoload_known_extensions` configuration option is now enabled by default (#582, #1084, #1134).
+
+- Support `STRUCT` in ALTREP data frames.
+
+- Add `dbConnect(array = "none")`, pass `array = "matrix"` to enable conversion of array columns (@joakimlinde, #1125).
+
+- Perform optional checks for ALTREP compatibility in `rel_from_df()` and `expr_constant()` (#1117).
+
+- Types exposed through ALTREP are the same as through DBI (#1111).
+
+- Mention column name for conversion errors (#1108).
+
+- Rework data frame creation (#1103).
+
+- Add optional alias argument to all functions returning an expression (#1100).
+
+- Add support for duckdb arrays in R (@joakimlinde, #102, #1090).
 
 ## Chore
 
@@ -21,33 +51,6 @@
 - Delete empty constructors.
 
 - Reorder.
-
-## Continuous integration
-
-- Fix detection for running without suggested.
-
-
-# duckdb 1.2.1.9901
-
-## Bug fixes
-
-- Avoid setting empty tzone attribute.
-
-- Correctly check unclassed vectors.
-
-- Use vctrs to construct funny data frames.
-
-- Windows builds.
-
-## Features
-
-- The `autoload_known_extensions` configuration option is now enabled by default (#582, #1084, #1134).
-
-- Support `STRUCT` in ALTREP data frames.
-
-- Add `dbConnect(array = "none")`, pass `array = "matrix"` to enable conversion of array columns (@joakimlinde, #1125).
-
-## Chore
 
 - Require R \>= 4.1 (#1087, #1133).
 
@@ -64,65 +67,6 @@
 - Fix `pkgload::load_all()` (#1128).
 
 - Fix build.
-
-## Continuous integration
-
-- Allow NOTEs if suggested packages are missing.
-
-- Only fail covr builds if token is given (#1131).
-
-- Tweak permissions.
-
-- Lints.
-
-- Always use `_R_CHECK_FORCE_SUGGESTS_=false` (#1129).
-
-- Correct installation of xml2 (#1123).
-
-- Explain (#1121).
-
-- Add xml2 for covr, print testthat results (#1120).
-
-- Sync (#1119).
-
-## Testing
-
-- Support relational datetime with time zones.
-
-- Skip tests using `grep()` or `sub()` on CRAN.
-
-- Skip test if vctrs not installed.
-
-- Skip ALTVEC for old R versions.
-
-- Skip ALTVEC for old R versions.
-
-- Add tests.
-
-- Sync tests.
-
-
-# duckdb 1.2.1.9900
-
-## Bug fixes
-
-- Support fractional seconds in `TIME` and `INTERVAL` data (#1109).
-
-## Features
-
-- Perform optional checks for ALTREP compatibility in `rel_from_df()` and `expr_constant()` (#1117).
-
-- Types exposed through ALTREP are the same as through DBI (#1111).
-
-- Mention column name for conversion errors (#1108).
-
-- Rework data frame creation (#1103).
-
-- Add optional alias argument to all functions returning an expression (#1100).
-
-- Add support for duckdb arrays in R (@joakimlinde, #102, #1090).
-
-## Chore
 
 - Backticks in error message.
 
@@ -156,11 +100,45 @@
 
 ## Continuous integration
 
+- Fix detection for running without suggested.
+
+- Allow NOTEs if suggested packages are missing.
+
+- Only fail covr builds if token is given (#1131).
+
+- Tweak permissions.
+
+- Lints.
+
+- Always use `_R_CHECK_FORCE_SUGGESTS_=false` (#1129).
+
+- Correct installation of xml2 (#1123).
+
+- Explain (#1121).
+
+- Add xml2 for covr, print testthat results (#1120).
+
+- Sync (#1119).
+
 - More accurate determination if no-suggests tests need to run.
 
 - Ignore arrow for R \< 4.2.
 
 - Fix script location.
+
+## Testing
+
+- Support relational datetime with time zones.
+
+- Skip tests using `grep()` or `sub()` on CRAN.
+
+- Skip test if vctrs not installed.
+
+- Skip ALTVEC for old R versions.
+
+- Add tests.
+
+- Sync tests.
 
 ## Uncategorized
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,4 +1,4 @@
-duckdb 1.2.1.9900
+duckdb 1.2.1.9902
 
 ## Cran Repository Policy
 


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2025-04-28, no problems (other than installation size) found.

## Action items

- [ ] Review PR
- [ ] Await successful CI/CD run
- [ ] Run `fledge::release()`
- [ ] When the package is accepted on CRAN, run `fledge::post_release()`