### PR TITLE
fix(vendor): Bound the base scan and say when it comes up empty

### DIFF
--- a/scripts/VENDORING.md
+++ b/scripts/VENDORING.md
@@ -88,8 +88,13 @@ Shared behaviour, in the order it happens:
 2. **Refuse to run on a dirty tree.**
    `git status --porcelain` must be empty.
 3. **Find the base.**
-   The last `duckdb/duckdb@<sha>` mentioned in the subject of a recent commit that touched `src/duckdb/`
-   (`vendor-one.sh` looks back 10 such commits, `vendor.sh` 3).
+   The last `duckdb/duckdb@<sha>` mentioned in the subject of a recent commit that touched `src/duckdb/`.
+   The pathspec narrows the walk, the subject decides:
+   patch-stack fixes edit the vendored tree in place and carry no upstream SHA,
+   so the scan looks past them — 20 commits deep, the same bound `vendored_sha()` uses
+   in [`series-advance.sh`](series-advance.sh), and `BASE_SCAN_DEPTH` raises it.
+   Coming up empty is not an answer: both scripts refuse and say which bound they hit,
+   because an empty base turns the enumeration below into a range nobody chose.
    This is the *only* record of where the branch stands in upstream history:
    it is parsed out of the commit message, so vendor commit subjects must keep their exact format.
 4. **Enumerate candidates** (`vendor-one.sh` only):

--- a/scripts/vendor-one.sh
+++ b/scripts/vendor-one.sh
@@ -22,6 +22,11 @@ upstream_basedir=""
 num_commits=1
 check_glue=true
 
+# How far to look past commits that touch the vendored tree without vendoring.
+# Matches the bound in vendored_sha() (scripts/series-advance.sh); override for a
+# branch that genuinely stacks more of them.
+base_scan_depth="${BASE_SCAN_DEPTH:-20}"
+
 while [ $# -gt 0 ]; do
   case "$1" in
     --commits|-c)
@@ -98,14 +103,46 @@ glue_compiles() {
     { ! grep -q .; }
 }
 
+# The upstream SHA the branch has vendored, and the base of the next walk.
+# The pathspec narrows the walk, the subject decides: the patch stack is applied
+# to the vendored tree in place, so commits land under ${vendor_dir} carrying no
+# upstream SHA, and this looks past them -- bounded, so git ends the walk itself
+# rather than being killed by a closing pipe.
+#
+# Answering empty is not an option here, which is why this refuses instead. An
+# empty base makes the range below read `..${start}`, whose missing left side
+# git resolves to the upstream clone's HEAD -- a range nobody chose, and one
+# that silently vendors the wrong span. The same rule, and the same bound, as
+# vendored_sha() in scripts/series-advance.sh; scripts/vendor.sh has its own copy.
+vendored_sha() {
+  local subjects sha n
+  subjects=$(git log -n "${base_scan_depth}" --format="%s" -- ${vendor_dir} | tee /dev/stderr)
+  sha=$(sed -nr '/^.*'${repo_org}.${repo_name}'@([0-9a-f]+)( .*)?$/{s//\1/;p;}' <<<"$subjects" | head -n 1)
+  if [ -z "$sha" ]; then
+    n=$(grep -c . <<<"$subjects" || true)
+    echo "Error: no ${repo_org}/${repo_name}@ subject among the newest $n" \
+      "${vendor_dir} commit(s) of $(git rev-parse --abbrev-ref HEAD)" >&2
+    if [ "$n" -ge "${base_scan_depth}" ]; then
+      echo "  the scan is bounded at ${base_scan_depth}; if that is genuinely too" \
+        "shallow, raise BASE_SCAN_DEPTH" >&2
+    fi
+    return 1
+  fi
+  echo "$sha"
+}
+
 # Loop for the specified number of commits
 commits_vendored=0
 
 while [ $commits_vendored -lt $num_commits ]; do
   echo "=== Vendoring commit $((commits_vendored + 1)) of $num_commits ==="
 
-  # Look back 10 commits to find the last vendor commit; needed when vendoring multiple commits per run
-  base=$(git log -n 10 --format="%s" -- ${vendor_dir} | tee /dev/stderr | sed -nr '/^.*'${repo_org}.${repo_name}'@([0-9a-f]+)( .*)?$/{s//\1/;p;}' | head -n 1)
+  # Where the last run left off; re-read every iteration, because each vendored
+  # commit moves it.
+  if ! base=$(vendored_sha); then
+    rm -rf "$upstream_dir"
+    exit 1
+  fi
 
   original=$(git -C "$upstream_dir" log --first-parent --reverse --format="%H" "${base}".."${start}" --)
 

--- a/scripts/vendor.sh
+++ b/scripts/vendor.sh
@@ -39,7 +39,27 @@ if [ -n "$(git -C "$upstream_dir" status --porcelain)" ]; then
   echo "Warning: working directory $upstream_dir not clean"
 fi
 
-base=$(git log -n 3 --format="%s" -- ${vendor_dir} | tee /dev/stderr | sed -nr '/^.*'${repo_org}.${repo_name}'@([0-9a-f]+)( .*)?$/{s//\1/;p;}' | head -n 1)
+# The upstream SHA the branch has vendored. The pathspec narrows the walk, the
+# subject decides: the patch stack is applied to the vendored tree in place, so
+# commits land under ${vendor_dir} carrying no upstream SHA, and this looks past
+# them -- bounded, so git ends the walk itself.
+#
+# Answering empty is not an option here, which is why this refuses instead: an
+# empty base makes the message body below read `${base}..${commit}` with a
+# missing left side, which git resolves to the clone's HEAD and which writes a
+# changelog nobody chose. The same rule, and the same bound, as vendored_sha()
+# in scripts/series-advance.sh; scripts/vendor-one.sh has its own copy.
+base_scan_depth="${BASE_SCAN_DEPTH:-20}"
+subjects=$(git log -n "${base_scan_depth}" --format="%s" -- ${vendor_dir} | tee /dev/stderr)
+base=$(sed -nr '/^.*'${repo_org}.${repo_name}'@([0-9a-f]+)( .*)?$/{s//\1/;p;}' <<<"$subjects" | head -n 1)
+if [ -z "$base" ]; then
+  n=$(grep -c . <<<"$subjects" || true)
+  echo "Error: no ${repo_org}/${repo_name}@ subject among the newest $n ${vendor_dir} commit(s)" >&2
+  if [ "$n" -ge "${base_scan_depth}" ]; then
+    echo "  the scan is bounded at ${base_scan_depth}; if that is genuinely too shallow, raise BASE_SCAN_DEPTH" >&2
+  fi
+  exit 1
+fi
 
 original=$(git -C "$upstream_dir" rev-parse --verify HEAD)
 


### PR DESCRIPTION
Phase 1a of [`plan/PLAN-vendoring-simplification.md`](../blob/main/plan/PLAN-vendoring-simplification.md), first step.

## What

Both vendoring scripts find their base by scanning the newest subjects that touch `src/duckdb/` for a `duckdb/duckdb@<sha>` reference.
They looked past non-vendoring commits — 10 deep in `vendor-one.sh`, 3 in `vendor.sh` — but returned **silently empty** when the bound was exhausted.

An empty base is not an absent answer downstream.
It turns `${base}..${start}` into `..${start}`, whose missing left side git resolves to the clone's HEAD:
`vendor-one.sh` walks a span nobody chose, `vendor.sh` writes a changelog for one.

Both now refuse instead, the way `vendored_sha()` does in `scripts/series-advance.sh` (#85):

* bounded, so git ends the walk itself;
* loud on stderr about which bound was hit;
* explicit that raising it is a decision — `BASE_SCAN_DEPTH` overrides.

The default moves to that helper's **20**, so the readers of this state agree on how deep "past" reaches.
`scripts/VENDORING.md` §"Find the base" is updated to match.

## Why this one goes first

Phase 1a resolves a contradiction: the port stage excludes the vendor strand by *path*, while the principle that landed the same day says *the subject is what decides, never the path*.
Relaxing the port's class to subject-decided is the companion PR.
This one is ordered first so nothing relies on an unbounded range while the class relaxes.

## Verification

Exercised against a synthetic history in all three states — no vendor commit within the bound, one 5 deep, one just outside — plus a check that the refusal names the bound it hit.
No behaviour changes when a vendor commit is found, which is every ordinary run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXpDkonMiTRwe147p6LBm8)_