### PR TITLE
chore(v1.4): Land the non-vendor work from `v1.4-andium-green` on the branch a forward seeds from

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -44,3 +44,4 @@ _files$
 ^src/include/deps\.mk$
 ^AGENTS\.md$
 ^BRANCHES\.md$
+^\.claude$

--- a/.claude/skills/series-loop.md
+++ b/.claude/skills/series-loop.md
@@ -16,7 +16,7 @@ this loop repairs in place and was proven on the `main` rewind
 | ref | who writes it | what it is |
 |---|---|---|
 | `<S>-build` | the routine, unconditionally | Every upstream first-parent commit vendored one-to-one, glue compiling at every commit. **No CI runs here** (`each.yaml` never matches `*-build`). The buffer. |
-| `<S>-dev` | the routine, force-push | `<S>-build` commits, consumed up to 25 at a time, with test/R/patch adaptations folded in as CI demands. What CI builds, commit by commit. |
+| `<S>-dev` | the routine, force-push | `<S>-build` commits, consumed up to 100 at a time, with test/R/patch adaptations folded in as CI demands. What CI builds, commit by commit. |
 | `<S>-green` | the routine, fast-forward only | The newest commit such that every commit in `<S>-green..it` has a `success` run. What r-universe should build from. |
 | `<S>-build-base` | the routine | The `<S>-build` commit equivalent to `<S>-green` (same vendored upstream SHA). Marks how much of the buffer has been consumed and verified. |
 
@@ -67,14 +67,14 @@ ADVANCE / WAIT / RETRY `<sha>` / REPAIR `<sha>` / IDLE)
 and `scripts/series-advance.sh <S>`
 (stages 3–4 — fast-forwards `-green`,
 moves `-build-base` by vendored-SHA match,
-extends `-dev` by ≤ 25;
+extends `-dev` by ≤ 100;
 refuses on any failure or non-fast-forward).
 Judgement — repairs, review, vendoring — stays here.
 
 ### 1. Vendor onto `<S>-build`
 
 ```sh
-scripts/vendor-one.sh --commits 25 <upstream-clone>
+scripts/vendor-one.sh --commits 100 <upstream-clone>
 ```
 
 The script gates itself:
@@ -263,7 +263,7 @@ stop and say so.
 
 If everything between `<S>-green` and the `<S>-dev` tip is green
 (or the tip equals `-green`),
-append the next ≤ 25 commits from `<S>-build` and push.
+append the next ≤ 100 commits from `<S>-build` and push.
 While `-dev` sits on `-build`'s line this is a plain ref move;
 after a repair it is a replay of the buffer commits
 onto the repaired tip —
@@ -337,19 +337,29 @@ One ref per series, so it records the retry in flight,
 not the history of them.
 
 The verdict reaches the loop the ordinary way.
-`runs2.ndjson` is keyed by SHA and readers take the first record for a key,
-so `each-harvest.sh` replaces the stale record rather than appending —
-the one case where a decided commit legitimately changes state.
-If the fan-in was lost, drop the commit's line
-and its `logs2/<sha>.log` from the `rcc` branch;
-the scheduled backstop re-derives both from the fresh status.
+A commit's record lives twice on `rcc` —
+`runs2.d/<xx>/<sha>.ndjson`, which the leg publishes within seconds,
+and a line in `runs2.ndjson`, which `rcc-merge.sh` keeps level with it.
+Readers take the per-commit record first,
+so `each-harvest.sh` and the leg both *replace* it rather than appending;
+that is the one case where a decided commit legitimately changes state.
+
+**Deleting a record by hand means deleting both.**
+Dropping only the line from `runs2.ndjson` does nothing:
+readers still find the record, and the next `rcc-merge.sh`
+re-appends the line from the part that is still there.
+To drop a commit's result, remove
+`runs2.d/<xx>/<sha>.ndjson`, its line in `runs2.ndjson`,
+and `logs2/<sha>.log`;
+then the scheduled backstop re-derives all of it from the fresh status.
 
 **Both mechanisms live in the tree at the commit under retry.**
 `each.yaml` and its scripts are read from the retried ref, not from `main`,
 so a series whose commits predate them retries by hand:
 push the branch, dispatch `each-rcc` on `retry-<S>-dev`
 with `force=true` and `max-commits=1`,
-and drop the stale record from `rcc` once the rerun is green.
+and drop the stale record from `rcc` once the rerun is green —
+both copies of it, per above.
 A rebase onto a newer mainline (`series-rebase.md`)
 is what carries the automatic path into a forward series.
 

--- a/.claude/skills/series-open.md
+++ b/.claude/skills/series-open.md
@@ -64,7 +64,7 @@ This skill is the release branch's birth certificate.
    if the fork point predates the current glue.
 
 5. **Walk forward** along `<U>`
-   with the gated `scripts/vendor-one.sh --commits 25 <upstream-clone>`,
+   with the gated `scripts/vendor-one.sh --commits 100 <upstream-clone>`,
    fixing glue breaks in place as the gate stops on them.
 
 6. The routine discovers every series from its refs

--- a/.github/workflows/custom/before-install/action.yml
+++ b/.github/workflows/custom/before-install/action.yml
@@ -7,3 +7,15 @@ runs:
       run: |
         echo '_R_CHECK_PKG_SIZES_=FALSE' | tee -a $GITHUB_ENV
       shell: bash
+
+    # Ubuntu 26.04 moved the legacy System V-style time zones (e.g. PST8PDT)
+    # into a separate tzdata-legacy package. Some DBItest specs call
+    # lubridate::with_tz(tzone = "PST8PDT"), which warns "Unrecognized time
+    # zone" when the zone is missing; testthat then promotes that warning to a
+    # failure. Install tzdata-legacy so the zone resolves and the tests run.
+    - name: Install tzdata-legacy (legacy time zones like PST8PDT)
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata-legacy
+      shell: bash

--- a/.github/workflows/each.yaml
+++ b/.github/workflows/each.yaml
@@ -292,14 +292,20 @@ jobs:
       # Still uploaded, and still the fan-in's input: the per-commit publish is
       # the fast path, not a replacement. A leg that could not reach the `rcc`
       # branch has its results collected from here instead.
+      #
+      # Named per *attempt*, and therefore not overwritten. A re-run of a leg
+      # resumes, so its index covers only the commits it rebuilt -- overwriting
+      # would delete the previous attempt's artifact, which is the one copy of
+      # anything that attempt decided but could not publish. The fan-in's
+      # `each-logs-*` pattern collects every attempt, and reconciling the same
+      # commit twice is a no-op.
       - uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: each-logs-${{ matrix.shard }}
+          name: each-logs-${{ matrix.shard }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/each-logs
           if-no-files-found: ignore
           retention-days: 14
-          overwrite: true
 
   harvest:
     needs:

--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -110,6 +110,26 @@ runs:
         echo packages=$packages >> $GITHUB_OUTPUT
       shell: bash
 
+    - name: Let sudo keep R library env vars (ubuntu-26.04 forbids `sudo -E`)
+      # r-lib/actions/setup-r-dependencies installs pak with
+      #   sudo -E --preserve-env=PATH env R -e 'dir.create(Sys.getenv("R_LIB_FOR_PAK"), ...)'
+      # From the ubuntu-26.04 runner image on, the sudoers policy rejects `-E`
+      # ("sudo: preserving the entire environment is not supported, '-E' is
+      # ignored"), so R_LIB_FOR_PAK is stripped and dir.create() aborts with a
+      # zero-length 'path' argument. Whitelisting the R_* vars via env_keep
+      # preserves them across sudo's env_reset even though blanket `-E` is
+      # denied, without granting the setenv privilege.
+      # Root cause is the ubuntu-26.04 image, still in public preview
+      # (actions/runner-images#14226). No upstream r-lib/actions issue tracks the
+      # `sudo -E` breakage yet -- one should be filed; drop this once fixed.
+      if: runner.os == 'Linux'
+      run: |
+        sudo tee /etc/sudoers.d/r-lib-pak >/dev/null <<'EOF'
+        Defaults env_keep += "R_LIB_FOR_PAK R_LIBS R_LIBS_USER R_LIBS_SITE MAKEFLAGS"
+        EOF
+        sudo chmod 0440 /etc/sudoers.d/r-lib-pak
+      shell: bash
+
     - uses: r-lib/actions/setup-r-dependencies@v2
       env:
         GITHUB_PAT: ${{ inputs.token }}

--- a/scripts/EACH.md
+++ b/scripts/EACH.md
@@ -380,7 +380,7 @@ The default leg deadline is 300 minutes and a cheap commit costs ~6,
 so 25 commits fit in two legs — and the branch tip waits five hours for a verdict
 that 20 legs would have delivered in fifty minutes.
 This is the common case, not the corner case:
-a series-loop batch is usually well under 25 commits.
+a series-loop batch is capped at 100 commits and is usually far smaller.
 A large backlog looks like it should be immune, since every slot is busy anyway,
 but it is not: see [below](#why-the-pass-cannot-stop-at-max_parallel).
 
@@ -770,6 +770,22 @@ Two writers can only collide here if they are deciding the same commit at the
 same moment, which the planner does not produce; if it somehow happened, the
 retry loop converges on whichever wrote last.
 
+**"Newer" is checked, not assumed**, and that is a consequence of publishing
+early rather than an incidental detail. A leg's verdict is on the branch within
+seconds, but its run's fan-in lands when the *whole run* is done — possibly hours
+later. So a retry can correctly overturn a commit while the run that first failed
+it is still building, and replaying that run's artifact afterwards would put the
+stale verdict back. Nothing would repair it: the commit-status is already the
+retry's, so the planner never rebuilds, and the backstop skips commits that have a
+record. The fan-in therefore compares run ids — they increase per repository, and a
+re-run keeps the id of the run it re-runs — and leaves alone any record written by
+a *higher* run id than its own.
+
+A verdict that stops being a failure also takes its log with it. That case cannot
+be caught by comparing what a writer was handed, because a success has no log to
+hand over; both the leg and the fan-in remove the log explicitly when the state is
+no longer a failure.
+
 The planner names the commits it replanned *despite* a verdict in the plan's
 `replanned_despite_verdict`, and the leg reads it from there. Without that the
 resume check above would skip exactly the commit a retry exists to rebuild, and
@@ -998,6 +1014,9 @@ Two details make it work in practice:
 | Two writers publish records at once | different files, no conflict; the loser of the ref race re-reads the tip and re-commits ([`rcc-part-push.sh`](rcc-part-push.sh)) |
 | Two writers extend the aggregate at once | the push is rejected, and [`rcc-push.sh`](rcc-push.sh) resets onto the new tip, re-derives, and appends what is still missing before retrying |
 | A retry overturns a verdict | the newer record and log replace the older ones, in the part and in the aggregate's line (§3) |
+| An earlier run's fan-in lands after a retry | it sees a higher run id on the branch and keeps that record; the stale verdict is not replayed (§3) |
+| A retry turns a failure green | the record is replaced and the log it overturned is dropped, on whichever path publishes first |
+| A leg is re-run after publishing failed | its artifact is named per attempt, so the earlier attempt's records stay collectable |
 | A writer lands during a consolidation | the lease refuses the force-push; nothing is lost, re-dispatch it |
 
 Nothing here needs a lock for correctness.

--- a/scripts/VENDORING.md
+++ b/scripts/VENDORING.md
@@ -116,7 +116,7 @@ Shared behaviour, in the order it happens:
    so every vendor commit is installable as a distinct version on r-universe.
 8. **Commit** with the message described in [Understanding Vendor Commits](#understanding-vendor-commits).
 
-`vendor-one.sh --commits N` repeats steps 3–8 up to `N` times (CI uses 25),
+`vendor-one.sh --commits N` repeats steps 3–8 up to `N` times (the routine uses 100),
 stopping early on a tag or when no candidates remain.
 
 ### Two properties of the regenerated tree
@@ -192,7 +192,7 @@ one case where the driver silently does less than a reader might assume.
 Vendoring is driven by the routine described in
 `.claude/skills/series-loop.md`: `scripts/vendor-one.sh` appends upstream
 commits to `<series>-build` with a glue-only compile gate, and the routine
-consumes them into `<series>-dev` at most 25 at a time, gated on the per-commit
+consumes them into `<series>-dev` at most 100 at a time, gated on the per-commit
 `rcc` results harvested to branch `rcc`. There is no vendoring workflow; CI's
 role is building each `-dev` commit (`each.yaml`) and recording results
 (`rcc-logs.yaml`, every 30 minutes).
@@ -202,7 +202,7 @@ It reads the `rcc` commit-status of a branch tip and the five commits before it:
 
 | Gate decision | Meaning                                                        | Action                                                                                                                    |
 |---------------|----------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
-| `green`       | some commit in the window is `rcc=success`                     | rewind to the youngest green commit (re-applying any non-vendored commits above it), then vendor at most 25 commits on top |
+| `green`       | some commit in the window is `rcc=success`                     | rewind to the youngest green commit (re-applying any non-vendored commits above it), then vendor at most 100 commits on top |
 | `red`         | no green in the window, but a failure/error                    | fail loudly — the breakage must be repaired before vendoring continues                                                    |
 | `stale`       | no green/red, and a commit has had no `rcc` result for over 6h | fail loudly — CI never decided; investigate                                                                               |
 | `undecided`   | no green/red, results still pending and younger than 6h        | succeed and do nothing; re-check tomorrow                                                                                 |

--- a/scripts/each-harvest.sh
+++ b/scripts/each-harvest.sh
@@ -30,6 +30,19 @@
 # record, log and all. Readers take the first record for a SHA, so a second one
 # would be invisible; replacing is the only thing that works.
 #
+# "Newer" has to be checked, not assumed, and that is a consequence of legs
+# publishing as they go. A leg's verdict is on the branch within seconds, but this
+# job runs when the *whole run* is done -- possibly hours later. So a retry can
+# land, and be correct, while an earlier run is still building: replaying that
+# earlier run's artifact here would put its stale verdict back, and nothing would
+# repair it. The commit-status is already the retry's, so the planner never
+# rebuilds; scripts/rcc-logs.sh skips commits that have a record. The verdict
+# would simply be wrong until someone noticed.
+#
+# Run ids order this reliably -- they increase per repository, and a re-run keeps
+# the id of the run it re-runs -- so a record from a *higher* run id than ours is
+# newer than anything we can offer, and we leave it alone.
+#
 # `scripts/rcc-logs.sh` remains the scheduled backstop for the case where this job
 # never runs at all, because the whole workflow was cancelled.
 #
@@ -61,21 +74,26 @@ part_path() { printf '%s/runs2.d/%s/%s.ndjson' "${OUT_DIR}" "${1:0:2}" "$1"; }
 
 mkdir -p "${OUT_DIR}/logs2"
 
-# The state a commit is already recorded with, from whichever layout holds it:
-# its own record first, then the aggregate for the records that predate
-# `runs2.d/` and are deliberately left there (scripts/rcc-merge.sh). Empty when
-# the commit is new.
-recorded_state() { # <sha>
+# What the branch already says about a commit, from whichever layout holds it: its
+# own record first, then the aggregate for the records that predate `runs2.d/` and
+# are deliberately left there (scripts/rcc-merge.sh). Emits
+# "<state> <run-id>"; empty when the commit is new.
+#
+# Both branches tolerate a malformed record rather than aborting: this loop is the
+# only path by which a whole run's results reach the branch, and one unreadable
+# line must not take the other twenty-six commits down with it.
+recorded_record() { # <sha>
   local sha="$1" part
   part="$(part_path "${sha}")"
   if [ -f "${part}" ]; then
-    jq -r '.status.state // ""' "${part}"
-    return
+    jq -r '"\(.status.state // "") \(.run.id // 0)"' "${part}" 2>/dev/null || true
+    return 0
   fi
   if [ -s "${OUT_DIR}/runs2.ndjson" ]; then
     grep -m 1 "\"commit\"[[:space:]]*:[[:space:]]*\"${sha}\"" "${OUT_DIR}/runs2.ndjson" \
-      | jq -r '.status.state // ""' 2>/dev/null || true
+      | jq -r '"\(.status.state // "") \(.run.id // 0)"' 2>/dev/null || true
   fi
+  return 0
 }
 
 # The run object, for the one case where a leg wrote an index line but no record
@@ -91,6 +109,7 @@ load_run_json() {
 published=0
 recorded=0
 replaced=0
+superseded=0
 logs=0
 known=0
 
@@ -100,7 +119,11 @@ while IFS= read -r index_file; do
     sha="$(jq -r '.commit' <<<"${line}")"
     state="$(jq -r '.state' <<<"${line}")"
     part="$(part_path "${sha}")"
-    previous="$(recorded_state "${sha}")"
+    known_record="$(recorded_record "${sha}")"
+    previous="${known_record%% *}"
+    previous_run="${known_record##* }"
+    [ "${known_record}" = "${previous}" ] && previous_run=0
+    case "${previous_run}" in ''|*[!0-9]*) previous_run=0 ;; esac
 
     # Same verdict as the branch already carries: nothing to add. This is the
     # common case on a retry of the push itself, and it is what makes this
@@ -111,16 +134,31 @@ while IFS= read -r index_file; do
       else
         known=$(( known + 1 ))
       fi
-      # A published record whose log never made it is still worth completing.
-      if [ "${state}" = "failure" ] && [ -f "${shard_dir}/${sha}.log" ] \
-         && [ ! -f "${OUT_DIR}/logs2/${sha}.log" ]; then
-        cp -f "${shard_dir}/${sha}.log" "${OUT_DIR}/logs2/${sha}.log"
-        logs=$(( logs + 1 ))
+      # A published record whose log never made it is still worth completing --
+      # and a log left over from a verdict this one overturned is worth removing,
+      # which is the case the leg's own publish cannot see (it compares blob ids,
+      # and a success simply has no log to compare).
+      if [ "${state}" = "failure" ]; then
+        if [ -f "${shard_dir}/${sha}.log" ] && [ ! -f "${OUT_DIR}/logs2/${sha}.log" ]; then
+          cp -f "${shard_dir}/${sha}.log" "${OUT_DIR}/logs2/${sha}.log"
+          logs=$(( logs + 1 ))
+        fi
+      elif [ -f "${OUT_DIR}/logs2/${sha}.log" ]; then
+        echo "Commit ${sha}: ${state}, dropping the log left by an earlier verdict"
+        rm -f "${OUT_DIR}/logs2/${sha}.log"
       fi
       continue
     fi
 
     if [ -n "${previous}" ]; then
+      # A record from a later run than ours has seen something we have not -- a
+      # retry, most likely. Ours is the stale one; leave the branch alone.
+      if [ "${previous_run}" -gt "${RUN_ID}" ]; then
+        echo "Commit ${sha}: recorded as ${previous} by run ${previous_run}," \
+          "newer than this run -- keeping it, not replacing with ${state}"
+        superseded=$(( superseded + 1 ))
+        continue
+      fi
       echo "Commit ${sha}: recorded as ${previous}, now ${state} -- replacing the record"
       # The stale log goes with the stale verdict; the new one is written below
       # if this verdict is a failure too.
@@ -164,4 +202,5 @@ while IFS= read -r index_file; do
 done < <(find "${ARTIFACTS}" -name 'index.ndjson' | LC_ALL=C sort)
 
 echo "Published by the legs: ${published}, reconciled here: ${recorded}," \
-  "replaced: ${replaced}, already known: ${known}, logs kept: ${logs}"
+  "replaced: ${replaced}, superseded by a newer run: ${superseded}," \
+  "already known: ${known}, logs kept: ${logs}"

--- a/scripts/each-shard.sh
+++ b/scripts/each-shard.sh
@@ -37,7 +37,10 @@
 #   * The leg *publishes as it goes*. Every verdict is pushed to the `rcc` branch
 #     the moment it exists (scripts/rcc-part-push.sh), so a leg that dies takes
 #     nothing with it but the commit it was in the middle of. The artifact and
-#     the fan-in stay as the backstop for the push itself failing.
+#     the fan-in stay as the backstop for the push itself failing -- which is why
+#     each.yaml names the artifact per run *attempt*: a resumed leg's index covers
+#     only what it rebuilt, so overwriting would delete the previous attempt's
+#     copy of anything that attempt decided but could not publish.
 #
 # Usage:
 #   SHARD=1 PLAN=plan.json LOG_DIR=/tmp/each-logs GH_TOKEN=<token> \

--- a/scripts/rcc-consolidate.sh
+++ b/scripts/rcc-consolidate.sh
@@ -78,15 +78,29 @@ here="$(cd "$(dirname "$0")" && pwd)"
 
 git_out() { git -C "${OUT_DIR}" "$@"; }
 
+# Every shape this branch can legitimately have, up front. The bootstrap path in
+# scripts/rcc-part-push.sh creates it with `runs2.d/` alone, and the pre-split
+# shape had `runs2.ndjson` alone, so neither is an error -- but under `set -e`
+# every probe below would abort on the missing one, and `2>/dev/null` would hide
+# why. An operator dispatching the dry run to *find out* what state the branch is
+# in deserves a report rather than a bare redirection error.
+mkdir -p "${OUT_DIR}/logs2" "${OUT_DIR}/runs2.d"
+[ -e "${OUT_DIR}/runs2.ndjson" ] || : > "${OUT_DIR}/runs2.ndjson"
+
+count_files() { # <dir> <name-glob>
+  [ -d "$1" ] || { echo 0; return 0; }
+  find "$1" -type f -name "$2" | wc -l | tr -d ' '
+}
+
 before_tip="$(git_out rev-parse HEAD)"
 before_commits="$(git_out rev-list --count HEAD)"
 before_bytes="$(git_out rev-list --disk-usage --objects HEAD 2>/dev/null || echo 0)"
-before_logs="$(find "${OUT_DIR}/logs2" -type f -name '*.log' 2>/dev/null | wc -l | tr -d ' ')"
+before_logs="$(count_files "${OUT_DIR}/logs2" '*.log')"
 
 echo "== ${BRANCH} before =="
 echo "   commits:  ${before_commits}"
-echo "   records:  $(wc -l < "${OUT_DIR}/runs2.ndjson" 2>/dev/null || echo 0) in runs2.ndjson," \
-  "$(find "${OUT_DIR}/runs2.d" -type f -name '*.ndjson' 2>/dev/null | wc -l | tr -d ' ') in runs2.d/"
+echo "   records:  $(wc -l < "${OUT_DIR}/runs2.ndjson" | tr -d ' ') in runs2.ndjson," \
+  "$(count_files "${OUT_DIR}/runs2.d" '*.ndjson') in runs2.d/"
 echo "   logs:     ${before_logs}"
 echo "   objects:  $(( before_bytes / 1048576 )) MB"
 echo

--- a/scripts/rcc-part-push.sh
+++ b/scripts/rcc-part-push.sh
@@ -29,6 +29,11 @@
 # moment, which the planner does not produce -- and if it somehow happened, the
 # retry loop would converge on whichever wrote last.
 #
+# "And its log" needs saying explicitly, because a retry that *succeeds* has no
+# log to hand over -- logs are kept for failures only. So the record changing to a
+# non-failure is what removes the log the previous verdict left; comparing what we
+# were given would never notice it, there being nothing to compare.
+#
 # The branch is reached through a blobless, shallow, checkout-less clone and
 # written with plumbing, because the point is to *not* pay for it. The `rcc`
 # branch is ~218 MB (2.5k harvested failure logs of a megabyte each), and a leg
@@ -93,6 +98,10 @@ fi
 
 part_path="runs2.d/${SHA:0:2}/${SHA}.ndjson"
 log_path="logs2/${SHA}.log"
+
+# Read from the record rather than taken as an argument, so the caller cannot
+# disagree with the record it just wrote.
+state="$(jq -r '.status.state // ""' "${RECORD}" 2>/dev/null || true)"
 
 # A blobless clone backfills on demand, and the demand is easy to trigger by
 # accident: plain `git write-tree` verifies that every index entry's object is
@@ -180,6 +189,13 @@ stage_if_changed() { # <path-on-branch> <source-file>
   return 0
 }
 
+# Removing an index entry needs no blob either, so this is as cheap as staging.
+unstage_if_present() { # <path-on-branch>
+  git_rcc ls-files --error-unmatch -- "$1" > /dev/null 2>&1 || return 1
+  git_rcc update-index --force-remove -- "$1"
+  return 0
+}
+
 attempt=1
 while :; do
   tip=""
@@ -197,6 +213,13 @@ while :; do
   stage_if_changed "${part_path}" "${RECORD}" && staged=$(( staged + 1 ))
   if [ -n "${LOG}" ]; then
     stage_if_changed "${log_path}" "${LOG}" && staged=$(( staged + 1 ))
+  elif [ "${state}" != "failure" ]; then
+    # No log to publish and no failure to explain: any log on the branch belongs
+    # to a verdict this record overturns.
+    if unstage_if_present "${log_path}"; then
+      echo "${SHA:0:9}: ${state:-decided}, dropping the log left by an earlier verdict"
+      staged=$(( staged + 1 ))
+    fi
   fi
 
   if [ "${staged}" -eq 0 ]; then

--- a/scripts/rcc-parts-test.sh
+++ b/scripts/rcc-parts-test.sh
@@ -21,7 +21,12 @@
 #   5. A newer verdict for a commit that already has one overwrites it, in the
 #      part and in the aggregate's line -- which is what a retry needs
 #      (.claude/skills/series-loop.md), and what a re-publish of the *same*
-#      verdict must not cost anything.
+#      verdict must not cost anything -- and a verdict that stops being a failure
+#      takes its log with it, on both the leg's path and the fan-in's.
+#   5b. A fan-in whose run is *older* than what the branch already records leaves
+#      it alone. Legs publish within seconds while a run takes hours, so an
+#      earlier run's fan-in can outlive a retry that corrected it; replaying its
+#      artifact must not put the overturned verdict back.
 #   6. scripts/rcc-consolidate.sh is a no-op as a dry run, makes the two layouts
 #      agree, drops logs past their retention, squashes to two commits, inherits
 #      its empty root on a second pass, and refuses to push over a writer that
@@ -63,6 +68,14 @@ record_for() { # <sha> <state>
 
 git init -q --bare "${work}/remote.git"
 git -C "${work}/remote.git" config uploadpack.allowFilter true
+# `receive.autogc` is on by default, so every push into this bare repo may fork a
+# `git gc --auto`. This test pushes hundreds of loose objects and then immediately
+# clones the result, and a clone that reads the repo while gc is repacking it
+# fails outright -- the harness runs without `set -e`, so the clone's failure used
+# to surface much later as whichever check first found a directory missing. Ruling
+# gc out here is what makes the checks below deterministic.
+git -C "${work}/remote.git" config gc.auto 0
+git -C "${work}/remote.git" config receive.autogc false
 
 echo "== 1. the aggregate is extended, not migrated =="
 # Seeded from a real branch, the whole tree is taken -- the harvested logs are
@@ -281,6 +294,71 @@ first="$(grep -m 1 "\"${retry_sha}\"" "${work}/agg2/runs2.ndjson" | jq -r '.stat
   && pass "the aggregate holds one line for the commit, with the newer verdict" \
   || fail "the aggregate has ${lines} line(s), first says ${first}"
 
+# The stale log must go when the verdict stops being a failure, on the leg path.
+git -C "${work}/remote.git" cat-file -e "rcc:logs2/${retry_sha}.log" 2>/dev/null \
+  && fail "the failure log survived a retry to success" \
+  || pass "the leg dropped the log its own new verdict overturned"
+
+echo
+echo "== 5b. an older run's fan-in does not overwrite a newer record =="
+stale_sha="$(sha_for 556001)"
+mkdir -p "${work}/sf/runs/runs2.d/${stale_sha:0:2}" "${work}/sf/runs/logs2" \
+  "${work}/sf/art/each-logs-1/parts"
+# The branch carries run 2's success (a retry, which corrected run 1).
+printf '{"commit":"%s","status":{"context":"rcc","state":"success","created_at":"2026-07-29T12:00:00Z"},"run":{"id":2}}\n' \
+  "${stale_sha}" > "${work}/sf/runs/runs2.d/${stale_sha:0:2}/${stale_sha}.ndjson"
+# Run 1's artifact, decided hours earlier, is what its slow fan-in replays.
+printf '{"commit":"%s","status":{"context":"rcc","state":"failure","created_at":"2026-07-29T08:00:00Z"},"run":{"id":1}}\n' \
+  "${stale_sha}" > "${work}/sf/art/each-logs-1/parts/${stale_sha}.ndjson"
+printf 'the overturned failure\n' > "${work}/sf/art/each-logs-1/${stale_sha}.log"
+printf '{"commit":"%s","state":"failure","shard":1,"duration_seconds":1,"exit_code":1}\n' \
+  "${stale_sha}" > "${work}/sf/art/each-logs-1/index.ndjson"
+ARTIFACTS="${work}/sf/art" OUT_DIR="${work}/sf/runs" RUN_ID=1 GH_TOKEN=x \
+  "${here}/each-harvest.sh" > "${work}/sf.log" 2>&1
+after="$(jq -r '.status.state' "${work}/sf/runs/runs2.d/${stale_sha:0:2}/${stale_sha}.ndjson")"
+[ "${after}" = "success" ] \
+  && pass "the newer run's verdict survived the older fan-in" \
+  || fail "an older fan-in overwrote a newer verdict with ${after}"
+[ ! -f "${work}/sf/runs/logs2/${stale_sha}.log" ] \
+  && pass "and it did not resurrect the overturned log" \
+  || fail "the overturned failure log was restored"
+grep -q 'newer than this run' "${work}/sf.log" \
+  && pass "the fan-in said why it kept the record" \
+  || fail "the fan-in was silent about superseding"
+
+# The reverse direction must still work: a *newer* run does replace.
+printf '{"commit":"%s","status":{"context":"rcc","state":"success","created_at":"2026-07-29T20:00:00Z"},"run":{"id":9}}\n' \
+  "${stale_sha}" > "${work}/sf/art/each-logs-1/parts/${stale_sha}.ndjson"
+printf '{"commit":"%s","state":"success","shard":1,"duration_seconds":1,"exit_code":0}\n' \
+  "${stale_sha}" > "${work}/sf/art/each-logs-1/index.ndjson"
+# Give the branch a failure for run 2 to be corrected.
+printf '{"commit":"%s","status":{"context":"rcc","state":"failure","created_at":"2026-07-29T12:00:00Z"},"run":{"id":2}}\n' \
+  "${stale_sha}" > "${work}/sf/runs/runs2.d/${stale_sha:0:2}/${stale_sha}.ndjson"
+printf 'stale\n' > "${work}/sf/runs/logs2/${stale_sha}.log"
+ARTIFACTS="${work}/sf/art" OUT_DIR="${work}/sf/runs" RUN_ID=9 GH_TOKEN=x \
+  "${here}/each-harvest.sh" > "${work}/sf2.log" 2>&1
+after="$(jq -r '.status.state' "${work}/sf/runs/runs2.d/${stale_sha:0:2}/${stale_sha}.ndjson")"
+[ "${after}" = "success" ] && [ ! -f "${work}/sf/runs/logs2/${stale_sha}.log" ] \
+  && pass "a newer run still replaces the record and drops the stale log" \
+  || fail "a newer run failed to replace (state=${after})"
+
+# A malformed record on the branch must not take the whole run down with it.
+mkdir -p "${work}/mf/runs/runs2.d/ff" "${work}/mf/runs/logs2" "${work}/mf/art/each-logs-1/parts"
+bad="ff$(sha_for 557001 | cut -c3-)"; ok_sha="$(sha_for 557002)"
+printf 'not json\n' > "${work}/mf/runs/runs2.d/${bad:0:2}/${bad}.ndjson"
+for c in "${bad}" "${ok_sha}"; do
+  record_for "${c}" success > "${work}/mf/art/each-logs-1/parts/${c}.ndjson"
+  printf '{"commit":"%s","state":"success","shard":1,"duration_seconds":1,"exit_code":0}\n' \
+    "${c}" >> "${work}/mf/art/each-logs-1/index.ndjson"
+done
+if ARTIFACTS="${work}/mf/art" OUT_DIR="${work}/mf/runs" RUN_ID=1 GH_TOKEN=x \
+     "${here}/each-harvest.sh" > "${work}/mf.log" 2>&1 \
+   && [ -f "${work}/mf/runs/runs2.d/${ok_sha:0:2}/${ok_sha}.ndjson" ]; then
+  pass "one unreadable record does not abort the fan-in"
+else
+  fail "a malformed record aborted the whole fan-in (see ${work}/mf.log)"
+fi
+
 echo
 echo "== 6. consolidation =="
 rm -rf "${work}/cons"
@@ -344,7 +422,13 @@ git -C "${work}/remote.git" cat-file -e "rcc:runs2.d/${legacy_sha:0:2}/${legacy_
 rm -rf "${work}/cons2"
 # --no-hardlinks: the consolidation just repacked the bare repo, and
 # git's local clone optimisation trips on that. Local paths only.
-git clone -q --no-hardlinks --single-branch --branch rcc "${work}/remote.git" "${work}/cons2"
+if ! git clone -q --no-hardlinks --single-branch --branch rcc \
+     "${work}/remote.git" "${work}/cons2"; then
+  # Checked because the harness runs without `set -e`: an unchecked failure here
+  # leaves no worktree, and every check below it then reports its own subject
+  # rather than the clone that actually broke.
+  fail "could not clone the consolidated branch for a second pass"
+fi
 git -C "${work}/cons2" config user.name t
 git -C "${work}/cons2" config user.email t@e
 OUT_DIR="${work}/cons2" APPLY=1 "${here}/rcc-consolidate.sh" > "${work}/cons2.log" 2>&1
@@ -371,6 +455,35 @@ else
     && pass "the lease refused the push and the other writer's record survived" \
     || fail "the push was refused but the record is gone anyway"
 fi
+
+# Every shape the branch can legitimately have must still produce a report.
+echo
+echo "== 6b. consolidation survives every branch shape =="
+for shape in no-aggregate no-logs no-parts empty; do
+  d="${work}/shape-${shape}"
+  rm -rf "${d}"
+  git init -q "${d}"
+  git -C "${d}" config user.name t
+  git -C "${d}" config user.email t@e
+  case "${shape}" in
+    no-aggregate) mkdir -p "${d}/runs2.d/aa" "${d}/logs2"
+                  record_for "$(sha_for 1)" success > "${d}/runs2.d/aa/$(sha_for 1).ndjson" ;;
+    no-logs)      mkdir -p "${d}/runs2.d/aa"
+                  record_for "$(sha_for 1)" success > "${d}/runs2.d/aa/$(sha_for 1).ndjson"
+                  record_for "$(sha_for 1)" success > "${d}/runs2.ndjson" ;;
+    no-parts)     mkdir -p "${d}/logs2"
+                  record_for "$(sha_for 1)" success > "${d}/runs2.ndjson" ;;
+    empty)        : ;;
+  esac
+  git -C "${d}" add -A > /dev/null 2>&1 || true
+  git -C "${d}" commit -qm "${shape}" --allow-empty
+  if OUT_DIR="${d}" "${here}/rcc-consolidate.sh" > "${work}/shape-${shape}.log" 2>&1 \
+     && grep -q 'dry run' "${work}/shape-${shape}.log"; then
+    pass "${shape}: the dry run reported instead of dying"
+  else
+    fail "${shape}: the dry run failed (see ${work}/shape-${shape}.log)"
+  fi
+done
 
 echo
 if [ "${failures}" -eq 0 ]; then

--- a/scripts/rcc-push.sh
+++ b/scripts/rcc-push.sh
@@ -47,9 +47,14 @@
 #   scripts/rcc-push.sh <commit-message> [-- <re-derive command>...]
 #
 # Run from the repository root (the re-derive command inherits that directory,
-# and `scripts/rcc-logs.sh` reads the *source* refs from there). Without a
-# re-derive command the retry still resets onto the remote, so it degrades to
-# "push whatever the remote now has" rather than looping on a doomed push.
+# and `scripts/rcc-logs.sh` reads the *source* refs from there).
+#
+# The re-derive command is what makes the reset non-destructive, so losing a race
+# without one is a failure, not a no-op: the reset discards whatever this writer
+# had staged and nothing puts it back. That used to be reported as
+# "No changes; nothing to commit." and exit 0 -- success, with the records gone.
+# It now says what was dropped and exits non-zero. Both real callers pass a
+# command; this is about not lying when someone does not.
 #
 # Examples:
 #   scripts/rcc-push.sh "rcc-logs: refresh $(date -u +%Y-%m-%dT%H:%M:%SZ)" \
@@ -105,6 +110,10 @@ attempt=1
 # commit is already made and the tree is clean -- would look like "nothing to
 # do" and exit 0 with the records still unpushed.
 pending=0
+# Set once a rejected push has reset us onto the remote, which is the point past
+# which "nothing staged" can mean "our work was thrown away" rather than
+# "there was nothing to do".
+reset=0
 
 while :; do
   # Appended to rather than merged, on every attempt: after a reset this sees the
@@ -115,6 +124,12 @@ while :; do
   git_out add -A
   if git_out diff --cached --quiet; then
     if [ "${pending}" -eq 0 ]; then
+      if [ "${reset}" -eq 1 ] && [ "${#rederive[@]}" -eq 0 ]; then
+        echo "Lost the push race and no re-derive command was given, so the" \
+          "records staged here were discarded by the reset and nothing" \
+          "recreated them. Re-run with a re-derive command." >&2
+        exit 1
+      fi
       # Either nothing was collected, or the other writer already published
       # everything this run had to add. Both are success.
       echo "No changes; nothing to commit."
@@ -150,6 +165,7 @@ while :; do
     # drop them so the producer starts from the remote's exact state.
     git_out clean -qfd
     pending=0
+    reset=1
     if [ "${#rederive[@]}" -gt 0 ]; then
       "${rederive[@]}"
     fi

--- a/scripts/series-advance.sh
+++ b/scripts/series-advance.sh
@@ -7,12 +7,12 @@
 # review) stay with the skill. Refuses to do anything when a commit in the
 # in-flight range has a failure — run series-check.sh first and repair.
 #
-# Usage: series-advance.sh <series> [chunk-size]     # chunk default 25
+# Usage: series-advance.sh <series> [chunk-size]     # chunk default 100
 
 set -euo pipefail
 
 S=${1:?usage: series-advance.sh <series> [chunk-size]}
-chunk=${2:-25}
+chunk=${2:-100}
 remote=origin
 
 git fetch -q "$remote"

--- a/scripts/vendor-gate.sh
+++ b/scripts/vendor-gate.sh
@@ -6,7 +6,7 @@
 # Decision (scanning the window newest -> oldest):
 #   green     -> some commit in the window has rcc=success. Prints
 #                "green_sha=<youngest-green-sha>". The caller resets the dev
-#                branch to that commit and vendors at most 25 commits on top.
+#                branch to that commit and vendors at most 100 commits on top.
 #   red       -> no green in the window, but at least one rcc=failure/error.
 #                The caller fails loudly (a real breakage is near the tip and no
 #                green base is within reach; repair is needed first).

--- a/tests/testthat/test-DBItest.R
+++ b/tests/testthat/test-DBItest.R
@@ -203,6 +203,16 @@ if (rlang::is_installed("DBItest")) DBItest::test_all(c(
   "arrow_write_table_arrow_roundtrip_timestamp_extended", # precision
   "arrow_append_table_arrow_roundtrip_timestamp_extended", # precision
 
+  # DBItest >= 1.8.3 uses lubridate::with_tz(tzone = "PST8PDT"), which warns
+  # with "Unrecognized time zone" on systems whose tz database lacks that zone
+  # (e.g. without tzdata-legacy). Skip only when the zone cannot be resolved.
+  if (!"PST8PDT" %in% OlsonNames()) c(
+    "append_roundtrip_timestamp",
+    "append_roundtrip_timestamp_extended",
+    "arrow_append_table_arrow_roundtrip_timestamp",
+    NULL
+  ),
+
   # https://github.com/duckdb/duckdb/pull/15125
   "data_date_current_typed",
   "data_time_current",


### PR DESCRIPTION
`v1.4-andium-green` is seven commits ahead of `v1.4-andium`.
A forward series regenerates its seed from **`v1.4-andium`'s tip**
and replays only `vendor:` diffs onto it,
so anything on green that is neither flavor prep nor vendoring
is dropped by the replay and has to be re-derived by hand.

`series-forward.md` states the rule directly —
quoting `v1.4-andium`'s own copy of the skill:

> Only `vendor:` subjects are replayed —
> a `-dev` branch's non-vendor commits belong to `main`
> and are already in the seed.

`main`'s copy of the same skill spells out the consequence
in a paragraph this line does not carry yet:
the seed carries a port's content, the replay leaves it behind,
"and that is where a port's life ends."

This PR puts that content in the seed,
so the next `v1.4-andium-fwd-*` starts with it
and green is left holding only the flavor prep and the one vendor commit.

## Triage of the seven commits on green

| Commit | Verdict |
|---|---|
| `91c198b` `chore: Bump version to dev` | flavor prep — regenerated by `scripts/flavor.sh` |
| `fa391ab` `chore: Update flavor patch to 1.4.dev` | flavor prep — regenerated |
| `b37043e` `chore: Update version to 1.4.dev` | flavor prep — regenerated |
| `323f4b8` `chore: Add fifth version component` | flavor prep — regenerated (`series-open.md`) |
| `3f44868` `vendor: … duckdb@6fc5718` | the one vendor commit — replayed, **minus three R-side fixes folded into it** |
| `9ad1c14` `chore(tooling): Replay main's vendoring tooling` | **belongs here** |
| `9673f1e` `ci(v1.4): Stop the whole-branch check from racing each-rcc` | **already here** as `5a36ccd` — identical patch-id, nothing to do |

## What this PR contains

**`chore(tooling): Replay main's vendoring tooling onto v1.4-andium`** —
`9ad1c14` verbatim, retargeted at the base branch.
This is the same shape as the previous replay (`1f649547d`, #2429),
which landed on `v1.4-andium` rather than on a series ref;
`9ad1c14` landed on the series ref instead,
which is the gap being closed.
The resulting tree matches `v1.4-andium-green` byte-for-byte
across all thirteen files.

The remaining three are **split out of the vendor commit**,
where they rode along as "R-side fix" paragraphs.
None of them is vendoring —
they are the v1.4 line catching up to `main` —
and leaving them inside the vendor diff
would keep them invisible on `v1.4-andium`
while the next seed goes on lacking them:

* **`build: Ignore .claude when building the tarball`** —
  `^\.claude$` in `.Rbuildignore`.
  Without it `R CMD build` ships the agent skills
  and check answers with a hidden-files NOTE,
  which the gate turns into a failure.
  `main`, `main-fwd-dev` and `v1.5-variegata-dev` all carry it already.
* **`ci: Let sudo keep the R library env vars on ubuntu-26.04`** —
  the ubuntu-26.04 sudoers policy rejects `sudo -E`,
  so `R_LIB_FOR_PAK` reached R empty
  and every shard died in "Install pak".
  `main` fixed this in `d176f02c5`; this is verbatim.
* **`ci: Install tzdata-legacy, and skip the specs needing it when it is absent`** —
  ubuntu-26.04 moved `PST8PDT` out of `tzdata`,
  and `DBItest` >= 1.8.3 calls `lubridate::with_tz(tzone = "PST8PDT")`,
  which testthat promotes to `FAIL 3`.
  Both halves are what `main-fwd-dev` carries.

The version bookkeeping that vendoring owns —
`DESCRIPTION`'s fifth component and `R/version.R` —
is deliberately **not** split out; it stays with the vendor commit.

## Verification

With these four commits applied, the only files still differing
between this branch and `v1.4-andium-green` are the flavor prep
(`DESCRIPTION`, `NAMESPACE`, `R/cpp11.R`, `R/duckdb-package.R`, `README.md`,
the `inst/include` and `man/` renames, `scripts/flavor.patch`,
`src/cpp11.cpp`, `src/include/rapi.hpp`, `tests/testthat.R`)
and the vendoring (`R/version.R` plus two files under `src/duckdb/`).
That is exactly the intended residue.

Checked locally: the thirteen tooling files match green byte-for-byte,
all eight replayed shell scripts pass `bash -n`,
the three touched YAML files parse,
`tests/testthat/test-DBItest.R` parses,
and every `.Rbuildignore` pattern compiles as a regex.
No `air.toml` in this tree, so no formatting step applies.
All content is verbatim from `v1.4-andium-green`,
which is the series' verified ref.

Base is `v1.4-andium`, not `main` — this is v1.4 maintenance-line work.

## Out of scope, but worth knowing before the forward

`v1.4-andium`'s `.claude/skills/series-forward.md` is stale relative to `main`:
it lacks the paragraph quoted above,
and it says "stage 4" where `main` says "stage 5"
for the loop stage that extends `-fwd-dev`.
`series-rebase.md` is likewise untouched by either replay.
`9ad1c14` scoped its skill sync to `series-loop.md` and `series-open.md`,
and this PR ports that scope verbatim rather than widening it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWGd5XcKpnfNyLxKYiNxCE