### PR TITLE
fix: Check the right-hand argument against the right-hand type in `BinaryTypeAssert()`

### DIFF
--- a/src/include/rfuns_extension.hpp
+++ b/src/include/rfuns_extension.hpp
@@ -44,7 +44,7 @@ BinaryChunk BinaryTypeAssert(DataChunk &args) {
 	D_ASSERT(lefts.GetType() == LHS_LOGICAL_TYPE);
 
 	auto &rights = args.data[1];
-	D_ASSERT(rights.GetType() == LHS_LOGICAL_TYPE);
+	D_ASSERT(rights.GetType() == RHS_LOGICAL_TYPE);
 
 	return {lefts, rights};
 }

--- a/tests/testthat/test-rfuns-mixed-types.R
+++ b/tests/testthat/test-rfuns-mixed-types.R
@@ -1,0 +1,25 @@
+test_that("mixed-type overloads of r_base functions work", {
+  drv <- duckdb()
+  con <- dbConnect(drv)
+  on.exit(dbDisconnect(con, shutdown = TRUE))
+
+  rapi_load_rfuns(drv@database_ref)
+
+  # These exercise the (INTEGER, DOUBLE) and (DOUBLE, INTEGER) overloads,
+  # whose argument types are verified by BinaryTypeAssert() in builds with
+  # assertions enabled.
+  res <- dbGetQuery(
+    con,
+    'SELECT
+       "r_base::+"(1::INTEGER, 2.5) AS add_id,
+       "r_base::+"(2.5, 1::INTEGER) AS add_di,
+       "r_base::<"(1::INTEGER, 2.5) AS lt_id,
+       "r_base::>="(2.5, 3::INTEGER) AS ge_di,
+       "r_base::=="(TRUE, 1::INTEGER) AS eq_bi'
+  )
+  expect_identical(res$add_id, 3.5)
+  expect_identical(res$add_di, 3.5)
+  expect_identical(res$lt_id, TRUE)
+  expect_identical(res$ge_di, FALSE)
+  expect_identical(res$eq_bi, TRUE)
+})


### PR DESCRIPTION
Sixth bug-fix PR from the C API review (`plan/REVIEW-duckdb-c-api.md` on `claude/duckdb-api-c-review-8xuu2i`).

## Bug

`BinaryTypeAssert()` in `src/include/rfuns_extension.hpp` verifies *both* arguments against the left-hand type:

```cpp
auto &lefts = args.data[0];
D_ASSERT(lefts.GetType() == LHS_LOGICAL_TYPE);

auto &rights = args.data[1];
D_ASSERT(rights.GetType() == LHS_LOGICAL_TYPE);   // should be RHS_LOGICAL_TYPE
```

In builds with assertions enabled (`DEBUG` or `-DDUCKDB_FORCE_ASSERT`), every mixed-type overload of the `r_base` scalar functions fails the assertion and aborts the query — that's 2 of the 4 `r_base::+` overloads and 10 of the 12 real overloads of each of the six comparison-operator sets. Verified against an assert-enabled build:

```
SELECT "r_base::+"(1::INTEGER, 2::INTEGER)  ->  3
SELECT "r_base::+"(1::INTEGER, 2.5)         ->  Error: Assertion triggered in file
    "include/rfuns_extension.hpp" on line 47: rights.GetType() == LHS_LOGICAL_TYPE
```

Release builds compile `D_ASSERT` away, which is why this never surfaced — but it makes assert-enabled builds (the configuration you'd reach for when debugging the glue) unusable with rfuns.

## Fix

Check `rights` against `RHS_LOGICAL_TYPE`. With the fix, the same assert-enabled build handles all mixed overloads correctly:

```
SELECT "r_base::+"(1::INTEGER, 2.5)   ->  3.5
SELECT "r_base::<"(1::INTEGER, 2.5)   ->  TRUE
SELECT "r_base::=="(TRUE, 1::INTEGER) ->  TRUE
```

The new test file adds runtime coverage for the mixed-type overloads (previously entirely untested), which exercises the corrected assertion in any future assert-enabled CI configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SPeDpq2naG8gVAQFmEVwE3

---
_Generated by [Claude Code](https://claude.ai/code/session_01SPeDpq2naG8gVAQFmEVwE3)_