### PR TITLE
fix: let `series-cutover.sh` create a base series that does not exist yet

### DIFF
--- a/.claude/skills/series-forward.md
+++ b/.claude/skills/series-forward.md
@@ -111,6 +111,11 @@ It swaps all four refs in a single `git push --atomic`
 with a per-ref lease,
 so consumers never observe a half-replaced series,
 then deletes the `-fwd` refs.
+A base ref that does not exist yet is **created** rather than swapped,
+leased as "must not exist" —
+a series opened directly as `-fwd`
+has no counterpart to replace,
+and its first cutover is what brings `<S>-*` into being.
 The swap is the **one sanctioned non-fast-forward move
 of a serving green ref**;
 a WIP `-fwd-green` may be reset by a rebase (above),

--- a/scripts/series-cutover.sh
+++ b/scripts/series-cutover.sh
@@ -8,6 +8,9 @@
 # half-replaced series. The swap is the one sanctioned non-fast-forward move
 # of a green ref.
 #
+# A base series ref that does not exist yet is created rather than swapped:
+# a series that started as -fwd has no counterpart to replace.
+#
 # Usage: series-cutover.sh <series> [remote] [upstream-clone]
 #   series-cutover.sh main origin ../duckdb
 #
@@ -28,13 +31,26 @@ vendored_sha() {
 }
 
 for r in build dev green build-base; do
-  git rev-parse -q --verify "refs/remotes/$remote/$S-$r" >/dev/null ||
-    { echo "Error: $S-$r does not exist on $remote"; exit 1; }
   git rev-parse -q --verify "refs/remotes/$remote/$S-fwd-$r" >/dev/null ||
     { echo "Error: $S-fwd-$r does not exist on $remote"; exit 1; }
 done
 
-old_up=$(vendored_sha "refs/remotes/$remote/$S-green")
+# A base series ref may legitimately be missing: a series started as -fwd has
+# no counterpart to replace, and the cutover creates the ref rather than
+# swapping it. Only the forward refs are required.
+missing=()
+for r in build dev green build-base; do
+  git rev-parse -q --verify "refs/remotes/$remote/$S-$r" >/dev/null ||
+    missing+=("$S-$r")
+done
+[ ${#missing[@]} -eq 0 ] ||
+  echo "Note: ${missing[*]} missing on $remote, will be created from $S-fwd-*"
+
+if git rev-parse -q --verify "refs/remotes/$remote/$S-green" >/dev/null; then
+  old_up=$(vendored_sha "refs/remotes/$remote/$S-green")
+else
+  old_up=
+fi
 new_up=$(vendored_sha "refs/remotes/$remote/$S-fwd-green")
 echo "old green vendors: ${old_up:-<nothing>}"
 echo "new green vendors: ${new_up:-<nothing>}"
@@ -59,14 +75,22 @@ fi
 leases=()
 refspecs=()
 for r in build dev green build-base; do
-  cur=$(git rev-parse "refs/remotes/$remote/$S-$r")
   new=$(git rev-parse "refs/remotes/$remote/$S-fwd-$r")
+  # An empty expected value leases the ref as "must not exist yet", which is
+  # what a base ref from `missing` needs. The refspecs carry no leading `+`:
+  # a forced refspec defeats --force-with-lease outright, and the lease alone
+  # already authorizes the non-fast-forward swap.
+  cur=$(git rev-parse -q --verify "refs/remotes/$remote/$S-$r") || cur=
   leases+=("--force-with-lease=refs/heads/$S-$r:$cur")
-  refspecs+=("+$new:refs/heads/$S-$r")
+  refspecs+=("$new:refs/heads/$S-$r")
 done
 
 git push --atomic "${leases[@]}" "$remote" "${refspecs[@]}"
-echo "Series $S replaced by its forward counterpart."
+if [ ${#missing[@]} -eq 4 ]; then
+  echo "Series $S created from its forward counterpart."
+else
+  echo "Series $S replaced by its forward counterpart."
+fi
 
 # Best-effort: some git proxies refuse deletions. Until these refs are gone,
 # the loop ignores a forward series whose refs equal its base series.


### PR DESCRIPTION
A series opened directly as `-fwd` has no base counterpart,
so its first cutover has nothing to swap.
Aborting on a missing `<S>-<ref>` made that first round unusable:

```console
$ scripts/series-cutover.sh v1.5-variegata krlmlr
Error: v1.5-variegata-build does not exist on krlmlr
```

## What changed

**Missing base refs are informational, not fatal.**
They are reported as a `Note:` and created by the push:

```console
$ scripts/series-cutover.sh v1.5-variegata krlmlr
Note: v1.5-variegata-build v1.5-variegata-dev v1.5-variegata-green v1.5-variegata-build-base missing on krlmlr, will be created from v1.5-variegata-fwd-*
```

Only the `-fwd` refs remain required — without them there is nothing to cut over.
The coverage gate is skipped when `<S>-green` does not exist yet,
rather than failing to read a vendored SHA from a missing ref,
and the closing line says *created from* rather than *replaced by*
when the whole base series was absent.

**The missing refs are still leased.**
Each gets `--force-with-lease=refs/heads/<S>-<r>:` with an empty expected value,
which git honours as "must not exist yet",
so a base ref created behind our back still aborts the atomic push.

**Incidental fix: the leases were decorative.**
The empty-value lease exposed this, and it applies to every ref, not just the new ones.
A refspec with a leading `+` sets `ref->force`,
which defeats `--force-with-lease` for that ref outright —
so none of this script's leases had ever bound.
The lease alone already authorizes the non-fast-forward swap,
so dropping `+` costs nothing and restores the protection
the script has always claimed to have.

## Verification

Against a fixture remote, with git 2.54:

| Scenario | Result |
| --- | --- |
| First round, no base refs at all | Four refs created, `-fwd-*` deleted |
| Mixed — some base refs present, some absent | Present ones swapped, absent ones created, one atomic push |
| Ordinary swap, base refs present | Green moves to the forward commit |
| Forward green vendors less than base green | Coverage gate rejects |
| `-fwd` refs missing | Still an error |
| Base green pushed by someone else after our fetch | Rejected `(stale info)`, nothing moved |
| Base green *created* by someone else after our fetch | Rejected `(stale info)`, nothing moved |

The concurrent-push cases were run against the pre-fix script as a control:
it clobbered the other push; this one rejects it.

`.claude/skills/series-forward.md` gains a note that a first cutover
brings `<S>-*` into being rather than swapping it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GgFrw6GC2Ye5d8YomhKjV6)_