### PR TITLE
docs: Document prebuilt-libduckdb fast path for testing; fix glue `-Wsign-compare` warnings

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,9 +14,18 @@ If tools are missing, adapt `.github/workflows/copilot-setup-steps.yaml` in addi
 - `export MAKEFLAGS="-j$(nproc)"` -- enables parallel compilation
 - `UserNM=true R CMD INSTALL . --no-byte-compile` -- builds and installs the package. NEVER CANCEL: takes 10-15 minutes on first build. Set timeout to 30+ minutes.
 
+#### Fast path: build/test against prebuilt DuckDB (recommended)
+
+For an interactive edit-build-test loop, link against a prebuilt libduckdb instead of compiling the ~1700 vendored `.cpp` files. This turns the first build from 10-15 minutes into seconds, and is exactly what CI does by default (see `.github/workflows/custom/before-install/action.yml`).
+
+- `sudo scripts/install-libduckdb.sh` -- one-time, downloads the libduckdb matching the vendored DuckDB version (re-run after every vendoring bump)
+- `export DUCKDB_R_USE_SYSTEM_LIB=1` -- in every shell that builds or tests the package
+
+With `DUCKDB_R_USE_SYSTEM_LIB=1` set, `R CMD INSTALL .`, `pkgload::load_all()`, `devtools::load_all()`, and `testthat::test_local()` all compile only the glue code and link the prebuilt library. See AGENTS.md for the full details, caveats, and the commit-match guard.
+
 ### Run Tests
 
-- `R -q -e "testthat::test_local()"` -- runs all tests. Takes about 45 seconds. NEVER CANCEL: set timeout to 5+ minutes.
+- `R -q -e "testthat::test_local()"` -- runs all tests. Takes about 45 seconds. NEVER CANCEL: set timeout to 5+ minutes. With the prebuilt fast path above, `load_all()` is ~1 second warm.
 - `R -q -e "testthat::test_local(filter = '^name$')"` -- runs specific test file by name
 
 ### Format Checking (Optional - Has Known Issues)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,8 @@ R package that contains a vendored copy of the DuckDB C++ library and glue code 
 - `export MAKEFLAGS="-j$(nproc)"` -- enables parallel compilation
 - `UserNM=true R CMD INSTALL . --no-byte-compile` -- builds and installs the package. NEVER CANCEL: takes 10-15 minutes on first build. Set timeout to 30+ minutes.
 
+For an interactive edit-build-test loop, prefer the prebuilt-libduckdb fast path (seconds instead of 10-15 minutes) -- see ["Fast build with system libduckdb"](#fast-build-with-system-libduckdb-linuxmacos-opt-in) and ["Testing with prebuilt DuckDB"](#testing-with-prebuilt-duckdb-the-fast-iterate-loop) below.
+
 ### Run Tests
 
 - `R -q -e "testthat::test_local()"` -- runs all tests. Takes about 45 seconds. NEVER CANCEL: set timeout to 5+ minutes.
@@ -119,6 +121,37 @@ The opt-in only applies to `R CMD INSTALL .` — not to `R CMD build`,
 since the resulting installation depends on libduckdb being present at
 runtime. The installed `duckdb.so` carries an rpath pointing at the
 libduckdb directory; do not move libduckdb after installing.
+
+### Testing with prebuilt DuckDB (the fast iterate loop)
+
+`pkgload::load_all()` / `devtools::load_all()` — and therefore
+`testthat::test_local()`, which loads the package the same way — honor
+`DUCKDB_R_USE_SYSTEM_LIB` too: they compile only the ~30 glue `.cpp`
+files in `src/` and link against the prebuilt libduckdb, exactly like
+`R CMD INSTALL .`. This is the recommended setup for any
+edit-build-test loop (including coding-agent sessions), because it turns
+the otherwise 10–15 minute first build into seconds.
+
+```bash
+# One-time, matching the vendored DuckDB version (see above)
+sudo scripts/install-libduckdb.sh          # or --prefix "$HOME/.local"
+
+# Then, in every shell that builds/tests the package:
+export DUCKDB_R_USE_SYSTEM_LIB=1
+export MAKEFLAGS="-j$(nproc)"
+
+R -q -e 'pkgload::load_all()'              # ~1 s warm, no source changes
+R -q -e 'testthat::test_local()'           # runs the suite against the glue
+```
+
+Measured on a clean container (R 4.5.3, ccache warm): a no-op
+`load_all()` takes about 1 second, and a `load_all()` after editing a
+single glue file (recompile one `.cpp` + relink) about 4 seconds —
+versus 10–15 minutes when the vendored sources are compiled. The same
+`configure` commit-match guard applies, so re-run
+`scripts/install-libduckdb.sh` after every vendoring bump; if it
+reports a `-dev` snapshot with no published prebuilt, drop
+`DUCKDB_R_USE_SYSTEM_LIB` and fall back to a source build.
 
 In CI, `.github/workflows/custom/before-install/action.yml` defaults all
 Linux/macOS builds (the smoke test and the regular matrix) to the fast

--- a/src/scan.cpp
+++ b/src/scan.cpp
@@ -168,7 +168,7 @@ static inline void AppendMatrixSegmentAtomic(SRC *src_ptr, int nrows, int ncols,
 	idx_t vector_idx = 0;
 	for (idx_t i = 0; i < count; i++) {
 		auto matrix_elt_idx = sexp_offset + i;
-		for (idx_t k = 0; k < ncols; k++) {
+		for (idx_t k = 0; k < static_cast<idx_t>(ncols); k++) {
 			auto val = src_ptr[matrix_elt_idx];
 			if (RTYPE::IsNull(val)) {
 				child_mask.SetInvalid(vector_idx++);
@@ -410,7 +410,7 @@ case_insensitive_map_t<vector<Value>> ListToVectorOfValue(list input_sexps) {
 
 		vector<Value> vv;
 		vv.reserve(size);
-		for (idx_t i = 0; i < size; ++i) {
+		for (idx_t i = 0; i < static_cast<idx_t>(size); ++i) {
 			vv.push_back(v.GetValue(i));
 		}
 


### PR DESCRIPTION
## What

CI already defaults Linux/macOS builds to linking against a **prebuilt libduckdb** instead of compiling the ~1700 vendored `.cpp` files (see `.github/workflows/custom/before-install/action.yml` → `scripts/install-libduckdb.sh`). The agent instructions documented this only for `R CMD INSTALL .` and even noted "the opt-in only applies to `R CMD INSTALL .`", which left the actual edit-build-**test** loop (`load_all()` / `test_local()`) looking like it had to compile from source.

This PR reviews that CI flow, infers the equivalent local steps, and documents them — plus cleans up the only two compiler warnings in the R glue.

## Changes

- **`AGENTS.md` / `.github/copilot-instructions.md`** — new "Testing with prebuilt DuckDB" guidance: `pkgload::load_all()`, `devtools::load_all()`, and `testthat::test_local()` all honor `DUCKDB_R_USE_SYSTEM_LIB`, so they compile only the ~30 glue files and link the prebuilt library. Includes the one-time `scripts/install-libduckdb.sh` step, measured timings, the `configure` commit-match guard, and the `-dev`-snapshot fallback. Added cross-links from the bootstrap section.
- **`src/scan.cpp`** — fix two `-Wsign-compare` warnings in the glue by casting the signed loop bounds (`int ncols`, `R_len_t size`) to `idx_t`. Both counts are non-negative (matrix column count / R vector length).

## Verification

Tested locally against prebuilt **libduckdb v1.5.4** (matching the vendored sources):

- Glue now compiles **warning-free** (was: 7 `-Wsign-compare` warnings at `scan.cpp:171` and `:413`).
- Prebuilt fast path works: install ~4 s, warm `load_all()` **~1 s**, `load_all()` after editing one glue file **~3.7 s** (vs 10–15 min compiling vendored sources).
- `testthat::test_local(filter = "^(array|relational)$")` → **268 passed, 0 failed** (exercises the changed matrix/array scan paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZcrW8V5TtnQBzfj9aButS

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZcrW8V5TtnQBzfj9aButS)_