### PR TITLE
chore: Fix compiler warning

### DIFF
--- a/src/scan.cpp
+++ b/src/scan.cpp
@@ -369,7 +369,7 @@ case_insensitive_map_t<vector<Value>> ListToVectorOfValue(list input_sexps) {
 		input_idx++;
 	}
 
-	return std::move(output);
+	return output;
 }
 
 static bool get_integer64_param(named_parameter_map_t &named_parameters) {


### PR DESCRIPTION
Compiler warns about unnecessary std::move(). See "guaranteed copy elision" in https://en.cppreference.com/w/cpp/language/copy_elision