### PR TITLE
fledge: CRAN release v1.3.3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: duckdb
 Title: DBI Package for the DuckDB Database Management System
-Version: 1.3.2.9902
+Version: 1.3.3
 Authors@R: c(
     person("Hannes", "Mühleisen", , "hannes@cwi.nl", role = "aut",
            comment = c(ORCID = "0000-0001-8552-0029")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,69 +2,17 @@
 
 # duckdb 1.3.3
 
-## fledge
-
-- CRAN pre-release v1.3.2.9900 (#1489).
-
-- CRAN release v1.3.2 (#1324).
-
-## vendor
-
-- Update vendored sources to duckdb/duckdb@f40ac6e5653dc7bc83fa03a5021d8aa09a938cef (#1404).
-
-- Update vendored sources to duckdb/duckdb@df0a3de74429887333ec4af047e7aac2737e52d8 (#1402).
-
-- Update vendored sources to duckdb/duckdb@3ed3b4fab80c714c731501cd1cfb738b110da1bd (#1398).
-
-- Update vendored sources to duckdb/duckdb@67cbce34e13c7b6c9178d13b3886428b3f6f7485 (#1395).
-
-- Update vendored sources to duckdb/duckdb@0e258ecaaf50d89eb4e73b5969994f9fb3656681 (#1392).
-
-- Update vendored sources to duckdb/duckdb@b84467e28a46562fa244949121c837a08f5c9afc (#1379).
-
-- Update vendored sources to duckdb/duckdb@4f243e8c1fe894c06efb252d8ae8c64bcf272906 (#1369).
-
-- Update vendored sources to duckdb/duckdb@61cf5c71bd6a2aac2e862ceeb5010d3cf396e709 (#1350).
-
-- Update vendored sources to duckdb/duckdb@c8164851be62bcad38c080e975c577ff951b16be (#1348).
-
-- Update vendored sources to duckdb/duckdb@10fee32d13a75ba5cfe6896cbef69c707067aed8 (#1346).
-
-- Update vendored sources to duckdb/duckdb@35391cb7f32572e45fd202513af4a1a63ae9daa3 (#1344).
-
-- Update vendored sources to duckdb/duckdb@473fd24cf22e6cf3c3f809977f3d90fe00759c1c (#1342).
-
-- Update vendored sources to duckdb/duckdb@7a3b90679ca17b835d070cf4a51ba38918436987 (#1341).
-
-- Update vendored sources to duckdb/duckdb@c306dc0c55d89904c92a9718e23cae6d644054b5 (#1340).
-
-- Update vendored sources to duckdb/duckdb@463731217f4ff95df63ff1cfbf30323079abebbe (#1339).
-
-- Update vendored sources to duckdb/duckdb@158b1ea4da43fa859f13437e24c1e533b06cebbb (#1338).
-
-- Update vendored sources to duckdb/duckdb@a1283de8cbcaca3aee7cef857cb97a16e3f2239e (#1336).
-
-- Update vendored sources to duckdb/duckdb@2a7e166a8b71e756f0c2a36e9896e602ceeed290 (#1334).
-
-- Update vendored sources to duckdb/duckdb@433c52483ac435e8183f97c3c5f0db291703fdc5 (#1333).
-
-- Update vendored sources to duckdb/duckdb@de3e17ed4e25f1f0010a2ae76c1ab7bdc3740e6f (#1331).
-
-- Update vendored sources to duckdb/duckdb@6966a00ab85ae7e67624354c4df9b68a32fe6c22 (#1330).
-
-- Update vendored sources to duckdb/duckdb@e35d665745d6599237f5b4585b44e67ce4008387 (#1329).
-
-- Update vendored sources to duckdb/duckdb@7f75bfdf3ba36e6925d39f43cbb08f67f0d951d6 (#1327).
+- Update to the current v1.3-ossivalis branch, see <https://github.com/duckdb/duckdb/tree/v1.3-ossivalis> for details.
 
 ## Bug fixes
 
-- Fix timezone conversion for invalid timestamps with `tz_out_convert = "force"`.
+- Fix timezone conversion for invalid timestamps with `tz_out_convert = "force"` (#1474).
 
 - Substitute invalid UTF-8 characters in error messages to avoid a failure when reporting the error.
 
 - Fix index calculation for retrieval of arrays (#1473).
 
-- Fix retrieval of large enums.
+- Fix conversion for retrieval of large enums.
 
 - Fix compiler error in debug build (@joakimlinde, #1368).
 
@@ -72,35 +20,11 @@
 
 - Add rich ErrorData-based error handling with structured error information (#1479).
 
-- Safeguard against deadlocks when accidentally issuing queries from the progress bar handler or other callbacks.
+- Safeguard against deadlocks when accidentally issuing queries from the progress bar handler or other callbacks (#1475).
 
-- `dbGetInfo()` gets the version from a hard-coded value and not from a DuckDB query.
+- `dbGetInfo()` gets the version from a hard-coded value and not from a DuckDB query (#1481).
 
-- Package uses two cores by default for compilation.
-
-## Chore
-
-- Add AI instructions.
-
-- Build-ignore.
-
-- Add Claude instructions.
-
-- Auto-update from GitHub Actions (#1456).
-
-## Continuous integration
-
-- Use reviewdog for external PRs (#1471).
-
-- Cleanup and fix macOS (#1394).
-
-- Format with air, check detritus, better handling of `extra-packages` (#1388).
-
-- Ignore all extra-packages.
-
-- Syntax.
-
-- Ignore adbcdrivermanager if it cannot be installed.
+- Package uses two cores by default for compilation (#1478).
 
 ## Documentation
 
@@ -108,7 +32,7 @@
 
 ## Testing
 
-- Add `local_con()` test fixture for cleaner DuckDB connection management.
+- Add `local_con()` test fixture for cleaner DuckDB connection management (#1476).
 
 
 # duckdb 1.3.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,20 +1,12 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# duckdb 1.3.2.9902
-
-## Features
-
-- Add rich ErrorData-based error handling with structured error information (#1479).
-
-
-# duckdb 1.3.2.9901
+# duckdb 1.3.3
 
 ## fledge
 
 - CRAN pre-release v1.3.2.9900 (#1489).
 
-
-# duckdb 1.3.2.9900
+- CRAN release v1.3.2 (#1324).
 
 ## vendor
 
@@ -64,10 +56,6 @@
 
 - Update vendored sources to duckdb/duckdb@7f75bfdf3ba36e6925d39f43cbb08f67f0d951d6 (#1327).
 
-## fledge
-
-- CRAN release v1.3.2 (#1324).
-
 ## Bug fixes
 
 - Fix timezone conversion for invalid timestamps with `tz_out_convert = "force"`.
@@ -81,6 +69,8 @@
 - Fix compiler error in debug build (@joakimlinde, #1368).
 
 ## Features
+
+- Add rich ErrorData-based error handling with structured error information (#1479).
 
 - Safeguard against deadlocks when accidentally issuing queries from the progress bar handler or other callbacks.
 

--- a/R/Result.R
+++ b/R/Result.R
@@ -119,5 +119,6 @@ tz_force_one <- function(x, timezone) {
   # convert to character in ISO format, stripping the timezone
   ct <- format(x, format = "%Y-%m-%d %H:%M:%OS", usetz = FALSE)
   # recreate the POSIXct with specified timezone
+  # this is the slow part, and it remains slow even if the input is a POSIXlt
   as.POSIXct(ct, format = "%Y-%m-%d %H:%M:%OS", tz = timezone)
 }

--- a/R/dbConnect__duckdb_driver.R
+++ b/R/dbConnect__duckdb_driver.R
@@ -34,6 +34,12 @@
 #'
 #' @return `dbConnect()` returns an object of class [duckdb_connection-class].
 #'
+#' @details
+#' The behavior of `with = "force"` at DST transitions depends on how R handles translation from
+#' the underlying time representation to a human-readable format.
+#' If the timestamp is invalid in the target timezone, the resulting value may be `NA`
+#' or an adjusted time.
+#'
 #' @rdname duckdb
 #' @examples
 #' drv <- duckdb()

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,4 +1,4 @@
-duckdb 1.3.2.9900
+duckdb 1.3.3
 
 ## Cran Repository Policy
 

--- a/man/duckdb.Rd
+++ b/man/duckdb.Rd
@@ -112,6 +112,12 @@ Connectivity via the adbcdrivermanager package.
 The associated DuckDB database instance is shut down automatically,
 it is no longer necessary to set \code{shutdown = TRUE} or to call \code{duckdb_shutdown()}.
 }
+\details{
+The behavior of \code{with = "force"} at DST transitions depends on how R handles translation from
+the underlying time representation to a human-readable format.
+If the timestamp is invalid in the target timezone, the resulting value may be \code{NA}
+or an adjusted time.
+}
 \examples{
 \dontshow{if (requireNamespace("adbcdrivermanager", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 library(adbcdrivermanager)

--- a/src/duckdb/extension/core_functions/include/core_functions/aggregate/algebraic/stddev.hpp
+++ b/src/duckdb/extension/core_functions/include/core_functions/aggregate/algebraic/stddev.hpp
@@ -9,7 +9,8 @@
 #pragma once
 
 #include "duckdb/function/aggregate_function.hpp"
-#include <ctgmath>
+#include <complex>
+#include <cmath>
 
 namespace duckdb {
 

--- a/tests/testthat/test-error-handling.R
+++ b/tests/testthat/test-error-handling.R
@@ -1,4 +1,5 @@
 test_that("rapi_error functions accept additional parameters", {
+  skip_if(getRversion() < "4.2", "Error message formatting differs in R 4.1")
   local_edition(3)
   rlang::local_options(cli.num_colors = 1)
 

--- a/tests/testthat/test-relational.R
+++ b/tests/testthat/test-relational.R
@@ -983,6 +983,7 @@ test_that("Handle zero-length lists (#186)", {
 })
 
 test_that("prudence", {
+  skip_if(getRversion() < "4.2", "Error message formatting differs in R 4.1")
   local_edition(3)
   withr::local_envvar(NO_COLOR = "true")
 

--- a/tests/testthat/test-timezone.R
+++ b/tests/testthat/test-timezone.R
@@ -164,9 +164,9 @@ test_that("tz_out_convert = force handles invalid timestamps during DST transiti
 
   # The first timestamp should remain valid with full time information
   # The second should be NA (not stripped to date only)
-  expected2 <- c(
-    as.POSIXct("2025-03-30 00:59:00", tz = "Europe/London"),
-    as.POSIXct(NA, tz = "Europe/London")
-  )
+  expected2 <- tz_force_one(timezone = "Europe/London", c(
+    as.POSIXct("2025-03-30 00:59:00", format = "%Y-%m-%d %H:%M:%OS", tzone = "UTC"),
+    as.POSIXct("2025-03-30 01:00:00", format = "%Y-%m-%d %H:%M:%OS", tzone = "UTC")
+  ))
   expect_equal(res2[[1]], expected2)
 })

--- a/tests/testthat/test-timezone.R
+++ b/tests/testthat/test-timezone.R
@@ -145,8 +145,7 @@ test_that("POSIXct with local time zone and existing but empty attribute", {
 })
 
 test_that("tz_out_convert = force handles invalid timestamps during DST transitions", {
-  # For some reason, this doesn't work on CI
-  skip_on_ci()
+  withr::local_timezone("Europe/London")
 
   # This test reproduces the issue where invalid timestamps during DST transitions
   # cause all timestamps to lose their time component when tz_out_convert = "force"


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2025-09-09, no problems (other than installation size) found.

## Action items

- [ ] Review PR
- [ ] Await successful CI/CD run
- [ ] Run `fledge::release()`
- [ ] When the package is accepted on CRAN, run `fledge::post_release()`