### PR TITLE
Correct url in NEWS for DuckDB v1.4.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 # duckdb 1.4.1
 
-- Update to DuckDB v1.4.1, see <https://github.com/duckdb/duckdb/releases/tag/v1.4.0> for details.
+- Update to DuckDB v1.4.1, see <https://github.com/duckdb/duckdb/releases/tag/v1.4.1> for details.
 
 ## Features
 


### PR DESCRIPTION
The link for 1.4.1 release notes goes to 1.4.0 so this may be a copy-and-paste error.  If the intent was to link truly to 1.4.0 please disregard this.