### PR TITLE
chore: Add out-of-line `SelectionData` destructor to fix GCC warnings

### DIFF
--- a/patch/0035-array-bounds-selection-data.patch
+++ b/patch/0035-array-bounds-selection-data.patch
@@ -1,0 +1,56 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+Subject: [PATCH] Out-of-line SelectionData destructor to silence g++-16
+ -Warray-bounds
+
+GCC 14+ (notably g++-16 used by r-devel) emits a spurious
+"array subscript 'duckdb::SelectionData[0]' is partly outside array
+bounds of 'unsigned char [24]'" warning at the call site of
+make_shared_ptr<TemplatedValidityData<...>> in
+TemplatedValidityMask::Initialize. The diagnostic chain shows
+_Sp_counted_ptr_inplace<SelectionData>::_M_dispose being inlined where
+_Sp_counted_ptr_inplace<TemplatedValidityData<...>>::_M_dispose is
+expected, which is consistent with IPA-ICF folding two structurally
+similar dispose specializations.
+
+Declaring an out-of-line user-defined destructor for SelectionData
+makes the SelectionData destruction sequence non-inline at the
+shared_ptr disposal site, which prevents the spurious fold and the
+resulting false-positive warning. The destructor body is = default so
+behaviour is unchanged.
+---
+ src/duckdb/src/common/types/selection_vector.cpp             | 2 ++
+ src/duckdb/src/include/duckdb/common/types/selection_vector.hpp | 5 +++++
+ 2 files changed, 7 insertions(+)
+
+diff --git a/src/duckdb/src/common/types/selection_vector.cpp b/src/duckdb/src/common/types/selection_vector.cpp
+index a123234..ca8b412 100644
+--- a/src/duckdb/src/common/types/selection_vector.cpp
++++ b/src/duckdb/src/common/types/selection_vector.cpp
+@@ -16,6 +16,8 @@ SelectionData::SelectionData(idx_t count) {
+ #endif
+ }
+
++SelectionData::~SelectionData() = default;
++
+ // LCOV_EXCL_START
+ string SelectionVector::ToString(idx_t count) const {
+ 	string result = "Selection Vector (" + to_string(count) + ") [";
+diff --git a/src/duckdb/src/include/duckdb/common/types/selection_vector.hpp b/src/duckdb/src/include/duckdb/common/types/selection_vector.hpp
+index 5575e5a..c695e04 100644
+--- a/src/duckdb/src/include/duckdb/common/types/selection_vector.hpp
++++ b/src/duckdb/src/include/duckdb/common/types/selection_vector.hpp
+@@ -19,6 +19,11 @@ class VectorBuffer;
+
+ struct SelectionData {
+ 	DUCKDB_API explicit SelectionData(idx_t count);
++	// Out-of-line destructor: prevents GCC IPA-ICF from folding
++	// _Sp_counted_ptr_inplace<SelectionData>::_M_dispose with the
++	// corresponding instantiation for TemplatedValidityData, which produces
++	// a spurious -Warray-bounds with g++ >= 14.
++	DUCKDB_API ~SelectionData();
+
+ 	AllocatedData owned_data;
+ };
+--
+2.52.0
+

--- a/src/duckdb/src/common/types/selection_vector.cpp
+++ b/src/duckdb/src/common/types/selection_vector.cpp
@@ -16,6 +16,8 @@ SelectionData::SelectionData(idx_t count) {
 #endif
 }
 
+SelectionData::~SelectionData() = default;
+
 // LCOV_EXCL_START
 string SelectionVector::ToString(idx_t count) const {
 	string result = "Selection Vector (" + to_string(count) + ") [";

--- a/src/duckdb/src/include/duckdb/common/types/selection_vector.hpp
+++ b/src/duckdb/src/include/duckdb/common/types/selection_vector.hpp
@@ -19,6 +19,11 @@ class VectorBuffer;
 
 struct SelectionData {
 	DUCKDB_API explicit SelectionData(idx_t count);
+	// Out-of-line destructor: prevents GCC IPA-ICF from folding
+	// _Sp_counted_ptr_inplace<SelectionData>::_M_dispose with the
+	// corresponding instantiation for TemplatedValidityData, which produces
+	// a spurious -Warray-bounds with g++ >= 14.
+	DUCKDB_API ~SelectionData();
 
 	AllocatedData owned_data;
 };


### PR DESCRIPTION
## Summary
This change adds an out-of-line user-defined destructor for the `SelectionData` struct to prevent spurious compiler warnings from GCC 14+ (particularly g++-16 used by r-devel).

## Changes
- **Header file** (`selection_vector.hpp`): Declared an out-of-line destructor for `SelectionData` with documentation explaining the purpose
- **Implementation file** (`selection_vector.cpp`): Defined the destructor with `= default` to maintain existing behavior

## Details
GCC 14+ emits a false-positive `-Warray-bounds` warning when `make_shared_ptr<TemplatedValidityData<...>>` is called in `TemplatedValidityMask::Initialize`. The compiler's IPA-ICF (Interprocedural Analysis - Identical Code Folding) optimization incorrectly folds the `_Sp_counted_ptr_inplace<SelectionData>::_M_dispose` specialization with the corresponding `TemplatedValidityData` specialization, leading to incorrect bounds checking diagnostics.

By declaring an out-of-line destructor (rather than relying on the implicitly-defined inline destructor), the destruction sequence becomes non-inline at the shared_ptr disposal site, preventing the spurious fold and the resulting false-positive warning. The destructor body is `= default`, so there is no change to actual behavior.

https://claude.ai/code/session_011h92QmvSCo5UmFMmMNwoyC