### PR TITLE
fix: Silence valgrind errors in TransactionContext and BaseStatistics

### DIFF
--- a/patch/0036-transaction-context-uninitialized.patch
+++ b/patch/0036-transaction-context-uninitialized.patch
@@ -1,0 +1,45 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+Subject: [PATCH] Initialize TransactionContext members
+
+Valgrind reports "Conditional jump or move depends on uninitialised
+value(s)" originating from
+duckdb::ClientContext::ErrorInvalidatesTransaction
+(client_context.cpp:638), which reads
+transaction.GetInvalidationPolicy().
+
+TransactionContext has two non-static members that are neither
+default-initialized in the class definition nor assigned in the
+constructor initializer list:
+
+  TransactionInvalidationPolicy invalidation_policy;
+  bool auto_rollback;
+
+They are only ever written via SetInvalidationPolicy / SetAutoRollback,
+both of which are called from PhysicalTransaction when a transaction
+statement is executed. For an auto-commit connection these setters are
+never reached before ErrorInvalidatesTransaction runs, so the read of
+invalidation_policy is on an uninitialized byte.
+
+Initialize both members in-class with the same defaults that
+TransactionInfo uses (STANDARD_POLICY and false).
+---
+ src/duckdb/src/include/duckdb/transaction/transaction_context.hpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/duckdb/src/include/duckdb/transaction/transaction_context.hpp b/src/duckdb/src/include/duckdb/transaction/transaction_context.hpp
+index 0000000..0000000 100644
+--- a/src/duckdb/src/include/duckdb/transaction/transaction_context.hpp
++++ b/src/duckdb/src/include/duckdb/transaction/transaction_context.hpp
+@@ -72,8 +72,8 @@ public:
+ private:
+ 	ClientContext &context;
+ 	bool auto_commit;
+-	TransactionInvalidationPolicy invalidation_policy;
+-	bool auto_rollback;
++	TransactionInvalidationPolicy invalidation_policy = TransactionInvalidationPolicy::STANDARD_POLICY;
++	bool auto_rollback = false;
+
+ 	unique_ptr<MetaTransaction> current_transaction;
+
+--
+2.52.0

--- a/patch/0037-base-statistics-uninitialized.patch
+++ b/patch/0037-base-statistics-uninitialized.patch
@@ -1,0 +1,68 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+Subject: [PATCH] Initialize BaseStatistics members
+
+Valgrind reports "Conditional jump or move depends on uninitialised
+value(s)" in StringValueComparison (string_stats.cpp:125 and 127),
+reached via StringStats::Update -> BaseStatistics::FromConstantType
+during StatisticsPropagator::StatisticsFromValue while the optimizer
+folds constants in a VARIANT -> STRUCT -> STRING recursion.
+
+The root cause is that BaseStatistics objects can reach code paths
+that read stats_union, has_null or has_no_null without all three
+having been written first:
+
+- BaseStatistics::BaseStatistics() only sets `type`, leaving
+  has_null, has_no_null, distinct_count, and stats_union uninitialized.
+- BaseStatistics::Construct() sets `distinct_count` and `type`, then
+  dispatches to the type-specific Construct. For STRING_STATS,
+  NUMERIC_STATS and GEOMETRY_STATS the default branch runs and
+  stats_union is never touched.
+- VariantStats::Construct() allocates `new BaseStatistics[2]` and
+  only calls Construct on child_stats[0], leaving child_stats[1] in
+  the default-constructed state above.
+
+CreateEmpty/CreateUnknown later overwrite the relevant fields, but
+copy and move operations - and the recursive Statistics propagation
+that runs the optimizer - can read stats_union or the validity flags
+before that fully completes. The padding bytes of stats_union also
+remain uninitialized because string_data is smaller than
+NumericStatsData (the largest union member).
+
+Fully initialize the three trivially-copyable fields and zero the
+stats_union storage in the default constructor and in
+BaseStatistics::Construct. The values match what InitializeEmpty()
+sets, so subsequent CreateEmpty/CreateUnknown paths still produce
+the same result; the only difference is that bytes are deterministic
+rather than indeterminate.
+---
+ src/duckdb/src/storage/statistics/base_statistics.cpp | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/src/duckdb/src/storage/statistics/base_statistics.cpp b/src/duckdb/src/storage/statistics/base_statistics.cpp
+index 0000000..0000000 100644
+--- a/src/duckdb/src/storage/statistics/base_statistics.cpp
++++ b/src/duckdb/src/storage/statistics/base_statistics.cpp
+@@ -12,7 +12,8 @@ namespace duckdb {
+ //===--------------------------------------------------------------------===//
+ // Base Statistics
+ //===--------------------------------------------------------------------===//
+-BaseStatistics::BaseStatistics() : type(LogicalType::INVALID) {
++BaseStatistics::BaseStatistics() : type(LogicalType::INVALID), has_null(false), has_no_null(false), distinct_count(0) {
++	memset(&stats_union, 0, sizeof(stats_union));
+ }
+
+ BaseStatistics::BaseStatistics(LogicalType type) {
+@@ -20,7 +21,10 @@ BaseStatistics::BaseStatistics(LogicalType type) {
+ }
+
+ void BaseStatistics::Construct(BaseStatistics &stats, LogicalType type) {
+-	stats.distinct_count = 0;
++	stats.has_null = false;
++	stats.has_no_null = false;
++	stats.distinct_count = 0;
++	memset(&stats.stats_union, 0, sizeof(stats.stats_union));
+ 	stats.type = std::move(type);
+ 	switch (GetStatsType(stats.type)) {
+ 	case StatisticsType::LIST_STATS:
+--
+2.52.0

--- a/src/duckdb/src/include/duckdb/transaction/transaction_context.hpp
+++ b/src/duckdb/src/include/duckdb/transaction/transaction_context.hpp
@@ -72,8 +72,8 @@ public:
 private:
 	ClientContext &context;
 	bool auto_commit;
-	TransactionInvalidationPolicy invalidation_policy;
-	bool auto_rollback;
+	TransactionInvalidationPolicy invalidation_policy = TransactionInvalidationPolicy::STANDARD_POLICY;
+	bool auto_rollback = false;
 
 	unique_ptr<MetaTransaction> current_transaction;
 

--- a/src/duckdb/src/storage/statistics/base_statistics.cpp
+++ b/src/duckdb/src/storage/statistics/base_statistics.cpp
@@ -12,7 +12,8 @@
 
 namespace duckdb {
 
-BaseStatistics::BaseStatistics() : type(LogicalType::INVALID) {
+BaseStatistics::BaseStatistics() : type(LogicalType::INVALID), has_null(false), has_no_null(false), distinct_count(0) {
+	memset(&stats_union, 0, sizeof(stats_union));
 }
 
 BaseStatistics::BaseStatistics(LogicalType type) {
@@ -20,7 +21,10 @@ BaseStatistics::BaseStatistics(LogicalType type) {
 }
 
 void BaseStatistics::Construct(BaseStatistics &stats, LogicalType type) {
+	stats.has_null = false;
+	stats.has_no_null = false;
 	stats.distinct_count = 0;
+	memset(&stats.stats_union, 0, sizeof(stats.stats_union));
 	stats.type = std::move(type);
 	switch (GetStatsType(stats.type)) {
 	case StatisticsType::LIST_STATS:


### PR DESCRIPTION
## Summary

Two valgrind "Conditional jump or move depends on uninitialised value(s)" reports surfaced by the r-hub valgrind job, both caused by structs that read members the constructor never wrote.

### 1. `TransactionContext` (commit `13ab0d3`)

- Reported at `ClientContext::ErrorInvalidatesTransaction` (`client_context.cpp:638`), which reads `transaction.GetInvalidationPolicy()`.
- `TransactionContext::invalidation_policy` and `auto_rollback` had no default initializers and were not set in the constructor; they are only written via setters that aren't reached on the auto-commit path before the read.
- Fix: default-initialize both members in the header to match `TransactionInfo`'s defaults (`STANDARD_POLICY`, `false`).
- Mirrored in `patch/0036-transaction-context-uninitialized.patch`.

### 2. `BaseStatistics` (commit `d39acd0`)

- Reported at `StringValueComparison` (`string_stats.cpp:125`/`127`), reached via `StringStats::Update` → `BaseStatistics::FromConstantType` while the optimizer folds VARIANT → STRUCT → STRING constants under `StatisticsPropagator::StatisticsFromValue`.
- Three construction paths can leave `has_null`, `has_no_null`, and `stats_union` uninitialized:
  - `BaseStatistics::BaseStatistics()` only sets `type`.
  - `BaseStatistics::Construct()` sets `distinct_count` and `type`, then for `STRING_STATS` / `NUMERIC_STATS` / `GEOMETRY_STATS` the default branch runs and `stats_union` is never touched.
  - `VariantStats::Construct()` allocates `new BaseStatistics[2]` and only constructs `child_stats[0]`, leaving `[1]` default-constructed.
- Fix: in both the default constructor and `BaseStatistics::Construct`, set the three flag/count fields to their `InitializeEmpty()` values and zero `stats_union`. Values are unchanged at the user level; only the bytes are now deterministic instead of indeterminate.
- Mirrored in `patch/0037-base-statistics-uninitialized.patch`.

### Effect on the r-hub valgrind job

| | original | after fix #1 | after fix #2 |
|---|---|---|---|
| `ErrorInvalidatesTransaction` | many | gone | gone |
| `StringValueComparison` (`VARIANT`/`STRUCT`/`STRING`) | many | still present | targeted |
| Total errors | 359 / 312 contexts | 310 / 308 contexts | expect 0 |

## Test plan

- [x] `UserNM=true R CMD INSTALL . --no-byte-compile` succeeds (twice — once per fix)
- [x] `R -q -e "testthat::test_local()"` → `FAIL 0 | WARN 0 | SKIP 59 | PASS 1074`
- [x] Minimal local valgrind reproducers (prepare/execute, struct/list/array, string-comparison queries) → `ERROR SUMMARY: 0 errors from 0 contexts`
- [ ] Full `testthat::test_local()` under valgrind — running locally (~2h), will report
- [ ] r-hub valgrind CI on this branch reports zero errors

https://claude.ai/code/session_01YEhKtsfniFtzSVgZvLPKHv