### PR TITLE
test: Skip DBItest timestamp roundtrip tests when `PST8PDT` is unresolvable

### DIFF
--- a/tests/testthat/test-DBItest.R
+++ b/tests/testthat/test-DBItest.R
@@ -203,6 +203,16 @@ if (rlang::is_installed("DBItest")) DBItest::test_all(c(
   "arrow_write_table_arrow_roundtrip_timestamp_extended", # precision
   "arrow_append_table_arrow_roundtrip_timestamp_extended", # precision
 
+  # DBItest >= 1.8.3 uses lubridate::with_tz(tzone = "PST8PDT"), which warns
+  # with "Unrecognized time zone" on systems whose tz database lacks that zone
+  # (e.g. without tzdata-legacy). Skip only when the zone cannot be resolved.
+  if (!"PST8PDT" %in% OlsonNames()) c(
+    "append_roundtrip_timestamp",
+    "append_roundtrip_timestamp_extended",
+    "arrow_append_table_arrow_roundtrip_timestamp",
+    NULL
+  ),
+
   # https://github.com/duckdb/duckdb/pull/15125
   "data_date_current_typed",
   "data_time_current",


### PR DESCRIPTION
## Problem

CI on `main` fails the "Smoke test: stock R" job with `[ FAIL 3 | WARN 9 | SKIP 61 | PASS 5590 ]`. All three failures share one cause:

```
── Failure: DBItest[duckdb]: SQL: append_roundtrip_timestamp ──
Expected `eval(test_fun_expr)` not to throw any warnings.
Actually got a <simpleWarning> with message:
  Unrecognized time zone 'PST8PDT'
  lubridate::with_tz(local, tzone = "PST8PDT")
```

Two recent `main` commits combined to trigger this:

- `fc6cdf5` bumped DBItest 1.8.1 → 1.8.3, whose timestamp roundtrip specs now call `lubridate::with_tz(tzone = "PST8PDT")`.
- `d176f02` switched CI to Ubuntu 26.04, whose tz database no longer ships the legacy `PST8PDT` zone (it moved to the `tzdata-legacy` package).

lubridate emits an "Unrecognized time zone" warning, which testthat promotes to a failure.

## Change

Skip the three affected tests **only when** `"PST8PDT"` is not in `OlsonNames()`, so they continue to run wherever the zone resolves:

- `append_roundtrip_timestamp`
- `append_roundtrip_timestamp_extended`
- `arrow_append_table_arrow_roundtrip_timestamp`

The companion PR #2409 installs `tzdata-legacy` in CI so the zone resolves there; with that in place this guard becomes a no-op and the tests run normally on the runners too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)