### PR TITLE
fix: Resolve the shared DuckDB home like the engine, not path.expand()

### DIFF
--- a/.github/versions-matrix.R
+++ b/.github/versions-matrix.R
@@ -24,5 +24,16 @@ list(
     r = r_versions[[2]],
     env = "DUCKDB_R_USE_SYSTEM_LIB=0",
     desc = "vendored build (compiles bundled DuckDB sources)"
+  ),
+  # Companion macOS vendored build. Regular macOS entries default to the fast
+  # system-libduckdb path (see the custom before-install action), so without
+  # this entry no macOS job would actually compile the bundled DuckDB sources.
+  # Windows always builds from source, so together with the Linux entry above
+  # this covers a source build on every OS in the matrix.
+  data.frame(
+    os = "macos-latest",
+    r = r_versions[[2]],
+    env = "DUCKDB_R_USE_SYSTEM_LIB=0",
+    desc = "vendored build (compiles bundled DuckDB sources)"
   )
 )

--- a/.github/workflows/custom/before-install/action.yml
+++ b/.github/workflows/custom/before-install/action.yml
@@ -83,3 +83,19 @@ runs:
           echo 'DUCKDB_R_USE_SYSTEM_LIB=0' | tee -a "$GITHUB_ENV"
         fi
       shell: bash
+
+    # Download the standalone DuckDB CLI that matches the vendored engine so the
+    # CLI<->R secret-sharing end-to-end tests can run (tests/testthat/
+    # test-storage-cli-e2e.R). Runs on every OS -- including Windows, where the
+    # original `path.expand("~/.duckdb")` bug surfaced -- via Git Bash. The CLI
+    # is published only for tagged releases; for a -dev snapshot the script
+    # prints nothing and the tests skip, so failures here never break the build.
+    - name: Install the DuckDB CLI (for CLI<->R end-to-end tests)
+      run: |
+        cli="$(scripts/install-duckdb-cli.sh --prefix "${RUNNER_TEMP}/duckdb-cli" || true)"
+        if [ -n "${cli}" ] && [ -f "${cli}" ]; then
+          echo "DUCKDB_CLI=${cli}" | tee -a "$GITHUB_ENV"
+        else
+          echo "No matching DuckDB CLI available; CLI<->R end-to-end tests will skip."
+        fi
+      shell: bash

--- a/R/extensions.R
+++ b/R/extensions.R
@@ -7,10 +7,37 @@ default_user_directory <- function() {
 # without touching the real filesystem or HOME. See `?duckdb_storage` and
 # plan/PLAN-storage-locations.md.
 
-# The DuckDB default home (`~/.duckdb`), shared with the DuckDB CLI and Python
-# client.
+# The DuckDB default home (`<home>/.duckdb`), shared with the DuckDB CLI and
+# Python client. The `<home>` base must match the engine's own notion of the
+# home directory or markers/secrets written here would not be seen by the CLI.
 duckdb_shared_home <- function() {
-  path.expand("~/.duckdb")
+  file.path(duckdb_home_directory(), ".duckdb")
+}
+
+# Replicate the default home directory the bundled DuckDB engine derives in
+# FileSystem::GetHomeDirectory() (src/duckdb/src/common/file_system.cpp):
+# the USERPROFILE environment variable on Windows, HOME elsewhere.
+#
+# This deliberately avoids R's `path.expand("~")`, which on Windows resolves to
+# the user's Documents folder (e.g. `C:/Users/<user>/Documents`), not the
+# profile root (`C:/Users/<user>`) that DuckDB, its CLI, and the Python client
+# treat as `~`. Using `path.expand()` there would point the "shared" root at a
+# directory the rest of the DuckDB ecosystem never looks in.
+duckdb_home_directory <- function() {
+  var <- if (is_windows()) "USERPROFILE" else "HOME"
+  home <- Sys.getenv(var, unset = "")
+  if (!nzchar(home)) {
+    # The environment variable DuckDB consults is unset (rare); fall back to
+    # R's own idea of the home directory rather than producing a rootless path.
+    home <- path.expand("~")
+  }
+  home
+}
+
+# Platform seam, mockable in tests. Mirrors DuckDB's compile-time
+# `DUCKDB_WINDOWS` switch.
+is_windows <- function() {
+  .Platform$OS.type == "windows"
 }
 
 cleanup_user_directory <- function() {

--- a/scripts/install-duckdb-cli.sh
+++ b/scripts/install-duckdb-cli.sh
@@ -1,0 +1,134 @@
+#!/bin/sh
+# Download the standalone DuckDB CLI matching the vendored DuckDB sources under
+# src/duckdb/. Used to drive the CLI<->R secret-sharing end-to-end tests
+# (tests/testthat/test-storage-cli-e2e.R), which need a CLI whose version
+# matches the bundled engine.
+#
+# Unlike libduckdb (scripts/install-libduckdb.sh), the CLI is published for
+# Windows too, so this script is cross-platform and runs under Git Bash on the
+# Windows runners.
+#
+# Prints the absolute path to the installed `duckdb` binary on stdout -- and
+# nothing else; all diagnostics go to stderr -- so a caller can capture it:
+#
+#   DUCKDB_CLI="$(scripts/install-duckdb-cli.sh --prefix "$RUNNER_TEMP/duckdb-cli")"
+#
+# Released versions only. For a development snapshot (no published CLI) the
+# script prints nothing and exits 0, so callers fall back to skipping the
+# CLI-dependent tests.
+#
+# Usage:
+#   scripts/install-duckdb-cli.sh [--prefix DIR] [--version vX.Y.Z] [--url URL]
+#
+# Environment:
+#   DUCKDB_R_LIB_VERSION  override the version (same as --version)
+#   DUCKDB_CLI_URL        explicit URL of the duckdb_cli-<platform>.zip to use
+
+set -eu
+
+prefix=""
+version=""
+url=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --prefix)  prefix="$2"; shift 2 ;;
+    --version) version="$2"; shift 2 ;;
+    --url)     url="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) echo "Unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+version_file="${repo_root}/src/duckdb/src/function/table/version/pragma_version.cpp"
+
+if [ -z "${version}" ] && [ -n "${DUCKDB_R_LIB_VERSION:-}" ]; then
+  version="${DUCKDB_R_LIB_VERSION}"
+fi
+if [ -z "${version}" ] && [ -f "${version_file}" ]; then
+  version=$(sed -n 's/^#define DUCKDB_VERSION "\(.*\)"$/\1/p' "${version_file}")
+fi
+if [ -z "${version}" ]; then
+  echo "Could not determine DuckDB version. Pass --version or set DUCKDB_R_LIB_VERSION." >&2
+  exit 1
+fi
+
+case "${version}" in
+  *-dev*|*-dev)
+    # No public per-commit CLI is published for development snapshots between
+    # releases. Exit cleanly so the caller skips the CLI-dependent tests.
+    echo "DuckDB ${version} is a development snapshot; no published CLI. Skipping." >&2
+    exit 0
+    ;;
+esac
+
+if [ -z "${url}" ] && [ -n "${DUCKDB_CLI_URL:-}" ]; then
+  url="${DUCKDB_CLI_URL}"
+fi
+
+binary="duckdb"
+uname_s=$(uname -s)
+uname_m=$(uname -m)
+case "${uname_s}" in
+  Linux)
+    case "${uname_m}" in
+      x86_64)        platform=linux-amd64 ;;
+      aarch64|arm64) platform=linux-arm64 ;;
+      *) echo "Unsupported Linux arch: ${uname_m}" >&2; exit 1 ;;
+    esac
+    ;;
+  Darwin)
+    platform=osx-universal
+    ;;
+  MINGW*|MSYS*|CYGWIN*|Windows_NT)
+    platform=windows-amd64
+    binary="duckdb.exe"
+    ;;
+  *)
+    echo "Unsupported platform: ${uname_s}-${uname_m}" >&2
+    exit 1
+    ;;
+esac
+
+if [ -z "${prefix}" ]; then
+  prefix="${repo_root}/.duckdb-cli"
+fi
+
+if [ -z "${url}" ]; then
+  url="https://github.com/duckdb/duckdb/releases/download/${version}/duckdb_cli-${platform}.zip"
+fi
+
+echo "Downloading DuckDB CLI ${version} for ${platform}" >&2
+echo "  from: ${url}" >&2
+echo "  to:   ${prefix}" >&2
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "${tmpdir}"' EXIT
+
+zip="${tmpdir}/duckdb_cli-${platform}.zip"
+if command -v curl >/dev/null 2>&1; then
+  curl --fail --location --silent --show-error --output "${zip}" "${url}"
+elif command -v wget >/dev/null 2>&1; then
+  wget --quiet -O "${zip}" "${url}"
+else
+  echo "Neither curl nor wget is available." >&2
+  exit 1
+fi
+
+mkdir -p "${prefix}"
+unzip -q -o "${zip}" -d "${prefix}"
+chmod +x "${prefix}/${binary}" 2>/dev/null || true
+
+if [ ! -f "${prefix}/${binary}" ]; then
+  echo "Expected ${binary} in the CLI archive but it was not found." >&2
+  exit 1
+fi
+
+echo "Installed DuckDB CLI ${version} to ${prefix}/${binary}" >&2
+
+# The captured value: absolute path to the binary, the only line on stdout.
+printf '%s/%s\n' "$(cd "${prefix}" && pwd)" "${binary}"

--- a/tests/testthat/test-storage-cli-e2e.R
+++ b/tests/testthat/test-storage-cli-e2e.R
@@ -1,0 +1,126 @@
+# End-to-end tests that the "shared" storage root the R package computes
+# (`duckdb_shared_home()`) is the *same* `~/.duckdb` the standalone DuckDB CLI
+# uses. This is the behavior the home-directory fix is about: on Windows the old
+# `path.expand("~/.duckdb")` pointed at the Documents folder, where the CLI never
+# looks. Rather than re-encode the platform rule in the test, we let a real CLI
+# tell us where it stores secrets and check that a secret crosses the boundary in
+# both directions.
+#
+# These tests need a DuckDB CLI whose version matches the bundled engine (secret
+# files are version-specific). They are therefore conditional: the package
+# "injects" them only when such a CLI is present. Point DUCKDB_CLI at the binary
+# (CI does this, see .github/workflows/custom/before-install) or put a matching
+# `duckdb` on the PATH; otherwise they skip.
+
+# Resolve the CLI to test against: an explicit DUCKDB_CLI wins, else `duckdb` on
+# the PATH. Returns "" when none is available.
+duckdb_cli_bin <- function() {
+  explicit <- Sys.getenv("DUCKDB_CLI", unset = "")
+  if (nzchar(explicit) && file.exists(explicit)) {
+    return(explicit)
+  }
+  unname(Sys.which("duckdb"))
+}
+
+# Run a single SQL statement through the CLI against an in-memory database and
+# return stdout as a character vector. Persistent secrets are loaded from the
+# CLI's secret directory regardless of the database, so `:memory:` is enough.
+run_cli <- function(cli, sql) {
+  suppressWarnings(system2(
+    cli,
+    c("-c", shQuote(sql)),
+    stdout = TRUE,
+    stderr = TRUE
+  ))
+}
+
+# TRUE when the CLI reports the same version as the bundled engine. Secret files
+# are version-specific, so a mismatched CLI cannot reliably read what the engine
+# wrote (and vice versa); such a CLI is treated as "not present" for these tests.
+cli_version_matches <- function(cli) {
+  out <- tryCatch(
+    system2(cli, "--version", stdout = TRUE, stderr = TRUE),
+    error = function(e) character()
+  )
+  any(grepl(get_duckdb_version(), out, fixed = TRUE))
+}
+
+# Skip unless a usable, version-matched CLI is available, and return its path.
+local_matching_cli <- function() {
+  skip_on_cran()
+  cli <- duckdb_cli_bin()
+  if (!nzchar(cli)) {
+    skip("No DuckDB CLI found (set DUCKDB_CLI or put `duckdb` on PATH).")
+  }
+  if (!cli_version_matches(cli)) {
+    skip(sprintf(
+      "DuckDB CLI does not match the bundled engine version (%s).",
+      get_duckdb_version()
+    ))
+  }
+  cli
+}
+
+# Point both the engine (via Sys.getenv-based duckdb_shared_home()) and the CLI
+# (via its own HOME/USERPROFILE expansion) at the same throwaway home, so the
+# "shared" root resolves to one place for both. Returns the shared
+# stored-secrets directory the R side will use.
+local_shared_home <- function(.local_envir = parent.frame()) {
+  home <- withr::local_tempdir("e2e-cli-home-", .local_envir = .local_envir)
+  # HOME for the CLI on Unix, USERPROFILE for the CLI on Windows; the engine in
+  # this R process reads the same variables through duckdb_home_directory().
+  withr::local_envvar(
+    HOME = home,
+    USERPROFILE = home,
+    DUCKDB_SECRET_DIRECTORY = NA,
+    .local_envir = .local_envir
+  )
+  file.path(duckdb_shared_home(), "stored_secrets")
+}
+
+test_that("a secret created in R is visible to the DuckDB CLI", {
+  cli <- local_matching_cli()
+  shared_secret_dir <- local_shared_home()
+
+  # The R engine writes its persistent secret into the shared root. We resolve
+  # the path through duckdb_shared_home() (the function under test) rather than
+  # hard-coding it, so a wrong home base fails this test.
+  withr::local_options(duckdb.secret_directory = shared_secret_dir)
+
+  con <- local_con()
+  dbExecute(
+    con,
+    "CREATE PERSISTENT SECRET r_to_cli (TYPE http, BEARER_TOKEN 'token')"
+  )
+  expect_true(file.exists(file.path(
+    shared_secret_dir,
+    "r_to_cli.duckdb_secret"
+  )))
+
+  # The CLI, using its own default secret directory (<home>/.duckdb), must see
+  # the same secret -- proving the two notions of `~/.duckdb` coincide.
+  out <- run_cli(cli, "SELECT name FROM duckdb_secrets() ORDER BY name")
+  expect_true(any(grepl("r_to_cli", out, fixed = TRUE)))
+})
+
+test_that("a secret created by the DuckDB CLI is visible to R", {
+  cli <- local_matching_cli()
+  shared_secret_dir <- local_shared_home()
+
+  # The CLI writes a persistent secret into its default <home>/.duckdb.
+  cli_out <- run_cli(
+    cli,
+    "CREATE PERSISTENT SECRET cli_to_r (TYPE http, BEARER_TOKEN 'token')"
+  )
+  # The file should appear where R expects the shared root to be.
+  expect_true(
+    file.exists(file.path(shared_secret_dir, "cli_to_r.duckdb_secret")),
+    info = paste(cli_out, collapse = "\n")
+  )
+
+  # R, reading the shared root, must see the CLI's secret.
+  withr::local_options(duckdb.secret_directory = shared_secret_dir)
+  con <- local_con()
+  secrets <- dbGetQuery(con, "SELECT name FROM duckdb_secrets()")
+  expect_true("cli_to_r" %in% secrets$name)
+})

--- a/tests/testthat/test-storage-home.R
+++ b/tests/testthat/test-storage-home.R
@@ -1,0 +1,42 @@
+# The "shared" storage root must resolve to the same `~/.duckdb` the bundled
+# DuckDB engine, its CLI, and the Python client use. DuckDB derives the home
+# from USERPROFILE on Windows and HOME elsewhere (see
+# FileSystem::GetHomeDirectory() in src/duckdb/src/common/file_system.cpp), not
+# from R's `path.expand("~")`, which on Windows points at the Documents folder.
+
+test_that("duckdb_home_directory follows HOME on non-Windows", {
+  local_mocked_bindings(is_windows = function() FALSE)
+  withr::local_envvar(HOME = "/home/someone")
+  expect_equal(duckdb_home_directory(), "/home/someone")
+})
+
+test_that("duckdb_home_directory follows USERPROFILE on Windows", {
+  local_mocked_bindings(is_windows = function() TRUE)
+  withr::local_envvar(
+    USERPROFILE = "C:/Users/someone",
+    # HOME must be ignored on Windows, matching the engine.
+    HOME = "C:/Users/someone/Documents"
+  )
+  expect_equal(duckdb_home_directory(), "C:/Users/someone")
+})
+
+test_that("duckdb_home_directory falls back to path.expand when the env var is unset", {
+  local_mocked_bindings(is_windows = function() FALSE)
+  withr::local_envvar(HOME = NA)
+  # Whatever R considers home, never the empty/rootless ".duckdb".
+  expect_equal(duckdb_home_directory(), path.expand("~"))
+})
+
+test_that("duckdb_shared_home appends .duckdb to the home directory", {
+  local_mocked_bindings(duckdb_home_directory = function() "/home/someone")
+  expect_equal(duckdb_shared_home(), file.path("/home/someone", ".duckdb"))
+})
+
+test_that("duckdb_shared_home does not use the Windows Documents folder", {
+  # Regression test for the original `path.expand('~/.duckdb')`, which on
+  # Windows expands to `<USERPROFILE>/Documents/.duckdb`.
+  local_mocked_bindings(is_windows = function() TRUE)
+  withr::local_envvar(USERPROFILE = "C:/Users/someone")
+  expect_equal(duckdb_shared_home(), file.path("C:/Users/someone", ".duckdb"))
+  expect_false(grepl("Documents", duckdb_shared_home(), fixed = TRUE))
+})


### PR DESCRIPTION
## Problem

`duckdb_shared_home()` computed the `"shared"` storage root as
`path.expand("~/.duckdb")`. On Windows R expands `~` to the user's **Documents**
folder, e.g. `C:/Users/<user>/Documents/.duckdb`, whereas the DuckDB engine,
its CLI, and the Python client treat `~` as the **profile root**,
`C:/Users/<user>/.duckdb`. As [noted in review](https://github.com/duckdb/duckdb-r/pull/2372#discussion_r3484626795),
the shared root therefore pointed somewhere the rest of the DuckDB ecosystem
never reads, defeating the purpose of a *shared* location.

```r
path.expand("~/.duckdb")
#> [1] "C:\\Users\\user\\Documents/.duckdb"   # wrong on Windows
```

## Fix

Replicate the engine's own rule from `FileSystem::GetHomeDirectory()`
(`src/duckdb/src/common/file_system.cpp`):

```cpp
#ifdef DUCKDB_WINDOWS
    return FileSystem::GetEnvVariable("USERPROFILE");
#else
    return FileSystem::GetEnvVariable("HOME");
#endif
```

`duckdb_shared_home()` now reads `USERPROFILE` on Windows and `HOME` elsewhere,
falling back to `path.expand("~")` only when that variable is unset. The
platform check is a small, mockable `is_windows()` seam.

## Tests

- **`test-storage-home.R`** — unit-tests the new home resolution on both
  platforms, with a regression test asserting the Windows path never lands in
  `Documents`.
- **`test-storage-cli-e2e.R`** — end-to-end tests that a persistent secret
  crosses the **R ↔ CLI boundary in both directions** (R writes / CLI reads,
  and CLI writes / R reads), proving the two notions of `~/.duckdb` coincide.
  Rather than re-encode the platform rule, the test lets a real CLI tell us
  where it stores secrets.

  The tests are **conditional**: they run only when a DuckDB CLI whose version
  matches the bundled engine is available (via `DUCKDB_CLI` or `duckdb` on
  `PATH`), and skip otherwise — secret files are version-specific, so a
  mismatched CLI is treated as "not present".

## CI

- **`scripts/install-duckdb-cli.sh`** downloads the CLI matching the vendored
  engine version (Linux, macOS, and Windows — the CLI is published for Windows,
  unlike `libduckdb`). It exits cleanly for `-dev` snapshots that have no
  published CLI, so the e2e tests just skip there.
- The custom **before-install** action now runs that script on **every OS**
  (including Windows, via Git Bash, where the bug surfaced) and exports
  `DUCKDB_CLI`, so the e2e tests actually execute in CI.
- Added a **macOS vendored-build** entry to the matrix. Regular macOS jobs
  default to the fast system-`libduckdb` path, so without it no macOS job
  compiled the bundled sources. Together with the existing Linux vendored entry
  and Windows (always source), a from-source build is now covered on every OS.

### On "do binary builds ship a CLI?"

No — the `libduckdb-<platform>.zip` used by the system-lib build contains only
`libduckdb.{so,dylib}` and the headers, not the `duckdb` CLI. The CLI is a
separate release asset (`duckdb_cli-<platform>.zip`), which is why the new
script fetches it explicitly.

## Verification

Built against the prebuilt `libduckdb` v1.5.4 and ran locally:

- `test-storage-home.R`: 5/5 pass
- `test-storage-cli-e2e.R`: both directions pass with a real v1.5.4 CLI; both
  skip cleanly when no matching CLI is present
- full storage/secret suite: 97 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XgKrfXptCJZNoE8t1jny9g)_