### PR TITLE
chore: Bump minimum R version requirement to 4.2.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,7 +138,7 @@ R
 
 System requirements already satisfied in typical development environment:
 
-- R >= 4.1.0
+- R >= 4.2.0
 - build-essential (gcc, g++, make)
 - Standard R packages: DBI, testthat, methods, utils
 - Optional: cmake-format for code formatting

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,7 +42,7 @@ URL: https://r.duckdb.org/, https://github.com/duckdb/duckdb-r
 BugReports: https://github.com/duckdb/duckdb-r/issues
 Depends:
     DBI,
-    R (>= 4.1.0)
+    R (>= 4.2.0)
 Imports:
     methods,
     utils
@@ -67,11 +67,6 @@ Config/build/compilation-database: false
 Config/build/never-clean: true
 Config/comment/compilation-database: Generate manually with
     pkgload:::generate_db() for faster pkgload::load_all()
-Config/gha/extra-packages: arrow=?ignore-before-r=4.2.0
-    adbcdrivermanager=?ignore-before-r=4.2.0
-Config/gha/filter: os != "windows-latest" | r != "4.1"
-Config/gha/filter-note: Inexplicable build failures on Windows GHA with R
-    4.1, works locally
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)


### PR DESCRIPTION
Closes #2233.

## Summary
This PR updates the minimum required R version from 4.1.0 to 4.2.0 across the package configuration and documentation.

## Key Changes
- Updated `DESCRIPTION` file to require `R (>= 4.2.0)` instead of `R (>= 4.1.0)`
- Removed conditional GitHub Actions configuration that was specific to R 4.1:
  - Removed `Config/gha/extra-packages` entries with `ignore-before-r=4.2.0` conditions for arrow and adbcdrivermanager packages
  - Removed `Config/gha/filter` that excluded Windows builds with R 4.1
  - Removed associated filter note about Windows GHA build failures with R 4.1
- Updated `AGENTS.md` documentation to reflect the new minimum R version requirement (>= 4.2.0)

## Rationale
With R 4.2.0 now set as the minimum version, the conditional package handling and platform-specific build filters for R 4.1 are no longer necessary, simplifying the CI/CD configuration.

https://claude.ai/code/session_012DegQwpGpZpf8ammCEXRjS