### PR TITLE
fledge: CRAN release v1.5.5

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: duckdb
 Title: DBI Package for the DuckDB Database Management System
-Version: 1.5.4.9903
+Version: 1.5.5
 Authors@R: c(
     person("Hannes", "Mühleisen", , "hannes@cwi.nl", role = "aut",
            comment = c(ORCID = "0000-0001-8552-0029")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,33 +4,25 @@
 
 ## Features
 
-- Disable extensions on libc++ Linux builds, with startup message and load error (#2414).
-
 - Update to DuckDB v1.5.5, see <https://github.com/duckdb/duckdb/releases/tag/v1.5.5> for details.
 
+- Disable extensions on libc++ Linux builds, with startup message and load error (#1107, #2414).
+
 - Rework how extensions and secrets choose their on-disk location, replacing the
-  package-library extension cache attempted across 1.5.4.1 through 1.5.4.3. Both
-  now share a single "home" root, resolved fresh for every `duckdb()` driver from
-  the first of these that yields a value: the `home` argument, the `duckdb.home`
-  option, the `DUCKDB_R_HOME` environment variable, an existing `~/.duckdb` (the
-  directory shared with the DuckDB CLI), a one-time interactive offer to create
-  `~/.duckdb`, and otherwise a per-session `tempdir()` sub-directory. Extensions
-  live in `<home>/extensions` and secrets in `<home>/stored_secrets`; by default
-  nothing is written under your home directory unless `~/.duckdb` already exists.
-  Pass `shared_home = TRUE` or `FALSE` to force `~/.duckdb` or `tempdir()`, and
-  call `duckdb_storage_status()` to see where each currently resolves. The chosen
-  location is announced only when the package picked it, and stays quiet once you
-  have made an explicit `home` or `shared_home` choice (#2396, #2398).
+  package-library extension cache attempted across 1.5.4.1 through 1.5.4.3.
+  Both now share a single "home" root, resolved fresh for every `duckdb()` driver.
+  An interactive prompt in `duckdb()` and messages in non-interactive sessions guide the process.
+  See `?duckdb_storage` for details. (#2396, #2398).
 
 ## Bug fixes
 
 - Support `OR` and `IN` predicates pushed down to registered Arrow tables (#2410).
 
+- Error instead of crashing when calling `duckdb_fetch_arrow()` on an Arrow result that has been consumed with `duckdb_fetch_record_batch()` (#2406).
+
 - Fix edge case in computation of `r_base::min`/`r_base::max`/`r_base::sum` aggregates (#2404, #2405).
 
 - Honor the `na.rm` argument of `r_base` aggregates in SQL queries (#2407).
-
-- Error instead of crashing when calling `duckdb_fetch_arrow()` on an Arrow result that has been consumed with `duckdb_fetch_record_batch()` (#2406).
 
 ## Documentation
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,13 +1,10 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# duckdb 1.5.4.9903
+# duckdb 1.5.5
 
-## Continuous integration
+## fledge
 
-- Create `~/.duckdb` so CI exercises the shared storage path (#2417).
-
-
-# duckdb 1.5.4.9902
+- CRAN pre-release v1.5.4.9900 (#2402).
 
 ## Bug fixes
 
@@ -27,41 +24,17 @@
 
 - Error instead of crashing when calling `duckdb_fetch_arrow()` on an Arrow result that has been consumed with `duckdb_fetch_record_batch()` (#2406).
 
+
+
+- Remove the package-library extension storage option. The `duckdb_extension_storage()` function no longer accepts `"library"` (#2390).
+
+
+
+- Fix shared on-disk storage path on Windows (#2385).
+
 ## Features
 
 - Disable extensions on libc++ Linux builds, with startup message and load error (#2414).
-
-## Documentation
-
-- Document all S4 class slots; deprecate the legacy connection slots (#2416).
-
-## Testing
-
-- Cover extensions env-var semantics and lock message wording (#2418).
-
-## Uncategorized
-
-- Ci: Harden `format-suggest` against `pull_request_target` pwn requests (#93).
-
-
-# duckdb 1.5.4.9901
-
-## Continuous integration
-
-- Install `tzdata-legacy` for legacy time zones like `PST8PDT` (#2409).
-
-## Testing
-
-- Skip DBItest timestamp roundtrip tests when `PST8PDT` is unresolvable (#2408).
-
-## fledge
-
-- CRAN pre-release v1.5.4.9900 (#2402).
-
-
-# duckdb 1.5.4.9900
-
-## Features
 
 - Update to DuckDB v1.5.5, see <https://github.com/duckdb/duckdb/releases/tag/v1.5.5> for details.
 
@@ -79,29 +52,6 @@
   location is announced only when the package picked it, and stays quiet once you
   have made an explicit `home` or `shared_home` choice (#2396, #2398).
 
-## Documentation
-
-- Document database-instance caching and driver reuse (#2399).
-
-
-# duckdb 1.5.4.3
-
-## Bug fixes
-
-- Remove the package-library extension storage option. The `duckdb_extension_storage()` function no longer accepts `"library"` (#2390).
-
-
-# duckdb 1.5.4.2
-
-## Bug fixes
-
-- Fix shared on-disk storage path on Windows (#2385).
-
-
-# duckdb 1.5.4.1
-
-## Features
-
 - DuckDB's on-disk storage locations now follow a unified policy. By
   default nothing is written outside the R session's temporary directory, with
   one exception: the extension cache is placed in the package library when it
@@ -113,6 +63,28 @@
 
   These functions replace the experimental `duckdb_consolidate_secrets()`
   introduced in 1.5.4.
+
+## Continuous integration
+
+- Create `~/.duckdb` so CI exercises the shared storage path (#2417).
+
+- Install `tzdata-legacy` for legacy time zones like `PST8PDT` (#2409).
+
+## Documentation
+
+- Document all S4 class slots; deprecate the legacy connection slots (#2416).
+
+- Document database-instance caching and driver reuse (#2399).
+
+## Testing
+
+- Cover extensions env-var semantics and lock message wording (#2418).
+
+- Skip DBItest timestamp roundtrip tests when `PST8PDT` is unresolvable (#2408).
+
+## Uncategorized
+
+- Ci: Harden `format-suggest` against `pull_request_target` pwn requests (#93).
 
 
 # duckdb 1.5.4

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,25 +2,13 @@
 
 # duckdb 1.5.5
 
-## fledge
-
-- CRAN pre-release v1.5.4.9900 (#2402).
-
 ## Bug fixes
-
-### ci
-
-- Emit empty package matrix when there are no (rev)deps.
 
 - Support `OR` and `IN` predicates pushed down to registered Arrow tables (#2410).
 
-- Merge partial states in `r_base::min`/`r_base::max` aggregates (#2404).
+- Fix edge case in computation of `r_base::min`/`r_base::max`/`r_base::sum` aggregates (#2404, #2405).
 
 - Honor the `na.rm` argument of `r_base` aggregates in SQL queries (#2407).
-
-- Merge partial states in the `r_base::sum` aggregate (#2405).
-
-- Check the right-hand argument against the right-hand type in `BinaryTypeAssert()` (#2411).
 
 - Error instead of crashing when calling `duckdb_fetch_arrow()` on an Arrow result that has been consumed with `duckdb_fetch_record_batch()` (#2406).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,16 +2,6 @@
 
 # duckdb 1.5.5
 
-## Bug fixes
-
-- Support `OR` and `IN` predicates pushed down to registered Arrow tables (#2410).
-
-- Fix edge case in computation of `r_base::min`/`r_base::max`/`r_base::sum` aggregates (#2404, #2405).
-
-- Honor the `na.rm` argument of `r_base` aggregates in SQL queries (#2407).
-
-- Error instead of crashing when calling `duckdb_fetch_arrow()` on an Arrow result that has been consumed with `duckdb_fetch_record_batch()` (#2406).
-
 ## Features
 
 - Disable extensions on libc++ Linux builds, with startup message and load error (#2414).
@@ -31,6 +21,16 @@
   call `duckdb_storage_status()` to see where each currently resolves. The chosen
   location is announced only when the package picked it, and stays quiet once you
   have made an explicit `home` or `shared_home` choice (#2396, #2398).
+
+## Bug fixes
+
+- Support `OR` and `IN` predicates pushed down to registered Arrow tables (#2410).
+
+- Fix edge case in computation of `r_base::min`/`r_base::max`/`r_base::sum` aggregates (#2404, #2405).
+
+- Honor the `na.rm` argument of `r_base` aggregates in SQL queries (#2407).
+
+- Error instead of crashing when calling `duckdb_fetch_arrow()` on an Arrow result that has been consumed with `duckdb_fetch_record_batch()` (#2406).
 
 ## Documentation
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,14 +12,6 @@
 
 - Error instead of crashing when calling `duckdb_fetch_arrow()` on an Arrow result that has been consumed with `duckdb_fetch_record_batch()` (#2406).
 
-
-
-- Remove the package-library extension storage option. The `duckdb_extension_storage()` function no longer accepts `"library"` (#2390).
-
-
-
-- Fix shared on-disk storage path on Windows (#2385).
-
 ## Features
 
 - Disable extensions on libc++ Linux builds, with startup message and load error (#2414).
@@ -39,6 +31,29 @@
   call `duckdb_storage_status()` to see where each currently resolves. The chosen
   location is announced only when the package picked it, and stays quiet once you
   have made an explicit `home` or `shared_home` choice (#2396, #2398).
+
+## Documentation
+
+- Document database-instance caching and driver reuse (#2399).
+
+
+# duckdb 1.5.4.3
+
+## Bug fixes
+
+- Remove the package-library extension storage option. The `duckdb_extension_storage()` function no longer accepts `"library"` (#2390).
+
+
+# duckdb 1.5.4.2
+
+## Bug fixes
+
+- Fix shared on-disk storage path on Windows (#2385).
+
+
+# duckdb 1.5.4.1
+
+## Features
 
 - DuckDB's on-disk storage locations now follow a unified policy. By
   default nothing is written outside the R session's temporary directory, with

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,4 +1,4 @@
-duckdb 1.5.4.9900
+duckdb 1.5.5
 
 ## Cran Repository Policy
 


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2026-07-24, no problems found.

## Action items

- [ ] Review PR
- [ ] Await successful CI/CD run
- [ ] Run `fledge::release()`
- [ ] When the package is accepted on CRAN, run `fledge::post_release()`