### PR TITLE
ci: Install `tzdata-legacy` for legacy time zones like `PST8PDT`

### DIFF
--- a/.github/workflows/custom/before-install/action.yml
+++ b/.github/workflows/custom/before-install/action.yml
@@ -26,6 +26,18 @@ runs:
         echo '_R_CHECK_PKG_SIZES_=FALSE' | tee -a $GITHUB_ENV
       shell: bash
 
+    # Ubuntu 26.04 moved the legacy System V-style time zones (e.g. PST8PDT)
+    # into a separate tzdata-legacy package. Some DBItest specs call
+    # lubridate::with_tz(tzone = "PST8PDT"), which warns "Unrecognized time
+    # zone" when the zone is missing; testthat then promotes that warning to a
+    # failure. Install tzdata-legacy so the zone resolves and the tests run.
+    - name: Install tzdata-legacy (legacy time zones like PST8PDT)
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata-legacy
+      shell: bash
+
     # The duckdb tests and runnable examples exercise the bundled C++ engine and
     # are gated behind DUCKDB_R_RUN_TESTS so they never run on CRAN (see
     # tests/testthat.R and R/cran-guard.R). The guard enables them automatically


### PR DESCRIPTION
## Problem

CI on `main` fails the "Smoke test: stock R" job with three DBItest failures, all caused by:

```
Actually got a <simpleWarning> with message:
  Unrecognized time zone 'PST8PDT'
  lubridate::with_tz(local, tzone = "PST8PDT")
```

DBItest >= 1.8.3 (`fc6cdf5`) timestamp roundtrip specs call `lubridate::with_tz(tzone = "PST8PDT")`. Ubuntu 26.04 — the new CI runner (`d176f02`) — moved the legacy System V-style zones (`PST8PDT`, etc.) into a separate `tzdata-legacy` package, so the zone no longer resolves and lubridate warns; testthat then promotes the warning to a failure.

## Change

Install `tzdata-legacy` on Linux runners in the shared `custom/before-install` composite action (used by the smoke, full-matrix, and suggests jobs). With the legacy zones present, `PST8PDT` resolves and the affected DBItest specs run in CI instead of being skipped.

This is the "make the environment complete" counterpart to #2408, which skips those specs only when the zone is unresolvable. With this PR in place, the zone resolves in CI, so #2408's guard becomes a no-op there and the tests execute normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0183T8JDoE6jVX1GXpko3qwA)_