### PR TITLE
fledge: CRAN pre-release v1.3.2.9900

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: duckdb
 Title: DBI Package for the DuckDB Database Management System
-Version: 1.3.2.9022
+Version: 1.3.2.9900
 Authors@R: c(
     person("Hannes", "Mühleisen", , "hannes@cwi.nl", role = "aut",
            comment = c(ORCID = "0000-0001-8552-0029")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,17 +1,58 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# duckdb 1.3.2.9022
+# duckdb 1.3.2.9900
 
-## Features
+## vendor
 
-- Safeguard against deadlocks when accidentally issuing queries from the progress bar handler or other callbacks.
+- Update vendored sources to duckdb/duckdb@f40ac6e5653dc7bc83fa03a5021d8aa09a938cef (#1404).
 
-## Documentation
+- Update vendored sources to duckdb/duckdb@df0a3de74429887333ec4af047e7aac2737e52d8 (#1402).
 
-- Document vendoring process and main/next branch relationship (#1488).
+- Update vendored sources to duckdb/duckdb@3ed3b4fab80c714c731501cd1cfb738b110da1bd (#1398).
 
+- Update vendored sources to duckdb/duckdb@67cbce34e13c7b6c9178d13b3886428b3f6f7485 (#1395).
 
-# duckdb 1.3.2.9021
+- Update vendored sources to duckdb/duckdb@0e258ecaaf50d89eb4e73b5969994f9fb3656681 (#1392).
+
+- Update vendored sources to duckdb/duckdb@b84467e28a46562fa244949121c837a08f5c9afc (#1379).
+
+- Update vendored sources to duckdb/duckdb@4f243e8c1fe894c06efb252d8ae8c64bcf272906 (#1369).
+
+- Update vendored sources to duckdb/duckdb@61cf5c71bd6a2aac2e862ceeb5010d3cf396e709 (#1350).
+
+- Update vendored sources to duckdb/duckdb@c8164851be62bcad38c080e975c577ff951b16be (#1348).
+
+- Update vendored sources to duckdb/duckdb@10fee32d13a75ba5cfe6896cbef69c707067aed8 (#1346).
+
+- Update vendored sources to duckdb/duckdb@35391cb7f32572e45fd202513af4a1a63ae9daa3 (#1344).
+
+- Update vendored sources to duckdb/duckdb@473fd24cf22e6cf3c3f809977f3d90fe00759c1c (#1342).
+
+- Update vendored sources to duckdb/duckdb@7a3b90679ca17b835d070cf4a51ba38918436987 (#1341).
+
+- Update vendored sources to duckdb/duckdb@c306dc0c55d89904c92a9718e23cae6d644054b5 (#1340).
+
+- Update vendored sources to duckdb/duckdb@463731217f4ff95df63ff1cfbf30323079abebbe (#1339).
+
+- Update vendored sources to duckdb/duckdb@158b1ea4da43fa859f13437e24c1e533b06cebbb (#1338).
+
+- Update vendored sources to duckdb/duckdb@a1283de8cbcaca3aee7cef857cb97a16e3f2239e (#1336).
+
+- Update vendored sources to duckdb/duckdb@2a7e166a8b71e756f0c2a36e9896e602ceeed290 (#1334).
+
+- Update vendored sources to duckdb/duckdb@433c52483ac435e8183f97c3c5f0db291703fdc5 (#1333).
+
+- Update vendored sources to duckdb/duckdb@de3e17ed4e25f1f0010a2ae76c1ab7bdc3740e6f (#1331).
+
+- Update vendored sources to duckdb/duckdb@6966a00ab85ae7e67624354c4df9b68a32fe6c22 (#1330).
+
+- Update vendored sources to duckdb/duckdb@e35d665745d6599237f5b4585b44e67ce4008387 (#1329).
+
+- Update vendored sources to duckdb/duckdb@7f75bfdf3ba36e6925d39f43cbb08f67f0d951d6 (#1327).
+
+## fledge
+
+- CRAN release v1.3.2 (#1324).
 
 ## Bug fixes
 
@@ -21,7 +62,13 @@
 
 - Fix index calculation for retrieval of arrays (#1473).
 
+- Fix retrieval of large enums.
+
+- Fix compiler error in debug build (@joakimlinde, #1368).
+
 ## Features
+
+- Safeguard against deadlocks when accidentally issuing queries from the progress bar handler or other callbacks.
 
 - `dbGetInfo()` gets the version from a hard-coded value and not from a DuckDB query.
 
@@ -35,99 +82,15 @@
 
 - Add Claude instructions.
 
-## Testing
-
-- Add `local_con()` test fixture for cleaner DuckDB connection management.
-
-
-# duckdb 1.3.2.9020
+- Auto-update from GitHub Actions (#1456).
 
 ## Continuous integration
 
 - Use reviewdog for external PRs (#1471).
 
-
-# duckdb 1.3.2.9019
-
-## Chore
-
-- Auto-update from GitHub Actions (#1456).
-
-
-# duckdb 1.3.2.9018
-
-## vendor
-
-- Update vendored sources to duckdb/duckdb@f40ac6e5653dc7bc83fa03a5021d8aa09a938cef (#1404).
-
-
-# duckdb 1.3.2.9017
-
-## vendor
-
-- Update vendored sources to duckdb/duckdb@df0a3de74429887333ec4af047e7aac2737e52d8 (#1402).
-
-
-# duckdb 1.3.2.9016
-
-## vendor
-
-- Update vendored sources to duckdb/duckdb@3ed3b4fab80c714c731501cd1cfb738b110da1bd (#1398).
-
-
-# duckdb 1.3.2.9015
-
-## Continuous integration
-
 - Cleanup and fix macOS (#1394).
 
-## vendor
-
-- Update vendored sources to duckdb/duckdb@67cbce34e13c7b6c9178d13b3886428b3f6f7485 (#1395).
-
-
-# duckdb 1.3.2.9014
-
-## vendor
-
-- Update vendored sources to duckdb/duckdb@0e258ecaaf50d89eb4e73b5969994f9fb3656681 (#1392).
-
-
-# duckdb 1.3.2.9013
-
-## Continuous integration
-
 - Format with air, check detritus, better handling of `extra-packages` (#1388).
-
-
-# duckdb 1.3.2.9012
-
-## vendor
-
-- Update vendored sources to duckdb/duckdb@b84467e28a46562fa244949121c837a08f5c9afc (#1379).
-
-
-# duckdb 1.3.2.9011
-
-## Bug fixes
-
-- Fix retrieval of large enums.
-
-
-# duckdb 1.3.2.9010
-
-## Bug fixes
-
-- Fix compiler error in debug build (@joakimlinde, #1368).
-
-## vendor
-
-- Update vendored sources to duckdb/duckdb@4f243e8c1fe894c06efb252d8ae8c64bcf272906 (#1369).
-
-
-# duckdb 1.3.2.9009
-
-## Continuous integration
 
 - Ignore all extra-packages.
 
@@ -135,86 +98,13 @@
 
 - Ignore adbcdrivermanager if it cannot be installed.
 
-## vendor
+## Documentation
 
-- Update vendored sources to duckdb/duckdb@61cf5c71bd6a2aac2e862ceeb5010d3cf396e709 (#1350).
+- Document vendoring process and main/next branch relationship (#1488).
 
+## Testing
 
-# duckdb 1.3.2.9008
-
-## vendor
-
-- Update vendored sources to duckdb/duckdb@c8164851be62bcad38c080e975c577ff951b16be (#1348).
-
-
-# duckdb 1.3.2.9007
-
-## vendor
-
-- Update vendored sources to duckdb/duckdb@10fee32d13a75ba5cfe6896cbef69c707067aed8 (#1346).
-
-
-# duckdb 1.3.2.9006
-
-## vendor
-
-- Update vendored sources to duckdb/duckdb@35391cb7f32572e45fd202513af4a1a63ae9daa3 (#1344).
-
-
-# duckdb 1.3.2.9005
-
-## vendor
-
-- Update vendored sources to duckdb/duckdb@473fd24cf22e6cf3c3f809977f3d90fe00759c1c (#1342).
-
-- Update vendored sources to duckdb/duckdb@7a3b90679ca17b835d070cf4a51ba38918436987 (#1341).
-
-- Update vendored sources to duckdb/duckdb@c306dc0c55d89904c92a9718e23cae6d644054b5 (#1340).
-
-- Update vendored sources to duckdb/duckdb@463731217f4ff95df63ff1cfbf30323079abebbe (#1339).
-
-- Update vendored sources to duckdb/duckdb@158b1ea4da43fa859f13437e24c1e533b06cebbb (#1338).
-
-
-# duckdb 1.3.2.9004
-
-## vendor
-
-- Update vendored sources to duckdb/duckdb@a1283de8cbcaca3aee7cef857cb97a16e3f2239e (#1336).
-
-
-# duckdb 1.3.2.9003
-
-## vendor
-
-- Update vendored sources to duckdb/duckdb@2a7e166a8b71e756f0c2a36e9896e602ceeed290 (#1334).
-
-- Update vendored sources to duckdb/duckdb@433c52483ac435e8183f97c3c5f0db291703fdc5 (#1333).
-
-
-# duckdb 1.3.2.9002
-
-## vendor
-
-- Update vendored sources to duckdb/duckdb@de3e17ed4e25f1f0010a2ae76c1ab7bdc3740e6f (#1331).
-
-- Update vendored sources to duckdb/duckdb@6966a00ab85ae7e67624354c4df9b68a32fe6c22 (#1330).
-
-- Update vendored sources to duckdb/duckdb@e35d665745d6599237f5b4585b44e67ce4008387 (#1329).
-
-
-# duckdb 1.3.2.9001
-
-## vendor
-
-- Update vendored sources to duckdb/duckdb@7f75bfdf3ba36e6925d39f43cbb08f67f0d951d6 (#1327).
-
-
-# duckdb 1.3.2.9000
-
-## fledge
-
-- CRAN release v1.3.2 (#1324).
+- Add `local_con()` test fixture for cleaner DuckDB connection management.
 
 
 # duckdb 1.3.2

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,4 +1,4 @@
-duckdb 1.3.2
+duckdb 1.3.2.9900
 
 ## Cran Repository Policy
 


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2025-09-08, no problems (other than installation size) found.

## Action items

- [ ] Review PR
- [ ] Await successful CI/CD run
- [ ] Run `fledge::release()`
- [ ] When the package is accepted on CRAN, run `fledge::post_release()`