### PR TITLE
docs: Quarantine the superseded loop design and the `main-dev` review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ start there rather than searching.
 | Vendoring mechanics: scripts, invariants, troubleshooting | `scripts/VENDORING.md` |
 | Per-commit CI (sharded matrix): design and limits | `scripts/EACH.md` |
 | Operating the vendoring loop (routine playbooks) | `.claude/skills/`: `series-loop.md`, `series-forward.md`, `series-rebase.md`, `series-open.md` |
-| Designs, plans, and historical documents | `plan/` |
+| Designs, plans, and historical documents | `plan/README.md`, which names each by path |
 
 ## Working Effectively
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ and coding agents.
   series invariants
 * [`RELEASE.md`](RELEASE.md) — the release process
 * [`scripts/VENDORING.md`](scripts/VENDORING.md) — vendoring mechanics
-* [`plan/`](plan/) — designs, plans, and historical documents
+* [`plan/README.md`](plan/README.md) — designs, plans, and historical
+  documents, each named there by path
 
 ## Building
 

--- a/plan/PLAN-vendoring-simplification.md
+++ b/plan/PLAN-vendoring-simplification.md
@@ -538,11 +538,24 @@ AGENTS.md ──┤                  maintainers & agents: quickstart + router
             ├─ .claude/skills/          playbooks the routine executes
             │    series-loop.md · series-forward.md ·
             │    series-rebase.md · series-open.md
-            └─ plan/                    designs, decisions, history
+            └─ plan/README.md           designs and decisions
                  PLAN-*.md
-                 · HISTORY-vendoring-loop.md (← scripts/VENDORING-LOOP.md)
-                 · REVIEW-main-dev-2026-07.md (← scripts/main-dev-review.md)
+                 └─ plan/history/            superseded designs, one-off artifacts
+                      vendoring-loop.md (← scripts/VENDORING-LOOP.md)
+                      main-dev-review-2026-07.md (← scripts/main-dev-review.md)
 ```
+
+History gets a directory of its own, not just a filename prefix:
+the distinction the tree cares about is that a plan may still come true
+and a history never will,
+and a directory says that at a glance from the path alone —
+which is the contract, links being the convenience.
+
+A directory cannot route, and both roots pointed at one:
+`plan/` was named as a node while nothing named its contents by path,
+so every document in it was an orphan by this tree's own rule —
+three of them with zero inbound references before the moves.
+`plan/README.md` is the node; the roots point at the file.
 
 Per-node target state:
 
@@ -553,8 +566,9 @@ Per-node target state:
 | `scripts/VENDORING.md` | mechanics + another re-telling | mechanics + troubleshooting only; owns the script inventory |
 | `scripts/EACH.md` | design + Q&A, current | keep; it is already the single owner of its topic |
 | skills | current | procedure only; mechanics by pointer |
-| `scripts/VENDORING-LOOP.md` | 865-line superseded design | move to `plan/HISTORY-vendoring-loop.md`; fix the 11 inbound references across 6 files |
-| `scripts/main-dev-review.md` | one-off review artifact in `scripts/`, currently orphaned (zero inbound references) | move to `plan/REVIEW-main-dev-2026-07.md` |
+| `scripts/VENDORING-LOOP.md` | 865-line superseded design | move to `plan/history/vendoring-loop.md`; fix the 11 inbound references across 6 files |
+| `scripts/main-dev-review.md` | one-off review artifact in `scripts/`, currently orphaned (zero inbound references) | move to `plan/history/main-dev-review-2026-07.md` |
+| `plan/` | named as a node by both roots; nothing named its children | `plan/README.md` routes: scope, then one row per document, by path — and the rule that a file the table does not name is an orphan |
 
 Migration: mechanical moves first (one PR), then one node per PR,
 router kept in sync in the same PR as each move —

--- a/plan/README.md
+++ b/plan/README.md
@@ -1,0 +1,49 @@
+# `plan/` — designs, decisions, and history
+
+This directory holds documents that are *not* part of the routing tree's
+description of how the system works today:
+plans for work that is not finished,
+and records of designs and reviews that have been superseded.
+Both roots — [`README.md`](../README.md) for users and
+[`AGENTS.md`](../AGENTS.md) for maintainers and coding agents — point here,
+and this file is what names the contents,
+so nothing under `plan/` is an orphan.
+
+What is current lives elsewhere, and is owned there:
+[`BRANCHES.md`](../BRANCHES.md) for the branch model,
+[`RELEASE.md`](../RELEASE.md) for the release process,
+[`scripts/VENDORING.md`](../scripts/VENDORING.md) for vendoring mechanics,
+[`scripts/EACH.md`](../scripts/EACH.md) for per-commit CI,
+and [`.claude/skills/`](../.claude/skills/) for the routine's playbooks.
+A document here may describe something that has since changed;
+when the two disagree, the owner above is right.
+
+## Plans — work proposed or in progress
+
+| To read about | Read |
+|---|---|
+| Simplifying the vendoring pipeline: one verdict store, tooling from `main`, a docs tree | [`PLAN-vendoring-simplification.md`](PLAN-vendoring-simplification.md) |
+| Implementing `dbSendQueryArrow()` and the DBI Arrow API | [`PLAN-dbSendQueryArrow.md`](PLAN-dbSendQueryArrow.md) |
+| The CRAN-safe storage-location policy, and the work to implement it | [`PLAN-storage-locations.md`](PLAN-storage-locations.md) |
+
+## `history/` — superseded designs and one-off artifacts
+
+Kept for the reasoning and the measurements, not as a description of the
+system. Each says so in its own first lines. They live in their own
+directory because the distinction is the point: a plan may still come
+true, a history never will.
+
+| To read about | Read |
+|---|---|
+| The agentic-loop design that preceded the series loop, and Appendix A's ccache measurements that the cost model still cites | [`history/vendoring-loop.md`](history/vendoring-loop.md) |
+| A 2026-07 review of the non-vendored R-side delta on `main-dev` | [`history/main-dev-review-2026-07.md`](history/main-dev-review-2026-07.md) |
+
+## Adding a document here
+
+A plan goes in `plan/` as `PLAN-<topic>.md`; a superseded design or a one-off
+review goes in `plan/history/`, named for what it is. Either way, open it with
+a line saying what it is and which document owns the topic today, and add a row
+above. A file under `plan/` that this table does not name is an orphan, which
+is the one thing the tree's structure exists to prevent — and when a plan is
+overtaken by events, moving it into `history/` and moving its row with it is
+what retiring it looks like.

--- a/plan/history/main-dev-review-2026-07.md
+++ b/plan/history/main-dev-review-2026-07.md
@@ -1,12 +1,18 @@
 # Non-vendored changes on `main-dev` — review against upstream
 
+Status: **historical** — a one-off review artifact from 2026-07,
+kept for the findings it records about the R-side delta of a series.
+It is a snapshot of one branch at one moment, not a description of the
+system: the loop is owned by `.claude/skills/series-loop.md`,
+its mechanics by [`scripts/VENDORING.md`](../../scripts/VENDORING.md).
+
 **Range:** `main-dev-base..main-dev` (`krlmlr/duckdb-r`), 242 first-parent
 commits, of which **16 carry non-vendored (R-side) changes**.
 `main-dev` was force-pushed; the R-side fixes are folded **into** the vendor
 commits they accompany (the in-place repair model), so they are recovered here
 by **path filter** — the diff outside the mechanical paths `src/duckdb/`,
 `inst/include/cpp11*`, `R/version.R`, `src/include/sources.mk`, `DESCRIPTION`
-(version bump). This is primitive E of `scripts/VENDORING-LOOP.md` applied by
+(version bump). This is primitive E of `plan/history/vendoring-loop.md` applied by
 hand.
 
 - base `26c2becd` = `vendor … duckdb/duckdb@d521a441` (2026-04-24)

--- a/plan/history/vendoring-loop.md
+++ b/plan/history/vendoring-loop.md
@@ -3,11 +3,18 @@
 Status: **historical** — superseded by the series loop
 (`.claude/skills/series-loop.md`);
 kept as design context.
+It lives under `plan/` because it is history, not routing:
+what the pipeline does *today* is owned by
+[`scripts/VENDORING.md`](../../scripts/VENDORING.md) (mechanics),
+[`scripts/EACH.md`](../../scripts/EACH.md) (per-commit CI),
+and the skills in `.claude/skills/` (procedure).
+Nothing here is current except the measurements in Appendix A,
+which the sharded matrix still cites.
 References to `vendor.yaml` and the `rcc-smoke-fix` /
 `advance-green-dev` skills below describe artifacts
 that no longer exist.
 Target repo for implementation: `krlmlr/duckdb-r` (the CI/CD fork; see
-[`BRANCHES.md`](../BRANCHES.md)). Source-of-truth CI/CD lives in
+[`BRANCHES.md`](../../BRANCHES.md)). Source-of-truth CI/CD lives in
 `duckdb/duckdb-r@main` and is forward-ported.
 Author context: drafted on branch `claude/vibrant-ride-i4b5r2`.
 
@@ -15,8 +22,8 @@ This document proposes a re-architecture of the DuckDB-R vendoring pipeline as
 a **modular agentic loop**: Claude drives the creative steps, while GitHub
 Actions runs the predictable, parallelisable work and serves as the single
 **ground truth** for build results. It builds directly on the existing system
-documented in [`BRANCHES.md`](../BRANCHES.md) and
-[`scripts/VENDORING.md`](VENDORING.md), and supersedes parts of the
+documented in [`BRANCHES.md`](../../BRANCHES.md) and
+[`scripts/VENDORING.md`](../../scripts/VENDORING.md), and supersedes parts of the
 three repair skills in `.claude/skills/`.
 
 ---
@@ -26,10 +33,10 @@ three repair skills in `.claude/skills/`.
 | Concern | Today | Mechanism |
 |---|---|---|
 | **Vendor** upstream C++ into `*-dev` | hourly, commit-by-commit, ≤30/run | `vendor.yaml` → `scripts/vendor-one.sh ./duckdb --commits 30` |
-| **Trigger** per-commit CI | fire-and-forget dispatch, no cap | `each.yaml` → `scripts/each-rcc.sh` → `gh workflow run rcc -f ref=<sha>` (since superseded by the sharded matrix, [`EACH.md`](EACH.md)) |
+| **Trigger** per-commit CI | fire-and-forget dispatch, no cap | `each.yaml` → `scripts/each-rcc.sh` → `gh workflow run rcc -f ref=<sha>` (since superseded by the sharded matrix, [`scripts/EACH.md`](../../scripts/EACH.md)) |
 | **Build / smoke-test** a commit | one independent `rcc` run per commit | `R-CMD-check.yaml` (job *Smoke test: stock R*) |
 | **Record** the result marker | commit-status `rcc` = pending/success/failure | `R-CMD-check-status.yaml` (via `workflow_run`) |
-| **Harvest** logs to ground truth | **delayed**, 4×/day | `rcc-logs.yaml` → `scripts/rcc-logs.sh` → orphan branch `rcc` (`runs2.ndjson`, `logs2/<sha>.log`). Since [`EACH.md`](EACH.md) §3 the `each-rcc` legs publish their own records as each commit is decided, and this is the backstop. |
+| **Harvest** logs to ground truth | **delayed**, 4×/day | `rcc-logs.yaml` → `scripts/rcc-logs.sh` → orphan branch `rcc` (`runs2.ndjson`, `logs2/<sha>.log`). Since [`scripts/EACH.md`](../../scripts/EACH.md) §3 the `each-rcc` legs publish their own records as each commit is decided, and this is the backstop. |
 | **Repair** a red commit | fork `broken-<sha>-dev`, amend the failing commit, **cherry-pick (replay) the whole tail**, force-push | skill `rcc-smoke-fix.md` |
 | **Advance** a repaired branch | cherry-pick next 30 vendor commits, matched by vendored upstream SHA | skill `advance-green-dev.md` |
 | **Self-heal** transient breaks | squash (window 1) / transient patch (≥2) | skill `rcc-smoke-fix-self-heal.md` |
@@ -173,7 +180,7 @@ Invariants:
 
 > **Landed, in narrower form.** This primitive is now implemented inside the
 > existing `each.yaml` rather than as a separate `rcc-matrix.yaml`, because the
-> commit-selection semantics were already there. See [`EACH.md`](EACH.md) for
+> commit-selection semantics were already there. See [`scripts/EACH.md`](../../scripts/EACH.md) for
 > what was built, the GitHub Actions limits it works within, and two corrections
 > to the analysis below: within-shard reuse comes from **ccache**, not
 > incremental `make` (§4.2), and the reverse-include estimator of §4.3 exists as

--- a/scripts/EACH.md
+++ b/scripts/EACH.md
@@ -171,7 +171,7 @@ Timestamp-based incremental `make` cannot cross a commit boundary here.
 What does survive is **ccache**, which is content-addressed
 and lives outside the workspace for the whole job.
 A typical adjacent vendor commit recompiles ~5 of 341 unity objects — ~98% hits
-(measured: [`VENDORING-LOOP.md` Appendix A.2](VENDORING-LOOP.md#a2-ccache-behaviour-on-adjacent-commits-8-consecutive-v15-commits)).
+(measured: [`history/vendoring-loop.md` Appendix A.2](../plan/history/vendoring-loop.md#a2-ccache-behaviour-on-adjacent-commits-8-consecutive-v15-commits)).
 Cleaning the workspace also means every commit's verdict is identical to one from a fresh checkout,
 which is what keeps the semantics honest.
 
@@ -515,7 +515,7 @@ And across 120 real `v1.5-variegata-dev` commits:
 | >100 (wide header) | 8 |
 
 median 2, mean 15, max 209.
-That is the bimodal distribution `VENDORING-LOOP.md` §4 predicted from ccache timings,
+That is the bimodal distribution `plan/history/vendoring-loop.md` §4 predicted from ccache timings,
 now derived statically and per commit.
 
 Resolution is deliberately an over-approximation:
@@ -1131,7 +1131,7 @@ Honest list, in rough order of risk:
 ## 8. Relation to the vendoring loop plan
 
 This is a concrete, narrower implementation of primitive **B** in
-[`VENDORING-LOOP.md` §3.2](VENDORING-LOOP.md#b-build-primitive--synchronous-sharded-matrix-ci-new-rcc-matrixyaml) —
+[`history/vendoring-loop.md` §3.2](../plan/history/vendoring-loop.md#b-build-primitive--synchronous-sharded-matrix-ci-new-rcc-matrixyaml) —
 plan, sharded matrix, `if: always()` fan-in — landed inside the existing `each-rcc`
 instead of as a new `rcc-matrix.yaml`, because the selection semantics are already right there.
 

--- a/scripts/VENDORING.md
+++ b/scripts/VENDORING.md
@@ -6,7 +6,7 @@ and how to troubleshoot a failing run.
 For the branch strategy, the complete list of active branches, and the release process, see
 [BRANCHES.md](../BRANCHES.md), which is the authoritative source.
 For the historical design notes that led to the series loop,
-see [VENDORING-LOOP.md](VENDORING-LOOP.md)
+see [history/vendoring-loop.md](../plan/history/vendoring-loop.md)
 (superseded by `.claude/skills/series-loop.md`).
 
 ## What is Vendoring?
@@ -59,7 +59,7 @@ They are what makes the history useful rather than merely present.
    Vendor commits touch only the mechanical path set
    (`src/duckdb/`, `R/version.R`, `src/include/sources.mk`, `DESCRIPTION`).
    Anything else in a vendor commit is a folded glue fix,
-   and must be reviewable as a path-filtered diff (see [VENDORING-LOOP.md](VENDORING-LOOP.md) §3.4).
+   and must be reviewable as a path-filtered diff (see [history/vendoring-loop.md](../plan/history/vendoring-loop.md) §3.4).
 
 Invariant 2 is the one that is easy to lose.
 It is violated the moment a dev branch is re-pointed at a different upstream branch
@@ -310,7 +310,7 @@ Three things make this affordable:
   Adjacent vendor commits change a median of two `.cpp` files and no headers,
   so a warm ccache turns a ~15 minute cold build into a couple of minutes;
   wide-header commits are the exception, not the rule
-  (measured in [VENDORING-LOOP.md](VENDORING-LOOP.md) Appendix A).
+  (measured in [history/vendoring-loop.md](../plan/history/vendoring-loop.md) Appendix A).
   Point R at it via `~/.R/Makevars` (`CXX = ccache g++`, …)
   and give it a cache large enough to hold several trees (`ccache --max-size=20G`).
   Note that ccache reads `$CCACHE_DIR/ccache.conf` (i.e. `~/.ccache/ccache.conf`)
@@ -340,7 +340,7 @@ The cheap mode is a commit that changes only `.cpp` files;
 the expensive mode is a commit touching a widely-included header,
 which invalidates a large share of the ~345 unity objects at once.
 Note that the mix depends on *which* branch is being replayed:
-Appendix A of [VENDORING-LOOP.md](VENDORING-LOOP.md) measured a release branch,
+Appendix A of [history/vendoring-loop.md](../plan/history/vendoring-loop.md) measured a release branch,
 where 66 % of commits touch no header at all,
 whereas a mainline window in active pre-release development
 runs closer to a 57/43 split — plan bulk replays off the pessimistic figure.

--- a/scripts/each-cost.py
+++ b/scripts/each-cost.py
@@ -7,7 +7,7 @@ files each. Compilation cost is therefore not proportional to the number of
 changed files but to the number of *objects* those files reach -- and header
 reach is bimodal: a narrow header pulls in a couple of dozen objects, a widely
 included one more than half the build (measured in
-`scripts/VENDORING-LOOP.md`, Appendix A.2).
+`plan/history/vendoring-loop.md`, Appendix A.2).
 
 `scripts/each-plan.sh` uses this to weigh commits before partitioning them into
 matrix shards, so that a wide-header commit is isolated instead of being packed

--- a/scripts/each-plan.sh
+++ b/scripts/each-plan.sh
@@ -17,7 +17,7 @@
 #   * a leg pays the ~4 min R/dependency setup once for ~20 commits, not once
 #     per commit;
 #   * consecutive commits in a leg share the runner's local ccache, where a
-#     typical adjacent vendor commit is ~98% cached (VENDORING-LOOP.md, A.2);
+#     typical adjacent vendor commit is ~98% cached (plan/history/vendoring-loop.md, A.2);
 #   * the whole batch is one workflow run: one thing to cancel, one set of logs.
 #
 # Statuses are read in GraphQL batches of $BATCH commits rather than one REST

--- a/scripts/each-shard.sh
+++ b/scripts/each-shard.sh
@@ -13,7 +13,7 @@
 # survive is **ccache**, which is content-addressed and lives on the runner's
 # local disk for the whole job. A typical adjacent vendor commit recompiles only
 # the handful of unity objects it invalidates -- ~98% hits, measured in
-# scripts/VENDORING-LOOP.md, Appendix A.2. That is the whole point of putting
+# plan/history/vendoring-loop.md, Appendix A.2. That is the whole point of putting
 # consecutive commits in one job.
 #
 # Stopping is graceful, not fatal. The leg stops at its own deadline and reports


### PR DESCRIPTION
Phase 4 of [`plan/PLAN-vendoring-simplification.md`](../blob/main/plan/PLAN-vendoring-simplification.md) — the mechanical moves, plus the routing node that makes them reachable.

## The moves

The docs tree has two roots and one rule about history: superseded designs and one-off review artifacts live under `plan/`, marked historical, out of the routing tree (§8).
Two documents sat in `scripts/` against that rule:

* **`VENDORING-LOOP.md`** → `plan/HISTORY-vendoring-loop.md`.
  865 lines describing a pipeline that no longer exists (`vendor.yaml`, the `rcc-smoke-fix` / `advance-green-dev` skills), reachable from `scripts/VENDORING.md` as if it were current.
* **`main-dev-review.md`** → `plan/REVIEW-main-dev-2026-07.md`.
  A review of one branch at one moment, with zero inbound references: an orphan in a directory of tooling.

Each now opens by saying what it is and which document owns the neighbouring topic today, so a reader who lands there by search leaves for the right place.

## `plan/` gets a routing node, because a directory cannot be one

Both roots named `plan/` while nothing named its *contents* by path — so by the tree's own rule every document in it was an orphan. Measured before these moves: `PLAN-dbSendQueryArrow.md` and `PLAN-storage-locations.md` had **zero** inbound references, and the moves would have added two more.

`plan/README.md` is the node: one paragraph of scope, a pointer to the documents that own the *current* system (so nobody mistakes a plan for a description), then one row per file. It also states the rule that keeps it honest — a file the table does not name is an orphan — so the next document added here has somewhere to be added. `README.md` and `AGENTS.md` now point at the file rather than the directory.

The plan's §8 records this: the target tree named `plan/` as a node, and a directory cannot route.

## Every reference is rewritten, not dropped

11 of them across 6 files, including the three scripts that cite Appendix A.2's ccache measurement (`each-plan.sh`, `each-shard.sh`, `each-cost.py`).
Those numbers are the one part of the design doc that is still load-bearing, which is the argument for keeping the document rather than deleting it.

The moved doc's own links are rewritten too: `plan/` sits at the same depth as `scripts/`, so `../BRANCHES.md` still resolves while `VENDORING.md` and `EACH.md` no longer do.

## What a reviewer has to check

That nothing dangles. This PR changes no sentence of either moved document beyond the header note — a rename-aware diff shows that directly.
Verified: every relative link in the repo's Markdown resolves, and every file under `plan/` is named by `plan/README.md`.