### PR TITLE
feat(each): Number shards along the history, and quote failing stages into the run summary

### DIFF
--- a/.github/workflows/each.yaml
+++ b/.github/workflows/each.yaml
@@ -21,6 +21,12 @@
 # shards back apart, spending at most EACH_SPLIT_FACTOR times the runner minutes
 # and never asking for more legs than EACH_MAX_PARALLEL can run at once.
 #
+# Shards are numbered along the history -- shard 1 is the oldest slice, shard N
+# the branch tip -- and queued the other way round, so under max-parallel
+# throttling the tip is decided first. A leg that fails a commit quotes the tail
+# of every stage that failed into its job summary, so the run summary says what
+# broke without opening the log.
+#
 # See scripts/EACH.md for the design, the GitHub Actions limits it works within,
 # and why `workflow_call` is not the mechanism that gets us there.
 #
@@ -268,6 +274,9 @@ jobs:
           PLAN: ${{ runner.temp }}/plan/plan.json
           LOG_DIR: ${{ runner.temp }}/each-logs
           DEADLINE_MINUTES: ${{ env.EACH_SHARD_BUDGET_MINUTES }}
+          # Empty falls through to the script's own default; 0 turns the
+          # per-failure log excerpts in the job summary off.
+          SUMMARY_TAIL: ${{ vars.EACH_RCC_SUMMARY_TAIL || '' }}
         run: scripts/each-shard.sh
         shell: bash
 

--- a/scripts/EACH.md
+++ b/scripts/EACH.md
@@ -115,7 +115,8 @@ build (one job per shard, throttled by max-parallel)
   └─ for sha in shard (oldest → newest):
        reset workspace → rcc status pending
        → scripts/rcc-one.sh → rcc status success/failure
-       → capture the log
+       → capture the log, whole and per stage
+       → on failure, quote each failed stage's tail into the job summary
      ... stops at its own deadline and defers the rest
 
 harvest (1 job, if: always())
@@ -319,8 +320,8 @@ and [30422580063](https://github.com/krlmlr/duckdb-r/actions/runs/30422580063)
 The three cold builds came in at 40.4, 39.7 and 40.1 minutes —
 flat, and independent of what their commit changed, exactly as the model says.
 Whole legs land within a few percent:
-the 12 commits of shard 0 were predicted at 243 min and took 252,
-and the first 12 of shard 1 were predicted at 304 and took 302.
+one leg's 12 commits were predicted at 243 min and took 252,
+and the other's first 12 at 304 against 302.
 
 These numbers replace the pre-2026 estimates the model shipped with
 (`COLD_MINUTES=22`, `FLOOR_MINUTES=11`, `OBJECT_SECONDS=4.3`),
@@ -329,7 +330,7 @@ they charged nearly twice too much for a cheap commit and half too little for an
 expensive one, so the predicted spread was *compressed*.
 Legs of "equal" predicted cost were not equal,
 and a leg full of wide-header commits overran its 300-minute deadline and
-deferred its last commit — which is what happened to shard 1 of run
+deferred its last commit — which is what happened to the second leg of run
 30406932093.
 Every leg records `duration_seconds` per commit and
 [`each-harvest.sh`](each-harvest.sh) now carries it onto the `rcc` branch
@@ -396,9 +397,25 @@ On the 998-commit `main-dev` backlog the greedy pass already emits 66 legs
 against a `max-parallel` of 20, so nothing is split and nothing is spent:
 19.2 h of wall clock either way.
 
-Shards are emitted newest-first, so under `max-parallel` throttling
-the branch tip — the thing the series loop and the release flow wait on — is decided first.
+#### Numbering, and the order they are queued in
+
+These are two different things, and conflating them is what made the first
+version confusing to read.
+
+A shard's **number** runs with the history: shard 1 holds the oldest commits of
+the plan, shard N the branch tip, and adjacent numbers are adjacent slices.
+So a leg's number reads the way its commits do, and the numbering starts at
+one rather than at zero.
+
+The **order** they are queued in is the reverse: newest shard first, so that
+under `max-parallel` throttling the branch tip — the thing the series loop and
+the release flow wait on — is decided first.
+The matrix therefore starts at shard N and finishes with shard 1.
 Within a shard, commits run oldest-first, for cache locality.
+
+Numbers are assigned after the matrix cap has dropped the oldest shards
+(§4), so shard 1 is the oldest shard *this run* will build,
+not the oldest one the planner considered.
 
 ### Can we measure which commit invalidates how many unity files?
 
@@ -539,6 +556,7 @@ are repository variables:
 | Compute traded for wall clock | `split-factor` | `EACH_RCC_SPLIT_FACTOR` | `1.5` |
 | Cap on commits considered | `max-commits` | — | `0` (no cap) |
 | Rebuild decided commits | `force` | — | `false` |
+| Log lines quoted per failed stage | — | `EACH_RCC_SUMMARY_TAIL` | `50` |
 
 `EACH_GATES` can drop individual gates, but note that `pkgdown` is **not** a
 candidate: a pkgdown failure is a real failure and has to be dealt with, so the
@@ -552,11 +570,41 @@ and the only way to shorten it is to make the longest leg shorter.
 Set `split-factor` to `1.0` to get the old fewest-legs, cheapest-compute
 behaviour back.
 
+### Reading a failure without opening the log
+
+A leg is one job for up to ~20 commits and up to five hours of output,
+so "which commit went red, and why" used to mean expanding the right
+`::group::` in a very long job log.
+The leg's job summary answers both directly.
+The result table names the stages that failed —
+a commit's cell reads `failure (check, pkgdown)`, not just `failure` —
+and below it each failed stage gets a collapsed `<details>` block holding the
+last `EACH_RCC_SUMMARY_TAIL` lines of *that stage's* output,
+which is enough to tell a compile error from a failing test.
+Setting the variable to `0` turns the excerpts off.
+
+The excerpt is not the record.
+The whole per-commit log still goes to `logs2/<sha>.log` on the `rcc` branch,
+which is what [`scripts/series-check.sh`](series-check.sh) classifies against;
+the summary is the fast path for a human.
+Two details make it work in practice:
+
+- [`scripts/rcc-one.sh`](rcc-one.sh) writes each stage's output to its own file
+  under `EACH_STAGE_DIR` and its verdict to `outcomes.tsv`,
+  rather than the leg parsing the combined log back apart.
+  Nothing is buffered that was not already buffered —
+  the leg redirects the whole commit to a file and prints it once the commit is
+  over — and a stage with a log but no verdict is precisely the stage the leg's
+  `timeout` killed, so that one is quoted too.
+- Excerpts stop at 900 kB, because GitHub truncates a step summary at 1 MiB and
+  a truncated summary would take the result table with it.
+  How many were dropped is stated.
+
 ### Failure modes and what happens
 
 | Situation | Outcome |
 |---|---|
-| A commit fails its gate | `rcc=failure`, the leg keeps going, log kept on the `rcc` branch |
+| A commit fails its gate | `rcc=failure`, the leg keeps going, log kept on the `rcc` branch, failed stages' tails in the job summary |
 | A leg runs out of budget | remaining commits stay statusless, next run replans them |
 | A leg dies hard mid-commit | that commit stays `pending`; replanned after `PENDING_TTL_HOURS` |
 | The whole run is cancelled | no fan-in; `rcc-logs.yaml` reconstructs the records on its next tick |

--- a/scripts/each-plan.sh
+++ b/scripts/each-plan.sh
@@ -9,7 +9,9 @@
 # paying for).
 # One shard becomes one matrix leg in `.github/workflows/each.yaml`, and one
 # leg builds its whole slice sequentially in a single job (see
-# `scripts/each-shard.sh`).
+# `scripts/each-shard.sh`). Shards are numbered along the history -- shard 1 is
+# the oldest slice, shard N the branch tip -- and emitted in the reverse order,
+# so the leg holding the tip is the one queued first.
 #
 # Why shards instead of one dispatch per commit:
 #   * a leg pays the ~4 min R/dependency setup once for ~20 commits, not once
@@ -284,9 +286,18 @@ if [ "${dropped}" -gt 0 ]; then
   echo "Capped to ${MAX_SHARDS} shards; ${dropped} older commit(s) deferred to the next run"
 fi
 
-# Newest first: under MAX_PARALLEL throttling the tip of the branch is decided
-# first, which is what scripts/vendor-gate.sh and the promotion flow wait on.
-jq -r 'reverse | to_entries | map(.value + {index: .key}) | .' \
+# Two independent things, deliberately not conflated:
+#
+#   * the *number* runs with history -- shard 1 holds the oldest commits of the
+#     plan and shard N the branch tip, so a shard number reads the way the
+#     commits do, and adjacent numbers are adjacent slices;
+#   * the *order* of the array is newest first, because that is the order
+#     GitHub starts the legs in, and under MAX_PARALLEL throttling the tip of
+#     the branch has to be decided first -- it is what scripts/vendor-gate.sh
+#     and the promotion flow wait on.
+#
+# So the matrix starts shard N and finishes with shard 1.
+jq -r 'to_entries | map(.value + {index: (.key + 1)}) | reverse' \
   "${workdir}/shards.json" > "${workdir}/shards.final.json"
 
 parallel="${MAX_PARALLEL}"
@@ -340,7 +351,10 @@ fi
 planned="$(jq '[.shards[].commits | length] | add // 0' "${OUT}")"
 
 echo "Plan written to ${OUT}: ${shards} shard(s), ${planned} commit(s), max-parallel ${parallel}"
-jq -r '.shards[] | "  shard \(.index): \(.commits | length) commits, ~\(.estimate_minutes) min"' "${OUT}"
+# Listed by number, which is oldest slice first; the legs are queued the other
+# way round.
+jq -r '.shards | sort_by(.index)[]
+       | "  shard \(.index): \(.commits | length) commits, ~\(.estimate_minutes) min"' "${OUT}"
 
 if [ -n "${GITHUB_OUTPUT:-}" ]; then
   {
@@ -375,7 +389,10 @@ if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
       echo
       echo "| Shard | Commits | Estimate | Invalidated objects (max) |"
       echo "| --- | --- | --- | --- |"
-      jq -r '.shards[] | "| \(.index) | \(.commits | length) | ~\(.estimate_minutes) min | \([.commits[].objects] | max) |"' "${OUT}"
+      jq -r '.shards | sort_by(.index)[]
+             | "| \(.index) | \(.commits | length) | ~\(.estimate_minutes) min | \([.commits[].objects] | max) |"' "${OUT}"
+      echo
+      echo "Shard 1 is the oldest slice; the legs are queued newest first, so shard ${shards} starts first."
     fi
   } >> "${GITHUB_STEP_SUMMARY}"
 fi

--- a/scripts/each-shard.sh
+++ b/scripts/each-shard.sh
@@ -22,18 +22,24 @@
 # replans whatever is left; nothing is checkpointed.
 #
 # Usage:
-#   SHARD=0 PLAN=plan.json LOG_DIR=/tmp/each-logs GH_TOKEN=<token> \
+#   SHARD=1 PLAN=plan.json LOG_DIR=/tmp/each-logs GH_TOKEN=<token> \
 #     scripts/each-shard.sh
 #
 # Environment variables:
 #   GH_TOKEN          - token with statuses:write (required unless DRY_RUN)
-#   SHARD             - index into plan.json's "shards" array (required)
+#   SHARD             - shard number from plan.json; 1 is the oldest slice of
+#                       the plan and N the branch tip (required)
 #   PLAN              - plan file (default: plan.json)
 #   LOG_DIR           - where per-commit logs and the index are written; must be
 #                       outside the workspace, which is wiped per commit
 #                       (default: $RUNNER_TEMP/each-logs)
 #   DEADLINE_MINUTES  - stop starting new commits past this (default: 300)
 #   LOG_TAIL          - trailing lines kept per commit (default: 10000)
+#   SUMMARY_TAIL      - trailing lines of every failed stage quoted into the job
+#                       summary (default: 50; 0 keeps the excerpts out)
+#   SUMMARY_MAX_BYTES - stop adding excerpts past this much summary text
+#                       (default: 900000; GitHub truncates a step summary at
+#                       1 MiB, and a truncated summary loses the table too)
 #   DRY_RUN           - if non-empty, list the commits and exit
 
 set -uo pipefail
@@ -43,6 +49,8 @@ PLAN="${PLAN:-plan.json}"
 LOG_DIR="${LOG_DIR:-${RUNNER_TEMP:-/tmp}/each-logs}"
 DEADLINE_MINUTES="${DEADLINE_MINUTES:-300}"
 LOG_TAIL="${LOG_TAIL:-10000}"
+SUMMARY_TAIL="${SUMMARY_TAIL:-50}"
+SUMMARY_MAX_BYTES="${SUMMARY_MAX_BYTES:-900000}"
 
 here="$(cd "$(dirname "$0")" && pwd)"
 started="$(date -u +%s)"
@@ -51,6 +59,16 @@ deadline=$(( started + DEADLINE_MINUTES * 60 ))
 mkdir -p "${LOG_DIR}"
 index="${LOG_DIR}/index.ndjson"
 : > "${index}"
+
+# Scratch, deliberately *not* under LOG_DIR: that directory is uploaded as the
+# leg's artifact, and the per-stage logs are the commit log sliced up, so
+# shipping both would double every artifact for nothing.
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+stage_dir="${workdir}/stages"
+excerpts="${workdir}/excerpts.md"
+excerpts_omitted=0
+: > "${excerpts}"
 
 mapfile -t commits < <(jq -r --argjson s "${SHARD}" '.shards[] | select(.index == $s) | .commits[].sha' "${PLAN}")
 
@@ -96,6 +114,65 @@ set_status() {
     -f "target_url=${job_url}" \
     -f "description=${description}" \
     -f "context=rcc" > /dev/null
+}
+
+# --------------------------------------------------------------- excerpts ----
+# What a red commit owes the reader of the run summary: which stage broke, and
+# enough of its tail to tell a compile error from a failing test -- without
+# opening a 40-minute job log and scrolling to the end of it. The full log is
+# still harvested onto the `rcc` branch; this is an excerpt, not the record.
+#
+# Fenced with four backticks, because R, roxygen and pkgdown output can contain
+# a triple fence of its own, and stripped of SGR escapes, which Markdown renders
+# as line noise.
+emit_excerpt() {
+  local sha="$1" stage="$2" log="$3"
+  [ -f "${log}" ] || return 0
+  if [ "$(wc -c < "${excerpts}")" -ge "${SUMMARY_MAX_BYTES}" ]; then
+    excerpts_omitted=$(( excerpts_omitted + 1 ))
+    return 0
+  fi
+  {
+    printf '<details><summary><code>%s</code> &mdash; <b>%s</b> (last %s lines)</summary>\n\n' \
+      "${sha:0:9}" "${stage}" "${SUMMARY_TAIL}"
+    printf '````text\n'
+    tail -n "${SUMMARY_TAIL}" "${log}" | sed -e 's/\r$//' -e 's/\x1b\[[0-9;?]*[a-zA-Z]//g'
+    printf '````\n\n</details>\n\n'
+  } >> "${excerpts}"
+}
+
+# One excerpt per failed stage, in the order the stages ran. `outcomes.tsv` is
+# written by scripts/rcc-one.sh; a stage with a log but no verdict in it is the
+# one the `timeout` killed, and it is the one worth showing.
+write_excerpts() {
+  local sha="$1" dir="$2" fallback="$3"
+  local outcomes="${dir}/outcomes.tsv"
+  local -a stages=()
+  local stage log
+
+  [ "${SUMMARY_TAIL}" -gt 0 ] || return 0
+
+  if [ -s "${outcomes}" ]; then
+    mapfile -t stages < <(awk -F'\t' '$2 == "failure" { print $1 }' "${outcomes}")
+  fi
+  for log in "${dir}"/*.log; do
+    [ -f "${log}" ] || continue
+    stage="$(basename "${log}" .log)"
+    awk -F'\t' -v n="${stage}" '$1 == n { seen = 1 } END { exit !seen }' \
+      "${outcomes}" 2>/dev/null || stages+=("${stage}")
+  done
+
+  if [ "${#stages[@]}" -eq 0 ]; then
+    # No stage detail at all: rcc-one.sh died before the first stage, or the
+    # checkout is old enough not to write any. The commit's own tail beats
+    # nothing.
+    emit_excerpt "${sha}" "whole commit" "${fallback}"
+    return 0
+  fi
+
+  for stage in "${stages[@]}"; do
+    emit_excerpt "${sha}" "${stage}" "${dir}/${stage}.log"
+  done
 }
 
 # ------------------------------------------------------------------- loop ----
@@ -144,7 +221,10 @@ for sha in "${commits[@]}"; do
 
   log="${LOG_DIR}/${sha}.log"
   full_log="${LOG_DIR}/${sha}.full"
-  timeout "${remaining}s" "${here}/rcc-one.sh" > "${full_log}" 2>&1
+  rm -rf "${stage_dir}"
+  mkdir -p "${stage_dir}"
+  EACH_STAGE_DIR="${stage_dir}" \
+    timeout "${remaining}s" "${here}/rcc-one.sh" > "${full_log}" 2>&1
   rc=$?
   tail -n "${LOG_TAIL}" "${full_log}" > "${log}"
   rm -f "${full_log}"
@@ -153,6 +233,12 @@ for sha in "${commits[@]}"; do
   commit_ended="$(date -u +%s)"
   last_duration=$(( commit_ended - commit_started ))
 
+  failed_stages='[]'
+  if [ -s "${stage_dir}/outcomes.tsv" ]; then
+    failed_stages="$(awk -F'\t' '$2 == "failure" { print $1 }' "${stage_dir}/outcomes.tsv" \
+      | jq -Rsc 'split("\n") | map(select(length > 0))')"
+  fi
+
   if [ "${rc}" -eq 0 ]; then
     state="success"
     built=$(( built + 1 ))
@@ -160,6 +246,7 @@ for sha in "${commits[@]}"; do
     state="failure"
     failed=$(( failed + 1 ))
     built=$(( built + 1 ))
+    write_excerpts "${sha}" "${stage_dir}" "${log}"
   fi
   set_status "${sha}" "${state}"
 
@@ -171,9 +258,11 @@ for sha in "${commits[@]}"; do
     --argjson shard "${SHARD}" \
     --argjson duration "${last_duration}" \
     --argjson rc "${rc}" \
+    --argjson failed_stages "${failed_stages}" \
     '{commit: $commit, state: $state, target_url: $target_url,
       description: $description, shard: $shard,
-      duration_seconds: $duration, exit_code: $rc}' >> "${index}"
+      duration_seconds: $duration, exit_code: $rc,
+      failed_stages: $failed_stages}' >> "${index}"
 
   echo "::endgroup::"
   echo "${sha}: ${state} (${last_duration}s, exit ${rc})"
@@ -194,10 +283,23 @@ if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
     echo
     echo "| Commit | Result | Duration |"
     echo "| --- | --- | --- |"
-    jq -r '"| `\(.commit[0:9])` | \(.state) | \(.duration_seconds)s |"' "${index}"
+    jq -r '"| `\(.commit[0:9])` | \(.state)"
+           + ((.failed_stages // []) | if length > 0 then " (" + join(", ") + ")" else "" end)
+           + " | \(.duration_seconds)s |"' "${index}"
     if [ "${skipped}" -gt 0 ]; then
       echo
       echo "${skipped} commit(s) deferred to the next run (leg deadline)."
+    fi
+    if [ -s "${excerpts}" ]; then
+      echo
+      echo "#### Failing stages"
+      echo
+      cat "${excerpts}"
+      if [ "${excerpts_omitted}" -gt 0 ]; then
+        echo "${excerpts_omitted} further excerpt(s) omitted to keep this summary under" \
+             "${SUMMARY_MAX_BYTES} bytes; the full logs are on the \`rcc\` branch."
+        echo
+      fi
     fi
   } >> "${GITHUB_STEP_SUMMARY}"
 fi

--- a/scripts/rcc-one.sh
+++ b/scripts/rcc-one.sh
@@ -43,6 +43,10 @@
 #   EACH_SNAPSHOT_BRANCH  - publish the snapshot-<sha>-rcc-smoke-null branch when
 #                           the snapshots gate changed anything
 #                           (default: true under GITHUB_ACTIONS, false locally)
+#   EACH_STAGE_DIR        - when set, each stage's combined output is also kept
+#                           in <dir>/<stage>.log and its verdict appended to
+#                           <dir>/outcomes.tsv, so scripts/each-shard.sh can
+#                           quote the failing stage into the run summary
 #   RCMDCHECK_ERROR_ON    - passed through to rcmdcheck (default: note)
 
 set -uo pipefail
@@ -50,6 +54,7 @@ set -uo pipefail
 ALL_GATES="style snapshots roxygen clean check pkgdown"
 GATES="${EACH_GATES:-${ALL_GATES}}"
 SNAPSHOT_BRANCH="${EACH_SNAPSHOT_BRANCH:-${GITHUB_ACTIONS:-false}}"
+STAGE_DIR="${EACH_STAGE_DIR:-}"
 
 # peter-evans/create-pull-request commits as this identity by default, not as
 # the repository's git config. Reproduced verbatim so the published branches stay
@@ -65,6 +70,11 @@ names=()
 outcomes=()
 status=0
 
+if [ -n "${STAGE_DIR}" ]; then
+  mkdir -p "${STAGE_DIR}"
+  : > "${STAGE_DIR}/outcomes.tsv"
+fi
+
 has_gate() {
   case " ${GATES} " in
     *" $1 "*) return 0 ;;
@@ -72,11 +82,39 @@ has_gate() {
   esac
 }
 
+# The per-stage verdict, in execution order. A stage that has a log here but no
+# line in this file is one that never returned -- which is exactly the stage the
+# leg's timeout killed, and the one worth showing.
+note_stage() {
+  [ -n "${STAGE_DIR}" ] || return 0
+  printf '%s\t%s\n' "$1" "$2" >> "${STAGE_DIR}/outcomes.tsv"
+}
+
 record() {
   names+=("$1")
   outcomes+=("$2")
+  note_stage "$1" "$2"
   [ "$2" = "failure" ] && status=1
   return 0
+}
+
+# Run one stage, keeping a copy of its combined output when EACH_STAGE_DIR is
+# set. Nothing is lost by buffering it: the caller (scripts/each-shard.sh)
+# already redirects the whole commit to a file and prints it once the commit is
+# over, so there is no live stream here to interleave with. What is gained is a
+# log that begins and ends at the stage boundary, which is what makes a useful
+# excerpt -- slicing the combined log back apart would mean parsing it.
+run_stage() {
+  local name="$1"
+  shift
+  local rc=0
+  if [ -z "${STAGE_DIR}" ]; then
+    "$@" || rc=$?
+    return "${rc}"
+  fi
+  "$@" > "${STAGE_DIR}/${name}.log" 2>&1 || rc=$?
+  cat "${STAGE_DIR}/${name}.log"
+  return "${rc}"
 }
 
 run_gate() {
@@ -87,7 +125,7 @@ run_gate() {
   fi
   echo "::group::gate: ${gate}"
   local outcome="success"
-  if ! "gate_${gate}"; then
+  if ! run_stage "${gate}" "gate_${gate}"; then
     outcome="failure"
   fi
   echo "::endgroup::"
@@ -109,12 +147,14 @@ rscript() {
 # install failure ends the commit right there. Everything downstream needs the
 # package loadable anyway (roxygen2, testthat, pkgdown).
 echo "::group::install"
-if ! _R_SHLIB_STRIP_=true R CMD INSTALL .; then
+if ! run_stage install env _R_SHLIB_STRIP_=true R CMD INSTALL .; then
+  note_stage install failure
   echo "::endgroup::"
   echo "install: failure -- skipping the remaining gates"
   echo "| install | failure |"
   exit 1
 fi
+note_stage install success
 echo "::endgroup::"
 
 # -------------------------------------------------------------------- gates --


### PR DESCRIPTION
Two unrelated papercuts in what `each-rcc` reports.

## Shard numbering

`each-plan.sh` reversed its shard list and *then* enumerated it,
so shard 0 held the branch tip and the highest number held the oldest commits —
zero-based, and running backwards against the history the commits sit in.

Numbering and queue order are now two separate things:

- a shard's **number** runs with the history,
  so shard 1 is the oldest slice of the plan and shard N the branch tip,
  and adjacent numbers are adjacent slices;
- the **order** the array is emitted in is still newest-first,
  because that is the order GitHub starts the legs in
  and the tip is what the series loop and the release flow wait on.

The matrix therefore starts at shard N and finishes with shard 1.
The plan listing and the shard table in the job summary are printed by number,
with a line saying which leg starts first.

Numbers are assigned after the matrix cap has dropped the oldest shards,
so shard 1 is the oldest shard *this run* will build.

```
  shard 1: 5 commits, ~69.0 min      <- oldest commits of the plan
  shard 2: 6 commits, ~75.0 min
  shard 3: 1 commits, ~45.0 min      <- branch tip, queued first
```

## Log excerpts for failed commits

A leg is one job for up to ~20 commits and up to five hours of output,
so "which commit went red, and why" meant expanding the right `::group::`
in a very long job log.

[`scripts/rcc-one.sh`](https://github.com/duckdb/duckdb-r/blob/claude/shard-numbering-run-logs-e8rmih/scripts/rcc-one.sh)
now writes each stage's combined output to its own file under `EACH_STAGE_DIR`
and its verdict to `outcomes.tsv`.
That lets
[`scripts/each-shard.sh`](https://github.com/duckdb/duckdb-r/blob/claude/shard-numbering-run-logs-e8rmih/scripts/each-shard.sh)
name the failed stages in the result table
and quote the last `SUMMARY_TAIL` lines of each one into the job summary
as a collapsed block.

Made-up numbers, real shape — this is how a red commit renders:

| Commit | Result | Duration |
| --- | --- | --- |
| `987b7b803` | failure (check, pkgdown) | 903s |

<details><summary><code>987b7b803</code> &mdash; <b>check</b> (last 50 lines)</summary>

````text
── Failed tests ────────────────────────────────────────────────────────────────
Error in `duckdb_result()`: rapi_execute: Unknown error
````

</details>

Slicing the combined log back apart would have meant parsing it,
so the stages are captured at the boundary instead.
Nothing is buffered that was not already buffered —
the leg redirects the whole commit to a file and prints it once the commit is over,
so there is no live stream to lose.
A stage that has a log but no verdict is precisely the stage the leg's `timeout`
killed, and it is quoted too; a commit with no stage detail at all falls back to
the tail of its own log.

Excerpts stop at 900 kB, because GitHub truncates a step summary at 1 MiB and a
truncated summary would take the result table with it; how many were dropped is
stated.

`SUMMARY_TAIL` defaults to 50 lines and is settable repo-wide as
`EACH_RCC_SUMMARY_TAIL`; `0` turns the excerpts off.

## Compatibility

- The per-commit log harvested onto the `rcc` branch is byte-for-byte what it
  was, so `scripts/series-check.sh` classifies failures exactly as before.
- `index.ndjson` gains a `failed_stages` field; `each-harvest.sh` picks fields
  by name and ignores it.
- Running `rcc-one.sh` without `EACH_STAGE_DIR` — the local path — is unchanged
  and leaves no extra files behind.

## Testing

- `shellcheck -S warning` clean on all three changed scripts.
- `each-plan.sh` run against this branch's last 12 commits through the offline
  `EACH_STATES_FILE` hook: shard 1 holds the 5 oldest, the matrix is emitted
  `[3, 2, 1]`.
- `each-shard.sh` driven over a scratch repo with a stubbed `rcc-one.sh`,
  covering multiple failed stages, a stage killed mid-run, no stage detail at
  all, `SUMMARY_TAIL=0`, and the byte cap. ANSI escapes and CRs are stripped
  from the excerpts.
- `rcc-one.sh` exercised for real on its install-failure path, with and without
  `EACH_STAGE_DIR`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJV9vTXRJFaVxRTdDyjuGE