### PR TITLE
docs: Use rlang::args_dots_empty for dots; drop `local_interactive()` shim

### DIFF
--- a/R/csv.R
+++ b/R/csv.R
@@ -7,7 +7,7 @@
 #'
 #' @inheritParams duckdb_register
 #' @param files One or more CSV file names, should all have the same structure though
-#' @param ... Reserved for future extensions, must be empty.
+#' @inheritParams rlang::args_dots_empty
 #' @param header Whether or not the CSV files have a separate header in the first line
 #' @param na.strings Which strings in the CSV files should be considered to be NULL
 #' @param nrow.check How many rows should be read from the CSV file to figure out data types
@@ -72,28 +72,52 @@ duckdb_read_csv <- function(
   temporary = FALSE
 ) {
   # FIXME: Warning as of duckdb 1.1.1, turn this into an error later
-  if (...length() > 0) warning("Arguments passed to ... are currently not used")
-  if (length(na.strings) > 1) stop("na.strings must be of length 1")
-  if (!missing(sep)) delim <- sep
+  if (...length() > 0) {
+    warning("Arguments passed to ... are currently not used")
+  }
+  if (length(na.strings) > 1) {
+    stop("na.strings must be of length 1")
+  }
+  if (!missing(sep)) {
+    delim <- sep
+  }
 
-  headers <- lapply(files, utils::read.csv,
-    sep = delim, na.strings = na.strings,
-    quote = quote, nrows = nrow.check, header = header, ...
+  headers <- lapply(
+    files,
+    utils::read.csv,
+    sep = delim,
+    na.strings = na.strings,
+    quote = quote,
+    nrows = nrow.check,
+    header = header,
+    ...
   )
   if (length(files) > 1) {
     nn <- sapply(headers, ncol)
-    if (!all(nn == nn[1])) stop("Files have different numbers of columns")
+    if (!all(nn == nn[1])) {
+      stop("Files have different numbers of columns")
+    }
     nms <- sapply(headers, names)
-    if (!all(nms == nms[, 1])) stop("Files have different variable names or order")
+    if (!all(nms == nms[, 1])) {
+      stop("Files have different variable names or order")
+    }
     if (is.null(col.types)) {
-      types <- sapply(headers, function(df) sapply(df, dbDataType, dbObj = conn))
+      types <- sapply(headers, function(df) {
+        sapply(df, dbDataType, dbObj = conn)
+      })
       if (!all(types == types[, 1])) stop("Files have different variable types")
     }
   }
 
-  fields <- set_csv_fields(found = headers[[1]][FALSE, , drop = FALSE], col.names, col.types)
+  fields <- set_csv_fields(
+    found = headers[[1]][FALSE, , drop = FALSE],
+    col.names,
+    col.types
+  )
 
-  if (lower.case.names) { names(fields) <- tolower(names(fields)) }
+  if (lower.case.names) {
+    names(fields) <- tolower(names(fields))
+  }
 
   if (transaction) {
     dbBegin(conn)
@@ -108,7 +132,18 @@ duckdb_read_csv <- function(
 
   for (i in seq_along(files)) {
     thefile <- dbQuoteString(conn, enc2native(normalizePath(files[i])))
-    dbExecute(conn, sprintf("COPY %s FROM %s (DELIMITER %s, QUOTE %s, HEADER %s, NULL %s)", tablename, thefile, dbQuoteString(conn, delim), dbQuoteString(conn, quote), tolower(header), dbQuoteString(conn, na.strings[1])))
+    dbExecute(
+      conn,
+      sprintf(
+        "COPY %s FROM %s (DELIMITER %s, QUOTE %s, HEADER %s, NULL %s)",
+        tablename,
+        thefile,
+        dbQuoteString(conn, delim),
+        dbQuoteString(conn, quote),
+        tolower(header),
+        dbQuoteString(conn, na.strings[1])
+      )
+    )
   }
   out <- dbGetQuery(conn, paste("SELECT COUNT(*) FROM", tablename))[[1]]
 
@@ -135,15 +170,20 @@ set_csv_fields <- function(found, col.names, col.types) {
   }
 
   if (!is.null(names(col.types)) && !is.null(col.names)) {
-    warning("Ignoring `col.names` as column names provided by `col.types` parameter")
+    warning(
+      "Ignoring `col.names` as column names provided by `col.types` parameter"
+    )
     return(col.types)
   }
 
   if (!is.null(col.types)) {
     if (length(col.types) != ncol(found)) {
       stop(
-        "You supplied ", length(col.types), " values to `col.names`, but file has ",
-        ncol(found), " columns."
+        "You supplied ",
+        length(col.types),
+        " values to `col.names`, but file has ",
+        ncol(found),
+        " columns."
       )
     }
 
@@ -152,8 +192,11 @@ set_csv_fields <- function(found, col.names, col.types) {
     } else {
       if (length(col.types) != ncol(found)) {
         stop(
-          "You supplied ", length(col.types), " values to `col.types`, but file has ",
-          ncol(found), " columns."
+          "You supplied ",
+          length(col.types),
+          " values to `col.types`, but file has ",
+          ncol(found),
+          " columns."
         )
       }
       fields <- col.types
@@ -166,8 +209,6 @@ set_csv_fields <- function(found, col.names, col.types) {
   }
   fields
 }
-
-
 
 
 #' Deprecated functions

--- a/R/dbConnect__duckdb_driver.R
+++ b/R/dbConnect__duckdb_driver.R
@@ -6,7 +6,7 @@
 #' @param dbdir Location for database files. Should be a path to an existing
 #'   directory in the file system. With the default (or `""`), all
 #'   data is kept in RAM.
-#' @param ... Reserved for future extensions, must be empty.
+#' @inheritParams rlang::args_dots_empty
 #' @param debug Print additional debug information, such as queries.
 #' @param read_only Set to `TRUE` for read-only operation.
 #'   For file-based databases, this is only applied when the database file is opened for the first time.

--- a/R/is_interactive.R
+++ b/R/is_interactive.R
@@ -12,7 +12,3 @@ is_interactive <- function() {
   }
   interactive()
 }
-
-local_interactive <- function(value = TRUE, frame = rlang::caller_env()) {
-  rlang::local_options(rlang_interactive = value, .frame = frame)
-}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -15,7 +15,6 @@
 
   if (requireNamespace("rlang", quietly = TRUE)) {
     is_interactive <<- rlang::is_interactive
-    local_interactive <<- rlang::local_interactive
     rapi_error <<- rapi_error_rlang
     check_dots_empty <<- rlang::check_dots_empty0
   } else {

--- a/man/duckdb.Rd
+++ b/man/duckdb.Rd
@@ -60,7 +60,7 @@ If \code{"integer64"} is selected, bigint integers will be set to bit64 encoding
 These flags are only applied when the database object is instantiated.
 Subsequent connections will silently ignore these flags.}
 
-\item{...}{Reserved for future extensions, must be empty.}
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{environment_scan}{Set to \code{TRUE} to treat
 data frames from the calling environment as tables.

--- a/man/duckdb_read_csv.Rd
+++ b/man/duckdb_read_csv.Rd
@@ -29,7 +29,7 @@ duckdb_read_csv(
 
 \item{files}{One or more CSV file names, should all have the same structure though}
 
-\item{...}{Reserved for future extensions, must be empty.}
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{header}{Whether or not the CSV files have a separate header in the first line}
 

--- a/tests/testthat/test-progress_display.R
+++ b/tests/testthat/test-progress_display.R
@@ -8,12 +8,18 @@ test_that("progress display", {
   }
 
   options(duckdb.progress_display = 5)
-  expect_message(expect_null(get_progress_display()), "expecting either a boolean or function")
+  expect_message(
+    expect_null(get_progress_display()),
+    "expecting either a boolean or function"
+  )
 
   options(duckdb.progress_display = function() {})
-  expect_message(expect_null(get_progress_display()), "has no argument, expecting at least one")
+  expect_message(
+    expect_null(get_progress_display()),
+    "has no argument, expecting at least one"
+  )
 
-  local_interactive()
+  rlang::local_interactive()
 
   options(duckdb.progress_display = function(x) {})
   expect_type(get_progress_display(), "closure")


### PR DESCRIPTION
Small rlang-related cleanups, split out of the storage-locations PR (#2375) where they were unrelated to the feature.

- Document the `...` argument of `duckdb_read_csv()` and `dbConnect()` via
  `@inheritParams rlang::args_dots_empty` instead of a hand-written line, so the
  wording is consistent with rlang's standard text.
- Drop the unused `local_interactive()` shim from `is_interactive.R`; the only
  test that needs it now calls `rlang::local_interactive()` directly.

No behavior change (docs + a test-only call site).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R5F1rPyR7Vo3r9BRqUXCfu

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5F1rPyR7Vo3r9BRqUXCfu)_