### PR TITLE
docs: document all S4 class slots; deprecate the legacy connection slots

### DIFF
--- a/R/Connection.R
+++ b/R/Connection.R
@@ -2,12 +2,17 @@
 #'
 #' Implements [DBIDriver-class].
 #'
-#' The driver object additionally carries an experimental `allow_extensions`
-#' slot `r lifecycle::badge("experimental")`: whether this driver permits
-#' loading DuckDB extensions (`INSTALL` / `LOAD`), resolved once when the driver
-#' is created.
-#' See the `allow_extensions` argument of [duckdb()].
-#'
+#' @slot database_ref external pointer to the underlying DuckDB database instance.
+#' @slot config named list of DuckDB configuration flags applied when the instance was created.
+#' @slot dbdir path to the database file, or `":memory:"` for an in-memory database.
+#' @slot read_only whether the database was opened read-only.
+#' @slot convert_opts internal options controlling how result values are converted to R
+#'   (bigint handling, time zone, ...).
+#' @slot bigint how 64-bit integers are returned (`"numeric"` or `"integer64"`).
+#' @slot allow_extensions `r lifecycle::badge("experimental")` whether this driver
+#'   permits loading DuckDB extensions (`INSTALL` / `LOAD`),
+#'   resolved once when the driver is created.
+#'   See the `allow_extensions` argument of [duckdb()].
 #' @aliases duckdb_driver
 #' @keywords internal
 #' @export
@@ -25,6 +30,14 @@ setClass("duckdb_driver", contains = "DBIDriver", slots = list(
 #'
 #' Implements [DBIConnection-class].
 #'
+#' @slot conn_ref external pointer to the underlying DuckDB connection.
+#' @slot driver the [duckdb_driver-class] this connection was opened from.
+#' @slot debug whether debug information (such as queries) is printed.
+#' @slot convert_opts internal options controlling how result values are converted to R.
+#' @slot reserved_words character vector of the engine's reserved SQL keywords, used to quote identifiers.
+#' @slot timezone_out (legacy) time zone results are returned in.
+#' @slot tz_out_convert (legacy) how timestamps are converted to `timezone_out` (`"with"` or `"force"`).
+#' @slot bigint (legacy) how 64-bit integers are returned.
 #' @aliases duckdb_connection
 #' @keywords internal
 #' @export

--- a/R/Connection.R
+++ b/R/Connection.R
@@ -35,9 +35,9 @@ setClass("duckdb_driver", contains = "DBIDriver", slots = list(
 #' @slot debug whether debug information (such as queries) is printed.
 #' @slot convert_opts internal options controlling how result values are converted to R.
 #' @slot reserved_words character vector of the engine's reserved SQL keywords, used to quote identifiers.
-#' @slot timezone_out (legacy) time zone results are returned in.
-#' @slot tz_out_convert (legacy) how timestamps are converted to `timezone_out` (`"with"` or `"force"`).
-#' @slot bigint (legacy) how 64-bit integers are returned.
+#' @slot timezone_out `r lifecycle::badge("deprecated")` time zone results are returned in; superseded by `convert_opts`, from which it is copied at construction, and no longer read internally.
+#' @slot tz_out_convert `r lifecycle::badge("deprecated")` how timestamps are converted to `timezone_out` (`"with"` or `"force"`); superseded by `convert_opts`.
+#' @slot bigint `r lifecycle::badge("deprecated")` how 64-bit integers are returned; superseded by `convert_opts`.
 #' @aliases duckdb_connection
 #' @keywords internal
 #' @export
@@ -48,7 +48,8 @@ setClass("duckdb_connection", contains = "DBIConnection", slots = list(
   convert_opts = "list",
   reserved_words = "character",
 
-  # Legacy
+  # Deprecated: superseded by convert_opts (copied from it at construction),
+  # retained for back-compat and no longer read internally.
   timezone_out = "character",
   tz_out_convert = "character",
   bigint = "character"

--- a/R/Result.R
+++ b/R/Result.R
@@ -120,8 +120,8 @@ duckdb_post_execute <- function(res, out) {
   }
   res@env$rows_affected <- rows_affected
 
-  if (res@connection@tz_out_convert == "force") {
-    out <- tz_force(out, res@connection@timezone_out)
+  if (res@connection@convert_opts$tz_out_convert == "force") {
+    out <- tz_force(out, res@connection@convert_opts$timezone_out)
   }
 
   res@env$resultset <- out

--- a/R/Result.R
+++ b/R/Result.R
@@ -3,6 +3,13 @@
 #' Methods for accessing result sets for queries on DuckDB connections.
 #' Implements [DBIResult-class].
 #'
+#' @slot connection the [duckdb_connection-class] the query was executed on.
+#' @slot stmt_lst internal list describing the prepared statement (names,
+#'   types, ...).
+#' @slot env environment holding the result's mutable fetch state.
+#' @slot arrow whether the result is fetched via Arrow.
+#' @slot query_result external pointer to the underlying materialized query
+#'   result.
 #' @aliases duckdb_result
 #' @keywords internal
 #' @export
@@ -22,6 +29,9 @@ setClass("duckdb_result",
 #' Streaming Arrow result for queries on DuckDB connections.
 #' Implements [DBIResultArrow-class][DBI::DBIResultArrow-class].
 #'
+#' @slot connection the [duckdb_connection-class] the query was executed on.
+#' @slot stmt_lst internal list describing the prepared statement.
+#' @slot env environment holding the result's mutable fetch state.
 #' @aliases duckdb_result_arrow
 #' @keywords internal
 #' @export

--- a/man/duckdb_connection-class.Rd
+++ b/man/duckdb_connection-class.Rd
@@ -158,11 +158,11 @@ Implements \link[DBI:DBIConnection-class]{DBIConnection}.
 
 \item{\code{reserved_words}}{character vector of the engine's reserved SQL keywords, used to quote identifiers.}
 
-\item{\code{timezone_out}}{(legacy) time zone results are returned in.}
+\item{\code{timezone_out}}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} time zone results are returned in; superseded by \code{convert_opts}, from which it is copied at construction, and no longer read internally.}
 
-\item{\code{tz_out_convert}}{(legacy) how timestamps are converted to \code{timezone_out} (\code{"with"} or \code{"force"}).}
+\item{\code{tz_out_convert}}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} how timestamps are converted to \code{timezone_out} (\code{"with"} or \code{"force"}); superseded by \code{convert_opts}.}
 
-\item{\code{bigint}}{(legacy) how 64-bit integers are returned.}
+\item{\code{bigint}}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} how 64-bit integers are returned; superseded by \code{convert_opts}.}
 }}
 
 \keyword{internal}

--- a/man/duckdb_connection-class.Rd
+++ b/man/duckdb_connection-class.Rd
@@ -145,4 +145,24 @@ with one column per query parameter.}
 \description{
 Implements \link[DBI:DBIConnection-class]{DBIConnection}.
 }
+\section{Slots}{
+
+\describe{
+\item{\code{conn_ref}}{external pointer to the underlying DuckDB connection.}
+
+\item{\code{driver}}{the \link[=duckdb_driver-class]{duckdb_driver} this connection was opened from.}
+
+\item{\code{debug}}{whether debug information (such as queries) is printed.}
+
+\item{\code{convert_opts}}{internal options controlling how result values are converted to R.}
+
+\item{\code{reserved_words}}{character vector of the engine's reserved SQL keywords, used to quote identifiers.}
+
+\item{\code{timezone_out}}{(legacy) time zone results are returned in.}
+
+\item{\code{tz_out_convert}}{(legacy) how timestamps are converted to \code{timezone_out} (\code{"with"} or \code{"force"}).}
+
+\item{\code{bigint}}{(legacy) how 64-bit integers are returned.}
+}}
+
 \keyword{internal}

--- a/man/duckdb_driver-class.Rd
+++ b/man/duckdb_driver-class.Rd
@@ -34,11 +34,26 @@
 \description{
 Implements \link[DBI:DBIDriver-class]{DBIDriver}.
 }
-\details{
-The driver object additionally carries an experimental \code{allow_extensions}
-slot \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}: whether this driver permits
-loading DuckDB extensions (\code{INSTALL} / \code{LOAD}), resolved once when the driver
-is created.
-See the \code{allow_extensions} argument of \code{\link[=duckdb]{duckdb()}}.
-}
+\section{Slots}{
+
+\describe{
+\item{\code{database_ref}}{external pointer to the underlying DuckDB database instance.}
+
+\item{\code{config}}{named list of DuckDB configuration flags applied when the instance was created.}
+
+\item{\code{dbdir}}{path to the database file, or \code{":memory:"} for an in-memory database.}
+
+\item{\code{read_only}}{whether the database was opened read-only.}
+
+\item{\code{convert_opts}}{internal options controlling how result values are converted to R
+(bigint handling, time zone, ...).}
+
+\item{\code{bigint}}{how 64-bit integers are returned (\code{"numeric"} or \code{"integer64"}).}
+
+\item{\code{allow_extensions}}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}} whether this driver
+permits loading DuckDB extensions (\code{INSTALL} / \code{LOAD}),
+resolved once when the driver is created.
+See the \code{allow_extensions} argument of \code{\link[=duckdb]{duckdb()}}.}
+}}
+
 \keyword{internal}

--- a/man/duckdb_result-class.Rd
+++ b/man/duckdb_result-class.Rd
@@ -86,4 +86,20 @@ special values.}
 Methods for accessing result sets for queries on DuckDB connections.
 Implements \link[DBI:DBIResult-class]{DBIResult}.
 }
+\section{Slots}{
+
+\describe{
+\item{\code{connection}}{the \link[=duckdb_connection-class]{duckdb_connection} the query was executed on.}
+
+\item{\code{stmt_lst}}{internal list describing the prepared statement (names,
+types, ...).}
+
+\item{\code{env}}{environment holding the result's mutable fetch state.}
+
+\item{\code{arrow}}{whether the result is fetched via Arrow.}
+
+\item{\code{query_result}}{external pointer to the underlying materialized query
+result.}
+}}
+
 \keyword{internal}

--- a/man/duckdb_result_arrow-class.Rd
+++ b/man/duckdb_result_arrow-class.Rd
@@ -85,4 +85,14 @@ or a \link[DBI:DBIResult-class]{DBIResult}}
 Streaming Arrow result for queries on DuckDB connections.
 Implements \link[DBI:DBIResultArrow-class]{DBIResultArrow-class}.
 }
+\section{Slots}{
+
+\describe{
+\item{\code{connection}}{the \link[=duckdb_connection-class]{duckdb_connection} the query was executed on.}
+
+\item{\code{stmt_lst}}{internal list describing the prepared statement.}
+
+\item{\code{env}}{environment holding the result's mutable fetch state.}
+}}
+
 \keyword{internal}


### PR DESCRIPTION
## What

Adds complete per-class `Slots` documentation for the package's S4 classes:

- `duckdb_driver` (7 slots): `database_ref`, `config`, `dbdir`, `read_only`, `convert_opts`, `bigint`, `allow_extensions`
- `duckdb_connection` (8 slots): `conn_ref`, `driver`, `debug`, `convert_opts`, `reserved_words`, `timezone_out`, `tz_out_convert`, `bigint`
- `duckdb_result` (5 slots): `connection`, `stmt_lst`, `env`, `arrow`, `query_result`
- `duckdb_result_arrow` (3 slots): `connection`, `stmt_lst`, `env`

Each class gets a `@slot` tag per slot in its roxygen block (`R/Connection.R`, `R/Result.R`) plus a matching `\section{Slots}{\describe{...}}` in the hand-maintained `man/*-class.Rd`.

## Why

R CMD check's S4 codoc check (`tools::codocClasses`) compares the documented slots against `getSlots(class)`, which reports **own and inherited** slots. Documenting only *some* slots emits a WARNING; documenting *none* skips the check. Each of these classes extends a **virtual** DBI base (`DBIDriver`/`DBIConnection`/`DBIResult`/`DBIResultArrow`) with **0 inherited slots**, so the complete slot set equals the class's own slots. Documenting exactly the own slots (all-or-none) yields a clean S4 codoc check with complete docs.

This **supersedes the interim prose bullet** introduced on the base branch, which described the driver's experimental `allow_extensions` slot in the class `@description` (with no `@slot`) purely to avoid the partial-documentation WARNING. That slot is now a proper `@slot`, keeping its experimental lifecycle badge.

## Deprecate the legacy connection slots

The connection's `timezone_out`, `tz_out_convert`, and `bigint` slots (already flagged `# Legacy` in the `setClass`) are the pre-`convert_opts` representation of result-conversion options — each is copied out of `convert_opts` at construction and duplicates a field it holds. This PR:

- marks them **deprecated** in the docs (lifecycle badge + explainer pointing at `convert_opts`), and updates the code comment; and
- drops the last internal readers: `duckdb_post_execute()` now reads `tz_out_convert` / `timezone_out` from `convert_opts` instead of the slots, matching every other consumer (`register.R`, both `dbBind` methods, the arrow/streaming paths). The connection's `bigint` slot already had no readers.

The slots are still populated at construction, so any external code reading them keeps working.

## `duckdb_explain` intentionally excluded

`duckdb_explain` extends the **concrete** `data.frame` class, so `getSlots()` also reports `data.frame`'s inherited slots (`.Data`, `names`, `row.names`, `.S3Class`). Documenting only its own slots (`explain_key`, `explain_value`) would leave those inherited slots undocumented and trip codoc; documenting none avoids the check entirely. It is therefore deliberately left without a `Slots` section.

## Validation

- `tools::parse_Rd()` passes for all four class `.Rd` files.
- The set and order of `\item{\code{...}}` slot names in each `.Rd` matches the class's `setClass()` own-slot list.
- The `@slot` roxygen source and the `.Rd` are kept consistent (the deprecated-badge markup mirrors `lifecycle::badge("deprecated")`; CI's roxygen step reconciles if needed).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qmm9Ucq8y89EniuCSYAkav)_