### PR TITLE
feat: Remove the package-library extension storage option

### DIFF
--- a/R/Driver.R
+++ b/R/Driver.R
@@ -67,16 +67,15 @@ duckdb <- function(
   }
 
   # Choose CRAN-safe locations for the engine's writable state unless the user
-  # set them explicitly. The extension cache lives alongside the package when
-  # that is writable and falls back to a temporary directory otherwise; the
-  # temp/spill directory is redirected for in-memory databases. See
-  # `?duckdb_storage`.
+  # set them explicitly. The extension cache defaults to a temporary directory
+  # (persist it with `duckdb_extension_storage()`); the temp/spill directory is
+  # redirected for in-memory databases. See `?duckdb_storage`.
   if (!("extension_directory" %in% names(config))) {
     extension <- resolve_extension_directory()
     config["extension_directory"] <- extension$directory
-    # Nag about ephemeral caching only for the per-session tempdir fallback. The
+    # Nag about ephemeral caching only for the per-session tempdir default. The
     # other sources are all persistent -- an option/env override, or a marked
-    # user/shared/library root -- so there is nothing ephemeral to warn about.
+    # user/shared root -- so there is nothing ephemeral to warn about.
     if (identical(extension$source, "session")) {
       maybe_ephemeral_state_message(extension$directory)
     }

--- a/R/storage-config.R
+++ b/R/storage-config.R
@@ -10,9 +10,8 @@
 #' Choose where the duckdb R package keeps downloaded extensions and persisted
 #' secrets, by writing a small marker file that records the choice:
 #'
-#' * `duckdb_extension_storage()` -- set or move the extension cache (default:
-#'   the package library when writable, otherwise a per-session temporary
-#'   directory).
+#' * `duckdb_extension_storage()` -- set or move the extension cache (default: a
+#'   per-session temporary directory).
 #' * `duckdb_secret_storage()` -- set or move the secret store (default: a
 #'   per-session temporary directory).
 #' * `duckdb_storage_status()` -- report where each currently resolves.
@@ -38,8 +37,6 @@
 #'     opt-out (removes the marker, reverting to a per-session location).
 #'   * `"user"` -- [tools::R_user_dir()].
 #'   * `"shared"` -- `~/.duckdb`, shared with the DuckDB CLI and Python client.
-#'   * `"library"` -- *(`duckdb_extension_storage()` only)* alongside the
-#'     installed package.
 #'
 #'   To use an arbitrary directory, set the option or environment variable
 #'   instead (see [duckdb_storage]).
@@ -66,7 +63,7 @@ NULL
 #' @rdname duckdb_storage_config
 #' @export
 duckdb_extension_storage <- function(
-  location = c("session", "user", "shared", "library"),
+  location = c("session", "user", "shared"),
   ...,
   migrate = TRUE,
   conflict = "error"

--- a/R/storage-locations.R
+++ b/R/storage-locations.R
@@ -6,15 +6,13 @@ session_temp_dir <- function() {
   tempdir()
 }
 
-# Base directory for a named root. `"library"` is only meaningful for
-# extensions (it is wiped on re-install, pairing binaries with the build ABI).
+# Base directory for a named root.
 storage_root_base <- function(root) {
   switch(
     root,
     session = file.path(session_temp_dir(), "duckdb"),
     user = default_user_directory(),
     shared = duckdb_shared_home(),
-    library = system_file_path(),
     stop("Unknown storage root: ", root, call. = FALSE)
   )
 }
@@ -31,7 +29,7 @@ storage_dir <- function(root, kind) {
 }
 
 # Persistent roots a marker may opt into, in priority order. (`session` is the
-# tempdir default/opt-out; `library` is auto-probed, not marker-selected.)
+# tempdir default/opt-out.)
 persistent_roots <- function() {
   c("user", "shared")
 }
@@ -198,13 +196,13 @@ override_setting <- function(kind) {
 
 # The resolvers below each return a named list `list(directory, source)`: the
 # resolved directory and the tier of the policy that chose it ("option", "env",
-# "marker", "library", or "session"; "default" when nothing is set). Callers use
+# "marker", or "session"; "default" when nothing is set). Callers use
 # `source` to decide follow-up behavior (e.g. whether to nag about an ephemeral
 # cache) without re-running the resolution. `directory` may be NULL when a
 # setting is deliberately left unset (see `resolve_temp_directory()`).
 
 # Resolve the extension cache directory (see ?duckdb_storage):
-# override -> marker (user/shared) -> "library" write-probe -> session tempdir.
+# override -> marker (user/shared) -> session tempdir default.
 resolve_extension_directory <- function() {
   override <- directory_override_with_source("extensions")
   if (!is.null(override)) {
@@ -214,23 +212,12 @@ resolve_extension_directory <- function() {
   if (!is.null(marked)) {
     return(list(directory = marked, source = "marker"))
   }
-  library_dir <- storage_dir("library", "extensions")
-  if (has_keep_marker(library_dir)) {
-    return(list(directory = library_dir, source = "library"))
-  }
-  # Writing the marker doubles as the writability probe. When it succeeds the
-  # marker did not exist before, so this is the first time the library cache is
-  # initialized -- say so once (it then persists across sessions).
-  if (write_keep_marker(library_dir)) {
-    inform_library_cache_init(library_dir)
-    return(list(directory = library_dir, source = "library"))
-  }
   list(directory = storage_dir("session", "extensions"), source = "session")
 }
 
 # Resolve the secrets directory (see ?duckdb_storage):
-# override -> marker (user/shared) -> session tempdir. There is no "library"
-# root for secrets, and the default is a per-session temporary directory.
+# override -> marker (user/shared) -> session tempdir default. Same shape as
+# resolve_extension_directory(); the default is a per-session temporary directory.
 resolve_secret_directory <- function() {
   override <- directory_override_with_source("stored_secrets")
   if (!is.null(override)) {
@@ -271,8 +258,7 @@ is_memory_dbdir <- function(dbdir) {
 # --- Inspecting and changing the persistent location -------------------------
 
 # Read-only counterpart to the resolvers, used by duckdb_storage_status(): the
-# resolved directory and the tier that selected it. Unlike the connect-time
-# resolver it does not write-probe the library, so it has no side effects and
+# resolved directory and the tier that selected it. It has no side effects and
 # reports only what is already persisted.
 describe_storage <- function(kind) {
   override <- directory_override_with_source(kind)
@@ -283,23 +269,7 @@ describe_storage <- function(kind) {
   if (!is.null(marked)) {
     return(list(directory = marked, source = "marker"))
   }
-  if (kind == "extensions") {
-    library_dir <- storage_dir("library", kind)
-    if (has_keep_marker(library_dir)) {
-      return(list(directory = library_dir, source = "library"))
-    }
-  }
   list(directory = storage_dir("session", kind), source = "session")
-}
-
-# Roots whose marker is cleared before a new one is written, so a kind is never
-# marked in more than one place. Extensions add "library" (the auto-probe root).
-marker_roots <- function(kind) {
-  if (kind == "extensions") {
-    c("user", "shared", "library")
-  } else {
-    c("user", "shared")
-  }
 }
 
 # Point a kind's persistent location at `location`: clear any existing markers,
@@ -315,7 +285,7 @@ set_storage_marker <- function(kind, location, migrate, conflict) {
   # for why this can be more than one directory).
   from <- migration_sources(kind)
 
-  for (root in marker_roots(kind)) {
+  for (root in persistent_roots()) {
     remove_keep_marker(storage_dir(root, kind))
   }
 
@@ -349,7 +319,7 @@ migration_sources <- function(kind) {
   }
   marked <- Filter(
     function(r) has_keep_marker(storage_dir(r, kind)),
-    marker_roots(kind)
+    persistent_roots()
   )
   if (length(marked) > 0L) {
     return(vapply(marked, function(r) storage_dir(r, kind), character(1)))
@@ -412,22 +382,6 @@ migrate_storage <- function(from, to, conflict) {
       call. = FALSE
     )
   }
-  invisible()
-}
-
-# Announce the first time the package library is used as the extension cache.
-# Only reached when the keep-marker was just written (it persists afterwards),
-# so this fires once per install rather than once per session.
-inform_library_cache_init <- function(dir) {
-  msg <- c(
-    "duckdb: caching downloaded extensions in the package library:",
-    i = dir,
-    i = paste0(
-      "This is removed when the package is re-installed; see `?duckdb_storage` ",
-      "to choose a different location."
-    )
-  )
-  inform(msg, class = "duckdb_library_cache_init")
   invisible()
 }
 

--- a/R/storage.R
+++ b/R/storage.R
@@ -9,13 +9,10 @@
 # tempdir() so that, with no config/option/env/marker, nothing is written
 # outside the session temporary directory and reverse dependencies pass checks
 # with no action:
-#   * Extensions default to the package library only when it is writable. On the
-#     CRAN check farm the library is remounted read-only, the marker-write probe
-#     fails, and the cache falls back to tempdir(); no persistent write is ever
-#     attempted where it would fail.
-#   * Secrets and the in-memory temp/spill directory are pointed at tempdir()
-#     explicitly, overriding DuckDB's own defaults ($HOME/.duckdb and a `.tmp`
-#     directory in the working directory, respectively).
+#   * Extensions, secrets, and the in-memory temp/spill directory are pointed at
+#     tempdir() explicitly, overriding DuckDB's own defaults (a sub-directory of
+#     the DuckDB home, $HOME/.duckdb, and a `.tmp` directory in the working
+#     directory, respectively).
 # The package's tests and runnable examples also avoid the bundled C++ engine on
 # CRAN; see the CRAN guard in tests/testthat.R.
 #
@@ -36,9 +33,7 @@
 #' DuckDB writes several distinct kinds of data to the file system. This page
 #' catalogs every such location and documents the unified policy the duckdb R
 #' package uses to choose them, so that by default nothing is written outside
-#' the R session's temporary directory -- except the extension cache, which is
-#' auto-probed into the writable package library (and falls back to the
-#' temporary directory when the library is read-only, as on CRAN).
+#' the R session's temporary directory.
 #'
 #' The functions that configure these locations are documented in
 #' [duckdb_storage_config()].
@@ -54,10 +49,9 @@
 #'   \item{Extension binaries}{Downloaded `*.duckdb_extension` files (e.g.
 #'     `spatial`, `httpfs`, `h3`). DuckDB setting: `extension_directory`. A
 #'     re-usable cache: a given binary is valid only for the exact DuckDB
-#'     version and platform/ABI that downloaded it. By default the cache is the
-#'     `"library"` root (alongside the installed package) when it is writable,
-#'     falling back to a [tempdir()] sub-directory when it is not. See the
-#'     marker section for how this is detected.}
+#'     version and platform/ABI that downloaded it. Set explicitly to a
+#'     [tempdir()] location by default, and kept across sessions by pointing it
+#'     at a persistent root with [duckdb_storage_config()].}
 #'   \item{Stored secrets}{Persisted credentials under `stored_secrets`. DuckDB
 #'     setting: `secret_directory`. Set explicitly to a [tempdir()] location by
 #'     default. Configured and migrated with [duckdb_storage_config()].}
@@ -89,14 +83,6 @@
 #'    `Sys.getenv("DUCKDB_TEMP_DIRECTORY")`;
 #' 1. a persistent location selected by a marker file (see below);
 #' 1. the default: a per-session sub-directory of [tempdir()].
-#'
-#' The extension cache inserts one extra step before the [tempdir()] fallback:
-#' if no marker has selected a root, the `"library"` root is probed at connect
-#' time by writing its marker -- the write doubles as the writability test, and
-#' the marker is left in place to record the choice. If the write fails (the
-#' library is read-only) the cache falls back to [tempdir()]. So the effective
-#' default is "library when writable, else tempdir", with no persistent write
-#' ever attempted where it would fail.
 #'
 #' # Marker files
 #'
@@ -132,13 +118,6 @@
 #'     package, surviving package upgrades.}
 #'   \item{`"shared"`}{`~/.duckdb` -- shared with the DuckDB CLI and Python
 #'     client.}
-#'   \item{`"library"`}{*(extensions only)* alongside the installed duckdb
-#'     package ([base::system.file()]). It pairs binaries with the build's ABI
-#'     but is wiped on every re-install. This is the automatic default for
-#'     extensions when the library is writable (see the resolution policy
-#'     above): rather than require an explicit opt-in, the package probes it at
-#'     connect time and uses it unless the write fails. Not offered for stored
-#'     secrets, which always default to `"session"`.}
 #' }
 #'
 #' ## The marker file
@@ -180,9 +159,7 @@
 #'   connection is opened the package emits a message naming the candidates and
 #'   falls back to the [tempdir()] default until the ambiguity is resolved.
 #' * The package never ships a marker. The only writes are by
-#'   `duckdb_extension_storage()` / `duckdb_secret_storage()`, and the
-#'   connect-time probe of the `"library"` root for extensions (which writes the
-#'   marker only when the directory is writable).
+#'   `duckdb_extension_storage()` / `duckdb_secret_storage()`.
 #' * A marked location that is not writable falls back to the [tempdir()]
 #'   default rather than failing.
 #'
@@ -197,7 +174,7 @@
 #' | Kind        | DuckDB setting        | Option / environment variable                              | Default                          |
 #' |-------------|-----------------------|------------------------------------------------------------|----------------------------------|
 #' | Home        | `home_directory`      | --                                                         | left untouched (not set)            |
-#' | Extensions  | `extension_directory` | `duckdb.extension_directory` / `DUCKDB_EXTENSION_DIRECTORY` | library if writable, else `tempdir()`|
+#' | Extensions  | `extension_directory` | `duckdb.extension_directory` / `DUCKDB_EXTENSION_DIRECTORY` | `tempdir()` sub-directory (set)     |
 #' | Stored secrets | `secret_directory` | `duckdb.secret_directory` / `DUCKDB_SECRET_DIRECTORY`       | `tempdir()` sub-directory (set)     |
 #' | Temp/spill  | `temp_directory`      | `duckdb.temp_directory` / `DUCKDB_TEMP_DIRECTORY`          | `tempdir()` sub-directory (set)     |
 #' | Logs        | `log_query_path`      | `duckdb.log_directory` / `DUCKDB_LOG_DIRECTORY`            | disabled (off)                      |
@@ -218,10 +195,6 @@
 #'     location itself; if you set the extension directory (via `config`, the
 #'     option, or the environment variable) the choice is yours and the message
 #'     is suppressed.}
-#'   \item{Library-cache notice}{The first time the extension cache is
-#'     initialized in the package library (when its marker is written), the
-#'     package says so once. The marker then persists, so this is effectively
-#'     once per installation.}
 #' }
 #'
 #' ## Silencing the startup message

--- a/man/duckdb_storage.Rd
+++ b/man/duckdb_storage.Rd
@@ -9,9 +9,7 @@
 DuckDB writes several distinct kinds of data to the file system. This page
 catalogs every such location and documents the unified policy the duckdb R
 package uses to choose them, so that by default nothing is written outside
-the R session's temporary directory -- except the extension cache, which is
-auto-probed into the writable package library (and falls back to the
-temporary directory when the library is read-only, as on CRAN).
+the R session's temporary directory.
 
 The functions that configure these locations are documented in
 \code{\link[=duckdb_storage_config]{duckdb_storage_config()}}.
@@ -26,10 +24,9 @@ below is pointed at a temporary directory directly instead.}
 \item{Extension binaries}{Downloaded \verb{*.duckdb_extension} files (e.g.
 \code{spatial}, \code{httpfs}, \code{h3}). DuckDB setting: \code{extension_directory}. A
 re-usable cache: a given binary is valid only for the exact DuckDB
-version and platform/ABI that downloaded it. By default the cache is the
-\code{"library"} root (alongside the installed package) when it is writable,
-falling back to a \code{\link[=tempdir]{tempdir()}} sub-directory when it is not. See the
-marker section for how this is detected.}
+version and platform/ABI that downloaded it. Set explicitly to a
+\code{\link[=tempdir]{tempdir()}} location by default, and kept across sessions by pointing it
+at a persistent root with \code{\link[=duckdb_storage_config]{duckdb_storage_config()}}.}
 \item{Stored secrets}{Persisted credentials under \code{stored_secrets}. DuckDB
 setting: \code{secret_directory}. Set explicitly to a \code{\link[=tempdir]{tempdir()}} location by
 default. Configured and migrated with \code{\link[=duckdb_storage_config]{duckdb_storage_config()}}.}
@@ -62,14 +59,6 @@ source that yields a value wins:
 \item a persistent location selected by a marker file (see below);
 \item the default: a per-session sub-directory of \code{\link[=tempdir]{tempdir()}}.
 }
-
-The extension cache inserts one extra step before the \code{\link[=tempdir]{tempdir()}} fallback:
-if no marker has selected a root, the \code{"library"} root is probed at connect
-time by writing its marker -- the write doubles as the writability test, and
-the marker is left in place to record the choice. If the write fails (the
-library is read-only) the cache falls back to \code{\link[=tempdir]{tempdir()}}. So the effective
-default is "library when writable, else tempdir", with no persistent write
-ever attempted where it would fail.
 }
 
 \section{Marker files}{
@@ -103,13 +92,6 @@ removes the marker and reverts that kind to a per-session location.}
 package, surviving package upgrades.}
 \item{\code{"shared"}}{\verb{~/.duckdb} -- shared with the DuckDB CLI and Python
 client.}
-\item{\code{"library"}}{\emph{(extensions only)} alongside the installed duckdb
-package (\code{\link[base:system.file]{base::system.file()}}). It pairs binaries with the build's ABI
-but is wiped on every re-install. This is the automatic default for
-extensions when the library is writable (see the resolution policy
-above): rather than require an explicit opt-in, the package probes it at
-connect time and uses it unless the write fails. Not offered for stored
-secrets, which always default to \code{"session"}.}
 }
 }
 
@@ -153,9 +135,7 @@ drops the colliding sources. Secret migration is folded into
 connection is opened the package emits a message naming the candidates and
 falls back to the \code{\link[=tempdir]{tempdir()}} default until the ambiguity is resolved.
 \item The package never ships a marker. The only writes are by
-\code{duckdb_extension_storage()} / \code{duckdb_secret_storage()}, and the
-connect-time probe of the \code{"library"} root for extensions (which writes the
-marker only when the directory is writable).
+\code{duckdb_extension_storage()} / \code{duckdb_secret_storage()}.
 \item A marked location that is not writable falls back to the \code{\link[=tempdir]{tempdir()}}
 default rather than failing.
 }
@@ -172,7 +152,7 @@ resurrecting a store root and reintroducing an ABI mismatch.
 \tabular{llll}{
    Kind \tab DuckDB setting \tab Option / environment variable \tab Default \cr
    Home \tab \code{home_directory} \tab -- \tab left untouched (not set) \cr
-   Extensions \tab \code{extension_directory} \tab \code{duckdb.extension_directory} / \code{DUCKDB_EXTENSION_DIRECTORY} \tab library if writable, else \code{tempdir()} \cr
+   Extensions \tab \code{extension_directory} \tab \code{duckdb.extension_directory} / \code{DUCKDB_EXTENSION_DIRECTORY} \tab \code{tempdir()} sub-directory (set) \cr
    Stored secrets \tab \code{secret_directory} \tab \code{duckdb.secret_directory} / \code{DUCKDB_SECRET_DIRECTORY} \tab \code{tempdir()} sub-directory (set) \cr
    Temp/spill \tab \code{temp_directory} \tab \code{duckdb.temp_directory} / \code{DUCKDB_TEMP_DIRECTORY} \tab \code{tempdir()} sub-directory (set) \cr
    Logs \tab \code{log_query_path} \tab \code{duckdb.log_directory} / \code{DUCKDB_LOG_DIRECTORY} \tab disabled (off) \cr
@@ -195,10 +175,6 @@ into a permanent location. It is shown only when the package chose the
 location itself; if you set the extension directory (via \code{config}, the
 option, or the environment variable) the choice is yours and the message
 is suppressed.}
-\item{Library-cache notice}{The first time the extension cache is
-initialized in the package library (when its marker is written), the
-package says so once. The marker then persists, so this is effectively
-once per installation.}
 }
 \subsection{Silencing the startup message}{
 

--- a/man/duckdb_storage_config.Rd
+++ b/man/duckdb_storage_config.Rd
@@ -8,7 +8,7 @@
 \title{Configure where DuckDB stores extensions and secrets}
 \usage{
 duckdb_extension_storage(
-  location = c("session", "user", "shared", "library"),
+  location = c("session", "user", "shared"),
   ...,
   migrate = TRUE,
   conflict = "error"
@@ -30,8 +30,6 @@ duckdb_storage_status()
 opt-out (removes the marker, reverting to a per-session location).
 \item \code{"user"} -- \code{\link[tools:R_user_dir]{tools::R_user_dir()}}.
 \item \code{"shared"} -- \verb{~/.duckdb}, shared with the DuckDB CLI and Python client.
-\item \code{"library"} -- \emph{(\code{duckdb_extension_storage()} only)} alongside the
-installed package.
 }
 
 To use an arbitrary directory, set the option or environment variable
@@ -62,9 +60,8 @@ summary when the result is auto-printed.
 Choose where the duckdb R package keeps downloaded extensions and persisted
 secrets, by writing a small marker file that records the choice:
 \itemize{
-\item \code{duckdb_extension_storage()} -- set or move the extension cache (default:
-the package library when writable, otherwise a per-session temporary
-directory).
+\item \code{duckdb_extension_storage()} -- set or move the extension cache (default: a
+per-session temporary directory).
 \item \code{duckdb_secret_storage()} -- set or move the secret store (default: a
 per-session temporary directory).
 \item \code{duckdb_storage_status()} -- report where each currently resolves.

--- a/tests/testthat/test-extension_path.R
+++ b/tests/testthat/test-extension_path.R
@@ -1,9 +1,9 @@
 skip_on_cran()
 skip_on_os(c("windows"))
 
-test_that("duckdb extensions are stored inside the duckdb package install directory", {
+test_that("duckdb extensions are stored in the resolved extension directory", {
   con <- local_con(config = list('allow_unsigned_extensions' = 'true'))
-  expected_dir <- system_file_path("extensions")
+  expected_dir <- resolve_extension_directory()$directory
   err <- expect_error(dbExecute(con, "LOAD 'bogus'"))
   expect_true(grepl(expected_dir, conditionMessage(err), fixed = TRUE))
   expect_true(grepl(

--- a/tests/testthat/test-storage-config.R
+++ b/tests/testthat/test-storage-config.R
@@ -4,8 +4,7 @@ local_storage_roots <- function(.local_envir = parent.frame()) {
   roots <- list(
     user = withr::local_tempdir("user-", .local_envir = .local_envir),
     shared = withr::local_tempdir("shared-", .local_envir = .local_envir),
-    session = withr::local_tempdir("session-", .local_envir = .local_envir),
-    library = withr::local_tempdir("library-", .local_envir = .local_envir)
+    session = withr::local_tempdir("session-", .local_envir = .local_envir)
   )
   withr::local_envvar(
     DUCKDB_EXTENSION_DIRECTORY = NA,
@@ -21,7 +20,6 @@ local_storage_roots <- function(.local_envir = parent.frame()) {
     default_user_directory = function() roots$user,
     duckdb_shared_home = function() roots$shared,
     session_temp_dir = function() roots$session,
-    system_file_path = function(...) file.path(roots$library, ...),
     .env = .local_envir
   )
   roots
@@ -74,19 +72,6 @@ test_that('location = "session" removes the marker and reverts to the default', 
   expect_equal(dir, file.path(roots$session, "duckdb", "stored_secrets"))
   sec <- duckdb_storage_status()
   expect_equal(sec[sec$kind == "stored_secrets", "source"], "session")
-})
-
-test_that("duckdb_storage_status reports the library root when it is marked", {
-  roots <- local_storage_roots()
-  write_keep_marker(file.path(roots$library, "extensions"))
-
-  ext <- duckdb_storage_status()
-  ext <- ext[ext$kind == "extensions", ]
-  expect_equal(ext$source, "library")
-  expect_equal(
-    normalizePath(ext$directory),
-    normalizePath(file.path(roots$library, "extensions"))
-  )
 })
 
 test_that("migrate moves cached files between roots", {
@@ -161,8 +146,9 @@ test_that("conflict modes decide who wins a name collision", {
 test_that("storage functions reject stray dots and non-root locations", {
   local_storage_roots()
   expect_error(duckdb_extension_storage("session", "oops"))
-  # arg_match() enforces the per-kind roots: "library" is extensions-only, and
-  # arbitrary paths are not accepted.
+  # arg_match() enforces the roots: the retired "library" root and arbitrary
+  # paths are not accepted.
+  expect_error(duckdb_extension_storage("library"), "one of")
   expect_error(duckdb_secret_storage("library"), "one of")
   expect_error(duckdb_extension_storage("/tmp/whatever"), "one of")
 })
@@ -184,11 +170,12 @@ test_that("migration sweeps every marked root (duplicate-marker recovery)", {
   writeLines("u", file.path(roots$user, "extensions", "u.txt"))
   writeLines("s", file.path(roots$shared, "extensions", "s.txt"))
 
-  duckdb_extension_storage("library")
+  # Relocating to one of the marked roots still sweeps in the files orphaned in
+  # the other root whose marker is cleared.
+  duckdb_extension_storage("user")
 
-  expect_true(file.exists(file.path(roots$library, "extensions", "u.txt")))
-  expect_true(file.exists(file.path(roots$library, "extensions", "s.txt")))
-  expect_false(file.exists(file.path(roots$user, "extensions", "u.txt")))
+  expect_true(file.exists(file.path(roots$user, "extensions", "u.txt")))
+  expect_true(file.exists(file.path(roots$user, "extensions", "s.txt")))
   expect_false(file.exists(file.path(roots$shared, "extensions", "s.txt")))
 })
 

--- a/tests/testthat/test-storage-markers.R
+++ b/tests/testthat/test-storage-markers.R
@@ -4,8 +4,7 @@ test_that("storage_dir maps known roots and kinds, and rejects unknown roots", {
   local_mocked_bindings(
     session_temp_dir = function() "/tmp/sess",
     default_user_directory = function() "/userdir",
-    duckdb_shared_home = function() "/home/.duckdb",
-    system_file_path = function(...) file.path("/pkg", ...)
+    duckdb_shared_home = function() "/home/.duckdb"
   )
   expect_equal(
     storage_dir("session", "extensions"),
@@ -16,7 +15,8 @@ test_that("storage_dir maps known roots and kinds, and rejects unknown roots", {
     storage_dir("shared", "stored_secrets"),
     "/home/.duckdb/stored_secrets"
   )
-  expect_equal(storage_dir("library", "extensions"), "/pkg/extensions")
+  # The retired "library" root and arbitrary paths are not known roots.
+  expect_error(storage_dir("library", "extensions"), "Unknown storage root")
   expect_error(
     storage_dir("/explicit/path", "extensions"),
     "Unknown storage root"

--- a/tests/testthat/test-storage-resolve.R
+++ b/tests/testthat/test-storage-resolve.R
@@ -15,7 +15,7 @@ test_that("resolve_extension_directory honors option then env override", {
   )
 })
 
-test_that("resolve_extension_directory uses a marked root over the library", {
+test_that("resolve_extension_directory uses a marked root", {
   user <- withr::local_tempdir()
   shared <- withr::local_tempdir()
   local_mocked_bindings(
@@ -31,34 +31,9 @@ test_that("resolve_extension_directory uses a marked root over the library", {
   expect_equal(resolved$source, "marker")
 })
 
-test_that("resolve_extension_directory uses the library when writable, announcing once", {
-  lib <- withr::local_tempdir()
+test_that("resolve_extension_directory defaults to the session tempdir", {
   local_mocked_bindings(
     marked_storage_dir = function(kind) NULL,
-    system_file_path = function(...) file.path(lib, ...)
-  )
-  # First use writes the marker and announces the library cache once.
-  expect_message(
-    {
-      resolved <- resolve_extension_directory()
-      expect_equal(
-        normalizePath(resolved$directory),
-        normalizePath(file.path(lib, "extensions"))
-      )
-      expect_equal(resolved$source, "library")
-    },
-    "package library"
-  )
-  expect_true(has_keep_marker(file.path(lib, "extensions")))
-  # Marker now present: no second announcement.
-  expect_silent(resolve_extension_directory())
-})
-
-test_that("resolve_extension_directory falls back to tempdir when library is read-only", {
-  local_mocked_bindings(
-    marked_storage_dir = function(kind) NULL,
-    has_keep_marker = function(dir) FALSE,
-    write_keep_marker = function(dir) FALSE,
     session_temp_dir = function() "/tmp/sess"
   )
   expect_equal(


### PR DESCRIPTION
## What

Removes the `"library"` storage root — the option to cache downloaded DuckDB extensions inside the installed package library.

## Why

Until now the extension cache defaulted to the package library when that directory was writable: at connect time the package wrote a keep-marker there (the write doubling as a writability probe) and used it as the cache. This location is **brittle**:

- It is **wiped on every package re-install/upgrade**, so the cache silently disappears and every extension has to be re-downloaded.
- It **pairs binaries with a specific build ABI** and lives under `system.file()`, a directory a package is not really meant to write into at runtime.

## What changes

The extension cache now resolves exactly like stored secrets:

```
override (option / env) → marker (user / shared) → per-session tempdir (default)
```

- Dropped the `"library"` root from `storage_root_base()`, the connect-time write-probe in `resolve_extension_directory()`, the `describe_storage()` library branch, and the one-time "library-cache" init notice.
- Removed `"library"` from the `location` choices of `duckdb_extension_storage()`; it now accepts `"session"`, `"user"`, `"shared"` (same as `duckdb_secret_storage()`).
- By default extensions now land in a `tempdir()` sub-directory and are kept across sessions only when the user explicitly opts in with `duckdb_extension_storage("user")` / `duckdb_extension_storage("shared")`, an option, or an environment variable — the same, non-brittle mechanisms already used for secrets.

## Docs

- Rewrote `?duckdb_storage` and `?duckdb_storage_config` (removed the library-probe resolution step, the `"library"` root description, the reference-table default, and the "Library-cache notice"), and regenerated the corresponding `man/*.Rd`.

## Tests

- Updated `test-storage-resolve.R`, `test-storage-config.R`, `test-storage-markers.R`, and `test-extension_path.R` to drop the library-storage expectations and cover the new default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KLX85JYm5Yyqe94w9825oq)_