### PR TITLE
feat: defer the storage-location message from duckdb() to the first INSTALL

### DIFF
--- a/R/Connection.R
+++ b/R/Connection.R
@@ -2,6 +2,12 @@
 #'
 #' Implements [DBIDriver-class].
 #'
+#' The driver object additionally carries an experimental `allow_extensions`
+#' slot `r lifecycle::badge("experimental")`: whether this driver permits
+#' loading DuckDB extensions (`INSTALL` / `LOAD`), resolved once when the driver
+#' is created.
+#' See the `allow_extensions` argument of [duckdb()].
+#'
 #' @aliases duckdb_driver
 #' @keywords internal
 #' @export
@@ -11,7 +17,8 @@ setClass("duckdb_driver", contains = "DBIDriver", slots = list(
   dbdir = "character",
   read_only = "logical",
   convert_opts = "list",
-  bigint = "character"
+  bigint = "character",
+  allow_extensions = "logical"
 ))
 
 #' DuckDB connection class

--- a/R/Driver.R
+++ b/R/Driver.R
@@ -57,6 +57,23 @@ driver_registry <- new.env(parent = emptyenv())
 #'   Cannot be combined with `home`.
 #'   Applied only when the database instance is created;
 #'   see the \sQuote{Database instances and driver reuse} section.
+#' @param allow_extensions `r lifecycle::badge("experimental")`
+#'   Whether this driver may load DuckDB extensions (`INSTALL` / `LOAD`).
+#'   One of:
+#'   * `NULL` (the default) -- decide automatically.
+#'     Extensions are enabled,
+#'     except on an affected Linux build (one not compiled with `libstdc++`),
+#'     where they are disabled and a throttled advisory message is shown.
+#'     See the \sQuote{DuckDB extensions on Linux} section.
+#'   * `TRUE` -- force-enable extensions,
+#'     attempting to load them even on an affected build (which may crash R).
+#'     No message.
+#'   * `FALSE` -- disable extensions and silence the advisory message.
+#'
+#'   The argument takes precedence over the `duckdb.allow_extensions` option (a scalar logical)
+#'   and the `DUCKDB_R_ALLOW_EXTENSIONS` environment variable (any non-empty value enables extensions).
+#'   Applied only when the database instance is created;
+#'   see the \sQuote{Database instances and driver reuse} section.
 #' @param environment_scan Set to `TRUE` to treat
 #'   data frames from the calling environment as tables.
 #'   If a database table with the same name exists, it takes precedence.
@@ -91,6 +108,32 @@ driver_registry <- new.env(parent = emptyenv())
 #' it does not release the instance, and its `shutdown` argument is unused.
 #' Instances are shut down automatically when the driver is garbage-collected or the session ends.
 #'
+#' @section DuckDB extensions on Linux:
+#'
+#' DuckDB's prebuilt extensions for Linux are compiled with the GNU C++ standard library (`libstdc++`).
+#' Loading one into a `duckdb` package that was itself built with a *different* C++ standard library --
+#' most commonly `libc++` (clang's `-stdlib=libc++`) --
+#' is an ABI mismatch that crashes R (\url{https://github.com/duckdb/duckdb-r/issues/1107}).
+#' Almost all Linux builds (CRAN binaries and most source installs) use `libstdc++` and are unaffected;
+#' macOS and Windows are unaffected.
+#'
+#' Each `duckdb()` call decides whether the driver it returns may load extensions,
+#' via the `allow_extensions` argument
+#' (defaulting to the `duckdb.allow_extensions` option,
+#' then the `DUCKDB_R_ALLOW_EXTENSIONS` environment variable,
+#' then automatic detection).
+#' On the automatic path a build that was not compiled with `libstdc++` on Linux disables extensions:
+#' `INSTALL` / `LOAD` raise a clear error instead of crashing,
+#' automatic extension install/load is turned off,
+#' and a throttled advisory message is shown at `duckdb()` time
+#' (it is no longer shown when the package is attached).
+#' Pass `allow_extensions = FALSE` to disable extensions and silence that message,
+#' or `allow_extensions = TRUE` to attempt loading anyway --
+#' for example to test whether it works on a particular build (which may still crash R).
+#'
+#' The decision is carried on the returned driver as the experimental `allow_extensions` slot
+#' (see [duckdb_driver-class]).
+#'
 #' @import methods DBI
 #' @export
 duckdb <- function(
@@ -101,6 +144,7 @@ duckdb <- function(
   ...,
   home = NULL,
   shared_home = NULL,
+  allow_extensions = NULL,
   environment_scan = FALSE
 ) {
   check_flag(read_only)
@@ -133,6 +177,15 @@ duckdb <- function(
     }
   }
 
+  # Decide once, past the driver-cache reuse above, whether this driver may load
+  # DuckDB extensions (argument > `duckdb.allow_extensions` option >
+  # `DUCKDB_R_ALLOW_EXTENSIONS` env var > auto). The resolved flag is plumbed
+  # into the engine via rapi_startup() and exposed as the driver's
+  # `allow_extensions` slot; on the auto path it also drives the advisory message
+  # below. Placed here so an argument a reused driver would ignore does not take
+  # effect.
+  ax <- resolve_allow_extensions(allow_extensions)
+
   # Choose CRAN-safe locations for the engine's writable state unless the user
   # set them explicitly. Extensions and secrets share a "home" directory
   # resolved fresh on every call (an existing ~/.duckdb, else a temporary
@@ -150,13 +203,13 @@ duckdb <- function(
     }
     resolved_home <- resolve_storage_home(home, shared_home)
     if (need_extension) {
-      config["extension_directory"] <- home_subdir(
+      config[["extension_directory"]] <- home_subdir(
         resolved_home$root,
         "extensions"
       )
     }
     if (need_secret) {
-      config["secret_directory"] <- home_subdir(
+      config[["secret_directory"]] <- home_subdir(
         resolved_home$root,
         "stored_secrets"
       )
@@ -182,8 +235,31 @@ duckdb <- function(
   if (!("temp_directory" %in% names(config))) {
     temp_directory <- resolve_temp_directory(dbdir)$directory
     if (!is.null(temp_directory)) {
-      config["temp_directory"] <- temp_directory
+      config[["temp_directory"]] <- temp_directory
     }
+  }
+
+  # When extensions are disallowed for this driver, also turn off automatic
+  # extension install/load so a query cannot implicitly pull in a prebuilt
+  # (libstdc++) extension and crash R (duckdb/duckdb-r#1107). Automatic loading
+  # is a separate engine mechanism the C++ INSTALL/LOAD guard does not
+  # intercept, so it must be disabled here. Explicit INSTALL/LOAD is refused in
+  # the engine glue (see rapi_prepare()). An explicit user setting wins.
+  if (!ax$allow) {
+    if (!("autoinstall_known_extensions" %in% names(config))) {
+      config[["autoinstall_known_extensions"]] <- "FALSE"
+    }
+    if (!("autoload_known_extensions" %in% names(config))) {
+      config[["autoload_known_extensions"]] <- "FALSE"
+    }
+  }
+
+  # Announce the disabled state, but only on the auto path (NULL argument and no
+  # option/env override) where extensions came out disabled -- an explicit
+  # argument/option/env silences it. Throttled like the storage message, and
+  # independent of the storage announce above.
+  if (ax$announce) {
+    maybe_extensions_message()
   }
 
   # Always create new database for in-memory,
@@ -195,12 +271,14 @@ duckdb <- function(
       dbdir,
       read_only,
       config,
-      environment_scan
+      environment_scan,
+      ax$allow
     ),
     dbdir = dbdir,
     read_only = read_only,
     convert_opts = convert_opts,
-    bigint = convert_opts$bigint
+    bigint = convert_opts$bigint,
+    allow_extensions = ax$allow
   )
 
   if (dbdir != DBDIR_MEMORY) {

--- a/R/Driver.R
+++ b/R/Driver.R
@@ -229,7 +229,11 @@ duckdb <- function(
       (identical(resolved_home$source, "session") ||
         (!is_interactive() && identical(resolved_home$source, "shared")))
     if (announce) {
-      maybe_storage_location_message(resolved_home)
+      # Defer the storage-location message: it only matters once the user
+      # actually installs an extension. Stash the resolved home and let the
+      # first INSTALL statement emit it (see flush_pending_storage_message(),
+      # called from dbSendQuery()).
+      set_pending_storage_message(resolved_home)
     }
   }
   if (!("temp_directory" %in% names(config))) {

--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -12,8 +12,8 @@ rapi_connection_valid <- function(conn) {
   .Call(`_duckdb_rapi_connection_valid`, conn)
 }
 
-rapi_startup <- function(dbdir, readonly, configsexp, environment_scan) {
-  .Call(`_duckdb_rapi_startup`, dbdir, readonly, configsexp, environment_scan)
+rapi_startup <- function(dbdir, readonly, configsexp, environment_scan, allow_extensions) {
+  .Call(`_duckdb_rapi_startup`, dbdir, readonly, configsexp, environment_scan, allow_extensions)
 }
 
 rapi_lock <- function(dual) {
@@ -242,6 +242,10 @@ rapi_execute <- function(stmt, convert_opts) {
 
 rapi_adbc_init_func <- function() {
   .Call(`_duckdb_rapi_adbc_init_func`)
+}
+
+rapi_cxx_stdlib <- function() {
+  .Call(`_duckdb_rapi_cxx_stdlib`)
 }
 
 rapi_ptr_to_str <- function(extptr) {

--- a/R/dbSendQuery__duckdb_connection_character.R
+++ b/R/dbSendQuery__duckdb_connection_character.R
@@ -15,8 +15,9 @@ dbSendQuery__duckdb_connection_character <- function(conn, statement, params = N
 
   # The storage-location message is deferred from duckdb() until an extension is
   # actually installed (the only time the extension cache location matters). This
-  # is that moment: emit it now for an INSTALL statement.
-  if (identical(stmt_lst$type, "LOAD") && is_install_statement(statement)) {
+  # is that moment: emit it now for an INSTALL statement. `is_install` is detected
+  # in the engine glue from the parsed LoadInfo (see rapi_prepare()).
+  if (isTRUE(stmt_lst$is_install)) {
     flush_pending_storage_message()
   }
 

--- a/R/dbSendQuery__duckdb_connection_character.R
+++ b/R/dbSendQuery__duckdb_connection_character.R
@@ -13,6 +13,13 @@ dbSendQuery__duckdb_connection_character <- function(conn, statement, params = N
   statement <- enc2utf8(statement)
   stmt_lst <- rethrow_rapi_prepare(conn@conn_ref, statement, env)
 
+  # The storage-location message is deferred from duckdb() until an extension is
+  # actually installed (the only time the extension cache location matters). This
+  # is that moment: emit it now for an INSTALL statement.
+  if (identical(stmt_lst$type, "LOAD") && is_install_statement(statement)) {
+    flush_pending_storage_message()
+  }
+
   res <- duckdb_result(
     connection = conn,
     stmt_lst = stmt_lst,

--- a/R/duckdb.R
+++ b/R/duckdb.R
@@ -1,5 +1,10 @@
 # Internal error function for C++ layer
 rapi_error <- function(context, message, error_type = NULL, raw_message = NULL, extra_info = NULL) {
+  # The extension INSTALL/LOAD guard throws with context "load_extension" and an
+  # empty message; the text is centralized in R (extensions_disabled_error()).
+  if (identical(context, "load_extension") && !any(nzchar(message))) {
+    message <- paste(extensions_disabled_error(), collapse = " ")
+  }
   if (is.null(error_type) && is.null(raw_message) && is.null(extra_info)) {
     extra_text <- ""
   } else {
@@ -16,6 +21,12 @@ rapi_error <- function(context, message, error_type = NULL, raw_message = NULL, 
 
 # rlang error function (will be conditionally replaced in .onLoad)
 rapi_error_rlang <- function(context, message, error_type = NULL, raw_message = NULL, extra_info = NULL) {
+  # The extension INSTALL/LOAD guard throws with context "load_extension" and an
+  # empty message; the text is centralized in R (extensions_disabled_error()).
+  if (identical(context, "load_extension") && !any(nzchar(message))) {
+    message <- extensions_disabled_error()
+  }
+
   # Avoid initializing NULL fields
   fields <- list()
   fields$context <- context

--- a/R/extensions.R
+++ b/R/extensions.R
@@ -40,6 +40,114 @@ is_windows <- function() {
   .Platform$OS.type == "windows"
 }
 
+# Platform seam, mockable in tests. Distinguishes Linux from other unix (e.g.
+# macOS): the libc++ extension incompatibility below is Linux-specific.
+is_linux <- function() {
+  Sys.info()[["sysname"]] == "Linux"
+}
+
+# The C++ standard library this build of duckdb was compiled against ("libc++",
+# "libstdc++", or "<an unknown C++ library>"), read from a compile-time macro
+# (see `rapi_cxx_stdlib()` in src/utils.cpp). Wrapped for mockability.
+compiled_cxx_stdlib <- function() {
+  rapi_cxx_stdlib()
+}
+
+# TRUE when this build can safely load DuckDB's prebuilt extensions. Those are
+# libstdc++ builds on Linux; loading one into a package built with a different
+# C++ standard library (libc++, or one we cannot identify) is ABI-incompatible
+# and crashes R (duckdb/duckdb-r#1107). So a Linux build is supported only when
+# positively compiled against libstdc++; every non-Linux build is supported
+# (macOS is libc++, but its prebuilt extensions match). This is the detector
+# behind the auto path of resolve_allow_extensions(): on an unsupported build
+# extensions default to disabled -- the engine glue errors on INSTALL/LOAD, and
+# automatic extension install/load is turned off at connect. Conservative for
+# the (Linux-unreachable in practice) unidentified stdlib; duckdb(allow_extensions
+# = TRUE) lets a user force-enable to test.
+extensions_supported <- function() {
+  !is_linux() || identical(compiled_cxx_stdlib(), "libstdc++")
+}
+
+# Decide, for a single duckdb() call, whether this driver may load DuckDB
+# extensions. Returns list(allow, source, announce). First match wins:
+#
+#   1. the `allow_extensions` argument (if non-NULL)   -> source "argument"
+#   2. the `duckdb.allow_extensions` option            -> source "option"
+#   3. the `DUCKDB_R_ALLOW_EXTENSIONS` environment var  -> source "env"
+#   4. otherwise: auto -- allow when this is a supported build (see
+#      extensions_supported())                          -> source "auto"
+#
+# `announce` is TRUE only on the auto path when the build is affected (so
+# extensions came out disabled). Any explicit argument/option/env silences the
+# advisory message. The option must be a scalar logical, else it warns and
+# resets to NULL, mirroring the `duckdb.home` option handling.
+resolve_allow_extensions <- function(allow_extensions) {
+  if (!is.null(allow_extensions)) {
+    check_flag(allow_extensions)
+    return(list(allow = allow_extensions, source = "argument", announce = FALSE))
+  }
+  opt <- getOption("duckdb.allow_extensions")
+  if (!is.null(opt)) {
+    if (is.logical(opt) && length(opt) == 1L && !is.na(opt)) {
+      return(list(allow = opt, source = "option", announce = FALSE))
+    }
+    warning("`duckdb.allow_extensions` option must be TRUE, FALSE, or NULL.", call. = FALSE)
+    options(duckdb.allow_extensions = NULL)
+  }
+  if (nzchar(Sys.getenv("DUCKDB_R_ALLOW_EXTENSIONS", unset = ""))) {
+    return(list(allow = TRUE, source = "env", announce = FALSE))
+  }
+  allow <- extensions_supported()
+  list(allow = allow, source = "auto", announce = !allow)
+}
+
+# The advisory lines shown when extensions are disabled automatically on an
+# affected build (Linux, not libstdc++). rlang-style character vector, names
+# "*"/"i" for bullets, like the storage-location message.
+extensions_disabled_message <- function() {
+  c(
+    paste0("duckdb was built with ", compiled_cxx_stdlib(), " (not libstdc++) on Linux, so DuckDB extensions are disabled:"),
+    "*" = "Loading a prebuilt (libstdc++) extension would crash R (https://github.com/duckdb/duckdb-r/issues/1107).",
+    "*" = "INSTALL/LOAD of an extension will error, and automatic extension loading is off.",
+    "i" = "Pass duckdb(allow_extensions = FALSE) to accept this and silence this message.",
+    "i" = "Pass duckdb(allow_extensions = TRUE) to attempt loading anyway (may crash R).",
+    "i" = "See ?duckdb for details."
+  )
+}
+
+# Message for the INSTALL/LOAD guard (CheckExtensionLoadAllowed() in
+# src/statement.cpp). The C++ guard throws with context "load_extension" and an
+# empty message; rapi_error()/rapi_error_rlang() fill it in from here, so the
+# guard's text lives only in R -- never duplicated in the C++ glue. Kept neutral
+# about the cause (unlike the duckdb() advisory, which names the stdlib): the
+# guard fires both on the auto-disable path (an affected non-libstdc++ Linux
+# build) and whenever the driver was created with duckdb(allow_extensions = FALSE),
+# which can happen on any platform.
+extensions_disabled_error <- function() {
+  c(
+    "DuckDB extension loading (INSTALL / LOAD) is disabled for this driver.",
+    "i" = paste0(
+      "Recreate the driver with duckdb(allow_extensions = TRUE) to enable it ",
+      "(this may crash R on a Linux build not compiled with libstdc++; ",
+      "see https://github.com/duckdb/duckdb-r/issues/1107)."
+    ),
+    "i" = "See ?duckdb for details."
+  )
+}
+
+# Emit the extensions-disabled advisory, throttled like the storage-location
+# message: interactively at most once every 8 hours, non-interactively a bounded
+# number of times before going silent. Called from duckdb() only on the auto
+# path when extensions came out disabled.
+maybe_extensions_message <- function() {
+  message <- extensions_disabled_message()
+  if (is_interactive()) {
+    inform_once_every("extensions", STORAGE_MESSAGE_INTERVAL, message)
+  } else {
+    inform_up_to("extensions", STORAGE_MESSAGE_MAX, message)
+  }
+}
+
 cleanup_user_directory <- function() {
   user_directory <- default_user_directory()
   if (!dir.exists(user_directory)) {

--- a/R/extensions.R
+++ b/R/extensions.R
@@ -148,6 +148,13 @@ maybe_extensions_message <- function() {
   }
 }
 
+# TRUE if `sql` is an extension INSTALL statement (`INSTALL` or `FORCE INSTALL`).
+# Paired with the parser-derived statement type ("LOAD") in dbSendQuery() to
+# decide when to emit the deferred storage-location message.
+is_install_statement <- function(sql) {
+  grepl("^\\s*(force\\s+)?install\\b", sql, ignore.case = TRUE)
+}
+
 cleanup_user_directory <- function() {
   user_directory <- default_user_directory()
   if (!dir.exists(user_directory)) {

--- a/R/extensions.R
+++ b/R/extensions.R
@@ -148,13 +148,6 @@ maybe_extensions_message <- function() {
   }
 }
 
-# TRUE if `sql` is an extension INSTALL statement (`INSTALL` or `FORCE INSTALL`).
-# Paired with the parser-derived statement type ("LOAD") in dbSendQuery() to
-# decide when to emit the deferred storage-location message.
-is_install_statement <- function(sql) {
-  grepl("^\\s*(force\\s+)?install\\b", sql, ignore.case = TRUE)
-}
-
 cleanup_user_directory <- function() {
   user_directory <- default_user_directory()
   if (!dir.exists(user_directory)) {

--- a/R/rethrow-gen.R
+++ b/R/rethrow-gen.R
@@ -27,9 +27,9 @@ rethrow_rapi_connection_valid <- function(conn, call = parent.frame(2)) {
   )
 }
 
-rethrow_rapi_startup <- function(dbdir, readonly, configsexp, environment_scan, call = parent.frame(2)) {
+rethrow_rapi_startup <- function(dbdir, readonly, configsexp, environment_scan, allow_extensions, call = parent.frame(2)) {
   rlang::try_fetch(
-    rapi_startup(dbdir, readonly, configsexp, environment_scan),
+    rapi_startup(dbdir, readonly, configsexp, environment_scan, allow_extensions),
     error = function(e) {
       rethrow_error_from_rapi(e, call)
     }
@@ -549,6 +549,15 @@ rethrow_rapi_adbc_init_func <- function(call = parent.frame(2)) {
   )
 }
 
+rethrow_rapi_cxx_stdlib <- function(call = parent.frame(2)) {
+  rlang::try_fetch(
+    rapi_cxx_stdlib(),
+    error = function(e) {
+      rethrow_error_from_rapi(e, call)
+    }
+  )
+}
+
 rethrow_rapi_ptr_to_str <- function(extptr, call = parent.frame(2)) {
   rlang::try_fetch(
     rapi_ptr_to_str(extptr),
@@ -629,6 +638,7 @@ rethrow_restore <- function() {
   rethrow_rapi_record_batch <<- rapi_record_batch
   rethrow_rapi_execute <<- rapi_execute
   rethrow_rapi_adbc_init_func <<- rapi_adbc_init_func
+  rethrow_rapi_cxx_stdlib <<- rapi_cxx_stdlib
   rethrow_rapi_ptr_to_str <<- rapi_ptr_to_str
   rethrow_rapi_load_rfuns <<- rapi_load_rfuns
 }

--- a/R/storage-home.R
+++ b/R/storage-home.R
@@ -196,6 +196,24 @@ mark_storage_choice_made <- function() {
   storage_message_state[["choice_made"]] <- TRUE
 }
 
+# The storage-location message is deferred from duckdb() until the user actually
+# installs an extension -- the only moment the extension cache location matters.
+# duckdb() stashes the resolved home here (when it would otherwise have
+# announced); the first INSTALL statement flushes it (see dbSendQuery). The
+# underlying maybe_storage_location_message() still dedupes per session, so
+# repeated installs stay quiet.
+set_pending_storage_message <- function(resolved) {
+  storage_message_state[["pending"]] <- resolved
+}
+
+flush_pending_storage_message <- function() {
+  resolved <- storage_message_state[["pending"]]
+  if (!is.null(resolved)) {
+    maybe_storage_location_message(resolved)
+  }
+  invisible()
+}
+
 # --- Temp / spill directory ---------------------------------------------------
 
 # An explicit temp/spill-directory override via the `duckdb.temp_directory`

--- a/man/duckdb.Rd
+++ b/man/duckdb.Rd
@@ -102,18 +102,19 @@ see the \sQuote{Database instances and driver reuse} section.}
 Whether this driver may load DuckDB extensions (\code{INSTALL} / \code{LOAD}).
 One of:
 \itemize{
-\item \code{NULL} (the default) -- decide automatically. Extensions are enabled,
+\item \code{NULL} (the default) -- decide automatically.
+Extensions are enabled,
 except on an affected Linux build (one not compiled with \verb{libstdc++}),
 where they are disabled and a throttled advisory message is shown.
 See the \sQuote{DuckDB extensions on Linux} section.
-\item \code{TRUE} -- force-enable extensions, attempting to load them even on an
-affected build (which may crash R). No message.
+\item \code{TRUE} -- force-enable extensions,
+attempting to load them even on an affected build (which may crash R).
+No message.
 \item \code{FALSE} -- disable extensions and silence the advisory message.
 }
 
-The argument takes precedence over the \code{duckdb.allow_extensions} option
-(a scalar logical) and the \code{DUCKDB_R_ALLOW_EXTENSIONS} environment variable
-(any non-empty value enables extensions).
+The argument takes precedence over the \code{duckdb.allow_extensions} option (a scalar logical)
+and the \code{DUCKDB_R_ALLOW_EXTENSIONS} environment variable (any non-empty value enables extensions).
 Applied only when the database instance is created;
 see the \sQuote{Database instances and driver reuse} section.}
 
@@ -220,29 +221,29 @@ Instances are shut down automatically when the driver is garbage-collected or th
 \section{DuckDB extensions on Linux}{
 
 
-DuckDB's prebuilt extensions for Linux are compiled with the GNU C++ standard
-library (\verb{libstdc++}). Loading one into a \code{duckdb} package that was itself
-built with a \emph{different} C++ standard library -- most commonly \verb{libc++}
-(clang's \verb{-stdlib=libc++}) -- is an ABI mismatch that crashes R
-(\url{https://github.com/duckdb/duckdb-r/issues/1107}). Almost all Linux
-builds (CRAN binaries and most source installs) use \verb{libstdc++} and are
-unaffected; macOS and Windows are unaffected.
+DuckDB's prebuilt extensions for Linux are compiled with the GNU C++ standard library (\verb{libstdc++}).
+Loading one into a \code{duckdb} package that was itself built with a \emph{different} C++ standard library --
+most commonly \verb{libc++} (clang's \verb{-stdlib=libc++}) --
+is an ABI mismatch that crashes R (\url{https://github.com/duckdb/duckdb-r/issues/1107}).
+Almost all Linux builds (CRAN binaries and most source installs) use \verb{libstdc++} and are unaffected;
+macOS and Windows are unaffected.
 
-Each \code{duckdb()} call decides whether the driver it returns may load
-extensions, via the \code{allow_extensions} argument (defaulting to the
-\code{duckdb.allow_extensions} option, then the \code{DUCKDB_R_ALLOW_EXTENSIONS}
-environment variable, then automatic detection). On the automatic path a
-build that was not compiled with \verb{libstdc++} on Linux disables
-extensions: \code{INSTALL} / \code{LOAD} raise a clear error instead of crashing,
-automatic extension install/load is turned off, and a throttled advisory
-message is shown at \code{duckdb()} time (it is no longer shown when the package
-is attached). Pass \code{allow_extensions = FALSE} to disable extensions and
-silence that message, or \code{allow_extensions = TRUE} to attempt loading anyway
--- for example to test whether it works on a particular build (which may
-still crash R).
+Each \code{duckdb()} call decides whether the driver it returns may load extensions,
+via the \code{allow_extensions} argument
+(defaulting to the \code{duckdb.allow_extensions} option,
+then the \code{DUCKDB_R_ALLOW_EXTENSIONS} environment variable,
+then automatic detection).
+On the automatic path a build that was not compiled with \verb{libstdc++} on Linux disables extensions:
+\code{INSTALL} / \code{LOAD} raise a clear error instead of crashing,
+automatic extension install/load is turned off,
+and a throttled advisory message is shown at \code{duckdb()} time
+(it is no longer shown when the package is attached).
+Pass \code{allow_extensions = FALSE} to disable extensions and silence that message,
+or \code{allow_extensions = TRUE} to attempt loading anyway --
+for example to test whether it works on a particular build (which may still crash R).
 
-The decision is carried on the returned driver as the experimental
-\code{allow_extensions} slot (see \link[=duckdb_driver-class]{duckdb_driver}).
+The decision is carried on the returned driver as the experimental \code{allow_extensions} slot
+(see \link[=duckdb_driver-class]{duckdb_driver}).
 }
 
 \examples{

--- a/man/duckdb.Rd
+++ b/man/duckdb.Rd
@@ -19,6 +19,7 @@ duckdb(
   ...,
   home = NULL,
   shared_home = NULL,
+  allow_extensions = NULL,
   environment_scan = FALSE
 )
 
@@ -94,6 +95,25 @@ already exists. Nothing persists beyond the session.
 }
 
 Cannot be combined with \code{home}.
+Applied only when the database instance is created;
+see the \sQuote{Database instances and driver reuse} section.}
+
+\item{allow_extensions}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
+Whether this driver may load DuckDB extensions (\code{INSTALL} / \code{LOAD}).
+One of:
+\itemize{
+\item \code{NULL} (the default) -- decide automatically. Extensions are enabled,
+except on an affected Linux build (one not compiled with \verb{libstdc++}),
+where they are disabled and a throttled advisory message is shown.
+See the \sQuote{DuckDB extensions on Linux} section.
+\item \code{TRUE} -- force-enable extensions, attempting to load them even on an
+affected build (which may crash R). No message.
+\item \code{FALSE} -- disable extensions and silence the advisory message.
+}
+
+The argument takes precedence over the \code{duckdb.allow_extensions} option
+(a scalar logical) and the \code{DUCKDB_R_ALLOW_EXTENSIONS} environment variable
+(any non-empty value enables extensions).
 Applied only when the database instance is created;
 see the \sQuote{Database instances and driver reuse} section.}
 
@@ -195,6 +215,34 @@ then create it again.
 \code{\link[DBI:dbDisconnect]{dbDisconnect()}} only closes a connection,
 it does not release the instance, and its \code{shutdown} argument is unused.
 Instances are shut down automatically when the driver is garbage-collected or the session ends.
+}
+
+\section{DuckDB extensions on Linux}{
+
+
+DuckDB's prebuilt extensions for Linux are compiled with the GNU C++ standard
+library (\verb{libstdc++}). Loading one into a \code{duckdb} package that was itself
+built with a \emph{different} C++ standard library -- most commonly \verb{libc++}
+(clang's \verb{-stdlib=libc++}) -- is an ABI mismatch that crashes R
+(\url{https://github.com/duckdb/duckdb-r/issues/1107}). Almost all Linux
+builds (CRAN binaries and most source installs) use \verb{libstdc++} and are
+unaffected; macOS and Windows are unaffected.
+
+Each \code{duckdb()} call decides whether the driver it returns may load
+extensions, via the \code{allow_extensions} argument (defaulting to the
+\code{duckdb.allow_extensions} option, then the \code{DUCKDB_R_ALLOW_EXTENSIONS}
+environment variable, then automatic detection). On the automatic path a
+build that was not compiled with \verb{libstdc++} on Linux disables
+extensions: \code{INSTALL} / \code{LOAD} raise a clear error instead of crashing,
+automatic extension install/load is turned off, and a throttled advisory
+message is shown at \code{duckdb()} time (it is no longer shown when the package
+is attached). Pass \code{allow_extensions = FALSE} to disable extensions and
+silence that message, or \code{allow_extensions = TRUE} to attempt loading anyway
+-- for example to test whether it works on a particular build (which may
+still crash R).
+
+The decision is carried on the returned driver as the experimental
+\code{allow_extensions} slot (see \link[=duckdb_driver-class]{duckdb_driver}).
 }
 
 \examples{

--- a/man/duckdb_driver-class.Rd
+++ b/man/duckdb_driver-class.Rd
@@ -38,6 +38,7 @@ Implements \link[DBI:DBIDriver-class]{DBIDriver}.
 The driver object additionally carries an experimental \code{allow_extensions}
 slot \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}: whether this driver permits
 loading DuckDB extensions (\code{INSTALL} / \code{LOAD}), resolved once when the driver
-is created; see the \code{allow_extensions} argument of \code{\link[=duckdb]{duckdb()}}.
+is created.
+See the \code{allow_extensions} argument of \code{\link[=duckdb]{duckdb()}}.
 }
 \keyword{internal}

--- a/man/duckdb_driver-class.Rd
+++ b/man/duckdb_driver-class.Rd
@@ -34,4 +34,10 @@
 \description{
 Implements \link[DBI:DBIDriver-class]{DBIDriver}.
 }
+\details{
+The driver object additionally carries an experimental \code{allow_extensions}
+slot \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}: whether this driver permits
+loading DuckDB extensions (\code{INSTALL} / \code{LOAD}), resolved once when the driver
+is created; see the \code{allow_extensions} argument of \code{\link[=duckdb]{duckdb()}}.
+}
 \keyword{internal}

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -28,10 +28,10 @@ extern "C" SEXP _duckdb_rapi_connection_valid(SEXP conn) {
   END_CPP11
 }
 // database.cpp
-duckdb::db_eptr_t rapi_startup(std::string dbdir, bool readonly, cpp11::list configsexp, bool environment_scan);
-extern "C" SEXP _duckdb_rapi_startup(SEXP dbdir, SEXP readonly, SEXP configsexp, SEXP environment_scan) {
+duckdb::db_eptr_t rapi_startup(std::string dbdir, bool readonly, cpp11::list configsexp, bool environment_scan, bool allow_extensions);
+extern "C" SEXP _duckdb_rapi_startup(SEXP dbdir, SEXP readonly, SEXP configsexp, SEXP environment_scan, SEXP allow_extensions) {
   BEGIN_CPP11
-    return cpp11::as_sexp(rapi_startup(cpp11::as_cpp<cpp11::decay_t<std::string>>(dbdir), cpp11::as_cpp<cpp11::decay_t<bool>>(readonly), cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(configsexp), cpp11::as_cpp<cpp11::decay_t<bool>>(environment_scan)));
+    return cpp11::as_sexp(rapi_startup(cpp11::as_cpp<cpp11::decay_t<std::string>>(dbdir), cpp11::as_cpp<cpp11::decay_t<bool>>(readonly), cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(configsexp), cpp11::as_cpp<cpp11::decay_t<bool>>(environment_scan), cpp11::as_cpp<cpp11::decay_t<bool>>(allow_extensions)));
   END_CPP11
 }
 // database.cpp
@@ -448,6 +448,13 @@ extern "C" SEXP _duckdb_rapi_adbc_init_func() {
   END_CPP11
 }
 // utils.cpp
+SEXP rapi_cxx_stdlib();
+extern "C" SEXP _duckdb_rapi_cxx_stdlib() {
+  BEGIN_CPP11
+    return cpp11::as_sexp(rapi_cxx_stdlib());
+  END_CPP11
+}
+// utils.cpp
 cpp11::r_string rapi_ptr_to_str(SEXP extptr);
 extern "C" SEXP _duckdb_rapi_ptr_to_str(SEXP extptr) {
   BEGIN_CPP11
@@ -469,6 +476,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_duckdb_rapi_bind",                    (DL_FUNC) &_duckdb_rapi_bind,                     3},
     {"_duckdb_rapi_connect",                 (DL_FUNC) &_duckdb_rapi_connect,                  2},
     {"_duckdb_rapi_connection_valid",        (DL_FUNC) &_duckdb_rapi_connection_valid,         1},
+    {"_duckdb_rapi_cxx_stdlib",              (DL_FUNC) &_duckdb_rapi_cxx_stdlib,               0},
     {"_duckdb_rapi_disconnect",              (DL_FUNC) &_duckdb_rapi_disconnect,               1},
     {"_duckdb_rapi_execute",                 (DL_FUNC) &_duckdb_rapi_execute,                  2},
     {"_duckdb_rapi_execute_arrow",           (DL_FUNC) &_duckdb_rapi_execute_arrow,            2},
@@ -524,7 +532,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_duckdb_rapi_rel_union_all",           (DL_FUNC) &_duckdb_rapi_rel_union_all,            2},
     {"_duckdb_rapi_release",                 (DL_FUNC) &_duckdb_rapi_release,                  1},
     {"_duckdb_rapi_shutdown",                (DL_FUNC) &_duckdb_rapi_shutdown,                 1},
-    {"_duckdb_rapi_startup",                 (DL_FUNC) &_duckdb_rapi_startup,                  4},
+    {"_duckdb_rapi_startup",                 (DL_FUNC) &_duckdb_rapi_startup,                  5},
     {"_duckdb_rapi_unlock",                  (DL_FUNC) &_duckdb_rapi_unlock,                   1},
     {"_duckdb_rapi_unregister_arrow",        (DL_FUNC) &_duckdb_rapi_unregister_arrow,         2},
     {"_duckdb_rapi_unregister_df",           (DL_FUNC) &_duckdb_rapi_unregister_df,            2},

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -20,7 +20,7 @@ static bool CastRstringToVarchar(Vector &source, Vector &result, idx_t count, Ca
 }
 
 [[cpp11::register]] duckdb::db_eptr_t rapi_startup(std::string dbdir, bool readonly, cpp11::list configsexp,
-                                                   bool environment_scan) {
+                                                   bool environment_scan, bool allow_extensions) {
 	// Hard stop when poisoned: every DuckDB session starts here, so this single
 	// guard ensures no test or example can reach the C++ engine on CRAN.
 	DUCKDB_R_POISON_GUARD();
@@ -54,6 +54,7 @@ static bool CastRstringToVarchar(Vector &source, Vector &result, idx_t count, Ca
 	// FIXME: Rewrite properly with shared pointers
 	auto wrapper_ = make_uniq<DBWrapper>();
 	DBWrapper *wrapper = wrapper_.get();
+	wrapper->allow_extensions = allow_extensions;
 
 	try {
 		auto data1 = make_uniq<ReplacementDataDBWrapper>();

--- a/src/include/rapi.hpp
+++ b/src/include/rapi.hpp
@@ -66,6 +66,7 @@ struct DBWrapper {
 	mutex lock;
 	cpp11::sexp env;
 	cpp11::sexp registered_dfs;
+	bool allow_extensions = true;
 };
 
 template <class T>
@@ -219,6 +220,9 @@ struct RStrings {
 	SEXP tbl_df_tbl_dataframe_str;
 	SEXP wk_wkb_wk_vctr_str;
 	SEXP vctrs_list_of_str;
+	SEXP cxx_stdlib_libstdcxx_str;
+	SEXP cxx_stdlib_libcxx_str;
+	SEXP cxx_stdlib_unknown_str;
 	SEXP enc2utf8_sym; // Rf_install
 	SEXP ptype_sym;
 	SEXP tzone_sym;
@@ -252,7 +256,7 @@ SEXP duckdb_execute_R_impl(MaterializedQueryResult *result, const duckdb::Conver
 
 // moved out of duckdb namespace for the time being (r-lib/cpp11#262)
 
-duckdb::db_eptr_t rapi_startup(std::string, bool, cpp11::list);
+duckdb::db_eptr_t rapi_startup(std::string, bool, cpp11::list, bool, bool);
 
 void rapi_shutdown(duckdb::db_eptr_t);
 

--- a/src/statement.cpp
+++ b/src/statement.cpp
@@ -87,6 +87,27 @@ static cpp11::list construct_retlist(duckdb::unique_ptr<PreparedStatement> stmt,
 		// no statements to execute
 		rapi_error_with_context("rapi_prepare", "No statements to execute");
 	}
+
+	// When extensions are disallowed for this driver (an affected non-libstdc++
+	// Linux build, or duckdb(allow_extensions = FALSE)), refuse the whole
+	// extension workflow. DuckDB parses INSTALL, FORCE INSTALL and LOAD all as
+	// StatementType::LOAD_STATEMENT, so this one check forbids installing as well
+	// as loading: LOAD would dlopen() a prebuilt (libstdc++) extension and crash R
+	// (duckdb/duckdb-r#1107), and there is no point installing an extension that
+	// can never be loaded. The decision is made in R (resolve_allow_extensions())
+	// and plumbed here via the DBWrapper external pointer. Every parsed statement
+	// is checked -- not just the last one returned to the caller -- so a LOAD
+	// anywhere in a multi-statement query is caught. The user-facing message is
+	// centralized in R: throw with context "load_extension" and an empty message,
+	// and rapi_error() fills in the text from extensions_disabled_error().
+	if (!conn->db->allow_extensions) {
+		for (auto &statement : statements) {
+			if (statement->type == StatementType::LOAD_STATEMENT) {
+				rapi_error_with_context("load_extension", "");
+			}
+		}
+	}
+
 	// if there are multiple statements, we directly execute the statements besides the last one
 	// we only return the result of the last statement to the user, unless one of the previous statements fails
 	for (idx_t i = 0; i + 1 < statements.size(); i++) {

--- a/src/statement.cpp
+++ b/src/statement.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/arrow/result_arrow_wrapper.hpp"
 #include "duckdb/common/types/timestamp.hpp"
 #include "duckdb/main/chunk_scan_state/query_result.hpp"
+#include "duckdb/parser/statement/load_statement.hpp"
 #include "duckdb/parser/statement/relation_statement.hpp"
 #include "httplib.hpp"
 #include "rapi.hpp"
@@ -28,14 +29,18 @@ using namespace cpp11::literals;
 }
 
 static cpp11::list construct_retlist(duckdb::unique_ptr<PreparedStatement> stmt, const string &query, idx_t n_param,
-                                     SEXP registered_dfs = R_NilValue) {
+                                     bool is_install, SEXP registered_dfs = R_NilValue) {
 	cpp11::writable::list retlist;
-	retlist.reserve(8);
+	retlist.reserve(9);
 	retlist.push_back({"str"_nm = query});
 
 	auto stmtholder = make_uniq<RStatement>(std::move(stmt));
 
 	retlist.push_back({"type"_nm = StatementTypeToString(stmtholder->stmt->GetStatementType())});
+	// Whether this is an extension INSTALL / FORCE INSTALL (detected from the
+	// parsed LoadInfo in rapi_prepare, since INSTALL/LOAD share LOAD_STATEMENT).
+	// R uses it to flush the deferred storage-location message on INSTALL.
+	retlist.push_back({"is_install"_nm = is_install});
 	retlist.push_back({"names"_nm = cpp11::as_sexp(stmtholder->stmt->GetNames())});
 
 	cpp11::writable::strings rtypes;
@@ -120,6 +125,17 @@ static cpp11::list construct_retlist(duckdb::unique_ptr<PreparedStatement> stmt,
 			rapi_error_with_context("rapi_prepare", error);
 		}
 	}
+	// Detect an extension INSTALL / FORCE INSTALL from the parsed statement before
+	// it is consumed by Prepare(). INSTALL, FORCE INSTALL and LOAD all parse to
+	// StatementType::LOAD_STATEMENT; only the LoadInfo's load_type distinguishes
+	// them. R uses this to flush the deferred storage-location message on the
+	// first INSTALL (see dbSendQuery() / flush_pending_storage_message()).
+	bool is_install = false;
+	if (statements.back()->type == StatementType::LOAD_STATEMENT) {
+		auto load_type = statements.back()->Cast<LoadStatement>().info->load_type;
+		is_install = load_type == LoadType::INSTALL || load_type == LoadType::FORCE_INSTALL;
+	}
+
 	auto stmt = conn->conn->Prepare(std::move(statements.back()));
 
 	signal_handler.HandleInterrupt();
@@ -131,7 +147,7 @@ static cpp11::list construct_retlist(duckdb::unique_ptr<PreparedStatement> stmt,
 		rapi_error_with_context("rapi_prepare", error);
 	}
 	auto n_param = stmt->named_param_map.size();
-	return construct_retlist(std::move(stmt), query, n_param, conn->db->registered_dfs);
+	return construct_retlist(std::move(stmt), query, n_param, is_install, conn->db->registered_dfs);
 }
 
 static SEXP rapi_execute_impl(RStatement *stmt, const duckdb::ConvertOpts &convert_opts, bool allow_stream_result);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -15,6 +15,22 @@ using namespace duckdb;
 	return R_MakeExternalPtrFn((DL_FUNC)duckdb_adbc_init, R_NilValue, R_NilValue);
 }
 
+// Report the C++ standard library this package was compiled against, read from a
+// compile-time macro. The R layer uses this to detect a Linux build NOT compiled
+// with libstdc++ (typically libc++), which cannot safely load prebuilt
+// (libstdc++) DuckDB extensions -- loading one crashes R (duckdb/duckdb-r#1107).
+// Returns a cached SEXP owned by RStrings (allocated once), so callers get the
+// same string without a fresh allocation on each call.
+[[cpp11::register]] SEXP rapi_cxx_stdlib() {
+#if defined(__GLIBCXX__)
+	return RStrings::get().cxx_stdlib_libstdcxx_str;
+#elif defined(_LIBCPP_VERSION)
+	return RStrings::get().cxx_stdlib_libcxx_str;
+#else
+	return RStrings::get().cxx_stdlib_unknown_str;
+#endif
+}
+
 [[cpp11::register]] cpp11::r_string rapi_ptr_to_str(SEXP extptr) {
 	if (TYPEOF(extptr) != EXTPTRSXP) {
 		rapi_error_with_context("rapi_ptr_to_str", "Need external pointer parameter");
@@ -57,7 +73,7 @@ RStrings::RStrings() {
 	R_PreserveObject(strings);
 	MARK_NOT_MUTABLE(strings);
 
-	cpp11::sexp chars = Rf_allocVector(VECSXP, 13);
+	cpp11::sexp chars = Rf_allocVector(VECSXP, 16);
 	SET_VECTOR_ELT(chars, 0, UTC_str = Rf_mkString("UTC"));
 	SET_VECTOR_ELT(chars, 1, Date_str = Rf_mkString("Date"));
 	SET_VECTOR_ELT(chars, 2, difftime_str = Rf_mkString("difftime"));
@@ -71,6 +87,9 @@ RStrings::RStrings() {
 	SET_VECTOR_ELT(chars, 10, tbl_df_tbl_dataframe_str = StringsToSexp({"tbl_df", "tbl", "data.frame"}));
 	SET_VECTOR_ELT(chars, 11, wk_wkb_wk_vctr_str = StringsToSexp({"wk_wkb", "wk_vctr"}));
 	SET_VECTOR_ELT(chars, 12, vctrs_list_of_str = StringsToSexp({"vctrs_list_of", "vctrs_vctr", "list"}));
+	SET_VECTOR_ELT(chars, 13, cxx_stdlib_libstdcxx_str = Rf_mkString("libstdc++"));
+	SET_VECTOR_ELT(chars, 14, cxx_stdlib_libcxx_str = Rf_mkString("libc++"));
+	SET_VECTOR_ELT(chars, 15, cxx_stdlib_unknown_str = Rf_mkString("<an unknown C++ library>"));
 
 	R_PreserveObject(chars);
 	MARK_NOT_MUTABLE(chars);

--- a/tests/testthat/test-duckdb-extensions.R
+++ b/tests/testthat/test-duckdb-extensions.R
@@ -1,6 +1,9 @@
 test_that("Install DuckDB extension", {
   skip_on_dev_version()
   skip_on_cran_except_r_universe()
+  # Disabled on a libc++ Linux build (loading a prebuilt extension crashes R --
+  # duckdb/duckdb-r#1107); INSTALL is refused there by design.
+  skip_if(!extensions_supported(), "DuckDB extensions disabled on this build (duckdb/duckdb-r#1107)")
 
   expect_no_error(sql_exec("INSTALL icu"))
 })

--- a/tests/testthat/test-extension_path.R
+++ b/tests/testthat/test-extension_path.R
@@ -1,5 +1,8 @@
 skip_on_cran()
 skip_on_os(c("windows"))
+# Extensions are disabled on a libc++ Linux build (they crash R -- #1107), so the
+# engine errors before this path-resolution behavior is reachable.
+skip_if(!extensions_supported(), "DuckDB extensions disabled on this build (duckdb/duckdb-r#1107)")
 
 test_that("duckdb extensions are stored in the resolved extension directory", {
   con <- local_con(config = list('allow_unsigned_extensions' = 'true'))

--- a/tests/testthat/test-extensions-libcxx.R
+++ b/tests/testthat/test-extensions-libcxx.R
@@ -1,0 +1,247 @@
+# Extensions are disabled on a Linux build not compiled with libstdc++, where
+# loading a prebuilt (libstdc++) extension crashes R (duckdb/duckdb-r#1107). The
+# per-driver decision is made in R by resolve_allow_extensions() and plumbed to
+# the engine; the detection seams (is_linux(), compiled_cxx_stdlib()) are mocked
+# here, like is_windows().
+
+test_that("extensions_supported() is FALSE on Linux unless the stdlib is libstdc++", {
+  local_mocked_bindings(
+    is_linux = function() TRUE,
+    compiled_cxx_stdlib = function() "libc++"
+  )
+  expect_false(extensions_supported())
+
+  # An unidentified stdlib is treated conservatively (also disabled).
+  local_mocked_bindings(
+    is_linux = function() TRUE,
+    compiled_cxx_stdlib = function() "<an unknown C++ library>"
+  )
+  expect_false(extensions_supported())
+})
+
+test_that("extensions_supported() is TRUE for libstdc++ and for non-Linux", {
+  # libstdc++ is the matching, safe standard library.
+  local_mocked_bindings(
+    is_linux = function() TRUE,
+    compiled_cxx_stdlib = function() "libstdc++"
+  )
+  expect_true(extensions_supported())
+
+  # Non-Linux is unaffected regardless of stdlib (macOS is libc++, but its
+  # prebuilt extensions match).
+  local_mocked_bindings(
+    is_linux = function() FALSE,
+    compiled_cxx_stdlib = function() "libc++"
+  )
+  expect_true(extensions_supported())
+
+  local_mocked_bindings(
+    is_linux = function() FALSE,
+    compiled_cxx_stdlib = function() "libstdc++"
+  )
+  expect_true(extensions_supported())
+})
+
+test_that("compiled_cxx_stdlib() reports a known standard library", {
+  # The real compile-time value on the CI/test toolchain; just assert it is one
+  # of the recognized tokens (guards against the macro logic silently breaking).
+  expect_true(
+    compiled_cxx_stdlib() %in% c("libc++", "libstdc++", "<an unknown C++ library>")
+  )
+})
+
+# --- resolve_allow_extensions() ----------------------------------------------
+
+test_that("resolve_allow_extensions(NULL) on an affected build disables + announces", {
+  withr::local_options(duckdb.allow_extensions = NULL)
+  withr::local_envvar(DUCKDB_R_ALLOW_EXTENSIONS = NA)
+  local_mocked_bindings(extensions_supported = function() FALSE)
+
+  res <- resolve_allow_extensions(NULL)
+  expect_false(res$allow)
+  expect_true(res$announce)
+  expect_identical(res$source, "auto")
+})
+
+test_that("resolve_allow_extensions(NULL) on a healthy build enables + stays quiet", {
+  withr::local_options(duckdb.allow_extensions = NULL)
+  withr::local_envvar(DUCKDB_R_ALLOW_EXTENSIONS = NA)
+  local_mocked_bindings(extensions_supported = function() TRUE)
+
+  res <- resolve_allow_extensions(NULL)
+  expect_true(res$allow)
+  expect_false(res$announce)
+  expect_identical(res$source, "auto")
+})
+
+test_that("an explicit allow_extensions argument wins and is silent", {
+  withr::local_options(duckdb.allow_extensions = NULL)
+  withr::local_envvar(DUCKDB_R_ALLOW_EXTENSIONS = NA)
+  # Even on an affected build, the explicit argument decides and never announces.
+  local_mocked_bindings(extensions_supported = function() FALSE)
+
+  res_true <- resolve_allow_extensions(TRUE)
+  expect_true(res_true$allow)
+  expect_false(res_true$announce)
+  expect_identical(res_true$source, "argument")
+
+  res_false <- resolve_allow_extensions(FALSE)
+  expect_false(res_false$allow)
+  expect_false(res_false$announce)
+  expect_identical(res_false$source, "argument")
+})
+
+test_that("the duckdb.allow_extensions option is honored (and silent)", {
+  withr::local_envvar(DUCKDB_R_ALLOW_EXTENSIONS = NA)
+  local_mocked_bindings(extensions_supported = function() FALSE)
+
+  withr::local_options(duckdb.allow_extensions = TRUE)
+  res_true <- resolve_allow_extensions(NULL)
+  expect_true(res_true$allow)
+  expect_false(res_true$announce)
+  expect_identical(res_true$source, "option")
+
+  withr::local_options(duckdb.allow_extensions = FALSE)
+  res_false <- resolve_allow_extensions(NULL)
+  expect_false(res_false$allow)
+  expect_false(res_false$announce)
+  expect_identical(res_false$source, "option")
+})
+
+test_that("a malformed duckdb.allow_extensions option warns and is reset", {
+  withr::local_envvar(DUCKDB_R_ALLOW_EXTENSIONS = NA)
+  withr::local_options(duckdb.allow_extensions = "yes")
+  local_mocked_bindings(extensions_supported = function() TRUE)
+
+  expect_warning(res <- resolve_allow_extensions(NULL), "must be TRUE, FALSE, or NULL")
+  # Falls through to the auto path once the bad option is cleared.
+  expect_identical(res$source, "auto")
+  expect_true(res$allow)
+  expect_null(getOption("duckdb.allow_extensions"))
+})
+
+test_that("a non-empty DUCKDB_R_ALLOW_EXTENSIONS env var enables extensions", {
+  withr::local_options(duckdb.allow_extensions = NULL)
+  withr::local_envvar(DUCKDB_R_ALLOW_EXTENSIONS = "1")
+  local_mocked_bindings(extensions_supported = function() FALSE)
+
+  res <- resolve_allow_extensions(NULL)
+  expect_true(res$allow)
+  expect_false(res$announce)
+  expect_identical(res$source, "env")
+})
+
+# --- duckdb() advisory message ------------------------------------------------
+
+# Clear the "extensions" throttle key so message tests are order-independent.
+reset_extensions_throttle <- function(env = parent.frame()) {
+  storage_message_state[["extensions"]] <- NULL
+  withr::defer(storage_message_state[["extensions"]] <- NULL, envir = env)
+}
+
+test_that("duckdb() announces on the auto path when extensions are disabled", {
+  skip_on_cran()
+  withr::local_options(
+    duckdb.allow_extensions = NULL,
+    duckdb.home = withr::local_tempdir(),
+    rlang_interactive = FALSE
+  )
+  withr::local_envvar(DUCKDB_R_ALLOW_EXTENSIONS = NA)
+  local_mocked_bindings(extensions_supported = function() FALSE)
+  reset_extensions_throttle()
+
+  drv <- NULL
+  expect_message(drv <- duckdb(), "extensions are disabled")
+  duckdb_shutdown(drv)
+})
+
+test_that("duckdb(allow_extensions = FALSE) is silent", {
+  skip_on_cran()
+  withr::local_options(
+    duckdb.allow_extensions = NULL,
+    duckdb.home = withr::local_tempdir(),
+    rlang_interactive = FALSE
+  )
+  withr::local_envvar(DUCKDB_R_ALLOW_EXTENSIONS = NA)
+  local_mocked_bindings(extensions_supported = function() FALSE)
+  reset_extensions_throttle()
+
+  drv <- NULL
+  expect_no_message(drv <- duckdb(allow_extensions = FALSE))
+  duckdb_shutdown(drv)
+})
+
+test_that("an option or env override silences the duckdb() advisory", {
+  skip_on_cran()
+  withr::local_options(
+    duckdb.home = withr::local_tempdir(),
+    rlang_interactive = FALSE
+  )
+  local_mocked_bindings(extensions_supported = function() FALSE)
+
+  # Option set: no advisory.
+  withr::with_options(
+    list(duckdb.allow_extensions = FALSE),
+    {
+      reset_extensions_throttle()
+      drv <- NULL
+      expect_no_message(drv <- duckdb())
+      duckdb_shutdown(drv)
+    }
+  )
+
+  # Env set: no advisory.
+  withr::with_options(
+    list(duckdb.allow_extensions = NULL),
+    withr::with_envvar(
+      list(DUCKDB_R_ALLOW_EXTENSIONS = "1"),
+      {
+        reset_extensions_throttle()
+        drv <- NULL
+        expect_no_message(drv <- duckdb())
+        duckdb_shutdown(drv)
+      }
+    )
+  )
+})
+
+# --- driver slots -------------------------------------------------------------
+
+test_that("duckdb() exposes the experimental allow_extensions slot", {
+  skip_on_cran()
+  drv <- duckdb()
+  on.exit(duckdb_shutdown(drv))
+  expect_type(drv@allow_extensions, "logical")
+})
+
+# --- plumbing integration (works on any platform) -----------------------------
+
+test_that("allow_extensions is plumbed to the engine's INSTALL/LOAD guard", {
+  # rapi_startup has a CRAN poison guard, so this exercises the C++ path only in
+  # our own CI, not on CRAN.
+  skip_on_cran()
+
+  # A driver created with extensions disabled refuses LOAD before the engine
+  # dlopen()s anything, regardless of the build's stdlib.
+  con <- dbConnect(duckdb(allow_extensions = FALSE))
+  on.exit(dbDisconnect(con, shutdown = TRUE))
+  expect_error(dbExecute(con, "LOAD spatial"), "disabled")
+
+  # Positive control: with extensions enabled the disabled-guard must NOT fire.
+  # A LOAD may still fail for another reason (e.g. the extension is unavailable
+  # or cannot be downloaded); only the guard's "disabled" error is forbidden.
+  con2 <- dbConnect(duckdb(allow_extensions = TRUE))
+  on.exit(dbDisconnect(con2, shutdown = TRUE), add = TRUE)
+  expect_error(
+    tryCatch(
+      dbExecute(con2, "LOAD spatial"),
+      error = function(e) {
+        if (grepl("disabled", conditionMessage(e), fixed = TRUE)) {
+          stop(e)
+        }
+        invisible(NULL)
+      }
+    ),
+    NA
+  )
+})

--- a/tests/testthat/test-storage-e2e.R
+++ b/tests/testthat/test-storage-e2e.R
@@ -4,7 +4,7 @@
 # skip on CRAN; the extension test additionally skips, best effort, when the
 # download/install fails (e.g. no network).
 
-test_that("a non-interactive connect announces the storage location, unless chosen", {
+test_that("a non-interactive connect queues the storage location, unless chosen", {
   skip_on_cran()
   withr::local_options(duckdb.home = NULL, rlang_interactive = FALSE)
   withr::local_envvar(DUCKDB_R_HOME = NA)
@@ -12,16 +12,21 @@ test_that("a non-interactive connect announces the storage location, unless chos
     duckdb_shared_home = function() file.path(tempdir(), "no-such-home-msg")
   )
 
-  # Auto-resolved (no ~/.duckdb, no args) -> the tempdir message fires once.
+  # Auto-resolved (no ~/.duckdb, no args) -> connect is silent; the tempdir
+  # message is deferred to INSTALL, where a flush fires it once.
   storage_message_state[["storage_location"]] <- NULL
   storage_message_state[["choice_made"]] <- NULL
+  storage_message_state[["pending"]] <- NULL
   drv <- NULL
-  expect_message({ drv <- duckdb() }, "temporary directory")
+  expect_no_message({ drv <- duckdb() })
+  expect_message(flush_pending_storage_message(), "temporary directory")
   duckdb_shutdown(drv)
 
-  # Explicit opt-out with shared_home = FALSE -> suppressed.
+  # Explicit opt-out with shared_home = FALSE -> nothing queued, flush silent.
   storage_message_state[["storage_location"]] <- NULL
+  storage_message_state[["pending"]] <- NULL
   expect_no_message({ drv <- duckdb(shared_home = FALSE) })
+  expect_silent(flush_pending_storage_message())
   duckdb_shutdown(drv)
 })
 
@@ -42,15 +47,19 @@ test_that("an interactive yes announces creation; a no announces the tempdir", {
   duckdb_shutdown(drv)
   expect_true(dir.exists(shared))
 
-  # "no" -> tempdir, and the storage-location message is announced.
+  # "no" -> tempdir; the storage-location message is deferred to INSTALL, so
+  # connect is silent and a flush emits it. (The "created" confirmation above is
+  # a separate message and still fires at connect.)
   storage_message_state[["home_prompt_declined"]] <- NULL
   storage_message_state[["storage_location"]] <- NULL
   storage_message_state[["choice_made"]] <- NULL
+  storage_message_state[["pending"]] <- NULL
   local_mocked_bindings(
     duckdb_shared_home = function() file.path(tempdir(), "no-such-home-int"),
     consent_to_create_home = function(path) FALSE
   )
-  expect_message({ drv <- duckdb() }, "temporary directory")
+  expect_no_message({ drv <- duckdb() })
+  expect_message(flush_pending_storage_message(), "temporary directory")
   duckdb_shutdown(drv)
 })
 

--- a/tests/testthat/test-storage-e2e.R
+++ b/tests/testthat/test-storage-e2e.R
@@ -79,6 +79,9 @@ test_that("a persistent secret is written under the configured home", {
 
 test_that("the httpfs extension installs and loads under the configured home", {
   skip_on_cran()
+  # Disabled on a libc++ Linux build (loading a prebuilt extension crashes R --
+  # duckdb/duckdb-r#1107).
+  skip_if(!extensions_supported(), "DuckDB extensions disabled on this build (duckdb/duckdb-r#1107)")
   home <- withr::local_tempdir("e2e-home-ext-")
   withr::local_envvar(DUCKDB_R_HOME = NA)
   withr::local_options(duckdb.home = home)

--- a/tests/testthat/test-storage-install-message.R
+++ b/tests/testthat/test-storage-install-message.R
@@ -1,0 +1,67 @@
+# The storage-location message is deferred from duckdb() to the first INSTALL.
+
+test_that("is_install_statement() matches INSTALL / FORCE INSTALL only", {
+  expect_true(is_install_statement("INSTALL spatial"))
+  expect_true(is_install_statement("install spatial"))
+  expect_true(is_install_statement("  INSTALL spatial"))
+  expect_true(is_install_statement("FORCE INSTALL spatial"))
+  expect_true(is_install_statement("force install spatial"))
+
+  expect_false(is_install_statement("LOAD spatial"))
+  expect_false(is_install_statement("SELECT 'install'"))
+  expect_false(is_install_statement("SELECT 1"))
+  expect_false(is_install_statement("INSTALLING")) # word boundary
+})
+
+test_that("duckdb() queues the message but does not emit it; a flush emits once", {
+  skip_on_cran()
+  withr::local_options(duckdb.home = NULL, rlang_interactive = FALSE)
+  withr::local_envvar(DUCKDB_R_HOME = NA)
+  local_mocked_bindings(
+    duckdb_shared_home = function() file.path(tempdir(), "no-such-home-defer")
+  )
+  storage_message_state[["choice_made"]] <- NULL
+  storage_message_state[["storage_location"]] <- NULL
+  storage_message_state[["pending"]] <- NULL
+
+  drv <- NULL
+  expect_no_message({
+    drv <- duckdb()
+  })
+  # The message is queued, not shown.
+  expect_false(is.null(storage_message_state[["pending"]]))
+  duckdb_shutdown(drv)
+
+  # Flushing emits it; a second flush is silent (session dedupe).
+  expect_message(flush_pending_storage_message(), "temporary directory")
+  expect_silent(flush_pending_storage_message())
+})
+
+test_that("an INSTALL statement flushes the deferred storage message", {
+  skip_on_cran()
+  # On a libc++ Linux build INSTALL is refused at prepare (before the flush), and
+  # extensions are disabled anyway -- there is nothing to announce.
+  skip_if(extensions_unsupported(), "extensions disabled on this build")
+
+  withr::local_options(duckdb.home = NULL, rlang_interactive = FALSE)
+  withr::local_envvar(DUCKDB_R_HOME = NA)
+  local_mocked_bindings(
+    duckdb_shared_home = function() file.path(tempdir(), "no-such-home-install")
+  )
+  storage_message_state[["choice_made"]] <- NULL
+  storage_message_state[["storage_location"]] <- NULL
+  storage_message_state[["pending"]] <- NULL
+
+  con <- dbConnect(duckdb())
+  on.exit(dbDisconnect(con, shutdown = TRUE), add = TRUE)
+
+  # Preparing an INSTALL flushes the queued message. Use a nonexistent extension
+  # and tolerate the execution error -- the message fires at prepare, before it.
+  expect_message(
+    try(
+      dbExecute(con, "INSTALL this_extension_does_not_exist_xyz"),
+      silent = TRUE
+    ),
+    "temporary directory"
+  )
+})

--- a/tests/testthat/test-storage-install-message.R
+++ b/tests/testthat/test-storage-install-message.R
@@ -1,17 +1,7 @@
 # The storage-location message is deferred from duckdb() to the first INSTALL.
-
-test_that("is_install_statement() matches INSTALL / FORCE INSTALL only", {
-  expect_true(is_install_statement("INSTALL spatial"))
-  expect_true(is_install_statement("install spatial"))
-  expect_true(is_install_statement("  INSTALL spatial"))
-  expect_true(is_install_statement("FORCE INSTALL spatial"))
-  expect_true(is_install_statement("force install spatial"))
-
-  expect_false(is_install_statement("LOAD spatial"))
-  expect_false(is_install_statement("SELECT 'install'"))
-  expect_false(is_install_statement("SELECT 1"))
-  expect_false(is_install_statement("INSTALLING")) # word boundary
-})
+# Whether a statement is an INSTALL is detected in the engine glue from the
+# parsed LoadInfo (see rapi_prepare()) and surfaced as stmt_lst$is_install; the
+# end-to-end test below exercises that path.
 
 test_that("duckdb() queues the message but does not emit it; a flush emits once", {
   skip_on_cran()
@@ -41,7 +31,7 @@ test_that("an INSTALL statement flushes the deferred storage message", {
   skip_on_cran()
   # On a libc++ Linux build INSTALL is refused at prepare (before the flush), and
   # extensions are disabled anyway -- there is nothing to announce.
-  skip_if(extensions_unsupported(), "extensions disabled on this build")
+  skip_if(!extensions_supported(), "extensions disabled on this build")
 
   withr::local_options(duckdb.home = NULL, rlang_interactive = FALSE)
   withr::local_envvar(DUCKDB_R_HOME = NA)

--- a/tests/testthat/test-storage-message-once.R
+++ b/tests/testthat/test-storage-message-once.R
@@ -1,5 +1,7 @@
-# An explicit `home`/`shared_home` choice this session silences the
-# storage-location message for subsequent auto-resolved duckdb() calls.
+# The storage-location message is deferred from duckdb() until an extension is
+# actually installed. duckdb() only *queues* it (stashing the resolved home);
+# the first INSTALL flushes it. An explicit `home`/`shared_home` choice this
+# session suppresses it entirely (nothing is queued).
 
 test_that("mark/read of the session choice flag round-trips", {
   storage_message_state[["choice_made"]] <- NULL
@@ -8,7 +10,7 @@ test_that("mark/read of the session choice flag round-trips", {
   expect_true(storage_choice_made())
 })
 
-test_that("an explicit shared_home choice silences a later bare duckdb()", {
+test_that("an explicit shared_home choice suppresses the deferred install message", {
   skip_on_cran()
   withr::local_options(duckdb.home = NULL, rlang_interactive = FALSE)
   withr::local_envvar(DUCKDB_R_HOME = NA)
@@ -17,19 +19,24 @@ test_that("an explicit shared_home choice silences a later bare duckdb()", {
   )
   storage_message_state[["choice_made"]] <- NULL
   storage_message_state[["storage_location"]] <- NULL
+  storage_message_state[["pending"]] <- NULL
 
-  # The explicit opt-out is itself silent, and marks the choice.
+  # Connecting never emits now (the message is deferred to INSTALL); the explicit
+  # opt-out also records the choice, so nothing is queued to announce later.
   drv <- NULL
   expect_no_message({
     drv <- duckdb(shared_home = FALSE)
   })
   duckdb_shutdown(drv)
+  expect_null(storage_message_state[["pending"]])
 
-  # A subsequent bare call auto-resolves to a tempdir but now stays quiet.
+  # A subsequent bare call auto-resolves to a tempdir but the choice persists,
+  # so still nothing is queued and a flush stays silent.
   expect_no_message({
     drv <- duckdb()
   })
   duckdb_shutdown(drv)
+  expect_silent(flush_pending_storage_message())
 })
 
 test_that("reusing a cached on-disk driver does not record a storage choice", {
@@ -41,6 +48,7 @@ test_that("reusing a cached on-disk driver does not record a storage choice", {
   )
   storage_message_state[["choice_made"]] <- NULL
   storage_message_state[["storage_location"]] <- NULL
+  storage_message_state[["pending"]] <- NULL
   dbfile <- withr::local_tempfile(fileext = ".db")
 
   # First creation resolves storage (a tempdir); no explicit choice yet.
@@ -53,19 +61,18 @@ test_that("reusing a cached on-disk driver does not record a storage choice", {
   expect_false(storage_choice_made())
   duckdb_shutdown(drv)
 
-  # So a later bare call still announces.
+  # So a later bare call still queues the (deferred) message, which a flush emits.
   storage_message_state[["storage_location"]] <- NULL
+  storage_message_state[["pending"]] <- NULL
   d <- NULL
-  expect_message(
-    {
-      d <- duckdb()
-    },
-    "temporary directory"
-  )
+  expect_no_message({
+    d <- duckdb()
+  })
+  expect_message(flush_pending_storage_message(), "temporary directory")
   duckdb_shutdown(d)
 })
 
-test_that("without a prior choice, a bare duckdb() still announces", {
+test_that("without a prior choice, a bare duckdb() queues the deferred install message", {
   skip_on_cran()
   withr::local_options(duckdb.home = NULL, rlang_interactive = FALSE)
   withr::local_envvar(DUCKDB_R_HOME = NA)
@@ -74,13 +81,13 @@ test_that("without a prior choice, a bare duckdb() still announces", {
   )
   storage_message_state[["choice_made"]] <- NULL
   storage_message_state[["storage_location"]] <- NULL
+  storage_message_state[["pending"]] <- NULL
 
+  # Connecting is silent now; the message is queued and emitted on INSTALL.
   drv <- NULL
-  expect_message(
-    {
-      drv <- duckdb()
-    },
-    "temporary directory"
-  )
+  expect_no_message({
+    drv <- duckdb()
+  })
+  expect_message(flush_pending_storage_message(), "temporary directory")
   duckdb_shutdown(drv)
 })


### PR DESCRIPTION
## What & why

The "duckdb keeps downloaded extensions and secrets in a temporary directory…" storage-location message currently fires from `duckdb()` / `dbConnect()` on **every** connection — even when the session never touches an extension. Its subject (where downloaded extensions are cached) only becomes relevant when the user actually **installs** one, so this moves the message to that moment.

## Change

- **`R/Driver.R`** — at connect, still resolve the storage home and set `extension_directory` / `secret_directory`, but instead of announcing, **stash** the resolved home (`set_pending_storage_message()`) when it would have announced.
- **`R/storage-home.R`** — `set_pending_storage_message()` / `flush_pending_storage_message()`. The flush reuses the existing `maybe_storage_location_message()`, which still dedupes per session, so repeated installs stay quiet.
- **`R/dbSendQuery__duckdb_connection_character.R`** — when a prepared statement is an extension `INSTALL` (parser-derived `type == "LOAD"` **and** `is_install_statement()`), flush the queued message.
- **`R/extensions.R`** — `is_install_statement()` (matches `INSTALL` / `FORCE INSTALL`).

Net effect: **connecting is silent**; the message appears the first time an `INSTALL` runs. An explicit `home`/`shared_home` choice still suppresses it entirely (nothing is queued).

## Detection & multi-statement

`INSTALL` is identified from the parser's statement `type` (`"LOAD"`) combined with a lightweight `is_install_statement()` check on the SQL (so `LOAD` of an already-installed extension does not trigger it, matching "when a user installs"). It keys off the same `rapi_prepare` statement metadata used elsewhere, so it composes with multi-statement handling.

## Tests

- Migrated the connect-time assertions in `test-storage-message-once.R` and `test-storage-e2e.R` to the deferred behavior (connect is silent → `flush_pending_storage_message()` emits). The direct `maybe_storage_location_message()` / `storage_location_message()` unit tests in `test-storage-home.R` are unchanged (that function's behavior is unchanged).
- New `test-storage-install-message.R`: `is_install_statement()`, the deferral (queued-but-silent at connect, emitted on flush), and an end-to-end check that an `INSTALL` statement flushes the message.

## Notes

- **Stacked on** #2414 (base is `claude/duckdb-docker-extensions-pyxlgx`); will retarget to `main` once that merges. On a libc++ Linux build (#2414), `INSTALL` is refused *before* this flush runs, so extensions-disabled builds correctly announce nothing.
- I was not able to run the R test suite locally in this environment; the migrated/new tests should be validated in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qmm9Ucq8y89EniuCSYAkav)_