### PR TITLE
add `n_distinct(..., na.rm = TRUE)` support for multiple passed columns.

### DIFF
--- a/R/backend-dbplyr__duckdb_connection.R
+++ b/R/backend-dbplyr__duckdb_connection.R
@@ -77,21 +77,14 @@ duckdb_n_distinct <- function(..., na.rm = FALSE) {
   }
   check_dots_unnamed()
 
+  # https://duckdb.org/docs/sql/data_types/struct.html#creating-structs-with-the-row-function
+  str_struct <- paste0("row(", paste0(list(...), collapse = ", "), ")")
+
   if (!identical(na.rm, FALSE)) {
-    cols <- list(...)
+    str_null_check <- paste0(paste0(list(...), " IS NOT NULL"), collapse = " AND ")
 
-    # check for more than one vector argument: only one vector is supported
-    # Why not use ROW() as well? Because duckdb's FILTER clause does not support
-    # a windowing context as of now: https://duckdb.org/docs/sql/query_syntax/filter.html
-    if (length(cols) > 1) {
-      stop("n_distinct(): Only one vector argument is currently supported when `na.rm = TRUE`.", call. = FALSE)
-    }
-
-    return(sql(paste0("COUNT(DISTINCT ", cols[[1]], ")")))
+    return(sql(paste0("COUNT(DISTINCT ", str_struct, ") FILTER (", str_null_check, ")")))
   } else {
-    # https://duckdb.org/docs/sql/data_types/struct.html#creating-structs-with-the-row-function
-    str_struct <- paste0("row(", paste0(list(...), collapse = ", "), ")")
-
     return(sql(paste0("COUNT(DISTINCT ", str_struct, ")")))
   }
 }

--- a/tests/testthat/test-backend-dbplyr__duckdb_connection.R
+++ b/tests/testthat/test-backend-dbplyr__duckdb_connection.R
@@ -278,9 +278,9 @@ test_that("aggregators translated correctly", {
   expect_equal(translate(n_distinct(x), window = FALSE), sql(r"{COUNT(DISTINCT row(x))}"))
   expect_equal(translate(n_distinct(x), window = TRUE), sql(r"{COUNT(DISTINCT row(x)) OVER ()}"))
   expect_equal(translate(n_distinct(x), window = TRUE, vars_group = "y"), sql(r"{COUNT(DISTINCT row(x)) OVER (PARTITION BY y)}"))
-  expect_equal(translate(n_distinct(x, na.rm = TRUE), window = FALSE), sql(r"{COUNT(DISTINCT x)}"))
-  expect_equal(translate(n_distinct(x, na.rm = TRUE), window = TRUE), sql(r"{COUNT(DISTINCT x) OVER ()}"))
-  expect_equal(translate(n_distinct(x, na.rm = TRUE), window = TRUE, vars_group = "y"), sql(r"{COUNT(DISTINCT x) OVER (PARTITION BY y)}"))
+  expect_equal(translate(n_distinct(x, na.rm = TRUE), window = FALSE), sql(r"{COUNT(DISTINCT row(x)) FILTER (x IS NOT NULL)}"))
+  expect_equal(translate(n_distinct(x, na.rm = TRUE), window = TRUE), sql(r"{COUNT(DISTINCT row(x)) FILTER (x IS NOT NULL) OVER ()}"))
+  expect_equal(translate(n_distinct(x, na.rm = TRUE), window = TRUE, vars_group = "y"), sql(r"{COUNT(DISTINCT row(x)) FILTER (x IS NOT NULL) OVER (PARTITION BY y)}"))
 })
 
 test_that("two variable aggregates are translated correctly", {
@@ -296,6 +296,10 @@ test_that("two variable aggregates are translated correctly", {
   expect_equal(translate(n_distinct(x, y), window = FALSE), sql(r"{COUNT(DISTINCT row(x, y))}"))
   expect_equal(translate(n_distinct(x, y), window = TRUE), sql(r"{COUNT(DISTINCT row(x, y)) OVER ()}"))
   expect_equal(translate(n_distinct(x, y), window = TRUE, vars_group = "y"), sql(r"{COUNT(DISTINCT row(x, y)) OVER (PARTITION BY y)}"))
+
+  expect_equal(translate(n_distinct(x, y, na.rm = TRUE), window = FALSE), sql(r"{COUNT(DISTINCT row(x, y)) FILTER (x IS NOT NULL AND y IS NOT NULL)}"))
+  expect_equal(translate(n_distinct(x, y, na.rm = TRUE), window = TRUE), sql(r"{COUNT(DISTINCT row(x, y)) FILTER (x IS NOT NULL AND y IS NOT NULL) OVER ()}"))
+  expect_equal(translate(n_distinct(x, y, na.rm = TRUE), window = TRUE, vars_group = "y"), sql(r"{COUNT(DISTINCT row(x, y)) FILTER (x IS NOT NULL AND y IS NOT NULL) OVER (PARTITION BY y)}"))
 })
 
 test_that("n_distinct() computations are correct", {
@@ -308,58 +312,71 @@ test_that("n_distinct() computations are correct", {
   mutate <- dplyr::mutate
   arrange <- dplyr::arrange
   pull <- dplyr::pull
+  n_distinct <- dplyr::n_distinct
 
-  duckdb_register(con, "df", data.frame(x = c(1, 1, 2, 2), y = c(1, 2, 2, 2)))
-  duckdb_register(con, "df_na", data.frame(x = c(1, 1, 2, NA, NA), y = c(1, 2, NA, 2, NA)))
+  df <- data.frame(x = c(1, 1, 2, 2), y = c(1, 2, 2, 2))
+  df_na <- data.frame(x = c(1, 1, 2, NA, NA), y = c(1, 2, NA, 2, NA))
 
-  df <- tbl(con, "df")
-  df_na <- tbl(con, "df_na")
+  duckdb_register(con, "df", df)
+  duckdb_register(con, "df_na", df_na)
+
+  df_duckdb <- tbl(con, "df")
+  df_na_duckdb <- tbl(con, "df_na")
 
   expect_equal(
-    pull(summarize(df, n = n_distinct(x, na.rm = TRUE)), n),
-    2
+    pull(summarize(df_duckdb, n = n_distinct(x, na.rm = TRUE)), n),
+    pull(summarize(df, n = n_distinct(x, na.rm = TRUE)), n)
   )
   expect_equal(
-    pull(summarize(df_na, n = n_distinct(x, na.rm = TRUE)), n),
-    2
+    pull(summarize(df_na_duckdb, n = n_distinct(x, na.rm = TRUE)), n),
+    pull(summarize(df_na, n = n_distinct(x, na.rm = TRUE)), n)
   )
-
-  expect_error(
-    pull(summarize(df, n = n_distinct(x, y, na.rm = TRUE)), n)
+  expect_equal(
+    pull(summarize(df_duckdb, n = n_distinct(x, y, na.rm = TRUE)), n),
+    pull(summarize(df, n = n_distinct(x, y, na.rm = TRUE)), n),
+  )
+  expect_equal(
+    pull(summarize(df_na_duckdb, n = n_distinct(x, y, na.rm = TRUE)), n),
+    pull(summarize(df_na, n = n_distinct(x, y, na.rm = TRUE)), n),
   )
 
   # single column is working as usual
   expect_equal(
     pull(summarize(df, n = n_distinct(x)), n),
-    2
+    pull(summarize(df_duckdb, n = n_distinct(x)), n)
   )
 
   expect_equal(
-    pull(summarize(df_na, n = n_distinct(x)), n),
-    3
+    pull(summarize(df_na_duckdb, n = n_distinct(x)), n),
+    pull(summarize(df_na, n = n_distinct(x)), n)
   )
 
   # two columns return correct results
   expect_equal(
-    pull(summarize(df, n = n_distinct(x, y)), n),
-    3
+    pull(summarize(df_duckdb, n = n_distinct(x, y)), n),
+    pull(summarize(df, n = n_distinct(x, y)), n)
   )
 
   # two columns containing NAs return correct results
   expect_equal(
-    pull(summarize(df_na, n = n_distinct(x, y)), n),
-    5
+    pull(summarize(df_na_duckdb, n = n_distinct(x, y)), n),
+    pull(summarize(df_na, n = n_distinct(x, y)), n)
   )
 
   # window functions are working
   expect_equal(
-    pull(mutate(df_na, n = n_distinct(x, y)), n),
-    rep(5, 5)
+    pull(mutate(df_na_duckdb, n = n_distinct(x, y)), n),
+    pull(mutate(df_na, n = n_distinct(x, y)), n)
   )
 
   expect_equal(
+    pull(mutate(df_na_duckdb, n = n_distinct(x, y, na.rm = TRUE)), n),
+    pull(mutate(df_na, n = n_distinct(x, y, na.rm = TRUE)), n)
+  )
+
+  expect_equal(
+    pull(arrange(mutate(df_duckdb, n = n_distinct(x), .by = y), x, y), n),
     pull(arrange(mutate(df, n = n_distinct(x), .by = y), x, y), n),
-    c(1, 2, 2, 2)
   )
 })
 


### PR DESCRIPTION
My previous contribution only supported `n_distinct(..., na.rm = TRUE)` with for a single column, because duckdb's `FILTER` clause was not supported in a windows context. This changed with duckdb v1.2.

This PR adds `na.rm = TRUE` support for multiple columns by using duckdb's `struct` and using `FILTER` to filter for non-null values before counting distinct elements.

I also adjusted the tests to simply compare against the dplyr result of `n_distinct()` instead of testing against explicit values to make sure the semantics is identical.