### PR TITLE
docs: document database-instance caching and driver reuse

### DIFF
--- a/R/Driver.R
+++ b/R/Driver.R
@@ -34,6 +34,8 @@ driver_registry <- new.env(parent = emptyenv())
 #'   (with an offer to create `~/.duckdb` in interactive sessions).
 #'   Pass a path to use it as the root explicitly, creating it if needed.
 #'   Cannot be combined with `shared_home`.
+#'   Like `config`, this takes effect only when a new database instance is
+#'   created; a call that reuses a cached driver for the same `dbdir` ignores it.
 #' @param shared_home Opt in or out of the shared `~/.duckdb` location,
 #'   overriding the automatic resolution.
 #'   One of:
@@ -53,6 +55,8 @@ driver_registry <- new.env(parent = emptyenv())
 #'     already exists. Nothing persists beyond the session.
 #'
 #'   Cannot be combined with `home`.
+#'   Like `config`, this takes effect only when a new database instance is
+#'   created; a call that reuses a cached driver for the same `dbdir` ignores it.
 #' @param environment_scan Set to `TRUE` to treat
 #'   data frames from the calling environment as tables.
 #'   If a database table with the same name exists, it takes precedence.
@@ -78,7 +82,9 @@ duckdb <- function(
   }
   if (
     !is.null(shared_home) &&
-      !(is.logical(shared_home) && length(shared_home) == 1L && !is.na(shared_home))
+      !(is.logical(shared_home) &&
+        length(shared_home) == 1L &&
+        !is.na(shared_home))
   ) {
     stop("`shared_home` must be TRUE, FALSE, or NULL.", call. = FALSE)
   }

--- a/R/Driver.R
+++ b/R/Driver.R
@@ -34,8 +34,8 @@ driver_registry <- new.env(parent = emptyenv())
 #'   (with an offer to create `~/.duckdb` in interactive sessions).
 #'   Pass a path to use it as the root explicitly, creating it if needed.
 #'   Cannot be combined with `shared_home`.
-#'   Applied only when the database instance is created; see the
-#'   \sQuote{Database instances and driver reuse} section.
+#'   Applied only when the database instance is created;
+#'   see the \sQuote{Database instances and driver reuse} section.
 #' @param shared_home Opt in or out of the shared `~/.duckdb` location,
 #'   overriding the automatic resolution.
 #'   One of:
@@ -55,8 +55,8 @@ driver_registry <- new.env(parent = emptyenv())
 #'     already exists. Nothing persists beyond the session.
 #'
 #'   Cannot be combined with `home`.
-#'   Applied only when the database instance is created; see the
-#'   \sQuote{Database instances and driver reuse} section.
+#'   Applied only when the database instance is created;
+#'   see the \sQuote{Database instances and driver reuse} section.
 #' @param environment_scan Set to `TRUE` to treat
 #'   data frames from the calling environment as tables.
 #'   If a database table with the same name exists, it takes precedence.
@@ -71,23 +71,24 @@ driver_registry <- new.env(parent = emptyenv())
 #' and many connections can share one instance.
 #'
 #' For a file-based `dbdir`, the instance is cached, keyed by the (normalized) path:
-#' calling `duckdb()` again with the same `dbdir` returns the same driver and instance while it is still alive.
+#' calling `duckdb()` again with the same `dbdir` returns the same driver and instance
+#' while it is still alive.
 #' This is deliberate.
 #' DuckDB allows only a single read-write handle to a database file at a time,
-#' so opening a second instance of the same file would fail with a lock error;
-#' reusing one instance instead lets any number of `dbConnect(duckdb(dbdir = "my.db"))` calls share it.
+#' so opening a second instance of the same file would fail with a lock error.
+#' Reusing one instance instead lets any number of `dbConnect(duckdb(dbdir = "my.db"))` calls share it.
 #' An in-memory database (`:memory:`, the default) has no file to lock and is never cached:
 #' every `duckdb()` call creates a fresh, isolated instance.
 #'
-#' Because the instance is created once,
-#' `config`, `read_only`, `home`, and `shared_home` take effect only at creation;
-#' a call that reuses an existing instance ignores them.
+#' Because the instance is created once per database file,
+#' `config`, `read_only`, `home`, and `shared_home` take effect only at creation.
+#' A call that reuses an existing instance ignores them.
 #' To apply different values to a file-based database --
 #' for example to reopen it read-only, or to send extensions and secrets elsewhere --
 #' first release the instance with [duckdb_shutdown()], which also drops it from the cache,
 #' then create it again.
-#' [dbDisconnect()] only closes a connection;
-#' it does not release the instance (its `shutdown` argument is unused).
+#' [dbDisconnect()] only closes a connection,
+#' it does not release the instance, and its `shutdown` argument is unused.
 #' Instances are shut down automatically when the driver is garbage-collected or the session ends.
 #'
 #' @import methods DBI

--- a/R/Driver.R
+++ b/R/Driver.R
@@ -34,8 +34,8 @@ driver_registry <- new.env(parent = emptyenv())
 #'   (with an offer to create `~/.duckdb` in interactive sessions).
 #'   Pass a path to use it as the root explicitly, creating it if needed.
 #'   Cannot be combined with `shared_home`.
-#'   Like `config`, this takes effect only when a new database instance is
-#'   created; a call that reuses a cached driver for the same `dbdir` ignores it.
+#'   Applied only when the database instance is created; see the
+#'   \sQuote{Database instances and driver reuse} section.
 #' @param shared_home Opt in or out of the shared `~/.duckdb` location,
 #'   overriding the automatic resolution.
 #'   One of:
@@ -55,14 +55,37 @@ driver_registry <- new.env(parent = emptyenv())
 #'     already exists. Nothing persists beyond the session.
 #'
 #'   Cannot be combined with `home`.
-#'   Like `config`, this takes effect only when a new database instance is
-#'   created; a call that reuses a cached driver for the same `dbdir` ignores it.
+#'   Applied only when the database instance is created; see the
+#'   \sQuote{Database instances and driver reuse} section.
 #' @param environment_scan Set to `TRUE` to treat
 #'   data frames from the calling environment as tables.
 #'   If a database table with the same name exists, it takes precedence.
 #'   The default of this setting may change in a future version.
 #'
 #' @return `duckdb()` returns an object of class [duckdb_driver-class].
+#'
+#' @section Database instances and driver reuse:
+#'
+#' `duckdb()` returns a driver object that owns a DuckDB *database instance*.
+#' `dbConnect()` opens connections to that instance, and many connections can
+#' share one instance.
+#'
+#' For a file-based `dbdir`, the instance is cached, keyed by the (normalized)
+#' path: calling `duckdb()` again with the same `dbdir` returns the same driver
+#' and instance while it is still alive, so repeated
+#' `dbConnect(duckdb(dbdir = "my.db"))` share one instance rather than competing
+#' for the file. An in-memory database (`:memory:`, the default) is never cached:
+#' every `duckdb()` call creates a fresh, isolated instance.
+#'
+#' Because the instance is created once, `config`, `read_only`, `home`, and
+#' `shared_home` take effect only at creation; a call that reuses an existing
+#' instance ignores them (only `bigint` is updated). To apply different values
+#' to a file-based database -- for example to reopen it read-only, or to send
+#' extensions and secrets elsewhere -- first release the instance with
+#' [duckdb_shutdown()], which also drops it from the cache, then create it again.
+#' [dbDisconnect()] only closes a connection; it does not release the instance
+#' (its `shutdown` argument is unused). Instances are shut down automatically
+#' when the driver is garbage-collected or the session ends.
 #'
 #' @import methods DBI
 #' @export

--- a/R/Driver.R
+++ b/R/Driver.R
@@ -72,10 +72,12 @@ driver_registry <- new.env(parent = emptyenv())
 #'
 #' For a file-based `dbdir`, the instance is cached, keyed by the (normalized)
 #' path: calling `duckdb()` again with the same `dbdir` returns the same driver
-#' and instance while it is still alive, so repeated
-#' `dbConnect(duckdb(dbdir = "my.db"))` share one instance rather than competing
-#' for the file. An in-memory database (`:memory:`, the default) is never cached:
-#' every `duckdb()` call creates a fresh, isolated instance.
+#' and instance while it is still alive. This is deliberate. DuckDB allows only a
+#' single read-write handle to a database file at a time, so opening a second
+#' instance of the same file would fail with a lock error; reusing one instance
+#' instead lets any number of `dbConnect(duckdb(dbdir = "my.db"))` calls share
+#' it. An in-memory database (`:memory:`, the default) has no file to lock and is
+#' never cached: every `duckdb()` call creates a fresh, isolated instance.
 #'
 #' Because the instance is created once, `config`, `read_only`, `home`, and
 #' `shared_home` take effect only at creation; a call that reuses an existing

--- a/R/Driver.R
+++ b/R/Driver.R
@@ -67,27 +67,28 @@ driver_registry <- new.env(parent = emptyenv())
 #' @section Database instances and driver reuse:
 #'
 #' `duckdb()` returns a driver object that owns a DuckDB *database instance*.
-#' `dbConnect()` opens connections to that instance, and many connections can
-#' share one instance.
+#' `dbConnect()` opens connections to that instance,
+#' and many connections can share one instance.
 #'
-#' For a file-based `dbdir`, the instance is cached, keyed by the (normalized)
-#' path: calling `duckdb()` again with the same `dbdir` returns the same driver
-#' and instance while it is still alive. This is deliberate. DuckDB allows only a
-#' single read-write handle to a database file at a time, so opening a second
-#' instance of the same file would fail with a lock error; reusing one instance
-#' instead lets any number of `dbConnect(duckdb(dbdir = "my.db"))` calls share
-#' it. An in-memory database (`:memory:`, the default) has no file to lock and is
-#' never cached: every `duckdb()` call creates a fresh, isolated instance.
+#' For a file-based `dbdir`, the instance is cached, keyed by the (normalized) path:
+#' calling `duckdb()` again with the same `dbdir` returns the same driver and instance while it is still alive.
+#' This is deliberate.
+#' DuckDB allows only a single read-write handle to a database file at a time,
+#' so opening a second instance of the same file would fail with a lock error;
+#' reusing one instance instead lets any number of `dbConnect(duckdb(dbdir = "my.db"))` calls share it.
+#' An in-memory database (`:memory:`, the default) has no file to lock and is never cached:
+#' every `duckdb()` call creates a fresh, isolated instance.
 #'
-#' Because the instance is created once, `config`, `read_only`, `home`, and
-#' `shared_home` take effect only at creation; a call that reuses an existing
-#' instance ignores them (only `bigint` is updated). To apply different values
-#' to a file-based database -- for example to reopen it read-only, or to send
-#' extensions and secrets elsewhere -- first release the instance with
-#' [duckdb_shutdown()], which also drops it from the cache, then create it again.
-#' [dbDisconnect()] only closes a connection; it does not release the instance
-#' (its `shutdown` argument is unused). Instances are shut down automatically
-#' when the driver is garbage-collected or the session ends.
+#' Because the instance is created once,
+#' `config`, `read_only`, `home`, and `shared_home` take effect only at creation;
+#' a call that reuses an existing instance ignores them.
+#' To apply different values to a file-based database --
+#' for example to reopen it read-only, or to send extensions and secrets elsewhere --
+#' first release the instance with [duckdb_shutdown()], which also drops it from the cache,
+#' then create it again.
+#' [dbDisconnect()] only closes a connection;
+#' it does not release the instance (its `shutdown` argument is unused).
+#' Instances are shut down automatically when the driver is garbage-collected or the session ends.
 #'
 #' @import methods DBI
 #' @export

--- a/man/duckdb.Rd
+++ b/man/duckdb.Rd
@@ -70,8 +70,8 @@ an existing \verb{~/.duckdb}, else a per-session temporary directory
 (with an offer to create \verb{~/.duckdb} in interactive sessions).
 Pass a path to use it as the root explicitly, creating it if needed.
 Cannot be combined with \code{shared_home}.
-Like \code{config}, this takes effect only when a new database instance is
-created; a call that reuses a cached driver for the same \code{dbdir} ignores it.}
+Applied only when the database instance is created; see the
+\sQuote{Database instances and driver reuse} section.}
 
 \item{shared_home}{Opt in or out of the shared \verb{~/.duckdb} location,
 overriding the automatic resolution.
@@ -94,8 +94,8 @@ already exists. Nothing persists beyond the session.
 }
 
 Cannot be combined with \code{home}.
-Like \code{config}, this takes effect only when a new database instance is
-created; a call that reuses a cached driver for the same \code{dbdir} ignores it.}
+Applied only when the database instance is created; see the
+\sQuote{Database instances and driver reuse} section.}
 
 \item{environment_scan}{Set to \code{TRUE} to treat
 data frames from the calling environment as tables.
@@ -168,6 +168,31 @@ the underlying time representation to a human-readable format.
 If the timestamp is invalid in the target timezone, the resulting value may be \code{NA}
 or an adjusted time.
 }
+\section{Database instances and driver reuse}{
+
+
+\code{duckdb()} returns a driver object that owns a DuckDB \emph{database instance}.
+\code{dbConnect()} opens connections to that instance, and many connections can
+share one instance.
+
+For a file-based \code{dbdir}, the instance is cached, keyed by the (normalized)
+path: calling \code{duckdb()} again with the same \code{dbdir} returns the same driver
+and instance while it is still alive, so repeated
+\code{dbConnect(duckdb(dbdir = "my.db"))} share one instance rather than competing
+for the file. An in-memory database (\verb{:memory:}, the default) is never cached:
+every \code{duckdb()} call creates a fresh, isolated instance.
+
+Because the instance is created once, \code{config}, \code{read_only}, \code{home}, and
+\code{shared_home} take effect only at creation; a call that reuses an existing
+instance ignores them (only \code{bigint} is updated). To apply different values
+to a file-based database -- for example to reopen it read-only, or to send
+extensions and secrets elsewhere -- first release the instance with
+\code{\link[=duckdb_shutdown]{duckdb_shutdown()}}, which also drops it from the cache, then create it again.
+\code{\link[DBI:dbDisconnect]{dbDisconnect()}} only closes a connection; it does not release the instance
+(its \code{shutdown} argument is unused). Instances are shut down automatically
+when the driver is garbage-collected or the session ends.
+}
+
 \examples{
 \dontshow{if (simulate_duckdb()$env$examples_enabled() && requireNamespace("adbcdrivermanager", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 library(adbcdrivermanager)

--- a/man/duckdb.Rd
+++ b/man/duckdb.Rd
@@ -70,8 +70,8 @@ an existing \verb{~/.duckdb}, else a per-session temporary directory
 (with an offer to create \verb{~/.duckdb} in interactive sessions).
 Pass a path to use it as the root explicitly, creating it if needed.
 Cannot be combined with \code{shared_home}.
-Applied only when the database instance is created; see the
-\sQuote{Database instances and driver reuse} section.}
+Applied only when the database instance is created;
+see the \sQuote{Database instances and driver reuse} section.}
 
 \item{shared_home}{Opt in or out of the shared \verb{~/.duckdb} location,
 overriding the automatic resolution.
@@ -94,8 +94,8 @@ already exists. Nothing persists beyond the session.
 }
 
 Cannot be combined with \code{home}.
-Applied only when the database instance is created; see the
-\sQuote{Database instances and driver reuse} section.}
+Applied only when the database instance is created;
+see the \sQuote{Database instances and driver reuse} section.}
 
 \item{environment_scan}{Set to \code{TRUE} to treat
 data frames from the calling environment as tables.
@@ -176,23 +176,24 @@ or an adjusted time.
 and many connections can share one instance.
 
 For a file-based \code{dbdir}, the instance is cached, keyed by the (normalized) path:
-calling \code{duckdb()} again with the same \code{dbdir} returns the same driver and instance while it is still alive.
+calling \code{duckdb()} again with the same \code{dbdir} returns the same driver and instance
+while it is still alive.
 This is deliberate.
 DuckDB allows only a single read-write handle to a database file at a time,
-so opening a second instance of the same file would fail with a lock error;
-reusing one instance instead lets any number of \code{dbConnect(duckdb(dbdir = "my.db"))} calls share it.
+so opening a second instance of the same file would fail with a lock error.
+Reusing one instance instead lets any number of \code{dbConnect(duckdb(dbdir = "my.db"))} calls share it.
 An in-memory database (\verb{:memory:}, the default) has no file to lock and is never cached:
 every \code{duckdb()} call creates a fresh, isolated instance.
 
-Because the instance is created once,
-\code{config}, \code{read_only}, \code{home}, and \code{shared_home} take effect only at creation;
-a call that reuses an existing instance ignores them.
+Because the instance is created once per database file,
+\code{config}, \code{read_only}, \code{home}, and \code{shared_home} take effect only at creation.
+A call that reuses an existing instance ignores them.
 To apply different values to a file-based database --
 for example to reopen it read-only, or to send extensions and secrets elsewhere --
 first release the instance with \code{\link[=duckdb_shutdown]{duckdb_shutdown()}}, which also drops it from the cache,
 then create it again.
-\code{\link[DBI:dbDisconnect]{dbDisconnect()}} only closes a connection;
-it does not release the instance (its \code{shutdown} argument is unused).
+\code{\link[DBI:dbDisconnect]{dbDisconnect()}} only closes a connection,
+it does not release the instance, and its \code{shutdown} argument is unused.
 Instances are shut down automatically when the driver is garbage-collected or the session ends.
 }
 

--- a/man/duckdb.Rd
+++ b/man/duckdb.Rd
@@ -172,27 +172,28 @@ or an adjusted time.
 
 
 \code{duckdb()} returns a driver object that owns a DuckDB \emph{database instance}.
-\code{dbConnect()} opens connections to that instance, and many connections can
-share one instance.
+\code{dbConnect()} opens connections to that instance,
+and many connections can share one instance.
 
-For a file-based \code{dbdir}, the instance is cached, keyed by the (normalized)
-path: calling \code{duckdb()} again with the same \code{dbdir} returns the same driver
-and instance while it is still alive. This is deliberate. DuckDB allows only a
-single read-write handle to a database file at a time, so opening a second
-instance of the same file would fail with a lock error; reusing one instance
-instead lets any number of \code{dbConnect(duckdb(dbdir = "my.db"))} calls share
-it. An in-memory database (\verb{:memory:}, the default) has no file to lock and is
-never cached: every \code{duckdb()} call creates a fresh, isolated instance.
+For a file-based \code{dbdir}, the instance is cached, keyed by the (normalized) path:
+calling \code{duckdb()} again with the same \code{dbdir} returns the same driver and instance while it is still alive.
+This is deliberate.
+DuckDB allows only a single read-write handle to a database file at a time,
+so opening a second instance of the same file would fail with a lock error;
+reusing one instance instead lets any number of \code{dbConnect(duckdb(dbdir = "my.db"))} calls share it.
+An in-memory database (\verb{:memory:}, the default) has no file to lock and is never cached:
+every \code{duckdb()} call creates a fresh, isolated instance.
 
-Because the instance is created once, \code{config}, \code{read_only}, \code{home}, and
-\code{shared_home} take effect only at creation; a call that reuses an existing
-instance ignores them (only \code{bigint} is updated). To apply different values
-to a file-based database -- for example to reopen it read-only, or to send
-extensions and secrets elsewhere -- first release the instance with
-\code{\link[=duckdb_shutdown]{duckdb_shutdown()}}, which also drops it from the cache, then create it again.
-\code{\link[DBI:dbDisconnect]{dbDisconnect()}} only closes a connection; it does not release the instance
-(its \code{shutdown} argument is unused). Instances are shut down automatically
-when the driver is garbage-collected or the session ends.
+Because the instance is created once,
+\code{config}, \code{read_only}, \code{home}, and \code{shared_home} take effect only at creation;
+a call that reuses an existing instance ignores them.
+To apply different values to a file-based database --
+for example to reopen it read-only, or to send extensions and secrets elsewhere --
+first release the instance with \code{\link[=duckdb_shutdown]{duckdb_shutdown()}}, which also drops it from the cache,
+then create it again.
+\code{\link[DBI:dbDisconnect]{dbDisconnect()}} only closes a connection;
+it does not release the instance (its \code{shutdown} argument is unused).
+Instances are shut down automatically when the driver is garbage-collected or the session ends.
 }
 
 \examples{

--- a/man/duckdb.Rd
+++ b/man/duckdb.Rd
@@ -69,7 +69,9 @@ Subsequent connections will silently ignore these flags.}
 an existing \verb{~/.duckdb}, else a per-session temporary directory
 (with an offer to create \verb{~/.duckdb} in interactive sessions).
 Pass a path to use it as the root explicitly, creating it if needed.
-Cannot be combined with \code{shared_home}.}
+Cannot be combined with \code{shared_home}.
+Like \code{config}, this takes effect only when a new database instance is
+created; a call that reuses a cached driver for the same \code{dbdir} ignores it.}
 
 \item{shared_home}{Opt in or out of the shared \verb{~/.duckdb} location,
 overriding the automatic resolution.
@@ -91,7 +93,9 @@ Applying this setting repeatedly is a fast no-op.
 already exists. Nothing persists beyond the session.
 }
 
-Cannot be combined with \code{home}.}
+Cannot be combined with \code{home}.
+Like \code{config}, this takes effect only when a new database instance is
+created; a call that reuses a cached driver for the same \code{dbdir} ignores it.}
 
 \item{environment_scan}{Set to \code{TRUE} to treat
 data frames from the calling environment as tables.

--- a/man/duckdb.Rd
+++ b/man/duckdb.Rd
@@ -177,10 +177,12 @@ share one instance.
 
 For a file-based \code{dbdir}, the instance is cached, keyed by the (normalized)
 path: calling \code{duckdb()} again with the same \code{dbdir} returns the same driver
-and instance while it is still alive, so repeated
-\code{dbConnect(duckdb(dbdir = "my.db"))} share one instance rather than competing
-for the file. An in-memory database (\verb{:memory:}, the default) is never cached:
-every \code{duckdb()} call creates a fresh, isolated instance.
+and instance while it is still alive. This is deliberate. DuckDB allows only a
+single read-write handle to a database file at a time, so opening a second
+instance of the same file would fail with a lock error; reusing one instance
+instead lets any number of \code{dbConnect(duckdb(dbdir = "my.db"))} calls share
+it. An in-memory database (\verb{:memory:}, the default) has no file to lock and is
+never cached: every \code{duckdb()} call creates a fresh, isolated instance.
 
 Because the instance is created once, \code{config}, \code{read_only}, \code{home}, and
 \code{shared_home} take effect only at creation; a call that reuses an existing


### PR DESCRIPTION
## Background

`duckdb()` caches the driver/database instance for a given on-disk `dbdir` and **reuses** it on later calls with the same path (via the driver registry), returning early. On that reuse path it silently ignores `config`, `read_only`, and — since #2396 — `home`/`shared_home`. This contract was only stated obliquely on the `config`/`read_only` params, and not at all for `home`/`shared_home`; the caching mechanism itself was undocumented.

Verified against the v1.5.5 engine:

```r
drv  <- duckdb(dbdir = "x.db")                     # extensions -> tempdir, driver cached
drv2 <- duckdb(dbdir = "x.db", shared_home = TRUE) # identical(drv, drv2); shared_home ignored
```

## Change

Doc-only.

- Add a **"Database instances and driver reuse"** section to `?duckdb` that describes the model in one place: a driver owns a database instance; connections share it; a file-based `dbdir` is cached and reused (keyed by path) while `:memory:` always creates a fresh, isolated instance; `config`/`read_only`/`home`/`shared_home` apply only at creation and are ignored on reuse; use `duckdb_shutdown()` to release the instance and rebuild it; `dbDisconnect()` does not release the instance (its `shutdown` argument is unused); instances are shut down automatically on GC / session end.
- The `home` and `shared_home` `@param` entries now point to that section instead of repeating the caveat.

`man/duckdb.Rd` regenerated. No behaviour change.

## Why doc-only (not a warning)

Silently ignoring config on reuse is the intended, established contract; a warning for `home`/`shared_home` alone would be inconsistent with `config`/`read_only` and would spam callers that legitimately reuse a driver. Documenting the model — including how to *force* a new instance when you do need different settings — is the right fit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeGe5ctVS9WFJdPmeGcjzf