### PR TITLE
test: cover extensions env-var semantics and lock message wording

### DIFF
--- a/tests/testthat/_snaps/extensions-libcxx.md
+++ b/tests/testthat/_snaps/extensions-libcxx.md
@@ -1,0 +1,35 @@
+# extensions message wording is stable
+
+    Code
+      rlang::inform(extensions_disabled_message())
+    Message
+      duckdb was built with libc++ (not libstdc++) on Linux, so DuckDB extensions are disabled:
+      * Loading a prebuilt (libstdc++) extension could crash R (https://github.com/duckdb/duckdb-r/issues/1107).
+      * INSTALL/LOAD of an extension will error, and automatic extension loading is off.
+      i Pass duckdb(allow_extensions = FALSE) to accept this and silence this message.
+      i Pass duckdb(allow_extensions = TRUE) to attempt loading anyway (may crash R).
+      i See ?duckdb for details.
+
+---
+
+    Code
+      rlang::inform(extensions_disabled_message())
+    Message
+      duckdb was built with <an unknown C++ library> (not libstdc++) on Linux, so DuckDB extensions are disabled:
+      * Loading a prebuilt (libstdc++) extension could crash R (https://github.com/duckdb/duckdb-r/issues/1107).
+      * INSTALL/LOAD of an extension will error, and automatic extension loading is off.
+      i Pass duckdb(allow_extensions = FALSE) to accept this and silence this message.
+      i Pass duckdb(allow_extensions = TRUE) to attempt loading anyway (may crash R).
+      i See ?duckdb for details.
+
+---
+
+    Code
+      rapi_error("load_extension", "")
+    Condition
+      Error in `rapi_error()`:
+      ! DuckDB extension loading (INSTALL / LOAD) is disabled for this driver.
+      i Recreate the driver with duckdb(allow_extensions = TRUE) to enable it (this may crash R on a Linux build not compiled with libstdc++; see https://github.com/duckdb/duckdb-r/issues/1107).
+      i See ?duckdb for details.
+      i Context: load_extension
+

--- a/tests/testthat/test-extensions-libcxx.R
+++ b/tests/testthat/test-extensions-libcxx.R
@@ -149,6 +149,32 @@ test_that("DUCKDB_R_ALLOW_EXTENSIONS enables or disables per as.logical()", {
   }
 })
 
+test_that("an unparseable DUCKDB_R_ALLOW_EXTENSIONS is treated as completely unset", {
+  withr::local_options(duckdb.allow_extensions = NULL)
+  # Affected build: the auto path disables extensions and announces.
+  local_mocked_bindings(extensions_supported = function() FALSE)
+
+  # Baseline: with the variable unset, the advisory fires (the library mismatch
+  # is genuinely the cause).
+  withr::with_envvar(list(DUCKDB_R_ALLOW_EXTENSIONS = NA), {
+    res <- resolve_allow_extensions(NULL)
+    expect_identical(res$source, "auto")
+    expect_false(res$allow)
+    expect_true(res$announce)
+  })
+
+  # A value as.logical() reads as neither TRUE nor FALSE is ignored entirely --
+  # same source, decision, and advisory as if the variable were unset.
+  for (v in c("", "1", "yes", "maybe")) {
+    withr::with_envvar(list(DUCKDB_R_ALLOW_EXTENSIONS = v), {
+      res <- resolve_allow_extensions(NULL)
+      expect_identical(res$source, "auto")
+      expect_false(res$allow)
+      expect_true(res$announce)
+    })
+  }
+})
+
 # --- duckdb() advisory message ------------------------------------------------
 
 # Clear the "extensions" throttle key so message tests are order-independent.
@@ -221,6 +247,44 @@ test_that("an option or env override silences the duckdb() advisory", {
       }
     )
   )
+})
+
+test_that("duckdb() still announces when DUCKDB_R_ALLOW_EXTENSIONS is unparseable", {
+  skip_on_cran()
+  # A value as.logical() cannot read as TRUE/FALSE is treated as completely
+  # unset, so the auto advisory fires exactly as it would with no variable set.
+  withr::local_options(
+    duckdb.allow_extensions = NULL,
+    duckdb.home = withr::local_tempdir(),
+    rlang_interactive = FALSE
+  )
+  local_mocked_bindings(extensions_supported = function() FALSE)
+  reset_extensions_throttle()
+
+  drv <- NULL
+  withr::with_envvar(
+    list(DUCKDB_R_ALLOW_EXTENSIONS = "1"),
+    expect_message(drv <- duckdb(), "extensions are disabled")
+  )
+  duckdb_shutdown(drv)
+})
+
+# --- message wording (snapshot) ----------------------------------------------
+
+test_that("extensions message wording is stable", {
+  # The advisory names the detected C++ standard library as the cause and is only
+  # shown on the auto path, so snapshot both stdlib variants that reach it.
+  local_mocked_bindings(compiled_cxx_stdlib = function() "libc++")
+  expect_snapshot(rlang::inform(extensions_disabled_message()))
+
+  local_mocked_bindings(compiled_cxx_stdlib = function() "<an unknown C++ library>")
+  expect_snapshot(rlang::inform(extensions_disabled_message()))
+
+  # The INSTALL / LOAD refusal error is cause-neutral: it fires both on the
+  # auto-disable path and for an explicit duckdb(allow_extensions = FALSE), so it
+  # never names the library. Snapshot it through the centralized rapi_error()
+  # bridge the C++ guard calls with context "load_extension" and an empty message.
+  expect_snapshot(rapi_error("load_extension", ""), error = TRUE)
 })
 
 # --- driver slots -------------------------------------------------------------


### PR DESCRIPTION
Follow-up test coverage for #2414. No production-code or documentation change — it locks the behavior `main` already has.

## `DUCKDB_R_ALLOW_EXTENSIONS` semantics

A value `as.logical()` reads as neither `TRUE` nor `FALSE` (e.g. `"1"`, `"yes"`, empty) is treated as **completely unset**: it has no effect on the source, the allow decision, or the advisory. On an affected build (Linux, not `libstdc++`) the auto advisory therefore still fires — the library mismatch is genuinely the cause, because the unreadable value is ignored entirely.

Tests added:
- resolve-level: unset and every unparseable value alike give `source = "auto"`, `allow = FALSE`, `announce = TRUE`.
- `duckdb()`-level: `DUCKDB_R_ALLOW_EXTENSIONS = "1"` on an affected build still shows the advisory.

## Message wording (snapshots)

Lock the exact text of the three messages the gate can produce:
- the auto-disable advisory for a **libc++** build,
- the same advisory for an **unidentified** C++ standard library,
- the **cause-neutral** INSTALL/LOAD refusal error (fires both on auto-disable and for an explicit `allow_extensions = FALSE`, so it never names the library), routed through the `rapi_error()` bridge the C++ guard calls with context `"load_extension"`.

Verified against a source build of the package: all `test-extensions-libcxx.R` tests pass (62 assertions, 0 failures) with the recorded snapshots matching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)