### PR TITLE
chore(tooling): Carry `main`'s `DESCRIPTION` merge attribute onto `v1.4-andium`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 src/duckdb/** linguist-vendored
+DESCRIPTION merge=ours-version


### PR DESCRIPTION
Follow-up to #2429.

That replay worked from a path set —
`scripts`, `.claude`, the series workflows, and the top-level docs —
and `.gitattributes` was not in it,
so the one committed half of the `ours-version` merge driver stayed behind.

The driver has two halves.
`scripts/setup-git.sh` registers the *name to command* mapping in `.git/config`,
which cannot live in a versioned file;
`.gitattributes` is what points `DESCRIPTION` at that name.
With only the first half in place the driver never runs,
and every replay or rebase that advances both version counters
stops on the `Version:` line by hand.

## How it surfaced

Seeding the `v1.4-andium` forward series.
`scripts/series-forward-build.sh` refuses to start
unless the driver is registered,
so `scripts/setup-git.sh` had been run;
it then conflicted on `DESCRIPTION` at the first replayed vendor commit —
the seed's counter `.0` against the picked commit's `.1` —
because the attribute was missing and the driver was never consulted.
With the line in place the same replay runs clean.

## Scope

One line in `.gitattributes`, byte-identical to `main`'s.
No script, workflow, or package content changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_0167nRrv42xUzUnzKXRaCnUF)_