### PR TITLE
fix: silence storage message for GeoTox's transitive use (temporary)

### DIFF
--- a/R/Driver.R
+++ b/R/Driver.R
@@ -78,7 +78,9 @@ duckdb <- function(
   }
   if (
     !is.null(shared_home) &&
-      !(is.logical(shared_home) && length(shared_home) == 1L && !is.na(shared_home))
+      !(is.logical(shared_home) &&
+        length(shared_home) == 1L &&
+        !is.na(shared_home))
   ) {
     stop("`shared_home` must be TRUE, FALSE, or NULL.", call. = FALSE)
   }
@@ -134,7 +136,10 @@ duckdb <- function(
       is.null(shared_home) &&
       (identical(resolved_home$source, "session") ||
         (!is_interactive() && identical(resolved_home$source, "shared")))
-    if (announce) {
+    # TEMPORARY: also suppress the message when duckdb is used transitively by
+    # GeoTox, whose test asserts silence (see R/storage-geotox-workaround.R).
+    # Remove this guard after the next release.
+    if (announce && !caller_is_geotox()) {
       maybe_storage_location_message(resolved_home)
     }
   }

--- a/R/storage-geotox-workaround.R
+++ b/R/storage-geotox-workaround.R
@@ -1,0 +1,25 @@
+# TEMPORARY GeoTox workaround -- remove after the next CRAN release.
+#
+# GeoTox opens a DuckDB connection transitively (through duckplyr) inside a test
+# that asserts the call is silent (`expect_silent()`). The storage-location
+# message introduced in #2396 therefore trips that test and shows up as a
+# reverse-dependency failure in GeoTox's CRAN check.
+#
+# Until GeoTox ships an adjusted test, suppress the storage-location message --
+# and only that message -- when GeoTox is somewhere on the call stack. This is
+# deliberately narrow: direct, top-level use of duckdb() still emits the message,
+# and interactive behaviour (including the offer to create `~/.duckdb`) is
+# unchanged.
+#
+# To revert: delete this file, the `!caller_is_geotox()` guard in R/Driver.R, and
+# tests/testthat/test-storage-geotox-workaround.R.
+# See https://github.com/duckdb/duckdb-r/pull/2397.
+caller_is_geotox <- function() {
+  frames <- sys.frames()
+  for (i in seq_along(frames)) {
+    if (identical(environmentName(topenv(frames[[i]])), "GeoTox")) {
+      return(TRUE)
+    }
+  }
+  FALSE
+}

--- a/R/storage-geotox-workaround.R
+++ b/R/storage-geotox-workaround.R
@@ -15,9 +15,8 @@
 # tests/testthat/test-storage-geotox-workaround.R.
 # See https://github.com/duckdb/duckdb-r/pull/2397.
 caller_is_geotox <- function() {
-  frames <- sys.frames()
-  for (i in seq_along(frames)) {
-    if (identical(environmentName(topenv(frames[[i]])), "GeoTox")) {
+  for (frame in sys.frames()) {
+    if (identical(environmentName(topenv(frame)), "GeoTox")) {
       return(TRUE)
     }
   }

--- a/tests/testthat/test-storage-geotox-workaround.R
+++ b/tests/testthat/test-storage-geotox-workaround.R
@@ -1,0 +1,27 @@
+# TEMPORARY: tests for the GeoTox reverse-dependency workaround
+# (R/storage-geotox-workaround.R). Remove together with the workaround.
+
+# Build an environment that topenv() treats as the named namespace, without
+# needing the package installed.
+fake_namespace <- function(name) {
+  ns <- new.env()
+  info <- new.env()
+  info$spec <- c(name = name, version = "0.0.0")
+  assign(".__NAMESPACE__.", info, envir = ns)
+  ns
+}
+
+test_that("caller_is_geotox detects GeoTox on the call stack, else FALSE", {
+  # Nothing GeoTox-related on the stack.
+  expect_false(caller_is_geotox())
+
+  # A function living in (a stand-in for) the GeoTox namespace, calling down.
+  from_geotox <- function() caller_is_geotox()
+  environment(from_geotox) <- fake_namespace("GeoTox")
+  expect_true(from_geotox())
+
+  # A different package on the stack must not trigger it.
+  from_other <- function() caller_is_geotox()
+  environment(from_other) <- fake_namespace("someOtherPkg")
+  expect_false(from_other())
+})


### PR DESCRIPTION
## Problem

The storage-location policy merged in #2396 emits an informational message when `duckdb()` picks a location itself. This fired even when duckdb was used **transitively** by another package, breaking the `GeoTox` reverse dependency: GeoTox connects to DuckDB through duckplyr inside a test that asserts silence.

```
── Failure ('test-calc_sensitivity.R:82:3'): calc sensitivity ──
Expected `calc_sensitivity(GT)` to run silently.
Actual noise: messages.
```

## Fix (temporary, to be reverted after the next release)

A deliberately narrow, GeoTox-specific workaround: suppress the storage-location message — and only that message — when the **GeoTox namespace is on the call stack**. Everything else is unchanged:

- direct, top-level `dbConnect(duckdb())` still emits the message;
- any *other* package's transitive use still emits it (this is not a general third-party rule);
- interactive behaviour, including the offer to create `~/.duckdb`, is untouched.

Detection scans `sys.frames()` for a frame whose `topenv()` is the `GeoTox` namespace, so it only triggers when GeoTox is genuinely the (transitive) caller — not merely loaded.

## Why so narrow / temporary

This is a stopgap so GeoTox's CRAN check passes for the current release; it is expected to be reverted once GeoTox ships an adjusted test. It is kept trivially revertible:

- `R/storage-geotox-workaround.R` — the `caller_is_geotox()` helper (delete the file);
- `R/Driver.R` — a single guarded line `if (announce && !caller_is_geotox())` (remove the guard);
- `tests/testthat/test-storage-geotox-workaround.R` — its test (delete the file).

## Verification

Against the vendored DuckDB v1.5.5 engine (non-interactive):

- top-level call → message shown ✅
- GeoTox on the call stack → silent ✅ (the failing case)
- a different package on the call stack → message shown ✅ (confirms it is GeoTox-specific)
- storage test suite: 81 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeGe5ctVS9WFJdPmeGcjzf