### PR TITLE
fledge: CRAN release v1.2.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: duckdb
 Title: DBI Package for the DuckDB Database Management System
-Version: 1.2.1.9903
+Version: 1.2.2
 Authors@R: c(
     person("Hannes", "Mühleisen", , "hannes@cwi.nl", role = "aut",
            comment = c(ORCID = "0000-0001-8552-0029")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,8 +16,6 @@
 
 ## Chore
 
-- Revdepchecks.
-
 - Require R \>= 4.1 (#1087, #1133).
 
 - Types exposed through ALTREP are the same as through DBI (#1111), including `STRUCT`. This enables support more types in upcoming duckplyr versions.
@@ -35,8 +33,6 @@
 - Avoid test for timings on CRAN (#1101).
 
 ## Documentation
-
-- Tweak wd.
 
 - Tweak README.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,19 +1,6 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# duckdb 1.2.1.9903
-
-## Chore
-
-- Revdepchecks.
-
-## Documentation
-
-- Tweak wd.
-
-- Tweak README.
-
-
-# duckdb 1.2.1.9902
+# duckdb 1.2.2
 
 ## Features
 
@@ -28,6 +15,8 @@
 - Mention column name for conversion errors (#1108).
 
 ## Chore
+
+- Revdepchecks.
 
 - Require R \>= 4.1 (#1087, #1133).
 
@@ -44,6 +33,12 @@
 - Clean up edge case for fetching zero rows (#1104).
 
 - Avoid test for timings on CRAN (#1101).
+
+## Documentation
+
+- Tweak wd.
+
+- Tweak README.
 
 
 # duckdb 1.2.1

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,4 +1,4 @@
-duckdb 1.2.1.9902
+duckdb 1.2.2
 
 ## Cran Repository Policy
 


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2025-04-29, no problems (other than installation size) found.

## Action items

- [ ] Review PR
- [ ] Await successful CI/CD run
- [ ] Run `fledge::release()`
- [ ] When the package is accepted on CRAN, run `fledge::post_release()`