### PR TITLE
test: Refactor example conditions to use the `simulate_duckdb()` helper

### DIFF
--- a/R/Driver.R
+++ b/R/Driver.R
@@ -135,7 +135,7 @@ duckdb_shutdown <- function(drv) {
 #' @return An object of class "adbc_driver"
 #' @rdname duckdb
 #' @export
-#' @examplesIf duckdb:::examples_enabled() && requireNamespace("adbcdrivermanager", quietly = TRUE)
+#' @examplesIf simulate_duckdb()$env$examples_enabled() && requireNamespace("adbcdrivermanager", quietly = TRUE)
 #' library(adbcdrivermanager)
 #' with_adbc(db <- adbc_database_init(duckdb_adbc()), {
 #'   as.data.frame(read_adbc(db, "SELECT 1 as one;"))

--- a/R/backend-dbplyr__duckdb_connection.R
+++ b/R/backend-dbplyr__duckdb_connection.R
@@ -531,7 +531,11 @@ tbl_query <- function(src, query, ...) {
 #' @export
 #' @rdname backend-duckdb
 simulate_duckdb <- function(...) {
-  structure(list(), ..., class = c("duckdb_connection", "TestConnection", "DBIConnection"))
+  structure(
+    list(pkg = get_package_name(), env = get_package_env()),
+    ...,
+    class = c("duckdb_connection", "TestConnection", "DBIConnection")
+  )
 }
 
 

--- a/R/dbConnect__duckdb_driver.R
+++ b/R/dbConnect__duckdb_driver.R
@@ -45,7 +45,7 @@
 #' or an adjusted time.
 #'
 #' @rdname duckdb
-#' @examplesIf duckdb:::examples_enabled()
+#' @examplesIf simulate_duckdb()$env$examples_enabled()
 #' drv <- duckdb()
 #' con <- dbConnect(drv)
 #'

--- a/R/package.R
+++ b/R/package.R
@@ -2,6 +2,10 @@ get_package_name <- function() {
   utils::packageName()
 }
 
+get_package_env <- function() {
+  asNamespace(get_package_name())
+}
+
 system_file_path <- function(...) {
   file.path(system.file(package = get_package_name()), ...)
 }

--- a/R/register.R
+++ b/R/register.R
@@ -31,7 +31,7 @@ encode_values <- function(value) {
 #' @param experimental Enable experimental optimizations
 #' @return These functions are called for their side effect.
 #' @export
-#' @examplesIf duckdb:::examples_enabled()
+#' @examplesIf simulate_duckdb()$env$examples_enabled()
 #' con <- dbConnect(duckdb())
 #'
 #' data <- data.frame(a = 1:3, b = letters[1:3])

--- a/R/sql.R
+++ b/R/sql.R
@@ -19,7 +19,7 @@
 #' @param conn An optional connection, defaults to [default_conn()]
 #' @return A data frame with the query result
 #' @export
-#' @examplesIf duckdb:::examples_enabled()
+#' @examplesIf simulate_duckdb()$env$examples_enabled()
 #' # Queries
 #' sql_query("SELECT 42")
 #'
@@ -67,7 +67,7 @@ the <- new.env(parent = emptyenv())
 #'
 #' @return A DuckDB connection object
 #' @export
-#' @examplesIf duckdb:::examples_enabled()
+#' @examplesIf simulate_duckdb()$env$examples_enabled()
 #' conn <- default_conn()
 #' sql_query("SELECT 42", conn = conn)
 default_conn <- function() {

--- a/man/default_conn.Rd
+++ b/man/default_conn.Rd
@@ -29,7 +29,7 @@ There is no way for this or other packages to comprehensively track the state
 of this connection, so scripts and packages should manage their own connections.
 }
 \examples{
-\dontshow{if (duckdb:::examples_enabled()) withAutoprint(\{ # examplesIf}
+\dontshow{if (simulate_duckdb()$env$examples_enabled()) withAutoprint(\{ # examplesIf}
 conn <- default_conn()
 sql_query("SELECT 42", conn = conn)
 \dontshow{\}) # examplesIf}

--- a/man/duckdb.Rd
+++ b/man/duckdb.Rd
@@ -125,13 +125,13 @@ If the timestamp is invalid in the target timezone, the resulting value may be \
 or an adjusted time.
 }
 \examples{
-\dontshow{if (duckdb:::examples_enabled() && requireNamespace("adbcdrivermanager", quietly = TRUE)) withAutoprint(\{ # examplesIf}
+\dontshow{if (simulate_duckdb()$env$examples_enabled() && requireNamespace("adbcdrivermanager", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 library(adbcdrivermanager)
 with_adbc(db <- adbc_database_init(duckdb_adbc()), {
   as.data.frame(read_adbc(db, "SELECT 1 as one;"))
 })
 \dontshow{\}) # examplesIf}
-\dontshow{if (duckdb:::examples_enabled()) withAutoprint(\{ # examplesIf}
+\dontshow{if (simulate_duckdb()$env$examples_enabled()) withAutoprint(\{ # examplesIf}
 drv <- duckdb()
 con <- dbConnect(drv)
 

--- a/man/duckdb_register.Rd
+++ b/man/duckdb_register.Rd
@@ -32,7 +32,7 @@ No data is copied.
 \code{duckdb_unregister()} unregisters a previously registered data frame.
 }
 \examples{
-\dontshow{if (duckdb:::examples_enabled()) withAutoprint(\{ # examplesIf}
+\dontshow{if (simulate_duckdb()$env$examples_enabled()) withAutoprint(\{ # examplesIf}
 con <- dbConnect(duckdb())
 
 data <- data.frame(a = 1:3, b = letters[1:3])

--- a/man/sql_query.Rd
+++ b/man/sql_query.Rd
@@ -33,7 +33,7 @@ Scripts and packages should manage their own connections
 and prefer the DBI methods for more control.
 }
 \examples{
-\dontshow{if (duckdb:::examples_enabled()) withAutoprint(\{ # examplesIf}
+\dontshow{if (simulate_duckdb()$env$examples_enabled()) withAutoprint(\{ # examplesIf}
 # Queries
 sql_query("SELECT 42")
 


### PR DESCRIPTION
## Summary

The `@examplesIf` conditions that gate DuckDB's C++-engine examples called the
internal guard as `duckdb:::examples_enabled()`. The literal package name in
`:::` breaks when the package is built under a different name (e.g. the
`duckdb.1.5.dev` dev builds), where it becomes `duckdb.1.5.dev:::…`.

This PR routes that access through the exported `simulate_duckdb()` instead, so
no source file hard-codes the package's own name.

## Changes

- **`simulate_duckdb()`** now returns `list(pkg = get_package_name(), env = get_package_env())`
  instead of an empty list. Both values are derived dynamically from
  `utils::packageName()`, so they resolve to whatever name the package is
  installed under.
- **New `get_package_env()` helper** (`R/package.R`): returns the package
  namespace via `asNamespace(get_package_name())`.
- **All example conditions** now use `simulate_duckdb()$env$examples_enabled()`
  — `$env` is the namespace, and `$` on it reaches the (still non-exported)
  internal guard. Replaced 10 occurrences across 8 files:
  - R: `sql.R` (×2), `Driver.R`, `register.R`, `dbConnect__duckdb_driver.R`
  - man: `sql_query.Rd`, `default_conn.Rd`, `duckdb_register.Rd`, `duckdb.Rd` (×2)

## Notes

- `examples_enabled()` stays internal; no public API is added.
- dbplyr/DBI define no `$` method for `duckdb_connection`/`TestConnection`/`DBIConnection`,
  so `simulate_duckdb()$env` uses default environment extraction and dbplyr's SQL
  simulation is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015unoYaEWmPuR5eCZjW2UrU