### PR TITLE
ci: Create `~/.duckdb` so CI exercises the shared storage path

### DIFF
--- a/.github/workflows/custom/before-install/action.yml
+++ b/.github/workflows/custom/before-install/action.yml
@@ -111,3 +111,25 @@ runs:
           echo "No matching DuckDB CLI available; CLI<->R end-to-end tests will skip."
         fi
       shell: bash
+
+    # Create the shared DuckDB home (~/.duckdb) so CI exercises the "shared"
+    # storage-resolution path. The package only treats ~/.duckdb as the home for
+    # downloaded extensions and stored secrets when that directory already
+    # exists; otherwise a non-interactive session (all of CI) falls back to a
+    # per-session tempdir (see R/storage-home.R and ?duckdb_storage). Creating it
+    # up front makes bare duckdb() connections resolve to ~/.duckdb ("shared"),
+    # the same location a user who opted in takes, instead of a throwaway
+    # tempdir. DuckDB -- the engine, its CLI, and this package via
+    # duckdb_shared_home() -- derives the home from USERPROFILE on Windows and
+    # HOME elsewhere (R/extensions.R, mirroring FileSystem::GetHomeDirectory()),
+    # so match that here rather than relying on shell ~ expansion.
+    - name: Create the shared DuckDB home (~/.duckdb)
+      run: |
+        if [ "${RUNNER_OS}" = "Windows" ]; then
+          home="$(cygpath -u "${USERPROFILE}")"
+        else
+          home="${HOME}"
+        fi
+        mkdir -p "${home}/.duckdb"
+        echo "Created shared DuckDB home: ${home}/.duckdb"
+      shell: bash


### PR DESCRIPTION
## What

Adds a step to the custom `before-install` composite action
(`.github/workflows/custom/before-install/action.yml`) that creates the shared
DuckDB home directory `~/.duckdb` before the R package is installed.

## Why

The storage policy (`R/storage-home.R`, documented at `?duckdb_storage`) treats
`~/.duckdb` as the home for downloaded extensions and stored secrets **only when
that directory already exists**. In a non-interactive session — which every CI
job is — it otherwise falls back to a per-session `tempdir()` and never
*creates* `~/.duckdb` on its own (a deliberate CRAN-policy constraint).

As a result, CI only ever exercised the `"session"` (tempdir) resolution branch;
the real, non-mocked `"shared"` branch went untested. Creating `~/.duckdb` up
front makes bare `duckdb()` connections resolve `extension_directory` /
`secret_directory` under it (source `"shared"`) — the same location a user who
opted in takes — giving genuine end-to-end coverage of that path.

## Details

- Placed right after the existing DuckDB-CLI install step, its natural sibling:
  both set up the storage / CLI↔R end-to-end test environment, and the action
  runs on every OS and job.
- The path derivation mirrors DuckDB's own (`USERPROFILE` on Windows via
  `cygpath`, `HOME` elsewhere — see `R/extensions.R`, mirroring
  `FileSystem::GetHomeDirectory()`), so the directory lines up exactly with
  `duckdb_shared_home()`, the bundled engine, and the CLI, rather than relying
  on shell `~` expansion.

## Safety

No test assertions or snapshots change. Every storage unit test deliberately
mocks `duckdb_shared_home()` or passes an explicit `home` / `shared_home`,
precisely so it stays deterministic regardless of a real `~/.duckdb`. I checked
every `expect_silent` / `expect_no_message` / `expect_snapshot` in the suite and
confirmed none wraps a bare connection, and the only snapshot touching storage
wording (`_snaps/storage-home.md`) uses hard-coded inputs. The change only
switches CI's default resolution from tempdir to the shared home. YAML
validates; no R code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PnYE6n6UoGUYQDbo7r1TCq

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnYE6n6UoGUYQDbo7r1TCq)_