### PR TITLE
test: Simplify CRAN guard: auto-enable tests on GitHub Actions

### DIFF
--- a/.github/versions-matrix.R
+++ b/.github/versions-matrix.R
@@ -2,14 +2,16 @@ list(
   # Add even earlier Windows versions
   data.frame(os = "windows-latest", r = r_versions[4:6]),
   # Build the DuckDB C++ engine with a tripwire (-DDUCKDB_R_POISON_ENGINE) and
-  # *without* DUCKDB_R_RUN_TESTS. The flag travels through the generic "env"
-  # matrix field and is picked up by the custom before-install action. Any test
-  # or example that reaches the C++ engine then aborts, so this run verifies
-  # that the CRAN guards keep the engine untouched.
+  # force DUCKDB_R_RUN_TESTS=false. The flag travels through the generic "env"
+  # matrix field and is picked up by the custom before-install action, which
+  # also opts this entry out of the tests/examples that otherwise run
+  # automatically on GitHub Actions. Any test or example that reaches the C++
+  # engine then aborts, so this run verifies that the CRAN guards keep the
+  # engine untouched.
   data.frame(
     os = "ubuntu-24.04",
     r = r_versions[[2]],
     env = "DUCKDB_R_POISON_ENGINE=true",
-    desc = "with engine poisoning, without DUCKDB_R_RUN_TESTS"
+    desc = "with engine poisoning, DUCKDB_R_RUN_TESTS=false"
   )
 )

--- a/.github/workflows/custom/before-install/action.yml
+++ b/.github/workflows/custom/before-install/action.yml
@@ -25,25 +25,24 @@ runs:
         echo '_R_CHECK_PKG_SIZES_=FALSE' | tee -a $GITHUB_ENV
       shell: bash
 
-    - name: Configure the duckdb CRAN guard
+    # The duckdb tests and runnable examples exercise the bundled C++ engine and
+    # are gated behind DUCKDB_R_RUN_TESTS so they never run on CRAN (see
+    # tests/testthat.R and R/cran-guard.R). The guard enables them automatically
+    # on GitHub Actions (GITHUB_ACTIONS=true), which also covers r-universe, so
+    # CI no longer has to opt in explicitly here.
+    #
+    # The engine-poisoning matrix entry is the one exception: it builds the C++
+    # tripwire (-DDUCKDB_R_POISON_ENGINE) and forces DUCKDB_R_RUN_TESTS=false, so
+    # that any test or example reaching the engine aborts the check and proves
+    # the CRAN guards are effective.
+    - name: Build the engine tripwire (engine-poisoning entry)
+      if: env.DUCKDB_R_POISON_ENGINE != ''
       run: |
-        # The duckdb tests and runnable examples exercise the bundled C++ engine
-        # and are gated behind DUCKDB_R_RUN_TESTS so they never run on CRAN
-        # (see tests/testthat.R and R/cran-guard.R). We opt in here for CI.
-        #
-        # The engine-poisoning matrix entry instead sets DUCKDB_R_POISON_ENGINE
-        # (via the generic "env" matrix field, applied above). When present we
-        # build the C++ tripwire (-DDUCKDB_R_POISON_ENGINE) and deliberately
-        # leave DUCKDB_R_RUN_TESTS unset, so that any test or example reaching
-        # the engine aborts the check and proves the CRAN guards are effective.
-        if [ -n "${DUCKDB_R_POISON_ENGINE:-}" ]; then
-          echo "DUCKDB_R_POISON_ENGINE is set; building the engine tripwire and leaving DUCKDB_R_RUN_TESTS unset."
-          mkdir -p ~/.R
-          echo 'CPPFLAGS += -DDUCKDB_R_POISON_ENGINE' | tee -a ~/.R/Makevars
-          # The snapshot updater bypasses tests/testthat.R via testthat::test_local(),
-          # so disable it here to keep it from exercising the poisoned engine.
-          echo 'SKIP_UPDATE_SNAPSHOTS=true' | tee -a "$GITHUB_ENV"
-        else
-          echo 'DUCKDB_R_RUN_TESTS=true' | tee -a "$GITHUB_ENV"
-        fi
+        echo "DUCKDB_R_POISON_ENGINE is set; building the engine tripwire and forcing DUCKDB_R_RUN_TESTS=false."
+        mkdir -p ~/.R
+        echo 'CPPFLAGS += -DDUCKDB_R_POISON_ENGINE' | tee -a ~/.R/Makevars
+        echo 'DUCKDB_R_RUN_TESTS=false' | tee -a "$GITHUB_ENV"
+        # The snapshot updater bypasses tests/testthat.R via testthat::test_local(),
+        # so disable it here to keep it from exercising the poisoned engine.
+        echo 'SKIP_UPDATE_SNAPSHOTS=true' | tee -a "$GITHUB_ENV"
       shell: bash

--- a/R/cran-guard.R
+++ b/R/cran-guard.R
@@ -3,20 +3,39 @@
 # DuckDB ships its own large C++ engine. Running the test suite or the runnable
 # examples exercises that engine, which is too heavy (in time and resource use)
 # for CRAN's check farm. We therefore gate everything that touches the C++ code
-# behind the `DUCKDB_R_RUN_TESTS` environment variable: it is unset on CRAN (so
-# nothing heavy runs) and set in our own continuous integration, where the full
-# suite runs on every change (<https://github.com/duckdb/duckdb-r>).
+# so that nothing heavy runs on CRAN, while it always runs on GitHub Actions
+# (our own CI as well as r-universe, both powered by GitHub Actions).
 #
-# This is intentional, not an oversight. The same variable is consulted, without
+# The behaviour is controlled by two environment variables:
+#
+# * `DUCKDB_R_RUN_TESTS` is an explicit opt-in (or opt-out) that always wins.
+#   Set it to a true-ish value to run the tests and examples locally, or to a
+#   false-ish value to force them off (used by the engine-poisoning CI entry).
+# * Otherwise we fall back to `GITHUB_ACTIONS`, which GitHub Actions sets to
+#   "true". This keeps the heavy code off on CRAN (where neither variable is
+#   set) but on for every GitHub Actions run, including r-universe.
+#
+# This is intentional, not an oversight. The same logic is consulted, without
 # relying on this file, directly in `tests/testthat.R`.
 
-# Name of the environment variable that opts in to running DuckDB's C++ code.
+# Name of the environment variable that opts in to (or out of) running code
+# that touches DuckDB's C++ engine.
 DUCKDB_R_RUN_TESTS_ENVVAR <- "DUCKDB_R_RUN_TESTS"
 
-# TRUE if the user has opted in to running code that touches DuckDB's C++ engine.
+# TRUE if code that touches DuckDB's C++ engine should run. An explicit
+# DUCKDB_R_RUN_TESTS setting always wins; otherwise we run on GitHub Actions.
 duckdb_run_tests_enabled <- function() {
   value <- tolower(trimws(Sys.getenv(DUCKDB_R_RUN_TESTS_ENVVAR, "")))
-  value %in% c("true", "1", "yes", "on")
+  if (value %in% c("true", "1", "yes", "on")) {
+    return(TRUE)
+  }
+  if (value %in% c("false", "0", "no", "off")) {
+    return(FALSE)
+  }
+
+  # No explicit opt-in/out: run automatically on GitHub Actions (this also
+  # covers r-universe), stay off everywhere else (notably CRAN).
+  tolower(trimws(Sys.getenv("GITHUB_ACTIONS", ""))) == "true"
 }
 
 # Used as the condition of `@examplesIf` for every runnable example that touches
@@ -30,11 +49,16 @@ examples_enabled <- function() {
   message(
     "Skipping duckdb examples that exercise the bundled C++ engine.\n",
     "This is intentional: these examples are not run on CRAN to keep check ",
-    "time and resource usage within CRAN's limits.\n",
+    "time and resource usage within CRAN's limits. They run automatically on ",
+    "GitHub Actions (including r-universe).\n",
     "duckdb has an extensive test suite that runs continuously in our own CI; ",
     "see <https://github.com/duckdb/duckdb-r>.\n",
-    "To run these examples, set ", DUCKDB_R_RUN_TESTS_ENVVAR, "=true, e.g. ",
-    "Sys.setenv(", DUCKDB_R_RUN_TESTS_ENVVAR, " = \"true\")."
+    "To run these examples, set ",
+    DUCKDB_R_RUN_TESTS_ENVVAR,
+    "=true, e.g. ",
+    "Sys.setenv(",
+    DUCKDB_R_RUN_TESTS_ENVVAR,
+    " = \"true\")."
   )
   FALSE
 }

--- a/R/cran-guard.R
+++ b/R/cran-guard.R
@@ -11,9 +11,10 @@
 # * `DUCKDB_R_RUN_TESTS` is an explicit opt-in (or opt-out) that always wins.
 #   Set it to a true-ish value to run the tests and examples locally, or to a
 #   false-ish value to force them off (used by the engine-poisoning CI entry).
-# * Otherwise we fall back to `GITHUB_ACTIONS`, which GitHub Actions sets to
-#   "true". This keeps the heavy code off on CRAN (where neither variable is
-#   set) but on for every GitHub Actions run, including r-universe.
+# * Otherwise we fall back to `GITHUB_ACTIONS` (set to "true" on GitHub Actions)
+#   and `MY_UNIVERSE` (set by r-universe). This keeps the heavy code off on CRAN
+#   (where none of these are set) but on for every GitHub Actions run and on
+#   r-universe.
 #
 # This is intentional, not an oversight. The same logic is consulted, without
 # relying on this file, directly in `tests/testthat.R`.
@@ -23,7 +24,8 @@
 DUCKDB_R_RUN_TESTS_ENVVAR <- "DUCKDB_R_RUN_TESTS"
 
 # TRUE if code that touches DuckDB's C++ engine should run. An explicit
-# DUCKDB_R_RUN_TESTS setting always wins; otherwise we run on GitHub Actions.
+# DUCKDB_R_RUN_TESTS setting always wins; otherwise we run on GitHub Actions and
+# on r-universe.
 duckdb_run_tests_enabled <- function() {
   value <- tolower(trimws(Sys.getenv(DUCKDB_R_RUN_TESTS_ENVVAR, "")))
   if (value %in% c("true", "1", "yes", "on")) {
@@ -33,9 +35,11 @@ duckdb_run_tests_enabled <- function() {
     return(FALSE)
   }
 
-  # No explicit opt-in/out: run automatically on GitHub Actions (this also
-  # covers r-universe), stay off everywhere else (notably CRAN).
-  tolower(trimws(Sys.getenv("GITHUB_ACTIONS", ""))) == "true"
+  # No explicit opt-in/out: run automatically on GitHub Actions (GITHUB_ACTIONS)
+  # and on r-universe (MY_UNIVERSE), stay off everywhere else (notably CRAN).
+  github_actions <- tolower(trimws(Sys.getenv("GITHUB_ACTIONS", ""))) == "true"
+  my_universe <- nzchar(trimws(Sys.getenv("MY_UNIVERSE", "")))
+  github_actions || my_universe
 }
 
 # Used as the condition of `@examplesIf` for every runnable example that touches

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -13,9 +13,9 @@ library(duckdb)
 #
 # The duckdb test suite exercises DuckDB's bundled C++ engine, which is too heavy
 # for CRAN's check farm, and checks were very fragile in the past. We therefore
-# keep it off on CRAN but run it automatically on GitHub Actions (our own CI as
-# well as r-universe). An explicit DUCKDB_R_RUN_TESTS opts in (true-ish) or out
-# (false-ish) and always wins; otherwise we fall back to GITHUB_ACTIONS.
+# keep it off on CRAN but run it automatically on GitHub Actions (GITHUB_ACTIONS)
+# and on r-universe (MY_UNIVERSE). An explicit DUCKDB_R_RUN_TESTS opts in
+# (true-ish) or out (false-ish) and always wins; otherwise we fall back to those.
 # This check is intentionally inlined here (rather than calling into the package)
 # so the guard is obvious and self-contained.
 run_tests <- tolower(trimws(Sys.getenv("DUCKDB_R_RUN_TESTS", "")))
@@ -25,7 +25,8 @@ if (run_tests %in% c("true", "1", "yes", "on")) {
 } else if (run_tests %in% c("false", "0", "no", "off")) {
   run <- FALSE
 } else {
-  run <- tolower(trimws(Sys.getenv("GITHUB_ACTIONS", ""))) == "true"
+  run <- tolower(trimws(Sys.getenv("GITHUB_ACTIONS", ""))) == "true" ||
+    nzchar(trimws(Sys.getenv("MY_UNIVERSE", "")))
 }
 
 if (run) {

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -13,23 +13,35 @@ library(duckdb)
 #
 # The duckdb test suite exercises DuckDB's bundled C++ engine, which is too heavy
 # for CRAN's check farm, and checks were very fragile in the past. We therefore
-# only run it when the DUCKDB_R_RUN_TESTS environment variable opts in.
+# keep it off on CRAN but run it automatically on GitHub Actions (our own CI as
+# well as r-universe). An explicit DUCKDB_R_RUN_TESTS opts in (true-ish) or out
+# (false-ish) and always wins; otherwise we fall back to GITHUB_ACTIONS.
 # This check is intentionally inlined here (rather than calling into the package)
 # so the guard is obvious and self-contained.
 run_tests <- tolower(trimws(Sys.getenv("DUCKDB_R_RUN_TESTS", "")))
 
 if (run_tests %in% c("true", "1", "yes", "on")) {
+  run <- TRUE
+} else if (run_tests %in% c("false", "0", "no", "off")) {
+  run <- FALSE
+} else {
+  run <- tolower(trimws(Sys.getenv("GITHUB_ACTIONS", ""))) == "true"
+}
+
+if (run) {
   test_check("duckdb")
 } else {
   message(
     "\n",
-    strrep("=", 78), "\n",
+    strrep("=", 78),
+    "\n",
     "Skipping the duckdb test suite.\n",
     "\n",
     "The duckdb tests exercise DuckDB's bundled C++ engine and are deliberately\n",
-    "NOT run unless the DUCKDB_R_RUN_TESTS environment variable is set. This keeps\n",
-    "check time and resource usage on CRAN within acceptable limits and helps\n",
-    "release duckdb in a predictable and controlled manner.\n",
+    "NOT run on CRAN. They run automatically on GitHub Actions (including\n",
+    "r-universe). This keeps check time and resource usage on CRAN within\n",
+    "acceptable limits and helps release duckdb in a predictable and controlled\n",
+    "manner.\n",
     "\n",
     "This is intentional, not an oversight. duckdb has an extensive test suite\n",
     "that runs continuously in our own CI; see <https://github.com/duckdb/duckdb-r>.\n",
@@ -37,6 +49,7 @@ if (run_tests %in% c("true", "1", "yes", "on")) {
     "To run the test suite locally, set the environment variable before checking:\n",
     "  Sys.setenv(DUCKDB_R_RUN_TESTS = \"true\")    # from within R, or\n",
     "  DUCKDB_R_RUN_TESTS=true R CMD check ...      # from the shell\n",
-    strrep("=", 78), "\n"
+    strrep("=", 78),
+    "\n"
   )
 }


### PR DESCRIPTION
## Summary
Simplifies the test gating mechanism by leveraging GitHub Actions' built-in `GITHUB_ACTIONS` environment variable instead of requiring explicit opt-in. Tests and examples now run automatically on GitHub Actions (including r-universe) while remaining disabled on CRAN, without needing manual configuration.

## Key Changes

- **Automatic GitHub Actions detection**: Modified `duckdb_run_tests_enabled()` in `R/cran-guard.R` to check `GITHUB_ACTIONS` environment variable as a fallback when `DUCKDB_R_RUN_TESTS` is not explicitly set
- **Explicit opt-in/out support**: `DUCKDB_R_RUN_TESTS` now supports both true-ish values (enable) and false-ish values (disable), with explicit settings always taking precedence
- **Simplified CI configuration**: Removed the need to explicitly set `DUCKDB_R_RUN_TESTS=true` in the before-install action for normal CI runs
- **Engine-poisoning refinement**: The engine-poisoning matrix entry now explicitly sets `DUCKDB_R_RUN_TESTS=false` to ensure the tripwire catches any code reaching the C++ engine
- **Updated documentation**: Clarified comments and messages in `R/cran-guard.R`, `tests/testthat.R`, and `.github/workflows/custom/before-install/action.yml` to explain the new behavior
- **Consistent logic**: Applied the same fallback logic to both `tests/testthat.R` and the package function for consistency

## Implementation Details

The new behavior follows this priority:
1. If `DUCKDB_R_RUN_TESTS` is explicitly set to a true-ish or false-ish value, use that
2. Otherwise, check if `GITHUB_ACTIONS=true` (set by GitHub Actions automatically)
3. Default to false (disabled) on all other environments (CRAN, local development)

This eliminates the need for manual CI configuration while maintaining the safety guarantees that keep heavy tests off CRAN.

https://claude.ai/code/session_01HzMbLgUqg7yrG2mzgTcfV2