### PR TITLE
ci: Sync R-CMD-check workflow; drop matrix-env plumbing from custom action

### DIFF
--- a/.github/versions-matrix.R
+++ b/.github/versions-matrix.R
@@ -3,8 +3,9 @@ list(
   data.frame(os = "windows-latest", r = r_versions[4:6]),
   # Build the DuckDB C++ engine with a tripwire (-DDUCKDB_R_POISON_ENGINE) and
   # force DUCKDB_R_RUN_TESTS=false. The flag travels through the generic "env"
-  # matrix field and is picked up by the custom before-install action, which
-  # also opts this entry out of the tests/examples that otherwise run
+  # matrix field, which the rcc-full job applies to the environment of all
+  # steps; the custom before-install action reacts by building the tripwire
+  # and opting this entry out of the tests/examples that otherwise run
   # automatically on GitHub Actions. Any test or example that reaches the C++
   # engine then aborts, so this run verifies that the CRAN guards keep the
   # engine untouched.

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -317,12 +317,23 @@ jobs:
         with:
           ref: ${{ needs.rcc-smoke.outputs.sha }}
 
+      - name: Apply environment variables from the test matrix
+        # Generic: matrix entries defined in .github/versions-matrix.R can
+        # carry an "env" field (one KEY=VALUE per line).
+        # Write it to $GITHUB_ENV here, in the workflow,
+        # because composite actions cannot read the matrix context.
+        # The variables then reach every subsequent step,
+        # including the custom before-install and after-install actions,
+        # without requiring repos to implement any plumbing of their own.
+        if: matrix.env != ''
+        env:
+          MATRIX_ENV: ${{ matrix.env }}
+        run: |
+          printf '%s\n' "$MATRIX_ENV" | tee -a "$GITHUB_ENV"
+        shell: bash
+
       - uses: ./.github/workflows/custom/before-install
         if: hashFiles('.github/workflows/custom/before-install/action.yml') != ''
-        with:
-          # Generic: forward any per-entry environment variables defined in the
-          # test matrix (see .github/versions-matrix.R) to the custom action.
-          env: ${{ matrix.env }}
 
       - uses: ./.github/workflows/install
         with:

--- a/.github/workflows/custom/before-install/action.yml
+++ b/.github/workflows/custom/before-install/action.yml
@@ -1,26 +1,15 @@
 name: 'Custom steps to run before R packages are installed'
 
-inputs:
-  env:
-    description: >
-      Additional environment variables (one KEY=VALUE per line) contributed by
-      the test matrix. Generic hook used by .github/versions-matrix.R to flag
-      special matrix entries (e.g. the engine-poisoning and vendored-build
-      entries below).
-    required: false
-    default: ""
+# Environment variables from the "env" field of test matrix entries
+# (see .github/versions-matrix.R, e.g. DUCKDB_R_POISON_ENGINE and
+# DUCKDB_R_USE_SYSTEM_LIB) are applied by the rcc-full job in
+# R-CMD-check.yaml before this action runs, so they are already visible
+# here (e.g. in the engine-tripwire and system-libduckdb steps below)
+# and in all later steps.
 
 runs:
   using: "composite"
   steps:
-    - name: Apply environment variables from the test matrix
-      if: inputs.env != ''
-      env:
-        MATRIX_ENV: ${{ inputs.env }}
-      run: |
-        printf '%s\n' "$MATRIX_ENV" | tee -a "$GITHUB_ENV"
-      shell: bash
-
     - name: Define R CMD check error condition
       run: |
         echo '_R_CHECK_PKG_SIZES_=FALSE' | tee -a $GITHUB_ENV

--- a/.github/workflows/versions-matrix/action.R
+++ b/.github/workflows/versions-matrix/action.R
@@ -67,9 +67,18 @@ if (!is.na(filter)) {
 
 to_json <- function(x) {
   if (nrow(x) == 0) return(character())
+  # Minimal JSON string escaping: backslash, double quote, newline.
+  # Newlines matter for the "env" field,
+  # which carries one KEY=VALUE per line.
+  escape <- function(v) {
+    v <- gsub("\\", "\\\\", v, fixed = TRUE)
+    v <- gsub('"', '\\"', v, fixed = TRUE)
+    v <- gsub("\n", "\\n", v, fixed = TRUE)
+    v
+  }
   parallel <- vector("list", length(x))
   for (i in seq_along(x)) {
-    parallel[[i]] <- paste0('"', names(x)[[i]], '":"', x[[i]], '"')
+    parallel[[i]] <- paste0('"', escape(names(x)[[i]]), '":"', escape(x[[i]]), '"')
   }
   paste0("{", do.call(paste, c(parallel, sep = ",")), "}")
 }


### PR DESCRIPTION
Sync `.github/workflows/R-CMD-check.yaml` and
`.github/workflows/versions-matrix/action.R` from cynkratemplate
(cynkra/cynkratemplate#95).

The template's `rcc-full` job now applies the generic `env` field
of test matrix entries to `$GITHUB_ENV` itself,
before the custom before-install action runs,
because composite actions cannot read the `matrix` context —
until now, every consumer repo had to carry
the same apply-to-`$GITHUB_ENV` boilerplate in its custom action,
and a repo without it silently dropped the variables.

The apply boilerplate and the `env` input
are therefore removed from the custom before-install action;
`DUCKDB_R_POISON_ENGINE` and `DUCKDB_R_USE_SYSTEM_LIB`
from the engine-poisoning and vendored-build matrix entries
keep reaching the tripwire and system-libduckdb steps
through the workflow-level step,
which runs before the custom action.

The same branch is also pushed to `krlmlr/duckdb-r`
(the vendoring pipeline repo, which shares these workflow files);
that copy is `krlmlr/duckdb-r@claude/gha-env-var-setup-ej3a28`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136C9bRMjBGkUrtLdkYNmAg

---
_Generated by [Claude Code](https://claude.ai/code/session_0136C9bRMjBGkUrtLdkYNmAg)_