### PR TITLE
docs: derive non-interactive message cap from `STORAGE_MESSAGE_MAX`, lower to 60

### DIFF
--- a/R/storage-home.R
+++ b/R/storage-home.R
@@ -271,7 +271,7 @@ inform_once_every <- function(id, seconds, message) {
 # time-based throttle used interactively) so that a long-running or automated
 # process -- which the time throttle would remind forever, once every interval
 # -- eventually stops being told.
-STORAGE_MESSAGE_MAX <- 100L
+STORAGE_MESSAGE_MAX <- 60L
 
 # Emit `message` up to `max` times per session (keyed by `id`), then stay
 # silent. The final allowed emission notes that it will not be shown again.

--- a/R/storage.R
+++ b/R/storage.R
@@ -120,7 +120,7 @@
 #'     an informational message describing where extensions and secrets are
 #'     going and how to change it. It is throttled by session type: in an
 #'     **interactive** session at most once every eight hours (a human can act
-#'     on it); in a **non-interactive** session up to 100 times, after which it
+#'     on it); in a **non-interactive** session up to `r duckdb:::STORAGE_MESSAGE_MAX` times, after which it
 #'     goes silent for good, so a long-running or automated process is not
 #'     reminded forever. The message is suppressed entirely when you chose the
 #'     location yourself -- the `home` or `shared_home` argument, the

--- a/man/duckdb_storage.Rd
+++ b/man/duckdb_storage.Rd
@@ -117,7 +117,7 @@ and takes precedence over the resolution above.
 an informational message describing where extensions and secrets are
 going and how to change it. It is throttled by session type: in an
 \strong{interactive} session at most once every eight hours (a human can act
-on it); in a \strong{non-interactive} session up to 100 times, after which it
+on it); in a \strong{non-interactive} session up to 60 times, after which it
 goes silent for good, so a long-running or automated process is not
 reminded forever. The message is suppressed entirely when you chose the
 location yourself -- the \code{home} or \code{shared_home} argument, the


### PR DESCRIPTION
## Change

Doc-only, plus a constant tweak.

- In `?duckdb_storage`, the non-interactive storage-location message cap is no longer hardcoded as "100 times". It now uses inline R (`` `r duckdb:::STORAGE_MESSAGE_MAX` ``) so the documentation stays in sync with the constant automatically.
- Lower `STORAGE_MESSAGE_MAX` from `100L` to `60L`.

`man/duckdb_storage.Rd` regenerated (now reads "up to 60 times").

The test in `tests/testthat/test-storage-home.R` already references `STORAGE_MESSAGE_MAX` symbolically, so no test change is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FLKnFc41KX9h2x7WiX8q1S)_