### PR TITLE
test: Add CRAN guards to prevent heavy C++ engine tests on CRAN

### DIFF
--- a/.github/versions-matrix.R
+++ b/.github/versions-matrix.R
@@ -1,2 +1,13 @@
-# Add even earlier Windows versions
-data.frame(os = "windows-latest", r = r_versions[4:6])
+list(
+  # Add even earlier Windows versions
+  data.frame(os = "windows-latest", r = r_versions[4:6]),
+  # Build with the DuckDB C++ engine poisoned (-DDUCKDB_R_POISON) and *without*
+  # DUCKDB_R_RUN_TESTS. Any test or example that reaches the C++ engine aborts,
+  # so this run verifies that the CRAN guards keep the engine untouched.
+  data.frame(
+    os = "ubuntu-24.04",
+    r = r_versions[[2]],
+    poison = "true",
+    desc = "with poisoning, without DUCKDB_R_RUN_TESTS"
+  )
+)

--- a/.github/versions-matrix.R
+++ b/.github/versions-matrix.R
@@ -1,13 +1,15 @@
 list(
   # Add even earlier Windows versions
   data.frame(os = "windows-latest", r = r_versions[4:6]),
-  # Build with the DuckDB C++ engine poisoned (-DDUCKDB_R_POISON) and *without*
-  # DUCKDB_R_RUN_TESTS. Any test or example that reaches the C++ engine aborts,
-  # so this run verifies that the CRAN guards keep the engine untouched.
+  # Build the DuckDB C++ engine with a tripwire (-DDUCKDB_R_POISON_ENGINE) and
+  # *without* DUCKDB_R_RUN_TESTS. The flag travels through the generic "env"
+  # matrix field and is picked up by the custom before-install action. Any test
+  # or example that reaches the C++ engine then aborts, so this run verifies
+  # that the CRAN guards keep the engine untouched.
   data.frame(
     os = "ubuntu-24.04",
     r = r_versions[[2]],
-    poison = "true",
-    desc = "with poisoning, without DUCKDB_R_RUN_TESTS"
+    env = "DUCKDB_R_POISON_ENGINE=true",
+    desc = "with engine poisoning, without DUCKDB_R_RUN_TESTS"
   )
 )

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -310,20 +310,12 @@ jobs:
         with:
           ref: ${{ needs.rcc-smoke.outputs.sha }}
 
-      # Build the DuckDB C++ engine with a hard stop at its entry points and
-      # leave DUCKDB_R_RUN_TESTS unset (the before-install step honours
-      # DUCKDB_R_POISON). If any test or example reaches the engine the check
-      # fails, proving the CRAN guards work.
-      - name: Configure poisoning to verify the CRAN guard
-        if: matrix.poison == 'true'
-        run: |
-          echo 'DUCKDB_R_POISON=1' | tee -a "$GITHUB_ENV"
-          mkdir -p ~/.R
-          echo 'CPPFLAGS += -DDUCKDB_R_POISON' | tee -a ~/.R/Makevars
-        shell: bash
-
       - uses: ./.github/workflows/custom/before-install
         if: hashFiles('.github/workflows/custom/before-install/action.yml') != ''
+        with:
+          # Generic: forward any per-entry environment variables defined in the
+          # test matrix (see .github/versions-matrix.R) to the custom action.
+          env: ${{ matrix.env }}
 
       - uses: ./.github/workflows/install
         with:
@@ -348,10 +340,10 @@ jobs:
         shell: Rscript {0}
 
       - uses: ./.github/workflows/update-snapshots
-        # Skip when poisoning: update-snapshots runs the tests directly via
-        # testthat::test_local(), bypassing the DUCKDB_R_RUN_TESTS guard in
-        # tests/testthat.R, which would hit the poisoned engine.
-        if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && matrix.poison != 'true'
+        # Generic escape hatch: a matrix entry may set SKIP_UPDATE_SNAPSHOTS
+        # (via the "env" field) to opt out of running the snapshot updater,
+        # which runs tests directly via testthat::test_local().
+        if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && env.SKIP_UPDATE_SNAPSHOTS != 'true'
         with:
           base: ${{ github.head_ref }}
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -340,9 +340,10 @@ jobs:
         shell: Rscript {0}
 
       - uses: ./.github/workflows/update-snapshots
-        # Generic escape hatch: a matrix entry may set SKIP_UPDATE_SNAPSHOTS
-        # (via the "env" field) to opt out of running the snapshot updater,
-        # which runs tests directly via testthat::test_local().
+        # Generic escape hatch: a custom action may set SKIP_UPDATE_SNAPSHOTS
+        # to opt out of running the snapshot updater,
+        # which runs tests directly via testthat::test_local()
+        # and is difficult to disable otherwise.
         if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && env.SKIP_UPDATE_SNAPSHOTS != 'true'
         with:
           base: ${{ github.head_ref }}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -310,6 +310,18 @@ jobs:
         with:
           ref: ${{ needs.rcc-smoke.outputs.sha }}
 
+      # Build the DuckDB C++ engine with a hard stop at its entry points and
+      # leave DUCKDB_R_RUN_TESTS unset (the before-install step honours
+      # DUCKDB_R_POISON). If any test or example reaches the engine the check
+      # fails, proving the CRAN guards work.
+      - name: Configure poisoning to verify the CRAN guard
+        if: matrix.poison == 'true'
+        run: |
+          echo 'DUCKDB_R_POISON=1' | tee -a "$GITHUB_ENV"
+          mkdir -p ~/.R
+          echo 'CPPFLAGS += -DDUCKDB_R_POISON' | tee -a ~/.R/Makevars
+        shell: bash
+
       - uses: ./.github/workflows/custom/before-install
         if: hashFiles('.github/workflows/custom/before-install/action.yml') != ''
 
@@ -336,7 +348,10 @@ jobs:
         shell: Rscript {0}
 
       - uses: ./.github/workflows/update-snapshots
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        # Skip when poisoning: update-snapshots runs the tests directly via
+        # testthat::test_local(), bypassing the DUCKDB_R_RUN_TESTS guard in
+        # tests/testthat.R, which would hit the poisoned engine.
+        if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && matrix.poison != 'true'
         with:
           base: ${{ github.head_ref }}
 

--- a/.github/workflows/custom/before-install/action.yml
+++ b/.github/workflows/custom/before-install/action.yml
@@ -1,25 +1,49 @@
 name: 'Custom steps to run before R packages are installed'
 
+inputs:
+  env:
+    description: >
+      Additional environment variables (one KEY=VALUE per line) contributed by
+      the test matrix. Generic hook used by .github/versions-matrix.R to flag
+      special matrix entries (e.g. the engine-poisoning entry below).
+    required: false
+    default: ""
+
 runs:
   using: "composite"
   steps:
+    - name: Apply environment variables from the test matrix
+      if: inputs.env != ''
+      env:
+        MATRIX_ENV: ${{ inputs.env }}
+      run: |
+        printf '%s\n' "$MATRIX_ENV" | tee -a "$GITHUB_ENV"
+      shell: bash
+
     - name: Define R CMD check error condition
       run: |
         echo '_R_CHECK_PKG_SIZES_=FALSE' | tee -a $GITHUB_ENV
       shell: bash
 
-    - name: Enable the duckdb test suite and examples (skipped on CRAN)
+    - name: Configure the duckdb CRAN guard
       run: |
         # The duckdb tests and runnable examples exercise the bundled C++ engine
         # and are gated behind DUCKDB_R_RUN_TESTS so they never run on CRAN
         # (see tests/testthat.R and R/cran-guard.R). We opt in here for CI.
         #
-        # The dedicated "poison" matrix entry sets DUCKDB_R_POISON instead and
-        # deliberately leaves DUCKDB_R_RUN_TESTS unset to verify the guard, so we
-        # skip enabling it when poisoning.
-        if [ -z "${DUCKDB_R_POISON:-}" ]; then
-          echo 'DUCKDB_R_RUN_TESTS=true' | tee -a $GITHUB_ENV
+        # The engine-poisoning matrix entry instead sets DUCKDB_R_POISON_ENGINE
+        # (via the generic "env" matrix field, applied above). When present we
+        # build the C++ tripwire (-DDUCKDB_R_POISON_ENGINE) and deliberately
+        # leave DUCKDB_R_RUN_TESTS unset, so that any test or example reaching
+        # the engine aborts the check and proves the CRAN guards are effective.
+        if [ -n "${DUCKDB_R_POISON_ENGINE:-}" ]; then
+          echo "DUCKDB_R_POISON_ENGINE is set; building the engine tripwire and leaving DUCKDB_R_RUN_TESTS unset."
+          mkdir -p ~/.R
+          echo 'CPPFLAGS += -DDUCKDB_R_POISON_ENGINE' | tee -a ~/.R/Makevars
+          # The snapshot updater bypasses tests/testthat.R via testthat::test_local(),
+          # so disable it here to keep it from exercising the poisoned engine.
+          echo 'SKIP_UPDATE_SNAPSHOTS=true' | tee -a "$GITHUB_ENV"
         else
-          echo "DUCKDB_R_POISON is set; leaving DUCKDB_R_RUN_TESTS unset to verify the CRAN guard."
+          echo 'DUCKDB_R_RUN_TESTS=true' | tee -a "$GITHUB_ENV"
         fi
       shell: bash

--- a/.github/workflows/custom/before-install/action.yml
+++ b/.github/workflows/custom/before-install/action.yml
@@ -7,3 +7,19 @@ runs:
       run: |
         echo '_R_CHECK_PKG_SIZES_=FALSE' | tee -a $GITHUB_ENV
       shell: bash
+
+    - name: Enable the duckdb test suite and examples (skipped on CRAN)
+      run: |
+        # The duckdb tests and runnable examples exercise the bundled C++ engine
+        # and are gated behind DUCKDB_R_RUN_TESTS so they never run on CRAN
+        # (see tests/testthat.R and R/cran-guard.R). We opt in here for CI.
+        #
+        # The dedicated "poison" matrix entry sets DUCKDB_R_POISON instead and
+        # deliberately leaves DUCKDB_R_RUN_TESTS unset to verify the guard, so we
+        # skip enabling it when poisoning.
+        if [ -z "${DUCKDB_R_POISON:-}" ]; then
+          echo 'DUCKDB_R_RUN_TESTS=true' | tee -a $GITHUB_ENV
+        else
+          echo "DUCKDB_R_POISON is set; leaving DUCKDB_R_RUN_TESTS unset to verify the CRAN guard."
+        fi
+      shell: bash

--- a/R/Driver.R
+++ b/R/Driver.R
@@ -135,7 +135,7 @@ duckdb_shutdown <- function(drv) {
 #' @return An object of class "adbc_driver"
 #' @rdname duckdb
 #' @export
-#' @examplesIf requireNamespace("adbcdrivermanager", quietly = TRUE)
+#' @examplesIf duckdb:::examples_enabled() && requireNamespace("adbcdrivermanager", quietly = TRUE)
 #' library(adbcdrivermanager)
 #' with_adbc(db <- adbc_database_init(duckdb_adbc()), {
 #'   as.data.frame(read_adbc(db, "SELECT 1 as one;"))

--- a/R/cran-guard.R
+++ b/R/cran-guard.R
@@ -1,0 +1,40 @@
+# CRAN guard
+#
+# DuckDB ships its own large C++ engine. Running the test suite or the runnable
+# examples exercises that engine, which is too heavy (in time and resource use)
+# for CRAN's check farm. We therefore gate everything that touches the C++ code
+# behind the `DUCKDB_R_RUN_TESTS` environment variable: it is unset on CRAN (so
+# nothing heavy runs) and set in our own continuous integration, where the full
+# suite runs on every change (<https://github.com/duckdb/duckdb-r>).
+#
+# This is intentional, not an oversight. The same variable is consulted, without
+# relying on this file, directly in `tests/testthat.R`.
+
+# Name of the environment variable that opts in to running DuckDB's C++ code.
+DUCKDB_R_RUN_TESTS_ENVVAR <- "DUCKDB_R_RUN_TESTS"
+
+# TRUE if the user has opted in to running code that touches DuckDB's C++ engine.
+duckdb_run_tests_enabled <- function() {
+  value <- tolower(trimws(Sys.getenv(DUCKDB_R_RUN_TESTS_ENVVAR, "")))
+  value %in% c("true", "1", "yes", "on")
+}
+
+# Used as the condition of `@examplesIf` for every runnable example that touches
+# DuckDB's C++ engine. When the example is skipped it emits a verbose, actionable
+# message so that it is obvious *why* nothing ran and how to opt in.
+examples_enabled <- function() {
+  if (duckdb_run_tests_enabled()) {
+    return(TRUE)
+  }
+
+  message(
+    "Skipping duckdb examples that exercise the bundled C++ engine.\n",
+    "This is intentional: these examples are not run on CRAN to keep check ",
+    "time and resource usage within CRAN's limits.\n",
+    "duckdb has an extensive test suite that runs continuously in our own CI; ",
+    "see <https://github.com/duckdb/duckdb-r>.\n",
+    "To run these examples, set ", DUCKDB_R_RUN_TESTS_ENVVAR, "=true, e.g. ",
+    "Sys.setenv(", DUCKDB_R_RUN_TESTS_ENVVAR, " = \"true\")."
+  )
+  FALSE
+}

--- a/R/dbConnect__duckdb_driver.R
+++ b/R/dbConnect__duckdb_driver.R
@@ -45,7 +45,7 @@
 #' or an adjusted time.
 #'
 #' @rdname duckdb
-#' @examples
+#' @examplesIf duckdb:::examples_enabled()
 #' drv <- duckdb()
 #' con <- dbConnect(drv)
 #'

--- a/R/register.R
+++ b/R/register.R
@@ -31,7 +31,7 @@ encode_values <- function(value) {
 #' @param experimental Enable experimental optimizations
 #' @return These functions are called for their side effect.
 #' @export
-#' @examples
+#' @examplesIf duckdb:::examples_enabled()
 #' con <- dbConnect(duckdb())
 #'
 #' data <- data.frame(a = 1:3, b = letters[1:3])

--- a/R/sql.R
+++ b/R/sql.R
@@ -19,7 +19,7 @@
 #' @param conn An optional connection, defaults to [default_conn()]
 #' @return A data frame with the query result
 #' @export
-#' @examples
+#' @examplesIf duckdb:::examples_enabled()
 #' # Queries
 #' sql_query("SELECT 42")
 #'
@@ -67,7 +67,7 @@ the <- new.env(parent = emptyenv())
 #'
 #' @return A DuckDB connection object
 #' @export
-#' @examples
+#' @examplesIf duckdb:::examples_enabled()
 #' conn <- default_conn()
 #' sql_query("SELECT 42", conn = conn)
 default_conn <- function() {

--- a/man/default_conn.Rd
+++ b/man/default_conn.Rd
@@ -29,6 +29,8 @@ There is no way for this or other packages to comprehensively track the state
 of this connection, so scripts and packages should manage their own connections.
 }
 \examples{
+\dontshow{if (duckdb:::examples_enabled()) withAutoprint(\{ # examplesIf}
 conn <- default_conn()
 sql_query("SELECT 42", conn = conn)
+\dontshow{\}) # examplesIf}
 }

--- a/man/duckdb.Rd
+++ b/man/duckdb.Rd
@@ -125,12 +125,13 @@ If the timestamp is invalid in the target timezone, the resulting value may be \
 or an adjusted time.
 }
 \examples{
-\dontshow{if (requireNamespace("adbcdrivermanager", quietly = TRUE)) withAutoprint(\{ # examplesIf}
+\dontshow{if (duckdb:::examples_enabled() && requireNamespace("adbcdrivermanager", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 library(adbcdrivermanager)
 with_adbc(db <- adbc_database_init(duckdb_adbc()), {
   as.data.frame(read_adbc(db, "SELECT 1 as one;"))
 })
 \dontshow{\}) # examplesIf}
+\dontshow{if (duckdb:::examples_enabled()) withAutoprint(\{ # examplesIf}
 drv <- duckdb()
 con <- dbConnect(drv)
 
@@ -143,4 +144,5 @@ duckdb_shutdown(drv)
 con <- dbConnect(duckdb())
 dbGetQuery(con, "SELECT 'Hello, world!'")
 dbDisconnect(con, shutdown = TRUE)
+\dontshow{\}) # examplesIf}
 }

--- a/man/duckdb_register.Rd
+++ b/man/duckdb_register.Rd
@@ -32,6 +32,7 @@ No data is copied.
 \code{duckdb_unregister()} unregisters a previously registered data frame.
 }
 \examples{
+\dontshow{if (duckdb:::examples_enabled()) withAutoprint(\{ # examplesIf}
 con <- dbConnect(duckdb())
 
 data <- data.frame(a = 1:3, b = letters[1:3])
@@ -42,4 +43,5 @@ dbReadTable(con, "data")
 duckdb_unregister(con, "data")
 
 dbDisconnect(con)
+\dontshow{\}) # examplesIf}
 }

--- a/man/sql_query.Rd
+++ b/man/sql_query.Rd
@@ -33,6 +33,7 @@ Scripts and packages should manage their own connections
 and prefer the DBI methods for more control.
 }
 \examples{
+\dontshow{if (duckdb:::examples_enabled()) withAutoprint(\{ # examplesIf}
 # Queries
 sql_query("SELECT 42")
 
@@ -43,4 +44,5 @@ sql_query("FROM test")
 
 # Data frames available as views
 sql_query("FROM mtcars")
+\dontshow{\}) # examplesIf}
 }

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -21,6 +21,10 @@ static bool CastRstringToVarchar(Vector &source, Vector &result, idx_t count, Ca
 
 [[cpp11::register]] duckdb::db_eptr_t rapi_startup(std::string dbdir, bool readonly, cpp11::list configsexp,
                                                    bool environment_scan) {
+	// Hard stop when poisoned: every DuckDB session starts here, so this single
+	// guard ensures no test or example can reach the C++ engine on CRAN.
+	DUCKDB_R_POISON_GUARD();
+
 	const char *dbdirchar;
 
 	if (dbdir.length() == 0 || dbdir.compare(IN_MEMORY_PATH) == 0) {

--- a/src/include/rapi.hpp
+++ b/src/include/rapi.hpp
@@ -29,6 +29,26 @@
 
 #define DUCKDB_PACKAGE_NAME "duckdb"
 
+// CRAN guard / poisoning
+//
+// DuckDB ships its own large C++ engine. Exercising it (running the test suite
+// or the runnable examples) is too heavy for CRAN's check farm, so everything
+// that touches the C++ code is gated behind the DUCKDB_R_RUN_TESTS environment
+// variable on the R side (see tests/testthat.R and R/cran-guard.R). That
+// variable is unset on CRAN and set in our own continuous integration.
+//
+// When duckdb is additionally built with -DDUCKDB_R_POISON, every C++ API entry
+// point aborts immediately. A poisoned build is used in CI *without* setting
+// DUCKDB_R_RUN_TESTS to prove that the R-side guards are effective: if any test
+// or example reaches the C++ engine, the check fails loudly.
+#ifdef DUCKDB_R_POISON
+#define DUCKDB_R_POISON_GUARD()                                                                                        \
+	cpp11::stop("This duckdb build is poisoned (-DDUCKDB_R_POISON): the DuckDB C++ engine must not be exercised "       \
+	            "during R CMD check. This is intentional; set DUCKDB_R_RUN_TESTS to run the suite outside CRAN.")
+#else
+#define DUCKDB_R_POISON_GUARD() ((void)0)
+#endif
+
 // Helper functions to communicate errors via R's stop() function with context information
 [[noreturn]] void rapi_error_with_context(const std::string &context, const std::string &message);
 [[noreturn]] void rapi_error_with_context(const std::string &context, const std::exception &e);

--- a/src/include/rapi.hpp
+++ b/src/include/rapi.hpp
@@ -32,10 +32,11 @@
 // CRAN guard / engine poisoning
 //
 // DuckDB ships its own large C++ engine. Exercising it (running the test suite
-// or the runnable examples) is too heavy for CRAN's check farm, so everything
-// that touches the C++ code is gated behind the DUCKDB_R_RUN_TESTS environment
-// variable on the R side (see tests/testthat.R and R/cran-guard.R). That
-// variable is unset on CRAN and set in our own continuous integration.
+// or the runnable examples) is too heavy for CRAN's check farm, and checks
+// were very fragile in the past. Everything that touches the C++ code is gated
+// behind the DUCKDB_R_RUN_TESTS environment variable on the R side (see
+// tests/testthat.R and R/cran-guard.R). That variable is unset on CRAN and set
+// in our own continuous integration.
 //
 // When duckdb is additionally built with -DDUCKDB_R_POISON_ENGINE, every C++
 // API entry point aborts immediately. Such a build is used in CI *without*
@@ -43,9 +44,8 @@
 // any test or example reaches the C++ engine, the check fails loudly.
 #ifdef DUCKDB_R_POISON_ENGINE
 #define DUCKDB_R_POISON_GUARD()                                                                                        \
-	cpp11::stop("This duckdb build is poisoned (-DDUCKDB_R_POISON_ENGINE): the DuckDB C++ engine must not be "          \
-	            "exercised during R CMD check. This is intentional; set DUCKDB_R_RUN_TESTS to run the suite outside "   \
-	            "CRAN.")
+	cpp11::stop("This duckdb build is poisoned (-DDUCKDB_R_POISON_ENGINE) to check that the DuckDB C++ engine"         \
+	            "is not exercised during R CMD check.")
 #else
 #define DUCKDB_R_POISON_GUARD() ((void)0)
 #endif

--- a/src/include/rapi.hpp
+++ b/src/include/rapi.hpp
@@ -29,7 +29,7 @@
 
 #define DUCKDB_PACKAGE_NAME "duckdb"
 
-// CRAN guard / poisoning
+// CRAN guard / engine poisoning
 //
 // DuckDB ships its own large C++ engine. Exercising it (running the test suite
 // or the runnable examples) is too heavy for CRAN's check farm, so everything
@@ -37,14 +37,15 @@
 // variable on the R side (see tests/testthat.R and R/cran-guard.R). That
 // variable is unset on CRAN and set in our own continuous integration.
 //
-// When duckdb is additionally built with -DDUCKDB_R_POISON, every C++ API entry
-// point aborts immediately. A poisoned build is used in CI *without* setting
-// DUCKDB_R_RUN_TESTS to prove that the R-side guards are effective: if any test
-// or example reaches the C++ engine, the check fails loudly.
-#ifdef DUCKDB_R_POISON
+// When duckdb is additionally built with -DDUCKDB_R_POISON_ENGINE, every C++
+// API entry point aborts immediately. Such a build is used in CI *without*
+// setting DUCKDB_R_RUN_TESTS to prove that the R-side guards are effective: if
+// any test or example reaches the C++ engine, the check fails loudly.
+#ifdef DUCKDB_R_POISON_ENGINE
 #define DUCKDB_R_POISON_GUARD()                                                                                        \
-	cpp11::stop("This duckdb build is poisoned (-DDUCKDB_R_POISON): the DuckDB C++ engine must not be exercised "       \
-	            "during R CMD check. This is intentional; set DUCKDB_R_RUN_TESTS to run the suite outside CRAN.")
+	cpp11::stop("This duckdb build is poisoned (-DDUCKDB_R_POISON_ENGINE): the DuckDB C++ engine must not be "          \
+	            "exercised during R CMD check. This is intentional; set DUCKDB_R_RUN_TESTS to run the suite outside "   \
+	            "CRAN.")
 #else
 #define DUCKDB_R_POISON_GUARD() ((void)0)
 #endif

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -9,4 +9,32 @@
 library(testthat)
 library(duckdb)
 
-test_check("duckdb")
+# CRAN guard
+#
+# The duckdb test suite exercises DuckDB's bundled C++ engine, which is too heavy
+# for CRAN's check farm. We therefore only run it when the DUCKDB_R_RUN_TESTS
+# environment variable opts in. This check is intentionally inlined here (rather
+# than calling into the package) so the guard is obvious and self-contained.
+run_tests <- tolower(trimws(Sys.getenv("DUCKDB_R_RUN_TESTS", "")))
+
+if (run_tests %in% c("true", "1", "yes", "on")) {
+  test_check("duckdb")
+} else {
+  message(
+    "\n",
+    strrep("=", 78), "\n",
+    "Skipping the duckdb test suite.\n",
+    "\n",
+    "The duckdb tests exercise DuckDB's bundled C++ engine and are deliberately\n",
+    "NOT run unless the DUCKDB_R_RUN_TESTS environment variable is set. This keeps\n",
+    "check time and resource usage on CRAN within acceptable limits.\n",
+    "\n",
+    "This is intentional, not an oversight. duckdb has an extensive test suite\n",
+    "that runs continuously in our own CI; see <https://github.com/duckdb/duckdb-r>.\n",
+    "\n",
+    "To run the test suite locally, set the environment variable before checking:\n",
+    "  Sys.setenv(DUCKDB_R_RUN_TESTS = \"true\")    # from within R, or\n",
+    "  DUCKDB_R_RUN_TESTS=true R CMD check ...      # from the shell\n",
+    strrep("=", 78), "\n"
+  )
+}

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -12,9 +12,10 @@ library(duckdb)
 # CRAN guard
 #
 # The duckdb test suite exercises DuckDB's bundled C++ engine, which is too heavy
-# for CRAN's check farm. We therefore only run it when the DUCKDB_R_RUN_TESTS
-# environment variable opts in. This check is intentionally inlined here (rather
-# than calling into the package) so the guard is obvious and self-contained.
+# for CRAN's check farm, and checks were very fragile in the past. We therefore
+# only run it when the DUCKDB_R_RUN_TESTS environment variable opts in.
+# This check is intentionally inlined here (rather than calling into the package)
+# so the guard is obvious and self-contained.
 run_tests <- tolower(trimws(Sys.getenv("DUCKDB_R_RUN_TESTS", "")))
 
 if (run_tests %in% c("true", "1", "yes", "on")) {
@@ -27,7 +28,8 @@ if (run_tests %in% c("true", "1", "yes", "on")) {
     "\n",
     "The duckdb tests exercise DuckDB's bundled C++ engine and are deliberately\n",
     "NOT run unless the DUCKDB_R_RUN_TESTS environment variable is set. This keeps\n",
-    "check time and resource usage on CRAN within acceptable limits.\n",
+    "check time and resource usage on CRAN within acceptable limits and helps\n",
+    "release duckdb in a predictable and controlled manner.\n",
     "\n",
     "This is intentional, not an oversight. duckdb has an extensive test suite\n",
     "that runs continuously in our own CI; see <https://github.com/duckdb/duckdb-r>.\n",


### PR DESCRIPTION
## Summary
This PR implements a guard system to prevent DuckDB's heavy C++ engine from being exercised during CRAN checks, while ensuring the full test suite runs in the project's own CI. The solution uses an environment variable (`DUCKDB_R_RUN_TESTS`) to gate all C++ code access and includes an "engine poisoning" mechanism to verify the guards are effective.

## Key Changes

- **New CRAN guard module** (`R/cran-guard.R`): Provides `duckdb_run_tests_enabled()` and `examples_enabled()` functions that check the `DUCKDB_R_RUN_TESTS` environment variable.

- **Test suite gating** (`tests/testthat.R`): Runs the suite only when `DUCKDB_R_RUN_TESTS` is set, otherwise emits a verbose message explaining the intentional skip and how to opt in. The check is inlined directly in the file so it is self-contained.

- **Example gating**: All runnable examples that touch the engine (`R/sql.R`, `R/Driver.R`, `R/dbConnect__duckdb_driver.R`, `R/register.R`) use `@examplesIf duckdb:::examples_enabled()`, which emits the same guidance when skipped. Man pages regenerated accordingly.

- **C++ engine tripwire** (`src/include/rapi.hpp`, `src/database.cpp`): A lightweight `DUCKDB_R_POISON_GUARD()` macro — a `cpp11::stop()` one-liner guarded by `#ifdef DUCKDB_R_POISON_ENGINE`, a no-op otherwise — placed at `rapi_startup`, the entry point of every DuckDB session. When built with `-DDUCKDB_R_POISON_ENGINE`, any test or example that reaches the engine aborts.

- **CI configuration (generic-first)**:
  - `.github/versions-matrix.R`: adds a matrix entry that carries the flag through a **generic `env` field** (`env = "DUCKDB_R_POISON_ENGINE=true"`) and leaves `DUCKDB_R_RUN_TESTS` unset.
  - `.github/workflows/R-CMD-check.yaml` stays generic: it only gains a generic forwarding of `matrix.env` to the custom `before-install` action, plus a generic `SKIP_UPDATE_SNAPSHOTS` escape hatch on the `update-snapshots` step. No poison-specific logic.
  - `.github/workflows/custom/before-install/action.yml` (custom action) picks up the flag: it applies the matrix `env`, and when `DUCKDB_R_POISON_ENGINE` is present it writes `CPPFLAGS += -DDUCKDB_R_POISON_ENGINE` to `~/.R/Makevars`, leaves `DUCKDB_R_RUN_TESTS` unset, and sets `SKIP_UPDATE_SNAPSHOTS=true` (the snapshot updater runs `testthat::test_local()`, bypassing `tests/testthat.R`). Normal CI runs opt in with `DUCKDB_R_RUN_TESTS=true`.

## Notable Implementation Details

- The guard accepts multiple truthy values: `"true"`, `"1"`, `"yes"`, `"on"` (case-insensitive).
- The tripwire sits at `rapi_startup`, which every DuckDB session must pass through, so no test or example can reach the engine without aborting.
- User-facing messages are verbose and actionable: they explain that the skip is intentional to avoid checking on CRAN, point to the extensive CI test suite, and show how to opt in locally.
- The solution is intentionally redundant (guards on both the R and C++ sides) for robustness.

https://claude.ai/code/session_01FsvpmBiT1sj31nSMaDGEXw