### PR TITLE
feat(series-loop): Vendor with `main`'s script, into the buffer worktree

### DIFF
--- a/.claude/skills/series-loop.md
+++ b/.claude/skills/series-loop.md
@@ -94,9 +94,29 @@ Judgement — repairs, review, vendoring — stays here.
 
 ### 1. Vendor onto `<S>-build`
 
+Run **`main`'s copy of the script**, against the buffer worktree:
+
 ```sh
-scripts/vendor-one.sh --commits 100 <upstream-clone>
+VENDOR_REPO=<S>-build-worktree \
+  <main-checkout>/scripts/vendor-one.sh --commits 100 <upstream-clone>
 ```
+
+This stage is the one place the port stage cannot reach.
+Stage 4 brings `.github/`, `scripts/` and `.claude/` on `<S>-dev`
+level with `main` every firing,
+but `-build` carries no ports by design —
+its tooling refreshes only at a forward,
+so a buffer opened last month vendors with last month's script.
+Invoking `main`'s copy closes that
+without teaching CI to read another branch's tree:
+it is a script the routine runs, not a cross-branch reference.
+
+Only the script comes from `main`.
+Everything it invokes by relative path —
+`scripts/rconfigure.py`, `patch/*.patch`, `./configure` —
+stays the buffer's,
+because those are coupled to the vendored tree
+they generate and patch.
 
 The script gates itself:
 after each vendored commit it syntax-checks the glue

--- a/scripts/vendor-one.sh
+++ b/scripts/vendor-one.sh
@@ -9,7 +9,26 @@ set -e
 set -x
 set -o pipefail
 
-cd "$(dirname "$0")"/..
+# The checkout to vendor into. Defaults to this script's own, which is what it
+# has always meant. The series loop sets it, so the routine can run `main`'s copy
+# of this script against a `<S>-build` worktree: stage 1 is the one stage the
+# port stage cannot reach, because ports land on `-dev` and the buffer's own
+# tooling only refreshes at a forward (.claude/skills/series-loop.md stage 1,
+# and plan/PLAN-vendoring-simplification.md §4).
+#
+# Only *this* script comes from `main` that way. Everything it invokes by
+# relative path -- `scripts/rconfigure.py`, `patch/*.patch`, `./configure` --
+# stays the target tree's, because those are coupled to the vendored tree they
+# generate and patch rather than to the loop that drives them.
+cd "${VENDOR_REPO:-$(dirname "$0")/..}"
+toplevel=$(git rev-parse --show-toplevel 2>/dev/null) || {
+  echo "Error: $PWD is not a git worktree" >&2
+  exit 1
+}
+[ "$toplevel" -ef . ] || {
+  echo "Error: $PWD is not the root of its worktree ($toplevel)" >&2
+  exit 1
+}
 
 project=duckdb
 vendor_base_dir=src/duckdb


### PR DESCRIPTION
Phase 1a of [`plan/PLAN-vendoring-simplification.md`](../blob/main/plan/PLAN-vendoring-simplification.md); closes the remaining half of finding **F4**.

## The blind spot

Stage 4 brings `.github/`, `scripts/` and `.claude/` on `<S>-dev` level with `main` every firing (#87), so a tooling fix takes effect on the branch CI judges without waiting for a forward.

Stage 1 is what was left: it runs `vendor-one.sh` from the `<S>-build` worktree, and ports never touch the buffer by design — its tooling refreshes only at a forward.
A series opened last month vendors with last month's script.

## The change

`vendor-one.sh` derived the tree to vendor into from its own location, so pointing at `main`'s copy would have vendored into `main`.
It now takes that tree from `VENDOR_REPO`, defaulting to its own checkout — which is what it always meant — and refuses anything that is not the root of a worktree.

The skill's stage 1 invokes it that way:

```sh
VENDOR_REPO=<S>-build-worktree \
  <main-checkout>/scripts/vendor-one.sh --commits 100 <upstream-clone>
```

## What deliberately does *not* come from `main`

Only the script does.
Everything it invokes by relative path — `scripts/rconfigure.py`, `patch/*.patch`, `./configure` — stays the buffer's, because those are coupled to the vendored tree they generate and patch, not to the loop that drives them.
(`rconfigure.py` in particular resolves source paths against its own checkout, so running `main`'s copy against another tree would compute nonsense.)

And this stays a script the routine runs: no workflow reads another branch's tree, which §4 of the plan rejected for the brittleness it buys.

## Verification

Four cases exercised: default (operates on the script's own checkout, unchanged), `VENDOR_REPO` pointing at another worktree (operates there), at a subdirectory (refused, names the toplevel), and outside any repository (refused).

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXpDkonMiTRwe147p6LBm8)_