### PR TITLE
chore: Initialize `ParquetReader::rows_read` atomic variable

### DIFF
--- a/patch/0034-parquet-rows-read-uninitialized.patch
+++ b/patch/0034-parquet-rows-read-uninitialized.patch
@@ -1,0 +1,31 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+Subject: [PATCH] Initialize ParquetReader::rows_read
+
+Valgrind reports "conditional jump depends on uninitialised value(s)"
+in ParquetReader::GetProgressInFile because the OpenFileInfo
+constructor of ParquetReader does not list rows_read in its
+initializer list, leaving the atomic<idx_t> default-initialized
+(which for std::atomic means uninitialized storage). The taint then
+propagates through MultiFileFunction::MultiFileProgress and the
+pipeline progress machinery.
+
+See https://www.stats.ox.ac.uk/pub/bdr/memtests/valgrind/duckdb/
+---
+ src/duckdb/extension/parquet/include/parquet_reader.hpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/duckdb/extension/parquet/include/parquet_reader.hpp b/src/duckdb/extension/parquet/include/parquet_reader.hpp
+--- a/src/duckdb/extension/parquet/include/parquet_reader.hpp
++++ b/src/duckdb/extension/parquet/include/parquet_reader.hpp
+@@ -156,7 +156,7 @@ public:
+ 	unique_ptr<ParquetColumnSchema> root_schema;
+ 	shared_ptr<EncryptionUtil> encryption_util;
+ 	//! How many rows have been read from this file
+-	atomic<idx_t> rows_read;
++	atomic<idx_t> rows_read {0};
+
+ public:
+ 	string GetReaderType() const override {
+--
+2.52.0
+

--- a/src/duckdb/extension/parquet/include/parquet_reader.hpp
+++ b/src/duckdb/extension/parquet/include/parquet_reader.hpp
@@ -156,7 +156,7 @@ public:
 	unique_ptr<ParquetColumnSchema> root_schema;
 	shared_ptr<EncryptionUtil> encryption_util;
 	//! How many rows have been read from this file
-	atomic<idx_t> rows_read;
+	atomic<idx_t> rows_read {0};
 
 public:
 	string GetReaderType() const override {


### PR DESCRIPTION
## Summary
This change fixes an uninitialized variable issue in the ParquetReader class by properly initializing the `rows_read` atomic variable.

## Key Changes
- Initialize `atomic<idx_t> rows_read` with value `{0}` in the ParquetReader class definition
- This ensures the atomic variable is properly initialized rather than left in an uninitialized state

## Details
The `rows_read` member variable is an `std::atomic<idx_t>` that was not being initialized in the constructor's initializer list. For `std::atomic` types, default construction leaves the storage uninitialized, which causes Valgrind to report "conditional jump depends on uninitialised value(s)" errors when the variable is read in `ParquetReader::GetProgressInFile`. The uninitialized value then propagates through `MultiFileFunction::MultiFileProgress` and the pipeline progress machinery.

By explicitly initializing the atomic variable with `{0}`, we ensure it starts with a well-defined value of 0, eliminating the undefined behavior and Valgrind warnings.

https://claude.ai/code/session_017KZnoQvSXXj6QLEH7q8vjy