### PR TITLE
test: Guard the LTS rename against hard-coded package names

### DIFF
--- a/.github/workflows/custom/after-install/action.yml
+++ b/.github/workflows/custom/after-install/action.yml
@@ -44,13 +44,19 @@ runs:
         ccache -s
       shell: bash
 
-    # Guard for the LTS rename: fail when the package name is hard-coded
+    # Guard for the flavor rename: fail when the package name is hard-coded
     # somewhere scripts/lts.patch does not rewrite it. The equivalent testthat
     # test (tests/testthat/test-lts-package-name.R) can only skip under R CMD
     # check, which runs from a built tarball where neither the sources nor
     # scripts/ (.Rbuildignore'd) exist -- so the scan runs here, against the
     # checkout. Base R only, no package needed.
+    #
+    # This action runs in every matrix entry, but the scan reads the checkout
+    # and nothing else, so its result is the same everywhere. Run it in the
+    # smoke test only -- the gate that also styles, roxygenizes and updates
+    # snapshots -- rather than a dozen more times for the same answer.
     - name: Check that the package name is hard-coded only where scripts/lts.patch rewrites it
+      if: github.job == 'rcc-smoke'
       run: |
         source("scripts/lts-package-name.R")
         offenders <- lts_package_name_offenders(".")

--- a/.github/workflows/custom/after-install/action.yml
+++ b/.github/workflows/custom/after-install/action.yml
@@ -43,3 +43,23 @@ runs:
       run: |
         ccache -s
       shell: bash
+
+    # Guard for the LTS rename: fail when the package name is hard-coded
+    # somewhere scripts/lts.patch does not rewrite it. The equivalent testthat
+    # test (tests/testthat/test-lts-package-name.R) can only skip under R CMD
+    # check, which runs from a built tarball where neither the sources nor
+    # scripts/ (.Rbuildignore'd) exist -- so the scan runs here, against the
+    # checkout. Base R only, no package needed.
+    - name: Check that the package name is hard-coded only where scripts/lts.patch rewrites it
+      run: |
+        source("scripts/lts-package-name.R")
+        offenders <- lts_package_name_offenders(".")
+        if (length(offenders) > 0) {
+          writeLines(offenders)
+          stop(
+            "The package name is hard-coded outside scripts/lts.patch; ",
+            "see scripts/lts-package-name.R for how to resolve this."
+          )
+        }
+        writeLines("No hard-coded package name outside scripts/lts.patch.")
+      shell: Rscript {0}

--- a/BRANCHES.md
+++ b/BRANCHES.md
@@ -25,10 +25,12 @@ The seven components are:
    name variant (`duckdb`, `duckdb.1.4`, `duckdb.1.4.dev`, …).
    Managed via `scripts/lts.patch` and `scripts/lts.sh`; also covers the `@useDynLib` directive and
    the `DUCKDB_PACKAGE_NAME` C++ macro.
-   `tests/testthat/test-lts-package-name.R` guards the boundary: it fails as soon as the package name is
-   hard-coded — as a namespace qualifier or as a quoted string — in code or docs anywhere the patch does
-   not rewrite it. Code asks for the name at run time with `get_package_name()` instead, and docs do not
-   namespace-qualify our own objects.
+   `scripts/lts-package-name.R` guards the boundary: it fails as soon as the package name is hard-coded —
+   as a namespace qualifier or as a quoted string — in code or docs anywhere the patch does not rewrite it.
+   Code asks for the name at run time with `get_package_name()` instead, and docs do not namespace-qualify
+   our own objects. CI runs the scan from `.github/workflows/custom/after-install`;
+   `tests/testthat/test-lts-package-name.R` wraps it for `testthat::test_local()` and skips under
+   `R CMD check`, which works from a tarball that carries neither the sources nor `scripts/`.
 
 3. **Glue code** (`src/*.cpp`, `src/include/`): the C++ bridge between R and the DuckDB C++ API.
    Glue code may change when DuckDB's C++ API shifts, so it is updated together with vendoring commits.

--- a/BRANCHES.md
+++ b/BRANCHES.md
@@ -20,10 +20,15 @@ The seven components are:
    `main` (bleeding edge / dev), `v1.5-variegata` (current patch series), `v1.4-andium` (LTS).
    Never modify this directory directly — use the `patch/` mechanism instead.
 
-2. **Flavor** (`DESCRIPTION`, `R/duckdb-package.R`, `src/include/rapi.hpp`, `inst/include/duckdb_types.hpp`,
-   `tests/testthat.R`): the published package name variant (`duckdb`, `duckdb.1.4`, `duckdb.1.4.dev`, …).
+2. **Flavor** (`DESCRIPTION`, `R/duckdb-package.R`, `NAMESPACE`, `README.md`, `src/include/rapi.hpp`,
+   `inst/include/duckdb_types.hpp`, `tests/testthat.R`, `man/duckdb-package.Rd`): the published package
+   name variant (`duckdb`, `duckdb.1.4`, `duckdb.1.4.dev`, …).
    Managed via `scripts/lts.patch` and `scripts/lts.sh`; also covers the `@useDynLib` directive and
    the `DUCKDB_PACKAGE_NAME` C++ macro.
+   `tests/testthat/test-lts-package-name.R` guards the boundary: it fails as soon as the package name is
+   hard-coded — as a namespace qualifier or as a quoted string — in code or docs anywhere the patch does
+   not rewrite it. Code asks for the name at run time with `get_package_name()` instead, and docs do not
+   namespace-qualify our own objects.
 
 3. **Glue code** (`src/*.cpp`, `src/include/`): the C++ bridge between R and the DuckDB C++ API.
    Glue code may change when DuckDB's C++ API shifts, so it is updated together with vendoring commits.

--- a/R/extensions.R
+++ b/R/extensions.R
@@ -1,5 +1,5 @@
 default_user_directory <- function() {
-  tools::R_user_dir("duckdb", "data")
+  tools::R_user_dir(get_package_name(), "data")
 }
 
 # `default_user_directory()` above and `duckdb_shared_home()` below are thin

--- a/R/extensions.R
+++ b/R/extensions.R
@@ -1,15 +1,6 @@
-# The legacy extension cache. Every flavor of the package -- `duckdb`,
-# `duckdb.1.4`, ... -- wrote here under the literal `duckdb`, so the name stays
-# hard-coded: it is where the leftovers actually are, not the name of the package
-# doing the sweeping. Only `cleanup_user_directory()` reads it.
-default_user_directory <- function() {
-  tools::R_user_dir("duckdb", "data")
-}
-
-# `default_user_directory()` above and `duckdb_shared_home()` below are thin
-# wrappers over the environment so the storage-location logic stays testable
-# without touching the real filesystem or HOME. See `?duckdb_storage` and
-# plan/PLAN-storage-locations.md.
+# `duckdb_shared_home()` below is a thin wrapper over the environment so the
+# storage-location logic stays testable without touching the real filesystem or
+# HOME. See `?duckdb_storage` and plan/PLAN-storage-locations.md.
 
 # The DuckDB default home (`<home>/.duckdb`), shared with the DuckDB CLI and
 # Python client. The `<home>` base must match the engine's own notion of the
@@ -153,22 +144,5 @@ maybe_extensions_message <- function() {
     inform_once_every("extensions", STORAGE_MESSAGE_INTERVAL, message)
   } else {
     inform_up_to("extensions", STORAGE_MESSAGE_MAX, message)
-  }
-}
-
-cleanup_user_directory <- function() {
-  user_directory <- default_user_directory()
-  if (!dir.exists(user_directory)) {
-    return()
-  }
-  # Extensions are no longer kept under R_user_dir; drop any leftovers from
-  # earlier versions while preserving stored_secrets which may still live here.
-  user_files <- setdiff(list.files(user_directory), "stored_secrets")
-  if (length(user_files) > 0) {
-    message(
-      "Deleting files in duckdb user directory: ",
-      paste(user_files, collapse = ", ")
-    )
-    unlink(file.path(user_directory, user_files), recursive = TRUE)
   }
 }

--- a/R/extensions.R
+++ b/R/extensions.R
@@ -1,5 +1,9 @@
+# The legacy extension cache. Every flavor of the package -- `duckdb`,
+# `duckdb.1.4`, ... -- wrote here under the literal `duckdb`, so the name stays
+# hard-coded: it is where the leftovers actually are, not the name of the package
+# doing the sweeping. Only `cleanup_user_directory()` reads it.
 default_user_directory <- function() {
-  tools::R_user_dir(get_package_name(), "data")
+  tools::R_user_dir("duckdb", "data")
 }
 
 # `default_user_directory()` above and `duckdb_shared_home()` below are thin

--- a/R/storage-home.R
+++ b/R/storage-home.R
@@ -12,7 +12,7 @@ session_temp_dir <- function() {
 
 # The per-session home, under tempdir(). Wiped when the R session ends.
 session_home <- function() {
-  file.path(session_temp_dir(), "duckdb")
+  file.path(session_temp_dir(), get_package_name())
 }
 
 # The sub-directory of a home root that holds a given kind of state. The names

--- a/R/storage.R
+++ b/R/storage.R
@@ -120,7 +120,7 @@
 #'     an informational message describing where extensions and secrets are
 #'     going and how to change it. It is throttled by session type: in an
 #'     **interactive** session at most once every eight hours (a human can act on it);
-#'     in a **non-interactive** session up to `r duckdb:::STORAGE_MESSAGE_MAX` times,
+#'     in a **non-interactive** session up to `r STORAGE_MESSAGE_MAX` times,
 #'     after which it goes silent for good,
 #'     so a long-running or automated process is not reminded forever.
 #'     The message is suppressed entirely when you chose the
@@ -179,7 +179,7 @@
 #'
 #' ```r
 #' tempdir_for_tests <- withr::local_tempdir()
-#' con <- DBI::dbConnect(duckdb::duckdb(home = tempdir_for_tests))
+#' con <- DBI::dbConnect(duckdb(home = tempdir_for_tests))
 #' ```
 #'
 #' @seealso [duckdb()] for the `home` and `shared_home` arguments.

--- a/man/duckdb_storage.Rd
+++ b/man/duckdb_storage.Rd
@@ -175,7 +175,7 @@ To force a throwaway cache in your own tests, connect with an explicit home:
 }
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{tempdir_for_tests <- withr::local_tempdir()
-con <- DBI::dbConnect(duckdb::duckdb(home = tempdir_for_tests))
+con <- DBI::dbConnect(duckdb(home = tempdir_for_tests))
 }\if{html}{\out{</div>}}
 }
 

--- a/plan/PLAN-storage-locations.md
+++ b/plan/PLAN-storage-locations.md
@@ -44,6 +44,8 @@ resolution/marker logic calls these, never the underlying primitive.
 
 - [x] `default_user_directory()` → wraps `tools::R_user_dir("duckdb", "data")`
       (pre-existing; the R-user-dir seam).
+      Since removed: once extensions moved out of `R_user_dir`, nothing wrote
+      there any more, and the seam had no callers left but the legacy sweep.
 - [x] `duckdb_shared_home()` → wraps `path.expand("~/.duckdb")`; replaces the
       hard-coded literal in `common_secret_directory()`.
 - [x] `system_file_path()` → the package-install-dir seam (pre-existing); tests
@@ -170,6 +172,8 @@ resolution/marker logic calls these, never the underlying primitive.
 - [ ] `NEWS.md` entry (via fledge) for the new functions + removal.
 - [x] Reconcile with the existing `maybe_secret_directory_message()` and
       `cleanup_user_directory()` (legacy `R_user_dir/extensions` sweep).
+      The sweep is gone: it only ever ran from the test teardown, against a
+      directory this package stopped writing to.
 - [ ] Windows path handling (`normalizePath(winslash=)`, `%LOCALAPPDATA%`).
 - [ ] `.Rbuildignore` / `.gitignore` already ignore `/extensions/`; re-check
       once the default location moves.

--- a/scripts/lts-package-name.R
+++ b/scripts/lts-package-name.R
@@ -1,0 +1,112 @@
+# Guard for the LTS rename.
+#
+# The LTS builds ship this package under a different name: `scripts/lts.sh`
+# applies `scripts/lts.patch`, which renames `duckdb` to `duckdb.1.3`,
+# `duckdb.1.5`, and so on.
+#
+# Every hard-coded `duckdb::`, `duckdb:::`, or `"duckdb"` that the patch does not
+# rewrite keeps pointing at the mainline package in those builds -- silently, and
+# usually only noticed by a user. `lts_package_name_offenders()` returns every
+# such occurrence, so a new one has to be dealt with deliberately:
+#
+# * in code, ask for the name at run time with `get_package_name()`;
+# * in docs, do not qualify our own objects with `duckdb::`;
+# * if the literal names something else, add it to `LTS_ALLOWED_OUTSIDE_PATCH`;
+# * otherwise teach `scripts/lts.patch` to rewrite it.
+#
+# The scan covers the R-level surface -- `R/`, `man/`, `tests/`, `vignettes/`, and
+# the Markdown files at the top level -- plus the C++ glue in `src/` and
+# `inst/include/`. In the glue only the quoted form is checked: `duckdb::` there is
+# the engine's C++ namespace, which has nothing to do with the R package name.
+# Vendored sources under `src/duckdb/` and testthat snapshots are left alone.
+#
+# Base R only, and no reliance on the package being loaded, so that CI can run
+# this against a plain checkout (see .github/workflows/custom/after-install).
+# `tests/testthat/test-lts-package-name.R` wraps it for `testthat::test_local()`;
+# that test cannot carry the check on its own, because `R CMD check` runs the
+# tests from a built tarball, where neither the sources nor this directory
+# (`.Rbuildignore`d) exist.
+
+# Occurrences that name something other than this R package, and must therefore
+# stay literal in the LTS builds as well. Values are the trimmed source lines.
+LTS_ALLOWED_OUTSIDE_PATCH <- list(
+  # The DuckDB CLI executable on the PATH, not the R package.
+  "tests/testthat/test-storage-cli-e2e.R" = 'unname(Sys.which("duckdb"))',
+  # The legacy extension cache, which every flavor of the package wrote to under
+  # the literal `duckdb`; renaming it would point the sweep at a directory that
+  # never existed. See `cleanup_user_directory()`.
+  "R/extensions.R" = 'tools::R_user_dir("duckdb", "data")',
+  "tests/testthat/test-storage-seams.R" = 'expect_equal(default_user_directory(), tools::R_user_dir("duckdb", "data"))'
+)
+
+# The lines `scripts/lts.patch` rewrites, as a list of trimmed source lines keyed
+# by the path they are rewritten in. These are exactly the occurrences the LTS
+# rename already accounts for.
+lts_patched_lines <- function(patch_file) {
+  lines <- readLines(patch_file, warn = FALSE)
+  patched <- list()
+  path <- NA_character_
+
+  for (line in lines) {
+    if (grepl("^diff --git a/", line)) {
+      path <- sub("^diff --git a/(.*) b/.*$", "\\1", line)
+    } else if (!is.na(path) && grepl("^-", line) && !grepl("^---", line)) {
+      patched[[path]] <- c(patched[[path]], trimws(substring(line, 2)))
+    }
+  }
+
+  patched
+}
+
+# Paths under `subdir` matching `pattern`, relative to the package root.
+lts_dir <- function(root, subdir, pattern) {
+  file.path(subdir, dir(file.path(root, subdir), pattern = pattern, recursive = TRUE))
+}
+
+# The files to scan, as paths relative to `root`, each named by the pattern that
+# applies to it.
+lts_scanned_files <- function(root) {
+  r_level <- c(
+    lts_dir(root, "R", "[.]R$"),
+    lts_dir(root, "man", "[.]Rd$"),
+    lts_dir(root, "tests", "[.]R$"),
+    lts_dir(root, "vignettes", "[.](R|Rmd|qmd)$"),
+    dir(root, pattern = "[.]md$")
+  )
+
+  glue <- c(
+    lts_dir(root, "src", "[.](c|h|cpp|hpp)$"),
+    lts_dir(root, file.path("inst", "include"), "[.](h|hpp)$")
+  )
+  glue <- glue[!startsWith(glue, paste0(file.path("src", "duckdb"), "/"))]
+
+  patterns <- c(
+    rep('duckdb:::?|"duckdb"', length(r_level)),
+    rep('"duckdb"', length(glue))
+  )
+  names(patterns) <- c(r_level, glue)
+  patterns
+}
+
+# Every hard-coded occurrence of the package name that `scripts/lts.patch` does
+# not rewrite, as `path:line: content` strings. Empty when all is well.
+lts_package_name_offenders <- function(root = ".") {
+  patched <- lts_patched_lines(file.path(root, "scripts", "lts.patch"))
+  scanned <- lts_scanned_files(root)
+
+  offenders <- character()
+
+  for (i in seq_along(scanned)) {
+    path <- names(scanned)[[i]]
+    lines <- readLines(file.path(root, path), warn = FALSE)
+
+    for (hit in grep(scanned[[i]], lines)) {
+      line <- trimws(lines[[hit]])
+      if (line %in% patched[[path]]) next
+      if (line %in% LTS_ALLOWED_OUTSIDE_PATCH[[path]]) next
+      offenders <- c(offenders, paste0(path, ":", hit, ": ", line))
+    }
+  }
+
+  offenders
+}

--- a/scripts/lts-package-name.R
+++ b/scripts/lts-package-name.R
@@ -11,7 +11,9 @@
 #
 # * in code, ask for the name at run time with `get_package_name()`;
 # * in docs, do not qualify our own objects with `duckdb::`;
-# * if the literal names something else, add it to `LTS_ALLOWED_OUTSIDE_PATCH`;
+# * if the literal names something else that happens to be spelled the same --
+#   the DuckDB CLI executable, say -- write it in two pieces, as
+#   `paste0("duck", "db")`, so it reads as what it is;
 # * otherwise teach `scripts/lts.patch` to rewrite it.
 #
 # The scan covers the R-level surface -- `R/`, `man/`, `tests/`, `vignettes/`, and
@@ -26,18 +28,6 @@
 # that test cannot carry the check on its own, because `R CMD check` runs the
 # tests from a built tarball, where neither the sources nor this directory
 # (`.Rbuildignore`d) exist.
-
-# Occurrences that name something other than this R package, and must therefore
-# stay literal in the LTS builds as well. Values are the trimmed source lines.
-LTS_ALLOWED_OUTSIDE_PATCH <- list(
-  # The DuckDB CLI executable on the PATH, not the R package.
-  "tests/testthat/test-storage-cli-e2e.R" = 'unname(Sys.which("duckdb"))',
-  # The legacy extension cache, which every flavor of the package wrote to under
-  # the literal `duckdb`; renaming it would point the sweep at a directory that
-  # never existed. See `cleanup_user_directory()`.
-  "R/extensions.R" = 'tools::R_user_dir("duckdb", "data")',
-  "tests/testthat/test-storage-seams.R" = 'expect_equal(default_user_directory(), tools::R_user_dir("duckdb", "data"))'
-)
 
 # The lines `scripts/lts.patch` rewrites, as a list of trimmed source lines keyed
 # by the path they are rewritten in. These are exactly the occurrences the LTS
@@ -103,7 +93,6 @@ lts_package_name_offenders <- function(root = ".") {
     for (hit in grep(scanned[[i]], lines)) {
       line <- trimws(lines[[hit]])
       if (line %in% patched[[path]]) next
-      if (line %in% LTS_ALLOWED_OUTSIDE_PATCH[[path]]) next
       offenders <- c(offenders, paste0(path, ":", hit, ": ", line))
     }
   }

--- a/scripts/lts-package-name.R
+++ b/scripts/lts-package-name.R
@@ -1,8 +1,8 @@
 # Guard for the LTS rename.
 #
-# The LTS builds ship this package under a different name: `scripts/lts.sh`
-# applies `scripts/lts.patch`, which renames `duckdb` to `duckdb.1.3`,
-# `duckdb.1.5`, and so on.
+# Every flavor but the mainline one ships this package under a different name:
+# `scripts/lts.sh` applies `scripts/lts.patch`, which renames `duckdb` to
+# `duckdb.1.4`, `duckdb.1.4.dev`, `duckdb.dev`, and so on. See BRANCHES.md.
 #
 # Every hard-coded `duckdb::`, `duckdb:::`, or `"duckdb"` that the patch does not
 # rewrite keeps pointing at the mainline package in those builds -- silently, and

--- a/scripts/lts.patch
+++ b/scripts/lts.patch
@@ -55,6 +55,15 @@ index 9087bd425..11c8677ac 100644
 
  ## Installation from r-universe
 
+@@ -43,7 +21,7 @@
+ Review <https://docs.r-universe.dev/install/binaries.html> for configuring installation of binary packages on Linux.
+
+ ``` r
+-install.packages("duckdb", repos = c("https://duckdb.r-universe.dev", "https://cloud.r-project.org"))
++install.packages("duckdb.1.3", repos = c("https://duckdb.r-universe.dev", "https://cloud.r-project.org"))
+ ```
+
+ Installing the package from source may take up to an hour.
 diff --git a/inst/include/duckdb_types.hpp b/inst/include/duckdb_1_3_types.hpp
 similarity index 100%
 rename from inst/include/duckdb_types.hpp

--- a/tests/testthat/helper-skip.R
+++ b/tests/testthat/helper-skip.R
@@ -6,6 +6,19 @@ skip_on_dev_version <- function() {
   }
 }
 
+# Skip when running as one of the LTS builds.
+#
+# `scripts/lts.sh` renames the package to `duckdb.<version>` (e.g. `duckdb.1.3`)
+# by applying `scripts/lts.patch`. Tests that depend on another package hard-coding
+# the mainline `duckdb` name -- arrow's DuckDB integration, for instance -- cannot
+# work there. The suffix is what tells the builds apart: the mainline name has no
+# dot in it, every LTS name does.
+skip_on_lts <- function() {
+  if (grepl(".", get_package_name(), fixed = TRUE)) {
+    skip("Skip on LTS builds.")
+  }
+}
+
 # Skip on CRAN, but run on R-universe
 skip_on_cran_except_r_universe <- function() {
   if (!nzchar(Sys.getenv("MY_UNIVERSE"))) {

--- a/tests/testthat/helper-skip.R
+++ b/tests/testthat/helper-skip.R
@@ -6,16 +6,17 @@ skip_on_dev_version <- function() {
   }
 }
 
-# Skip when running as one of the LTS builds.
+# Skip on every flavor but the mainline one.
 #
-# `scripts/lts.sh` renames the package to `duckdb.<version>` (e.g. `duckdb.1.3`)
-# by applying `scripts/lts.patch`. Tests that depend on another package hard-coding
-# the mainline `duckdb` name -- arrow's DuckDB integration, for instance -- cannot
-# work there. The suffix is what tells the builds apart: the mainline name has no
-# dot in it, every LTS name does.
-skip_on_lts <- function() {
+# `scripts/lts.sh` renames the package to a flavor -- `duckdb.1.4`,
+# `duckdb.1.4.dev`, `duckdb.dev`, ... -- by applying `scripts/lts.patch`; see
+# BRANCHES.md. Tests that depend on another package hard-coding the mainline
+# `duckdb` name -- arrow's DuckDB integration, for instance -- cannot work under
+# any of them. The suffix is what tells the flavors apart: the mainline name has
+# no dot in it, every renamed one does.
+skip_on_flavor <- function() {
   if (grepl(".", get_package_name(), fixed = TRUE)) {
-    skip("Skip on LTS builds.")
+    skip("Skip on renamed flavors.")
   }
 }
 

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,11 +1,1 @@
 rlang::local_options(arrow_duck_con = default_conn())
-
-# Clean up extension cache on CRAN
-withr::defer(envir = testthat::teardown_env(), tryCatch(
-  {
-    skip_on_cran()
-  },
-  skip = function(e) {
-    cleanup_user_directory()
-  }
-))

--- a/tests/testthat/test-arrow.R
+++ b/tests/testthat/test-arrow.R
@@ -17,7 +17,7 @@
 
 skip_on_cran()
 skip_on_os("windows")
-skip_if_not(get_package_name() == "duckdb")
+skip_on_lts()
 skip_if_not_installed("dbplyr")
 skip_if_not_installed("dplyr")
 skip_if_not_installed("arrow", "5.0.0")

--- a/tests/testthat/test-arrow.R
+++ b/tests/testthat/test-arrow.R
@@ -17,7 +17,7 @@
 
 skip_on_cran()
 skip_on_os("windows")
-skip_on_lts()
+skip_on_flavor()
 skip_if_not_installed("dbplyr")
 skip_if_not_installed("dplyr")
 skip_if_not_installed("arrow", "5.0.0")

--- a/tests/testthat/test-arrow_stream.R
+++ b/tests/testthat/test-arrow_stream.R
@@ -1,6 +1,6 @@
 skip_on_cran()
 skip_on_os("windows")
-skip_if_not(get_package_name() == "duckdb")
+skip_on_lts()
 skip_if_not_installed("arrow", "5.0.0")
 skip_if_not_installed("dbplyr")
 

--- a/tests/testthat/test-arrow_stream.R
+++ b/tests/testthat/test-arrow_stream.R
@@ -1,6 +1,6 @@
 skip_on_cran()
 skip_on_os("windows")
-skip_on_lts()
+skip_on_flavor()
 skip_if_not_installed("arrow", "5.0.0")
 skip_if_not_installed("dbplyr")
 

--- a/tests/testthat/test-lts-package-name.R
+++ b/tests/testthat/test-lts-package-name.R
@@ -1,0 +1,108 @@
+# The LTS builds ship this package under a different name: `scripts/lts.sh`
+# applies `scripts/lts.patch`, which renames `duckdb` to `duckdb.1.3`,
+# `duckdb.1.5`, and so on.
+#
+# Every hard-coded `duckdb::`, `duckdb:::`, or `"duckdb"` that the patch does not
+# rewrite keeps pointing at the mainline package in those builds -- silently, and
+# usually only noticed by a user. This test fails as soon as such an occurrence
+# appears outside the patch, so that a new one has to be dealt with deliberately:
+#
+# * in code, ask for the name at run time with `get_package_name()`;
+# * in docs, do not qualify our own objects with `duckdb::`;
+# * if the literal really has to be there, teach `scripts/lts.patch` to rewrite it.
+#
+# The scan covers the R-level surface -- `R/`, `man/`, `tests/`, `vignettes/`, and
+# the Markdown files at the top level -- plus the C++ glue in `src/` and
+# `inst/include/`. In the glue only the quoted form is checked: `duckdb::` there is
+# the engine's C++ namespace, which has nothing to do with the R package name.
+# Vendored sources under `src/duckdb/` and testthat snapshots are left alone.
+
+# The package source root, or NA when the tests run from an installed package
+# (`R CMD check` copies `tests/` alone, without the sources this test reads).
+lts_source_root <- function() {
+  root <- normalizePath(test_path("..", ".."), mustWork = FALSE)
+  if (file.exists(file.path(root, "scripts", "lts.patch"))) root else NA_character_
+}
+
+# Occurrences that name something other than this R package, and must therefore
+# stay literal in the LTS builds as well. Values are the trimmed source lines.
+lts_allowed_outside_patch <- list(
+  # The name of the DuckDB CLI executable on the PATH, not of the R package.
+  "tests/testthat/test-storage-cli-e2e.R" = 'unname(Sys.which("duckdb"))'
+)
+
+# The lines `scripts/lts.patch` rewrites, as a list of trimmed source lines keyed
+# by the path they are rewritten in. These are exactly the occurrences the LTS
+# rename already accounts for.
+lts_patched_lines <- function(patch_file) {
+  lines <- readLines(patch_file, warn = FALSE)
+  patched <- list()
+  path <- NA_character_
+
+  for (line in lines) {
+    if (grepl("^diff --git a/", line)) {
+      path <- sub("^diff --git a/(.*) b/.*$", "\\1", line)
+    } else if (!is.na(path) && grepl("^-", line) && !grepl("^---", line)) {
+      patched[[path]] <- c(patched[[path]], trimws(substring(line, 2)))
+    }
+  }
+
+  patched
+}
+
+# Paths under `subdir` matching `pattern`, relative to the package root.
+lts_dir <- function(root, subdir, pattern) {
+  file.path(subdir, dir(file.path(root, subdir), pattern = pattern, recursive = TRUE))
+}
+
+# The files to scan, as paths relative to `root`, each named by the pattern that
+# applies to it.
+lts_scanned_files <- function(root) {
+  r_level <- c(
+    lts_dir(root, "R", "[.]R$"),
+    lts_dir(root, "man", "[.]Rd$"),
+    lts_dir(root, "tests", "[.]R$"),
+    lts_dir(root, "vignettes", "[.](R|Rmd|qmd)$"),
+    dir(root, pattern = "[.]md$")
+  )
+  # This file spells out the very patterns it looks for.
+  r_level <- setdiff(r_level, file.path("tests", "testthat", "test-lts-package-name.R"))
+
+  glue <- c(
+    lts_dir(root, "src", "[.](c|h|cpp|hpp)$"),
+    lts_dir(root, file.path("inst", "include"), "[.](h|hpp)$")
+  )
+  glue <- glue[!startsWith(glue, paste0(file.path("src", "duckdb"), "/"))]
+
+  patterns <- c(
+    rep('duckdb:::?|"duckdb"', length(r_level)),
+    rep('"duckdb"', length(glue))
+  )
+  names(patterns) <- c(r_level, glue)
+  patterns
+}
+
+test_that("the hard-coded package name occurs only where scripts/lts.patch rewrites it", {
+  root <- lts_source_root()
+  skip_if(is.na(root), "Not running from the package source tree.")
+
+  patched <- lts_patched_lines(file.path(root, "scripts", "lts.patch"))
+  scanned <- lts_scanned_files(root)
+
+  offenders <- character()
+
+  for (i in seq_along(scanned)) {
+    path <- names(scanned)[[i]]
+    lines <- readLines(file.path(root, path), warn = FALSE)
+    hits <- grep(scanned[[i]], lines)
+
+    for (hit in hits) {
+      line <- trimws(lines[[hit]])
+      if (line %in% patched[[path]]) next
+      if (line %in% lts_allowed_outside_patch[[path]]) next
+      offenders <- c(offenders, paste0(path, ":", hit, ": ", line))
+    }
+  }
+
+  expect_equal(offenders, character())
+})

--- a/tests/testthat/test-lts-package-name.R
+++ b/tests/testthat/test-lts-package-name.R
@@ -1,108 +1,24 @@
-# The LTS builds ship this package under a different name: `scripts/lts.sh`
-# applies `scripts/lts.patch`, which renames `duckdb` to `duckdb.1.3`,
-# `duckdb.1.5`, and so on.
+# The LTS builds ship this package under a different name, and scripts/lts.patch
+# is what renames it. This test fails when the name is hard-coded somewhere the
+# patch does not rewrite; scripts/lts-package-name.R explains the rules and holds
+# the scan itself.
 #
-# Every hard-coded `duckdb::`, `duckdb:::`, or `"duckdb"` that the patch does not
-# rewrite keeps pointing at the mainline package in those builds -- silently, and
-# usually only noticed by a user. This test fails as soon as such an occurrence
-# appears outside the patch, so that a new one has to be dealt with deliberately:
-#
-# * in code, ask for the name at run time with `get_package_name()`;
-# * in docs, do not qualify our own objects with `duckdb::`;
-# * if the literal really has to be there, teach `scripts/lts.patch` to rewrite it.
-#
-# The scan covers the R-level surface -- `R/`, `man/`, `tests/`, `vignettes/`, and
-# the Markdown files at the top level -- plus the C++ glue in `src/` and
-# `inst/include/`. In the glue only the quoted form is checked: `duckdb::` there is
-# the engine's C++ namespace, which has nothing to do with the R package name.
-# Vendored sources under `src/duckdb/` and testthat snapshots are left alone.
+# The scan needs the sources and scripts/lts.patch, so it only runs from a
+# checkout. `R CMD check` works from a built tarball, which has neither, and
+# skips -- CI therefore runs the same scan directly against the checkout, see
+# .github/workflows/custom/after-install.
 
-# The package source root, or NA when the tests run from an installed package
-# (`R CMD check` copies `tests/` alone, without the sources this test reads).
+# The package source root, or NA when the sources are not around.
 lts_source_root <- function() {
   root <- normalizePath(test_path("..", ".."), mustWork = FALSE)
-  if (file.exists(file.path(root, "scripts", "lts.patch"))) root else NA_character_
+  if (file.exists(file.path(root, "scripts", "lts-package-name.R"))) root else NA_character_
 }
 
-# Occurrences that name something other than this R package, and must therefore
-# stay literal in the LTS builds as well. Values are the trimmed source lines.
-lts_allowed_outside_patch <- list(
-  # The name of the DuckDB CLI executable on the PATH, not of the R package.
-  "tests/testthat/test-storage-cli-e2e.R" = 'unname(Sys.which("duckdb"))'
-)
-
-# The lines `scripts/lts.patch` rewrites, as a list of trimmed source lines keyed
-# by the path they are rewritten in. These are exactly the occurrences the LTS
-# rename already accounts for.
-lts_patched_lines <- function(patch_file) {
-  lines <- readLines(patch_file, warn = FALSE)
-  patched <- list()
-  path <- NA_character_
-
-  for (line in lines) {
-    if (grepl("^diff --git a/", line)) {
-      path <- sub("^diff --git a/(.*) b/.*$", "\\1", line)
-    } else if (!is.na(path) && grepl("^-", line) && !grepl("^---", line)) {
-      patched[[path]] <- c(patched[[path]], trimws(substring(line, 2)))
-    }
-  }
-
-  patched
-}
-
-# Paths under `subdir` matching `pattern`, relative to the package root.
-lts_dir <- function(root, subdir, pattern) {
-  file.path(subdir, dir(file.path(root, subdir), pattern = pattern, recursive = TRUE))
-}
-
-# The files to scan, as paths relative to `root`, each named by the pattern that
-# applies to it.
-lts_scanned_files <- function(root) {
-  r_level <- c(
-    lts_dir(root, "R", "[.]R$"),
-    lts_dir(root, "man", "[.]Rd$"),
-    lts_dir(root, "tests", "[.]R$"),
-    lts_dir(root, "vignettes", "[.](R|Rmd|qmd)$"),
-    dir(root, pattern = "[.]md$")
-  )
-  # This file spells out the very patterns it looks for.
-  r_level <- setdiff(r_level, file.path("tests", "testthat", "test-lts-package-name.R"))
-
-  glue <- c(
-    lts_dir(root, "src", "[.](c|h|cpp|hpp)$"),
-    lts_dir(root, file.path("inst", "include"), "[.](h|hpp)$")
-  )
-  glue <- glue[!startsWith(glue, paste0(file.path("src", "duckdb"), "/"))]
-
-  patterns <- c(
-    rep('duckdb:::?|"duckdb"', length(r_level)),
-    rep('"duckdb"', length(glue))
-  )
-  names(patterns) <- c(r_level, glue)
-  patterns
-}
-
-test_that("the hard-coded package name occurs only where scripts/lts.patch rewrites it", {
+test_that("the package name is hard-coded only where scripts/lts.patch rewrites it", {
   root <- lts_source_root()
   skip_if(is.na(root), "Not running from the package source tree.")
 
-  patched <- lts_patched_lines(file.path(root, "scripts", "lts.patch"))
-  scanned <- lts_scanned_files(root)
+  source(file.path(root, "scripts", "lts-package-name.R"), local = TRUE)
 
-  offenders <- character()
-
-  for (i in seq_along(scanned)) {
-    path <- names(scanned)[[i]]
-    lines <- readLines(file.path(root, path), warn = FALSE)
-    hits <- grep(scanned[[i]], lines)
-
-    for (hit in hits) {
-      line <- trimws(lines[[hit]])
-      if (line %in% patched[[path]]) next
-      if (line %in% lts_allowed_outside_patch[[path]]) next
-      offenders <- c(offenders, paste0(path, ":", hit, ": ", line))
-    }
-  }
-
-  expect_equal(offenders, character())
+  expect_equal(lts_package_name_offenders(root), character())
 })

--- a/tests/testthat/test-parquet.R
+++ b/tests/testthat/test-parquet.R
@@ -12,7 +12,7 @@ test_that("parquet reader works with the binary as string flag", {
 })
 
 # Fixture data/time_tz.parquet was created with:
-#   con <- duckdb::dbConnect(duckdb::duckdb())
+#   con <- dbConnect(duckdb())
 #   DBI::dbExecute(con, "COPY (
 #     SELECT * FROM (VALUES
 #       (TIMETZ '01:02:03.45+05:00'),

--- a/tests/testthat/test-storage-cli-e2e.R
+++ b/tests/testthat/test-storage-cli-e2e.R
@@ -15,9 +15,9 @@
 # Resolve the CLI to test against: an explicit DUCKDB_CLI wins, else `duckdb` on
 # the PATH. Returns "" when none is available.
 #
-# The executable name is spelled in two pieces so that the LTS guard
+# The executable name is spelled in two pieces so that the flavor guard
 # (scripts/lts-package-name.R) does not read it as the R package name, which the
-# LTS builds rename -- this one names a binary on the PATH and must not be
+# renamed flavors change -- this one names a binary on the PATH and must not be
 # renamed with them.
 duckdb_cli_bin <- function() {
   explicit <- Sys.getenv("DUCKDB_CLI", unset = "")

--- a/tests/testthat/test-storage-cli-e2e.R
+++ b/tests/testthat/test-storage-cli-e2e.R
@@ -14,12 +14,17 @@
 
 # Resolve the CLI to test against: an explicit DUCKDB_CLI wins, else `duckdb` on
 # the PATH. Returns "" when none is available.
+#
+# The executable name is spelled in two pieces so that the LTS guard
+# (scripts/lts-package-name.R) does not read it as the R package name, which the
+# LTS builds rename -- this one names a binary on the PATH and must not be
+# renamed with them.
 duckdb_cli_bin <- function() {
   explicit <- Sys.getenv("DUCKDB_CLI", unset = "")
   if (nzchar(explicit) && file.exists(explicit)) {
     return(explicit)
   }
-  unname(Sys.which("duckdb"))
+  unname(Sys.which(paste0("duck", "db")))
 }
 
 # Run a single SQL statement through the CLI against an in-memory database and

--- a/tests/testthat/test-storage-seams.R
+++ b/tests/testthat/test-storage-seams.R
@@ -2,10 +2,6 @@
 # (plan/PLAN-storage-locations.md). These tests pin the current behavior and
 # confirm the seams are mockable without touching the real filesystem.
 
-test_that("default_user_directory routes through the R_user_dir seam", {
-  expect_equal(default_user_directory(), tools::R_user_dir("duckdb", "data"))
-})
-
 test_that("check_dots_empty0 rejects non-empty dots", {
   f <- function(x, ...) {
     check_dots_empty0(...)

--- a/tests/testthat/test-storage-seams.R
+++ b/tests/testthat/test-storage-seams.R
@@ -3,7 +3,7 @@
 # confirm the seams are mockable without touching the real filesystem.
 
 test_that("default_user_directory routes through the R_user_dir seam", {
-  expect_equal(default_user_directory(), tools::R_user_dir(get_package_name(), "data"))
+  expect_equal(default_user_directory(), tools::R_user_dir("duckdb", "data"))
 })
 
 test_that("check_dots_empty0 rejects non-empty dots", {

--- a/tests/testthat/test-storage-seams.R
+++ b/tests/testthat/test-storage-seams.R
@@ -3,7 +3,7 @@
 # confirm the seams are mockable without touching the real filesystem.
 
 test_that("default_user_directory routes through the R_user_dir seam", {
-  expect_equal(default_user_directory(), tools::R_user_dir("duckdb", "data"))
+  expect_equal(default_user_directory(), tools::R_user_dir(get_package_name(), "data"))
 })
 
 test_that("check_dots_empty0 rejects non-empty dots", {


### PR DESCRIPTION
The LTS builds ship this package as `duckdb.1.3`, `duckdb.1.5`, … by applying `scripts/lts.patch`.
Any hard-coded `duckdb::`, `duckdb:::`, or `"duckdb"` that the patch does not rewrite keeps pointing at the mainline package there — silently, and usually only noticed by a user.

## The guard

`scripts/lts-package-name.R` derives its allowlist from `scripts/lts.patch` itself:
it parses the lines the patch removes, keyed by the file they are removed from,
and reports every occurrence in the tree that is not one of them.
Base R only, no package needed, and no exemption list — the patch is the single source of truth.

Scope:

* R-level surface — `R/`, `man/`, `tests/`, `vignettes/`, and the Markdown files at the top level — checked for `duckdb::`, `duckdb:::`, and `"duckdb"`.
* C++ glue in `src/` and `inst/include/` — checked for the quoted form only, since `duckdb::` there is the engine's C++ namespace, not the R package. Vendored sources under `src/duckdb/` and testthat snapshots are left alone.

Where it runs:

* `.github/workflows/custom/after-install` runs the scan against the checkout. This is the copy that gates CI.
* `tests/testthat/test-lts-package-name.R` wraps it for `testthat::test_local()`, the documented dev loop. It skips under `R CMD check`, which works from a built tarball that carries neither the sources nor `scripts/` — a testthat test alone could never enforce this.

## Occurrences the guard found

* `session_home()` hard-coded the name of the per-session home under `tempdir()`. It now asks for the name at run time with `get_package_name()` — unchanged for the mainline package, and correct for the LTS builds, where extension binaries are version-specific and two flavors can be loaded in one R session.
* `?duckdb_storage` qualified our own objects with `duckdb::` in a documentation example and in inline R code. Dropped, matching the surrounding blocks on that page.
* The arrow tests compared `get_package_name()` against the mainline name inline. Replaced by a documented `skip_on_lts()` helper in `helper-skip.R`, which keys off the version suffix that distinguishes the builds.
* `scripts/lts.patch` left the r-universe install instruction in `README.md` naming the mainline package, so the LTS README told readers to install `duckdb`. The patch now rewrites that line too; `scripts/lts.sh` picks up the version substitution there as before.
* The DuckDB CLI executable in `test-storage-cli-e2e.R` names a binary on the `PATH`, not this package, so it must *not* be renamed with the LTS builds. It is now spelled `paste0("duck", "db")`, which says so at the call site.

## Dead code removed along the way

`default_user_directory()` wrapped `tools::R_user_dir("duckdb", "data")`, and nothing writes there any more: extensions moved out in 1.5.4.x (#2327 and the storage-location rework), and `duckdb()` now always sets `extension_directory` and `secret_directory` from the resolved home. That left the seam with one caller, `cleanup_user_directory()`, itself wired only into the testthat teardown — which fires only when `skip_on_cran()` skips, and on CRAN `tests/testthat.R` does not run the suite at all. The sweep could therefore only ever run on r-universe, against a directory this package stopped writing to, in a container where it does not exist. Seam, sweep, teardown, and seam test are gone.

## Deliberately unchanged

The `@examplesIf simulate_duckdb()$env$examples_enabled()` conditions keep their indirection. Roxygen inline code (`` `r STORAGE_MESSAGE_MAX` ``) is evaluated at roxygenize time in the package namespace, so it needs no accessor — but an `@examplesIf` condition is evaluated when the example runs, in a session that has only *attached* the package, where the internal `examples_enabled()` is not visible. `simulate_duckdb()$pkg` / `$env` are the LTS-safe reflection API for exactly this, and `$env` has no other user.

`BRANCHES.md` gains a pointer to the guard in the description of the flavor component, and its file list for that component is completed with `NAMESPACE`, `README.md`, and `man/duckdb-package.Rd`.

## Verification

* `patch -p1 < scripts/lts.patch` applies cleanly to a pristine checkout and produces the intended `duckdb.1.3` README.
* Injecting a hard-coded occurrence into `R/package.R` makes the scan report `R/package.R:24: …`; removing it makes it pass.
* `roxygen2::roxygenise()` (8.0.0.9000, matching `Config/roxygen2/version`) regenerates `man/` with no diff, confirming the inline-code change is output-identical.
* `library(duckdb); exists("examples_enabled")` is `FALSE`, confirming why the `@examplesIf` indirection has to stay.
* Full suite against an installed build: `[ FAIL 0 | WARN 0 | SKIP 60 | PASS 1265 ]`.