### PR TITLE
feat: stop announcing storage location after an explicit choice

### DIFF
--- a/R/Driver.R
+++ b/R/Driver.R
@@ -87,11 +87,6 @@ duckdb <- function(
   if (!is.null(home) && !is.null(shared_home)) {
     stop("Pass either `home` or `shared_home`, not both.", call. = FALSE)
   }
-  # An explicit `home`/`shared_home` means the user knows about the storage
-  # knobs; remember it so later auto-resolved calls this session stay quiet.
-  if (!is.null(home) || !is.null(shared_home)) {
-    mark_storage_choice_made()
-  }
 
   convert_opts <- duckdb_convert_opts(bigint = bigint)
 
@@ -117,6 +112,13 @@ duckdb <- function(
   need_extension <- !("extension_directory" %in% names(config))
   need_secret <- !("secret_directory" %in% names(config))
   if (need_extension || need_secret) {
+    # An explicit `home`/`shared_home` means the user knows the storage
+    # settings; remember it so later auto-resolved calls this session stay
+    # quiet. Set here, past the driver-cache reuse above, so an argument that a
+    # reused driver would ignore does not silence future messages.
+    if (!is.null(home) || !is.null(shared_home)) {
+      mark_storage_choice_made()
+    }
     resolved_home <- resolve_storage_home(home, shared_home)
     if (need_extension) {
       config["extension_directory"] <- home_subdir(
@@ -137,8 +139,8 @@ duckdb <- function(
     # interactively when the user opted out of creating ~/.duckdb; an existing
     # ~/.duckdb ("shared") is announced only non-interactively (interactively it
     # is the user's own directory, used without a prompt). Once the user has
-    # made any explicit `home`/`shared_home` choice this session they are
-    # informed, so we stay quiet from then on.
+    # made any explicit `home`/`shared_home` choice this session they have seen
+    # the settings, so we stay quiet from then on.
     announce <- is.null(home) &&
       is.null(shared_home) &&
       !storage_choice_made() &&

--- a/R/Driver.R
+++ b/R/Driver.R
@@ -78,12 +78,19 @@ duckdb <- function(
   }
   if (
     !is.null(shared_home) &&
-      !(is.logical(shared_home) && length(shared_home) == 1L && !is.na(shared_home))
+      !(is.logical(shared_home) &&
+        length(shared_home) == 1L &&
+        !is.na(shared_home))
   ) {
     stop("`shared_home` must be TRUE, FALSE, or NULL.", call. = FALSE)
   }
   if (!is.null(home) && !is.null(shared_home)) {
     stop("Pass either `home` or `shared_home`, not both.", call. = FALSE)
+  }
+  # An explicit `home`/`shared_home` means the user knows about the storage
+  # knobs; remember it so later auto-resolved calls this session stay quiet.
+  if (!is.null(home) || !is.null(shared_home)) {
+    mark_storage_choice_made()
   }
 
   convert_opts <- duckdb_convert_opts(bigint = bigint)
@@ -129,9 +136,12 @@ duckdb <- function(
     # ("session") is announced in both modes -- non-interactively, and
     # interactively when the user opted out of creating ~/.duckdb; an existing
     # ~/.duckdb ("shared") is announced only non-interactively (interactively it
-    # is the user's own directory, used without a prompt).
+    # is the user's own directory, used without a prompt). Once the user has
+    # made any explicit `home`/`shared_home` choice this session they are
+    # informed, so we stay quiet from then on.
     announce <- is.null(home) &&
       is.null(shared_home) &&
+      !storage_choice_made() &&
       (identical(resolved_home$source, "session") ||
         (!is_interactive() && identical(resolved_home$source, "shared")))
     if (announce) {

--- a/R/storage-home.R
+++ b/R/storage-home.R
@@ -184,10 +184,10 @@ mark_home_prompt_declined <- function() {
 }
 
 # Whether the user has, in this session, chosen a storage location explicitly by
-# passing `home` or `shared_home` to duckdb(). The storage-location message is a
-# teaching device for exactly those arguments, so once the user has used one of
-# them they are "informed" and later auto-resolved calls no longer announce (see
-# the announce logic in duckdb()).
+# passing `home` or `shared_home` to duckdb(). The storage-location message
+# exists to point at exactly those arguments, so once the user has used one of
+# them they have seen the settings and later auto-resolved calls no longer
+# announce (see the announce logic in duckdb()).
 storage_choice_made <- function() {
   isTRUE(storage_message_state[["choice_made"]])
 }
@@ -200,7 +200,7 @@ mark_storage_choice_made <- function() {
 
 # An explicit temp/spill-directory override via the `duckdb.temp_directory`
 # option or the `DUCKDB_R_TEMP_DIRECTORY` environment variable, or NULL if neither
-# is set. Unlike the extension/secret home this stays a separate knob: spill
+# is set. Unlike the extension/secret home this stays a separate setting: spill
 # files can be large and are unrelated to the extension cache.
 temp_directory_override <- function() {
   opt <- getOption("duckdb.temp_directory")

--- a/R/storage-home.R
+++ b/R/storage-home.R
@@ -125,7 +125,10 @@ fixed_storage_home <- function(home = NULL) {
   if (is_nonempty_string(opt)) {
     return(list(root = path.expand(opt), source = "option"))
   } else if (!is.null(opt)) {
-    warning("`duckdb.home` option must be a single non-empty string (a directory path), or NULL.", call. = FALSE)
+    warning(
+      "`duckdb.home` option must be a single non-empty string (a directory path), or NULL.",
+      call. = FALSE
+    )
     options(duckdb.home = NULL)
   }
   env <- Sys.getenv("DUCKDB_R_HOME", unset = "")
@@ -178,6 +181,19 @@ home_prompt_declined <- function() {
 
 mark_home_prompt_declined <- function() {
   storage_message_state[["home_prompt_declined"]] <- TRUE
+}
+
+# Whether the user has, in this session, chosen a storage location explicitly by
+# passing `home` or `shared_home` to duckdb(). The storage-location message is a
+# teaching device for exactly those arguments, so once the user has used one of
+# them they are "informed" and later auto-resolved calls no longer announce (see
+# the announce logic in duckdb()).
+storage_choice_made <- function() {
+  isTRUE(storage_message_state[["choice_made"]])
+}
+
+mark_storage_choice_made <- function() {
+  storage_message_state[["choice_made"]] <- TRUE
 }
 
 # --- Temp / spill directory ---------------------------------------------------

--- a/R/storage.R
+++ b/R/storage.R
@@ -58,7 +58,7 @@
 #'     `max_temp_directory_size`. For an in-memory (`:memory:`) database DuckDB's
 #'     own default spills to `.tmp` in the current working directory, so the
 #'     package overrides it with a [tempdir()] sub-directory by default. This is
-#'     a separate knob from the extension/secret home (see below).}
+#'     a separate setting from the extension/secret home (see below).}
 #'   \item{Logs and profiling output}{Written only when a path is explicitly
 #'     configured (DuckDB settings `log_query_path`, `http_logging_output`,
 #'     profiling output). They default to *off*, so nothing is written without
@@ -129,8 +129,9 @@
 #'     `~/.duckdb`; interactively it is issued only when the user opts out of
 #'     creating `~/.duckdb`.
 #'     It is also suppressed once you have made any explicit `home` or
-#'     `shared_home` choice earlier in the session: having used those arguments,
-#'     you already know the knob, so later auto-resolved calls stay quiet.
+#'     `shared_home` choice earlier in the session: having set the location
+#'     explicitly once, you have seen how, so later auto-resolved calls stay
+#'     quiet.
 #'   }
 #' }
 #'

--- a/R/storage.R
+++ b/R/storage.R
@@ -128,6 +128,9 @@
 #'     Non-interactively it covers both the temporary directory and an existing
 #'     `~/.duckdb`; interactively it is issued only when the user opts out of
 #'     creating `~/.duckdb`.
+#'     It is also suppressed once you have made any explicit `home` or
+#'     `shared_home` choice earlier in the session: having used those arguments,
+#'     you already know the knob, so later auto-resolved calls stay quiet.
 #'   }
 #' }
 #'

--- a/man/duckdb_storage.Rd
+++ b/man/duckdb_storage.Rd
@@ -125,6 +125,9 @@ location yourself -- the \code{home} or \code{shared_home} argument, the
 Non-interactively it covers both the temporary directory and an existing
 \verb{~/.duckdb}; interactively it is issued only when the user opts out of
 creating \verb{~/.duckdb}.
+It is also suppressed once you have made any explicit \code{home} or
+\code{shared_home} choice earlier in the session: having used those arguments,
+you already know the knob, so later auto-resolved calls stay quiet.
 }
 }
 \subsection{Silencing the message}{

--- a/man/duckdb_storage.Rd
+++ b/man/duckdb_storage.Rd
@@ -52,7 +52,7 @@ joins, and similar operations. DuckDB settings: \code{temp_directory},
 \code{max_temp_directory_size}. For an in-memory (\verb{:memory:}) database DuckDB's
 own default spills to \code{.tmp} in the current working directory, so the
 package overrides it with a \code{\link[=tempdir]{tempdir()}} sub-directory by default. This is
-a separate knob from the extension/secret home (see below).}
+a separate setting from the extension/secret home (see below).}
 \item{Logs and profiling output}{Written only when a path is explicitly
 configured (DuckDB settings \code{log_query_path}, \code{http_logging_output},
 profiling output). They default to \emph{off}, so nothing is written without
@@ -126,8 +126,9 @@ Non-interactively it covers both the temporary directory and an existing
 \verb{~/.duckdb}; interactively it is issued only when the user opts out of
 creating \verb{~/.duckdb}.
 It is also suppressed once you have made any explicit \code{home} or
-\code{shared_home} choice earlier in the session: having used those arguments,
-you already know the knob, so later auto-resolved calls stay quiet.
+\code{shared_home} choice earlier in the session: having set the location
+explicitly once, you have seen how, so later auto-resolved calls stay
+quiet.
 }
 }
 \subsection{Silencing the message}{

--- a/tests/testthat/test-storage-e2e.R
+++ b/tests/testthat/test-storage-e2e.R
@@ -14,6 +14,7 @@ test_that("a non-interactive connect announces the storage location, unless chos
 
   # Auto-resolved (no ~/.duckdb, no args) -> the tempdir message fires once.
   storage_message_state[["storage_location"]] <- NULL
+  storage_message_state[["choice_made"]] <- NULL
   drv <- NULL
   expect_message({ drv <- duckdb() }, "temporary directory")
   duckdb_shutdown(drv)
@@ -44,6 +45,7 @@ test_that("an interactive yes announces creation; a no announces the tempdir", {
   # "no" -> tempdir, and the storage-location message is announced.
   storage_message_state[["home_prompt_declined"]] <- NULL
   storage_message_state[["storage_location"]] <- NULL
+  storage_message_state[["choice_made"]] <- NULL
   local_mocked_bindings(
     duckdb_shared_home = function() file.path(tempdir(), "no-such-home-int"),
     consent_to_create_home = function(path) FALSE

--- a/tests/testthat/test-storage-message-once.R
+++ b/tests/testthat/test-storage-message-once.R
@@ -32,6 +32,39 @@ test_that("an explicit shared_home choice silences a later bare duckdb()", {
   duckdb_shutdown(drv)
 })
 
+test_that("reusing a cached on-disk driver does not record a storage choice", {
+  skip_on_cran()
+  withr::local_options(duckdb.home = NULL, rlang_interactive = FALSE)
+  withr::local_envvar(DUCKDB_R_HOME = NA)
+  local_mocked_bindings(
+    duckdb_shared_home = function() file.path(tempdir(), "no-such-home-reuse")
+  )
+  storage_message_state[["choice_made"]] <- NULL
+  storage_message_state[["storage_location"]] <- NULL
+  dbfile <- withr::local_tempfile(fileext = ".db")
+
+  # First creation resolves storage (a tempdir); no explicit choice yet.
+  drv <- duckdb(dbdir = dbfile)
+
+  # A second call for the same path reuses the cached driver and silently
+  # ignores shared_home. That ignored argument must NOT record a choice.
+  drv2 <- duckdb(dbdir = dbfile, shared_home = TRUE)
+  expect_true(identical(drv, drv2))
+  expect_false(storage_choice_made())
+  duckdb_shutdown(drv)
+
+  # So a later bare call still announces.
+  storage_message_state[["storage_location"]] <- NULL
+  d <- NULL
+  expect_message(
+    {
+      d <- duckdb()
+    },
+    "temporary directory"
+  )
+  duckdb_shutdown(d)
+})
+
 test_that("without a prior choice, a bare duckdb() still announces", {
   skip_on_cran()
   withr::local_options(duckdb.home = NULL, rlang_interactive = FALSE)

--- a/tests/testthat/test-storage-message-once.R
+++ b/tests/testthat/test-storage-message-once.R
@@ -1,0 +1,53 @@
+# An explicit `home`/`shared_home` choice this session silences the
+# storage-location message for subsequent auto-resolved duckdb() calls.
+
+test_that("mark/read of the session choice flag round-trips", {
+  storage_message_state[["choice_made"]] <- NULL
+  expect_false(storage_choice_made())
+  mark_storage_choice_made()
+  expect_true(storage_choice_made())
+})
+
+test_that("an explicit shared_home choice silences a later bare duckdb()", {
+  skip_on_cran()
+  withr::local_options(duckdb.home = NULL, rlang_interactive = FALSE)
+  withr::local_envvar(DUCKDB_R_HOME = NA)
+  local_mocked_bindings(
+    duckdb_shared_home = function() file.path(tempdir(), "no-such-home-once")
+  )
+  storage_message_state[["choice_made"]] <- NULL
+  storage_message_state[["storage_location"]] <- NULL
+
+  # The explicit opt-out is itself silent, and marks the choice.
+  drv <- NULL
+  expect_no_message({
+    drv <- duckdb(shared_home = FALSE)
+  })
+  duckdb_shutdown(drv)
+
+  # A subsequent bare call auto-resolves to a tempdir but now stays quiet.
+  expect_no_message({
+    drv <- duckdb()
+  })
+  duckdb_shutdown(drv)
+})
+
+test_that("without a prior choice, a bare duckdb() still announces", {
+  skip_on_cran()
+  withr::local_options(duckdb.home = NULL, rlang_interactive = FALSE)
+  withr::local_envvar(DUCKDB_R_HOME = NA)
+  local_mocked_bindings(
+    duckdb_shared_home = function() file.path(tempdir(), "no-such-home-once2")
+  )
+  storage_message_state[["choice_made"]] <- NULL
+  storage_message_state[["storage_location"]] <- NULL
+
+  drv <- NULL
+  expect_message(
+    {
+      drv <- duckdb()
+    },
+    "temporary directory"
+  )
+  duckdb_shutdown(drv)
+})


### PR DESCRIPTION
## Motivation

Consider:

```r
duckdb::duckdb(shared_home = FALSE)  # explicit opt-out: silent
duckdb::duckdb()                      # bare call: currently re-announces the tempdir
```

The second call resolves to the *same* temporary directory the user just accepted explicitly, yet it still emits the storage-location message telling them how to change or silence it. That reminder is noise: the message exists to point at the `home`/`shared_home` arguments, and the user has just demonstrated they know them.

## Change

Record when the user passes an explicit `home` or `shared_home` to `duckdb()` in a session, and suppress the storage-location message for subsequent auto-resolved calls that session. Making any explicit choice marks the user as having seen the settings; from then on bare calls resolve quietly.

- `R/storage-home.R` — `storage_choice_made()` / `mark_storage_choice_made()` on the existing session-state env.
- `R/Driver.R` — set the flag when `home`/`shared_home` is non-`NULL`; add `!storage_choice_made()` to the announce gate.
- `R/storage.R` / `man/duckdb_storage.Rd` — document it.
- Tests — a dedicated `test-storage-message-once.R`; existing message-expecting e2e tests reset the session flag so the suite stays order-independent.

## Driver-cache interaction (reviewed)

`duckdb(dbdir = "x.db")` caches the driver and **reuses** it on later calls with the same path, returning early and silently ignoring `home`/`shared_home` (the same contract as `config`/`read_only`). So the choice flag is recorded **only in the block that actually resolves storage**, past that early-return: an argument a reused driver would ignore must not silence future messages. A test covers the reuse path (`identical(drv, drv2)` and `storage_choice_made()` stays `FALSE`). The message itself was already skipped on reuse, since the announce lives in the same block.

(The pre-existing gap — that `home`/`shared_home` are silently ignored on reuse but, unlike `config`/`read_only`, their docs don't say so — is addressed in a separate PR.)

## Tradeoff (the design decision worth a look)

The flag is **session-global and sticky**, and triggered by **any** explicit choice — not just `shared_home = FALSE`. Two consequences to weigh:

- **`home = "/x"` then bare `duckdb()`** → the bare call uses a *tempdir*, not `/x`, but stays silent. Intentional under "the user has seen the settings," but it does mean a later default call elsewhere in a long session won't be re-announced. If you'd rather keep it narrow, we can instead trigger only on `shared_home = FALSE` (the exact "I accept the tempdir" signal), the tightest match to the motivating example.
- **Stickiness** matches how the interactive create-prompt already behaves (a declined prompt is not re-asked). It does not persist beyond the session.

I implemented the broad "any explicit choice → seen the settings → quiet" version because it aligns with the message's purpose (pointing at those arguments). Happy to narrow it to `shared_home = FALSE`-only if you prefer.

## Verification

Against the vendored DuckDB v1.5.5 engine: `duckdb(shared_home = FALSE)` then bare `duckdb()` → the second call is silent; a bare `duckdb()` with no prior choice still announces; a reused on-disk driver records no choice. Storage suite: 86 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeGe5ctVS9WFJdPmeGcjzf