### PR TITLE
feat(arrow): add opt-in streaming flag for Arrow result conversion

### DIFF
--- a/R/Result.R
+++ b/R/Result.R
@@ -57,7 +57,7 @@ duckdb_result_arrow <- function(connection, stmt_lst) {
 duckdb_execute_arrow <- function(res) {
   rethrow_rapi_execute(
     res@stmt_lst$ref,
-    duckdb_convert_opts_impl(res@connection@convert_opts, arrow = TRUE)
+    duckdb_convert_opts_impl(res@connection@convert_opts, arrow = TRUE, streaming = TRUE)
   )
 }
 

--- a/R/convert.R
+++ b/R/convert.R
@@ -32,6 +32,7 @@ duckdb_convert_opts <- function(
     array = array,
     geometry = geometry,
     arrow = FALSE,
+    streaming = FALSE,
     experimental = FALSE,
     strict_relational = TRUE
   )
@@ -46,6 +47,7 @@ duckdb_convert_opts_impl <- function(
   array = NULL,
   geometry = NULL,
   arrow = NULL,
+  streaming = NULL,
   experimental = NULL,
   strict_relational = NULL
 ) {
@@ -66,6 +68,9 @@ duckdb_convert_opts_impl <- function(
   }
   if (!is.null(arrow)) {
     x$arrow <- arrow
+  }
+  if (!is.null(streaming)) {
+    x$streaming <- streaming
   }
   if (!is.null(experimental)) {
     x$experimental <- experimental

--- a/R/dbBind__duckdb_result_arrow.R
+++ b/R/dbBind__duckdb_result_arrow.R
@@ -20,7 +20,7 @@ dbBind__duckdb_result_arrow <- function(res, params, ...) {
   out <- rethrow_rapi_bind(
     res@stmt_lst$ref,
     params,
-    duckdb_convert_opts_impl(res@connection@convert_opts, arrow = TRUE)
+    duckdb_convert_opts_impl(res@connection@convert_opts, arrow = TRUE, streaming = TRUE)
   )
   if (length(out) == 0L) {
     # Zero-length bind: no executions; result is immediately drained.

--- a/plan/PLAN-dbSendQueryArrow.md
+++ b/plan/PLAN-dbSendQueryArrow.md
@@ -15,22 +15,38 @@ chunk-by-chunk rather than materializing up front.
   goes into `Suggests`; missing-package error includes an install hint.
 - `duckdb_fetch_arrow()` and `duckdb_fetch_record_batch()` stay; new docs
   cross-link them and flag them for future deprecation.
+- Streaming is opt-in via a dedicated `streaming` flag on `ConvertOpts`, set
+  only by the new `duckdb_result_arrow` paths. The legacy
+  `dbSendQuery(arrow = TRUE)` path keeps materializing results, so it remains
+  fully backward compatible (results survive interleaved queries on the same
+  connection, and the existing single-row-bind restriction is preserved).
+- Multi-row binding is supported for the new Arrow API: streams cannot
+  coexist on one prepared statement, so multi-row binds materialize one
+  result per row and `dbFetchArrow()` concatenates them into a single stream.
 
 ## Commits
 
 Each commit is self-contained and keeps the existing test suite green.
 
-### 1. fix(arrow): stream results when arrow execute is requested
+### 1. feat(arrow): add an opt-in `streaming` flag and stream when requested
 
 In `src/statement.cpp`, `rapi_execute` calls
 `stmt->Execute(stmt->parameters, /*allow_stream_result=*/false)` even when
-arrow is enabled. Switch this to `true` for the arrow path so the result is
-not materialized up front.
+arrow is enabled, materializing the result up front. Allow streaming, but
+gate it behind a new `streaming` flag so only the new Arrow API opts in.
 
-- Change confined to `rapi_execute`.
+- Add `ConvertOpts::ResultStreaming { DISABLED, ENABLED }` and a `streaming`
+  field (`src/include/convert.hpp`), parsed from the `streaming` list element
+  (`src/convert.cpp`). Thread it through the R helper `duckdb_convert_opts()` /
+  `duckdb_convert_opts_impl()` (`R/convert.R`), defaulting to `FALSE`.
+- `rapi_execute`: `allow_stream_result = arrow && streaming`.
+- `rapi_bind`: `allow_stream_result = arrow && streaming && n_rows == 1`;
+  keep the historical "length one for arrow queries" error for the
+  non-streaming (legacy) arrow path.
 - Existing arrow tests (`test-fetch_arrow.R`, `test-arrow_stream.R`,
-  `test-register_arrow.R`) keep passing because `QueryResultChunkScanState`
-  consumes both streaming and materialized results.
+  `test-register_arrow.R`) keep passing unchanged: the legacy path never sets
+  `streaming`, so it still materializes. `QueryResultChunkScanState` consumes
+  both streaming and materialized results.
 
 ### 2. feat(arrow): add `duckdb_result_arrow` class and `dbSendQueryArrow()`
 
@@ -79,19 +95,25 @@ Wire up nanoarrow-based fetching against DuckDB's
   a streaming-proof test that calling `dbSendQueryArrow()` on a `range()`
   query without fetching completes immediately (no materialization).
 
-### 4. feat(arrow): implement `dbBindArrow()`
+### 4. feat(arrow): implement `dbBind()`, `dbBindArrow()`, and multi-row binding
 
-- New `R/dbBindArrow__duckdb_result_arrow.R`.
-- Converts the nanoarrow stream params via `nanoarrow::convert_array_stream`
-  (or equivalent) into the existing single-row list form, then delegates to
-  the bind path. The single-row restriction from `rapi_bind` (arrow path)
-  carries over.
-- Tests cover: bind a parameterized arrow query and fetch the result.
+- `R/dbBind__duckdb_result_arrow.R`: `dbBind()` rebinds the result, resetting
+  completion/schema state. A single bound row keeps the streaming result;
+  multiple rows materialize one result per row, stored as
+  `query_result` + `pending_query_results` so fetching drains them in order.
+- `R/dbBindArrow__duckdb_result_arrow.R`: converts the nanoarrow stream params
+  into the list form and delegates to `dbBind()`. Multi-row streams therefore
+  run the query once per row.
+- `R/dbFetchArrow__duckdb_result_arrow.R`: for a single execution, hands the
+  streaming wrapper to nanoarrow directly; for multiple pending results,
+  drains every per-row result via `dbFetchArrowChunk()` and emits one unified
+  `basic_array_stream`.
+- Tests cover: bind a parameterized arrow query and fetch the result,
+  `dbBind()` rebind/reset, `dbBindArrow()` with a stream, and a multi-row
+  stream running the query once per row.
 
 ## Out of scope
 
-- Multi-row parameter binding for arrow queries — `rapi_bind` already
-  rejects this for arrow, and we keep that restriction.
 - Soft-deprecation of `duckdb_fetch_arrow()` / `duckdb_fetch_record_batch()`
   — only cross-link via `@seealso`.
 - The plain `dbFetch()` (data-frame) streaming work mentioned in the same

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -47,6 +47,10 @@ ConvertOpts::ArrowConversion bool_to_arrow_conversion(bool use_arrow) {
 	return use_arrow ? ConvertOpts::ArrowConversion::ENABLED : ConvertOpts::ArrowConversion::DISABLED;
 }
 
+ConvertOpts::ResultStreaming bool_to_result_streaming(bool use_streaming) {
+	return use_streaming ? ConvertOpts::ResultStreaming::ENABLED : ConvertOpts::ResultStreaming::DISABLED;
+}
+
 ConvertOpts::ExperimentalFeatures bool_to_experimental_features(bool use_experimental) {
 	return use_experimental ? ConvertOpts::ExperimentalFeatures::ENABLED : ConvertOpts::ExperimentalFeatures::DISABLED;
 }
@@ -79,6 +83,9 @@ ConvertOpts::ConvertOpts(cpp11::sexp options_nullable) {
 
 	// Extract arrow
 	arrow = bool_to_arrow_conversion(as_cpp<bool>(options["arrow"]));
+
+	// Extract streaming
+	streaming = bool_to_result_streaming(as_cpp<bool>(options["streaming"]));
 
 	// Extract experimental
 	experimental = bool_to_experimental_features(as_cpp<bool>(options["experimental"]));

--- a/src/include/convert.hpp
+++ b/src/include/convert.hpp
@@ -17,6 +17,8 @@ struct ConvertOpts {
 
 	enum class ArrowConversion { DISABLED, ENABLED };
 
+	enum class ResultStreaming { DISABLED, ENABLED };
+
 	enum class ExperimentalFeatures { DISABLED, ENABLED };
 
 	enum class StrictRelational { DISABLED, ENABLED };
@@ -28,6 +30,7 @@ struct ConvertOpts {
 	ArrayConversion array = ArrayConversion::NONE;
 	GeometryConversion geometry = GeometryConversion::BLOB;
 	ArrowConversion arrow = ArrowConversion::DISABLED;
+	ResultStreaming streaming = ResultStreaming::DISABLED;
 	ExperimentalFeatures experimental = ExperimentalFeatures::DISABLED;
 	StrictRelational strict_relational = StrictRelational::ENABLED;
 

--- a/src/statement.cpp
+++ b/src/statement.cpp
@@ -143,10 +143,19 @@ static SEXP rapi_execute_impl(RStatement *stmt, const duckdb::ConvertOpts &conve
 		}
 	}
 
+	bool arrow = convert_opts.arrow == ConvertOpts::ArrowConversion::ENABLED;
+	bool streaming = convert_opts.streaming == ConvertOpts::ResultStreaming::ENABLED;
+
+	// The legacy arrow path (`dbSendQuery(arrow = TRUE)`) materializes results and
+	// has never supported binding multiple rows; preserve that error.
+	if (arrow && !streaming && n_rows != 1) {
+		rapi_error_with_context("rapi_bind", "Bind parameter values need to have length one for arrow queries");
+	}
+
 	// Streaming arrow results from the same prepared statement cannot coexist
 	// (each Execute() invalidates the previous StreamQueryResult). Materialize
 	// per-row arrow results when binding multiple rows.
-	bool allow_stream_result = convert_opts.arrow == ConvertOpts::ArrowConversion::ENABLED && n_rows == 1;
+	bool allow_stream_result = arrow && streaming && n_rows == 1;
 
 	cpp11::writable::list out;
 	out.reserve(n_rows);
@@ -422,6 +431,7 @@ static SEXP rapi_execute_impl(RStatement *stmt, const duckdb::ConvertOpts &conve
 		rapi_error_with_context("rapi_execute", "Invalid statement");
 	}
 
-	bool allow_stream_result = convert_opts.arrow == ConvertOpts::ArrowConversion::ENABLED;
+	bool allow_stream_result = convert_opts.arrow == ConvertOpts::ArrowConversion::ENABLED &&
+	                           convert_opts.streaming == ConvertOpts::ResultStreaming::ENABLED;
 	return rapi_execute_impl(stmt.get(), convert_opts, allow_stream_result);
 }

--- a/tests/testthat/test-dbSendQueryArrow.R
+++ b/tests/testthat/test-dbSendQueryArrow.R
@@ -1,3 +1,5 @@
+skip_if_not_installed("nanoarrow")
+
 test_that("dbSendQueryArrow() returns a duckdb_result_arrow", {
   con <- local_con()
   dbExecute(con, "CREATE TABLE t (a INTEGER, b VARCHAR)")


### PR DESCRIPTION
## Summary

This PR introduces an opt-in `streaming` flag to the Arrow result conversion pipeline, enabling streaming results for the new `duckdb_result_arrow` API while maintaining full backward compatibility with the legacy `dbSendQuery(arrow = TRUE)` path.

## Key Changes

- **New `ResultStreaming` enum and `streaming` field** (`src/include/convert.hpp`, `src/convert.cpp`): Added a `ConvertOpts::ResultStreaming` enum with `DISABLED`/`ENABLED` states, parsed from the `streaming` list element in conversion options.

- **Thread streaming flag through R API** (`R/convert.R`): Added `streaming` parameter to `duckdb_convert_opts()` and `duckdb_convert_opts_impl()`, defaulting to `FALSE` for backward compatibility.

- **Gate streaming behind the flag** (`src/statement.cpp`):
  - `rapi_execute`: Only allows streaming when both `arrow` and `streaming` are enabled
  - `rapi_bind`: Only allows streaming when `arrow`, `streaming`, and single-row binding are all true; preserves the historical "length one for arrow queries" error for the legacy (non-streaming) arrow path

- **Enable streaming for new Arrow API** (`R/Result.R`, `R/dbBind__duckdb_result_arrow.R`): The new `duckdb_result_arrow` paths explicitly set `streaming = TRUE` when calling conversion functions.

## Implementation Details

- The legacy `dbSendQuery(arrow = TRUE)` path never sets the `streaming` flag, so it continues to materialize results and maintains all existing behavior (single-row binding restriction, result survival across interleaved queries).
- The new Arrow API (`duckdb_result_arrow`) opts into streaming by setting `streaming = TRUE`, enabling chunk-by-chunk result consumption.
- Existing tests remain unchanged and passing because `QueryResultChunkScanState` handles both streaming and materialized results transparently.
- The change is fully backward compatible—no existing code is affected unless explicitly using the new Arrow API.

https://claude.ai/code/session_01E5xa1S7hHvTSo4M1ddAPSu