### PR TITLE
refactor(series-port): Let the subject decide what a vendor commit is

### DIFF
--- a/.claude/skills/series-loop.md
+++ b/.claude/skills/series-loop.md
@@ -314,19 +314,22 @@ at best to empty, at worst to a conflict —
 and could sever a coupled change
 (a script from the test that exercises it),
 minting a commit whose message describes more than it contains.
-VENDOR commits —
-`vendor:` subjects,
-anything touching `src/duckdb/`
-or the generated `R/version.R` / `src/include/sources.mk` —
-are listed and never auto-picked:
+VENDOR commits are listed and never auto-picked:
 `main`'s engine is not this series' engine,
-and `vendor-one.sh`'s base scan and stage 5's anchors
-rely on every `src/duckdb`-touching commit on `-dev`
-being one of this series' vendor commits.
-Port volume threatens nothing:
-those scans are pathspec-filtered on `src/duckdb`,
-so they never see a ported commit —
-the boundary is that exclusion, not any count.
+and the series' own vendoring owns that strand.
+**The subject is what decides one, never the path** —
+the same rule as everywhere else in this skill.
+The patch stack is applied to the vendored tree in place,
+so CRAN and compiler-warning fixes land under `src/duckdb/`
+carrying no upstream SHA;
+excluding them by path made exactly those fixes wait for a forward,
+which is the one thing the port exists to end.
+They are ordinary commits, ported like any other.
+Port volume threatens nothing either:
+the readers of the strand — `vendored_sha()` in stage 5,
+the base scan in `vendor-one.sh` — look *past* such commits by subject,
+bounded, and say so on stderr when the bound is exhausted,
+so a ported commit is invisible to them whatever it touched.
 After the picks the script closes whatever tooling delta remains
 with one sync commit taking `main`'s tooling tree verbatim,
 so the identity goal holds even where history diverged

--- a/scripts/series-port.sh
+++ b/scripts/series-port.sh
@@ -9,18 +9,26 @@
 # The script lists EVERY commit on `main` since the series' base that has no
 # patch-id equivalent on <S>-dev (`git cherry`), oldest first, classified by
 # what it touches: TOOLING (only tooling paths), MIXED (tooling and more),
-# OTHER (no tooling), VENDOR (`vendor:` subject, or anything under
-# src/duckdb/ or the generated R/version.R / src/include/sources.mk).
+# OTHER (no tooling), VENDOR.
 # --apply cherry-picks everything except VENDOR — a MIXED or OTHER commit is
 # a forward-port like any other, judged by CI like every -dev commit — or
 # exactly the SHAs given, for when judgement says a commit cannot work
 # against this series' engine yet. Picks are always whole commits: a pick
 # that matches its main commit is skipped by patch-id at the next rebase,
-# a half-pick would only replay. VENDOR commits are never auto-picked: the
-# series' own vendoring owns that strand, main's engine is not this series'
-# engine, and the base scan in vendor-one.sh and the anchors in
-# series-advance.sh rely on every src/duckdb-touching commit on -dev being
-# one of this series' vendor commits. After the picks, whatever tooling
+# a half-pick would only replay. VENDOR commits are never auto-picked,
+# because main's engine is not this series' engine: the series' own
+# vendoring owns that strand.
+#
+# **The subject is what decides a VENDOR commit, never the path.** The patch
+# stack is applied to the vendored tree in place, so CRAN and
+# compiler-warning fixes land under src/duckdb/ carrying no upstream SHA, and
+# excluding them by path made exactly those fixes wait for a forward — the
+# one thing this script exists to end. The readers of the vendor strand look
+# past such commits by subject and say so when their bound is exhausted
+# (vendored_sha() in scripts/series-advance.sh and scripts/series-check.sh,
+# the base scans in scripts/vendor-one.sh and scripts/vendor.sh), so a ported
+# commit under src/duckdb/ is invisible to them whether or not this class
+# names it. After the picks, whatever tooling
 # delta remains (history that diverged inside vendor commits, picks dropped
 # as empty) is closed with one sync commit that takes `main`'s tooling tree
 # verbatim; its diff is the residue the commit walk could not explain, and
@@ -56,7 +64,11 @@ remote=origin
 # but the sync commit never rewrites them.
 tooling=(.github scripts .claude)
 paths_re='^(\.github/|scripts/|\.claude/)'
-vendor_re='^(src/duckdb/|R/version\.R$|src/include/sources\.mk$)'
+# A vendor commit is one whose subject says it vendored: the `vendor:` prefix
+# vendor-one.sh writes, or the `<owner>/<repo>@<sha>` reference that carries the
+# upstream commit as machine-readable state. Same rule as every other reader of
+# the strand — see the header on why the path is not the rule.
+vendor_subject_re='^vendor:|duckdb/duckdb@[0-9a-f]+'
 
 git fetch -q "$remote"
 dev="$remote/$S-dev" main="$remote/main"
@@ -64,9 +76,8 @@ git rev-parse -q --verify "$dev" >/dev/null || { echo "Error: no $S-dev on $remo
 
 classify() { # <sha> -> TOOLING | MIXED | OTHER | VENDOR
   local f t= o=
-  case "$(git log -1 --format=%s "$1")" in vendor:*) echo VENDOR; return ;; esac
+  if [[ "$(git log -1 --format=%s "$1")" =~ $vendor_subject_re ]]; then echo VENDOR; return; fi
   while IFS= read -r f; do
-    if [[ "$f" =~ $vendor_re ]]; then echo VENDOR; return; fi
     if [[ "$f" =~ $paths_re ]]; then t=1; else o=1; fi
   done < <(git diff-tree --no-commit-id --name-only -r "$1")
   if [ -n "$t" ] && [ -n "$o" ]; then


### PR DESCRIPTION
Phase 1a of [`plan/PLAN-vendoring-simplification.md`](../blob/main/plan/PLAN-vendoring-simplification.md) — the contradiction §4 records, resolved in the subject's favour.

## The contradiction

The port stage (#87) excluded the vendor strand by **path** as well as by subject: anything under `src/duckdb/`, plus the generated `R/version.R` and `src/include/sources.mk`.

The principle that landed the same day (#85) says the opposite, and it is the one that holds:

> **The subject is what decides, never the path.**

The patch stack is applied to the vendored tree in place, so every CRAN and compiler-warning fix lands under `src/duckdb/` carrying no upstream SHA — 89 such commits on `main` today.
The path class made exactly those fixes wait for a forward, which is the one thing the port exists to end.

## The change

`classify()` reads the subject only: the `vendor:` prefix `vendor-one.sh` writes, or the `duckdb/duckdb@<sha>` reference the subject carries as machine-readable state.
A patch-stack fix becomes an OTHER commit and ports like any other, judged by CI like every `-dev` commit.

The rationale is rewritten in both places that carried the old one: `series-port.sh`'s header and `series-loop.md` stage 4.

## Why the old rationale does not survive

It claimed the strand's readers rely on every `src/duckdb`-touching commit being a vendor commit.
They do not — they look *past* such commits by subject, bounded, and say so when the bound is exhausted.
`vendored_sha()` has done that since #85; the base scans in `vendor-one.sh` and `vendor.sh` are hardened to match in the companion PR, which is why **that one should merge first**.

## Verification

Ran the script against a synthetic `main`/`S-dev` pair carrying one commit of each shape, old and new side by side:

| commit | before | after |
|---|---|---|
| `feat(series): tooling only` | TOOLING | TOOLING |
| `fix: Silence a compiler warning in the vendored tree` | **VENDOR** | **OTHER** |
| `vendor: … duckdb/duckdb@0123456…` | VENDOR | VENDOR |
| `chore: mixed tooling and package` | MIXED | MIXED |
| `docs: package only` | OTHER | OTHER |
| `vendor: … (tag v1.5.0) to duckdb/duckdb@fedcba9…` | VENDOR | VENDOR |
| `chore: Bump version, generated files included` | **VENDOR** | **OTHER** |

`--apply` was exercised end to end: picks apply, and a genuine conflict stops the sequence with the worktree kept, as documented.

## One residual, called out

`R/version.R` is no longer excluded by path. In practice only vendor runs write it (`rconfigure.py` generates it), so it stays inside the subject class; a MIXED commit that regenerated it would carry `main`'s engine version into the pick, and that is a conflict for the routine to resolve rather than a silent wrong value — the file is generated from the vendored tree at the next vendor commit either way.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXpDkonMiTRwe147p6LBm8)_