### PR TITLE
feat: Add `is_distinct_from()` / `is_not_distinct_from()` dbplyr translations for compatibility with dbplyr 2.6.0

### DIFF
--- a/R/backend-dbplyr__duckdb_connection.R
+++ b/R/backend-dbplyr__duckdb_connection.R
@@ -286,6 +286,10 @@ sql_translation.duckdb_connection <- function(con) {
       paste = sql_paste(" "),
       paste0 = sql_paste(""),
 
+      # https://duckdb.org/docs/sql/expressions/comparison_operators
+      is_distinct_from = function(x, y) build_sql("(", x, ") IS DISTINCT FROM (", y, ")"),
+      is_not_distinct_from = function(x, y) build_sql("(", x, ") IS NOT DISTINCT FROM (", y, ")"),
+
       # clock
       add_days = function(x, n, ...) {
         build_sql("DATE_ADD(", !!x, ", INTERVAL (", n ,") day)")

--- a/tests/testthat/test-backend-dbplyr__duckdb_connection.R
+++ b/tests/testthat/test-backend-dbplyr__duckdb_connection.R
@@ -247,6 +247,29 @@ test_that("is_distinct_from and is_not_distinct_from produce correct results", {
   )
 })
 
+test_that("filter() and filter_out() produce correct results", {
+  skip_if_not_installed("dbplyr", "2.5.2.9000")
+  skip_if_not_installed("dplyr", "1.2.0")
+
+  con <- local_con()
+  df <- data.frame(id = 1:4, x = c(1, 2, NA, 3))
+  duckdb_register(con, "df", df)
+  df_duckdb <- dplyr::tbl(con, "df")
+
+  # filter drops rows where the predicate is FALSE or NA
+  expect_equal(
+    dplyr::pull(dplyr::arrange(dplyr::filter(df_duckdb, x > 1), id), id),
+    c(2L, 4L)
+  )
+
+  # filter_out drops rows where the predicate is TRUE; NA rows are kept
+  # because dbplyr translates the condition through is_distinct_from(., TRUE)
+  expect_equal(
+    dplyr::pull(dplyr::arrange(dplyr::filter_out(df_duckdb, x > 1), id), id),
+    c(1L, 3L)
+  )
+})
+
 test_that("datetime escaping working as in DBI", {
   skip_if_not_installed("dbplyr")
   con <- local_con()

--- a/tests/testthat/test-backend-dbplyr__duckdb_connection.R
+++ b/tests/testthat/test-backend-dbplyr__duckdb_connection.R
@@ -212,6 +212,41 @@ test_that("custom stringr functions translated correctly", {
   expect_equal(translate(str_ilike(x, "a")), sql(r"{x ILIKE 'a'}"))
 })
 
+test_that("is_distinct_from and is_not_distinct_from translated correctly", {
+  skip_if_not_installed("dbplyr", "2.5.2.9000")
+  con <- local_con()
+  translate <- function(...) dbplyr::translate_sql(..., con = con)
+  sql <- function(...) dbplyr::sql(...)
+
+  expect_equal(
+    translate(is_distinct_from(x, y)),
+    sql(r"{(x) IS DISTINCT FROM (y)}")
+  )
+  expect_equal(
+    translate(is_not_distinct_from(x, y)),
+    sql(r"{(x) IS NOT DISTINCT FROM (y)}")
+  )
+})
+
+test_that("is_distinct_from and is_not_distinct_from produce correct results", {
+  skip_if_not_installed("dbplyr", "2.5.2.9000")
+  skip_if_not_installed("dplyr")
+
+  con <- local_con()
+  df <- data.frame(x = c(1, NA, 2, NA), y = c(1, 2, NA, NA))
+  duckdb_register(con, "df", df)
+  df_duckdb <- dplyr::tbl(con, "df")
+
+  expect_equal(
+    dplyr::pull(dplyr::mutate(df_duckdb, r = is_distinct_from(x, y)), r),
+    c(FALSE, TRUE, TRUE, FALSE)
+  )
+  expect_equal(
+    dplyr::pull(dplyr::mutate(df_duckdb, r = is_not_distinct_from(x, y)), r),
+    c(TRUE, FALSE, FALSE, TRUE)
+  )
+})
+
 test_that("datetime escaping working as in DBI", {
   skip_if_not_installed("dbplyr")
   con <- local_con()


### PR DESCRIPTION
Closes #2326.

The upcoming dbplyr release deprecates `sql_expr_matches()` in favour of
`is_distinct_from()` / `is_not_distinct_from()` translations defined in
`sql_translation()`. Translate them to DuckDB's native `IS DISTINCT FROM`
and `IS NOT DISTINCT FROM` operators, following the postgres backend
pattern from the issue. The existing `sql_expr_matches.duckdb_connection`
method is kept for compatibility with older dbplyr versions.

## Test plan

New tests are gated to `dbplyr >= 2.5.2.9000` (the version that introduces
the generics). Verified locally:

- CRAN dbplyr 2.5.2: `[ FAIL 0 | WARN 0 | SKIP 11 | PASS 149 ]` — new tests are skipped with reason "Installed dbplyr is version 2.5.2; but 2.5.2.9000 is required"
- GitHub dbplyr 2.5.2.9000: `[ FAIL 0 | WARN 0 | SKIP 9 | PASS 153 ]` — new tests run and pass

- [ ] CI passes on both dbplyr versions


---
_Generated by [Claude Code](https://claude.ai/code/session_01T5mt3S6NxuNynSEroq8Wzg)_