### PR TITLE
feat(sync): Mirror the release branches, not only `main`

### DIFF
--- a/.claude/skills/series-open.md
+++ b/.claude/skills/series-open.md
@@ -103,11 +103,15 @@ Two things to check before pushing:
   and the fork is disconnected from `duckdb/duckdb-r`,
   so a base branch that exists only in the canonical repo
   renders as an error, not a count.
-  Mirror the release branch into the fork —
-  and keep the mirror fresh:
-  `sync.yaml` fast-forwards only `main`,
-  so a mirror left behind makes *ahead*
-  count commits that have already shipped.
+  `sync.yaml` mirrors the release branches hourly
+  alongside `main`, creating a mirror that does not exist yet
+  and fast-forwarding one that does,
+  so the base of an *ahead* badge is there and stays fresh —
+  as long as the upstream branch is named like a release line
+  (`v<major>.<minor>-<codename>`, optionally `-lts`),
+  which is what that job discovers by.
+  Check the run once after a release cut;
+  a stale mirror makes *ahead* count commits that have already shipped.
 * **The table must stay clear of `scripts/flavor.patch`.**
   `README.md` is a flavored file;
   the patch rewrites the installation hunks near the top.

--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -1,5 +1,18 @@
-# Fast-forward sync: updates the main branch in krlmlr/duckdb-r from duckdb/duckdb-r.
-# Runs hourly and on manual dispatch.
+# Fast-forward sync: updates the mirrored branches in krlmlr/duckdb-r from
+# duckdb/duckdb-r. Runs hourly and on manual dispatch.
+#
+# `main` is what every series seeds from. The release branches are mirrored for
+# the badges: README.md's `Flavors` table counts each `.dev` series *ahead* of
+# the branch it releases from, and shields.io compares within one repository, so
+# the base of that comparison has to live here too. A mirror nobody refreshes
+# makes *ahead* count commits that have already shipped.
+#
+# Fast-forward only, never force: a mirror that has diverged is reported and
+# skipped, because whatever put a commit there did not come from upstream, and
+# this job is not the place to decide what happens to it. The other mirrors are
+# still moved, and the job then fails — an hourly green run's annotations are
+# read by nobody, and a mirror carrying a commit of its own is not a state to
+# sit in quietly.
 
 on:
   schedule:
@@ -13,7 +26,7 @@ jobs:
     runs-on: ubuntu-26.04
     if: github.repository == 'krlmlr/duckdb-r'
 
-    name: "Fast-forward main from duckdb/duckdb-r"
+    name: "Fast-forward the mirrors from duckdb/duckdb-r"
 
     permissions:
       contents: write
@@ -25,31 +38,53 @@ jobs:
           ref: main
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: ./.github/workflows/git-identity
-
-      - name: Fast-forward main from duckdb/duckdb-r
+      # No git-identity: nothing here creates a commit. Every branch is moved by
+      # pushing an upstream commit that already exists, which is also what keeps
+      # this a mirror rather than a merge.
+      - name: Fast-forward the mirrors from duckdb/duckdb-r
         run: |
-          set -x
+          ## -- Fast-forward the mirrors from duckdb/duckdb-r --
+          set -euxo pipefail
 
-          # Shallow clone duckdb/duckdb-r, excluding commits already reachable from our
-          # HEAD (assuming it exists there). Fail if HEAD is not found in the upstream history.
-          git clone --depth=100 --single-branch https://github.com/duckdb/duckdb-r.git /tmp/upstream
+          # Fetched straight from upstream rather than through a clone: a clone
+          # keeps only its own default branch under refs/heads/, so refetching
+          # from it would find `main` and nothing else. Shallow and deep enough
+          # to reach the point each mirror stands at, and no deeper -- this runs
+          # hourly. A mirror further behind than this is reported below rather
+          # than guessed at.
+          git remote add upstream https://github.com/duckdb/duckdb-r.git
+          git fetch --no-tags --depth=200 upstream '+refs/heads/*:refs/remotes/upstream/*'
 
-          # Add the cloned upstream as a local remote and fetch its main branch.
-          git remote add upstream /tmp/upstream
-          git fetch upstream main
+          # Discovered, not configured: `main` plus every release line
+          # (`v<major>.<minor>-<codename>` and its `-lts` sibling). A series
+          # branch lives only in this fork and matches nothing upstream, so the
+          # loop can never touch one.
+          branches="$(git for-each-ref --format='%(refname:strip=3)' 'refs/remotes/upstream/' \
+            | grep -E '^(main|v[0-9]+\.[0-9]+-[a-z]+(-lts)?)$' || true)"
+          echo "Mirroring: ${branches}"
 
-          # Get the current HEAD SHA of our main branch.
-          HEAD=$(git rev-parse HEAD)
+          rc=0
+          for b in ${branches}; do
+            theirs="$(git rev-parse "refs/remotes/upstream/${b}")"
+            ours="$(git ls-remote origin "refs/heads/${b}" | cut -f1)"
 
-          # Fast-forward our main to upstream/main.
-          git merge --ff-only upstream/main
+            if [ -z "${ours}" ]; then
+              echo "${b}: no mirror yet, creating it at ${theirs}"
+            elif [ "${ours}" = "${theirs}" ]; then
+              echo "${b}: already up to date"
+              continue
+            elif git merge-base --is-ancestor "${ours}" "${theirs}" 2>/dev/null; then
+              echo "${b}: fast-forwarding ${ours} -> ${theirs}"
+            else
+              # Either the mirror carries commits upstream does not, or it sits
+              # further back than this clone reaches. Both want a human.
+              echo "::warning::${b}: not a fast-forward from ${ours} (diverged, or behind the clone depth) -- skipped"
+              rc=1
+              continue
+            fi
 
-          NEW_HEAD=$(git rev-parse HEAD)
-          if [ "${HEAD}" != "${NEW_HEAD}" ]; then
-            echo "Pushing fast-forward from ${HEAD} to ${NEW_HEAD}"
-            git push
-          else
-            echo "Already up to date"
-          fi
+            git push origin "${theirs}:refs/heads/${b}"
+          done
+
+          exit "${rc}"
         shell: bash

--- a/BRANCHES.md
+++ b/BRANCHES.md
@@ -90,7 +90,7 @@ duckdb-r/
 ├── .github/
 │   └── workflows/
 │       ├── each.yaml               # Per-commit rcc, as a sharded matrix           [5]
-│       ├── sync.yaml               # Fast-forward krlmlr/main from duckdb/main     [5]
+│       ├── sync.yaml               # Mirror main + release lines from duckdb/      [5]
 │       ├── fledge.yaml             # Automated version-bump PRs                    [5]
 │       └── R-CMD-check*.yaml       # Package check workflows                       [5]
 ├── DESCRIPTION                     # Package metadata — name + version = flavor    [2]


### PR DESCRIPTION
Phase 3 of [`plan/PLAN-vendoring-simplification.md`](../blob/main/plan/PLAN-vendoring-simplification.md), pulled ahead of the fork move so the fix serves the standalone repo too.

## The defect

The `Flavors` table counts each `.dev` series *ahead* of the branch it releases from, and shields.io compares **within a single repository** — so the base of that comparison has to exist in `krlmlr/duckdb-r`, not only in `duckdb/duckdb-r`.

`sync.yaml` fast-forwarded `main` and nothing else.
That makes this a live defect and not only a fork-migration item: today's `duckdb.1.4.dev` *ahead* badge compares against a `v1.4-andium` mirror that nothing refreshes, so it counts commits that have already shipped.

## The change

The job mirrors `main` plus every release line it finds upstream — `v<major>.<minor>-<codename>`, and its `-lts` sibling — **discovered from the refs** rather than configured, the way a series is.
A branch the fork does not have yet is created, which also retires the manual "mirror the release branch into the fork" step in `series-open.md`.

Fast-forward only, never force.
A mirror carrying a commit upstream does not have is skipped and the job then fails: the other mirrors still move, and a mirror with a commit of its own is not a state an hourly job should sit on quietly.

Two mechanical notes:

* upstream is now fetched **directly** rather than through a clone. A clone keeps only its own default branch under `refs/heads/`, so refetching from it would have found `main` and nothing else — the release branches would have been silently skipped. (This is the bug the first draft had, caught in testing.)
* no `git-identity` step: nothing here creates a commit any more. Each branch moves by pushing a commit that already exists upstream, which is what keeps this a mirror rather than a merge.

## Verification

Simulated against a fake upstream and a fake fork covering all four states at once:

| branch | state | outcome |
|---|---|---|
| `main` | behind | fast-forwarded |
| `v1.4-andium` | behind | fast-forwarded |
| `v1.5-variegata` | missing in the fork | created |
| `v1.4-andium-lts` | carries a local commit | warned, skipped, untouched; job exits non-zero |
| `b-re2`, `gh-pages` | not release lines | never considered |

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXpDkonMiTRwe147p6LBm8)_