### PR TITLE
fledge: CRAN release v1.5.4

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: duckdb
 Title: DBI Package for the DuckDB Database Management System
-Version: 1.5.3.9901
+Version: 1.5.4
 Authors@R: c(
     person("Hannes", "Mühleisen", , "hannes@cwi.nl", role = "aut",
            comment = c(ORCID = "0000-0001-8552-0029")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,16 +2,6 @@
 
 # duckdb 1.5.4
 
-## fledge
-
-- CRAN pre-release v1.5.3.9900 (#2360).
-
-## Compatibility
-
-- Add `is_distinct_from()` / `is_not_distinct_from()` dbplyr translations for compatibility with upcoming dbplyr 2.6.0 (#2326, #2332).
-
-- Bump minimum R version requirement to 4.2.0 (#2233, #2334).
-
 ## Features
 
 - Update to DuckDB v1.5.4, see <https://github.com/duckdb/duckdb/releases/tag/v1.5.4> for details.
@@ -26,13 +16,13 @@
 
 - Add secret directory configuration, package startup message, and consolidation support via new experimental `duckdb_consolidate_secrets()` (#2305, #2340).
 
-## Chore
+## Compatibility
 
-- Also ignore `inst/extensions`.
+- Add `is_distinct_from()` / `is_not_distinct_from()` dbplyr translations for compatibility with upcoming dbplyr 2.6.0 (#2326, #2332).
+
+- Bump minimum R version requirement to 4.2.0 (#2233, #2334).
 
 ## Testing
-
-- More precise check for development version.
 
 - Add CRAN guards to prevent heavy C++ engine tests on CRAN (#2353, #2358).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,21 +1,16 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# duckdb 1.5.3.9901
-
-## Chore
-
-- Also ignore `inst/extensions`.
-
-## Testing
-
-- More precise check for development version.
+# duckdb 1.5.4
 
 ## fledge
 
 - CRAN pre-release v1.5.3.9900 (#2360).
 
+## Compatibility
 
-# duckdb 1.5.3.9900
+- Add `is_distinct_from()` / `is_not_distinct_from()` dbplyr translations for compatibility with upcoming dbplyr 2.6.0 (#2326, #2332).
+
+- Bump minimum R version requirement to 4.2.0 (#2233, #2334).
 
 ## Features
 
@@ -31,13 +26,13 @@
 
 - Add secret directory configuration, package startup message, and consolidation support via new experimental `duckdb_consolidate_secrets()` (#2305, #2340).
 
-## Compatibility
+## Chore
 
-- Add `is_distinct_from()` / `is_not_distinct_from()` dbplyr translations for compatibility with upcoming dbplyr 2.6.0 (#2326, #2332).
-
-- Bump minimum R version requirement to 4.2.0 (#2233, #2334).
+- Also ignore `inst/extensions`.
 
 ## Testing
+
+- More precise check for development version.
 
 - Add CRAN guards to prevent heavy C++ engine tests on CRAN (#2353, #2358).
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,7 +1,5 @@
-duckdb 1.5.3.9900
+duckdb 1.5.4
 
 ## Cran Repository Policy
 
-- [ ] Reviewed CRP last edited 2026-05-31.
-
-See changes at https://github.com/eddelbuettel/crp/compare/master@%7B2026-04-21%7D...master@%7B2026-05-31%7D
+- [x] Reviewed CRP last edited 2026-05-31.


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2026-06-18, problems found: https://cran.r-project.org/web/checks/check_results_duckdb.html
- [ ] WARN: r-devel-linux-x86_64-debian-gcc
     Found the following significant warnings:
     duckdb/src/include/duckdb/common/types/selection_vector.hpp:20:8: warning: array subscript ‘duckdb::SelectionData[0]’ is partly outside array bounds of ‘unsigned char [24]’ [-Warray-bounds=]
     See ‘/home/hornik/tmp/R.check/r-devel-gcc/Work/PKGS/duckdb.Rcheck/00install.out’ for details.
     * used C++ compiler: ‘g++-16 (Debian 16.1.0-1) 16.1.0’
- [ ] WARN: r-release-linux-x86_64
     Found the following significant warnings:
     duckdb/src/include/duckdb/common/types/selection_vector.hpp:20:8: warning: array subscript ‘duckdb::SelectionData[0]’ is partly outside array bounds of ‘unsigned char [24]’ [-Warray-bounds=]
     See ‘/home/hornik/tmp/R.check/r-release-gcc/Work/PKGS/duckdb.Rcheck/00install.out’ for details.
     * used C++ compiler: ‘g++-16 (Debian 16.1.0-1) 16.1.0’
- [ ] other_issue: NA
See: <https://www.stats.ox.ac.uk/pub/bdr/memtests/valgrind/duckdb>

Check results at: https://cran.r-project.org/web/checks/check_results_duckdb.html

## Action items

- [ ] Review PR
- [ ] Await successful CI/CD run
- [ ] Run `fledge::release()`
- [ ] When the package is accepted on CRAN, run `fledge::post_release()`