### PR TITLE
feat(each): Select work from the verdict store, not from statuses

### DIFF
--- a/BRANCHES.md
+++ b/BRANCHES.md
@@ -82,6 +82,7 @@ duckdb-r/
 │   ├── rcc-one.sh                  # The per-commit rcc gate
 │   ├── each-harvest.sh             # Reconcile shard results onto the rcc branch
 │   ├── rcc-part-push.sh            # Publish one commit's result from its leg
+│   ├── rcc-decided.sh              # Commits the rcc branch has a verdict for
 │   ├── rcc-merge.sh                # Bring runs2.ndjson level with the records
 │   ├── rcc-consolidate.sh          # Manual: GC old logs, squash the rcc branch
 │   ├── EACH.md                     # Sharded per-commit CI design (→ see §Vendoring)
@@ -701,6 +702,7 @@ the first step of any CI job that rebases, cherry-picks, or merges — to regist
 | `scripts/rcc-one.sh`            | The per-commit gate (style, snapshots, roxygen, clean tree, `R CMD check`, pkgdown), as a script           |
 | `scripts/each-harvest.sh`       | Fan-in onto the orphan `rcc` branch: reconciles whatever the legs could not publish themselves              |
 | `scripts/rcc-part-push.sh`      | Publishes one commit's record and log to the `rcc` branch from the leg that decided it, conflict-free       |
+| `scripts/rcc-decided.sh`        | Lists the commits the `rcc` branch holds a verdict for; the single source work selection reads                |
 | `scripts/rcc-merge.sh`          | Brings `runs2.ndjson` level with the per-commit records in `runs2.d/`: appends the missing, replaces the stale |
 | `scripts/rcc-consolidate.sh`    | Manual: makes the two record layouts agree, drops logs past their retention, squashes `rcc` to two commits   |
 | `scripts/merge-version.sh`      | Git merge driver for `DESCRIPTION`: combines the 4th/5th version counters, gated on an equal prefix         |

--- a/scripts/EACH.md
+++ b/scripts/EACH.md
@@ -26,7 +26,7 @@ The contract every consumer reads is untouched.
 
 | Contract | Before | After |
 |---|---|---|
-| Commits considered | `<S>-green..HEAD` on a series branch, else first-parent since `SINCE`; no `rcc` status | same |
+| Commits considered | `<S>-green..HEAD` on a series branch, else first-parent since `SINCE`; undecided | same range; "undecided" now means *no record on the `rcc` branch* rather than *no `rcc` status* ([§1](#the-green-marker-and-why-rcc-smoke-sha-has-no-successor)) |
 | Marker written | commit-status, context `rcc`, `pending` → `success`/`failure` | same, written by the leg |
 | Re-trigger a commit | rebase it past the boundary and force-push | same |
 | Results on the `rcc` branch | `runs2.ndjson` + `logs2/<sha>.log` | same schema, same paths, existing records untouched — plus `runs2.d/<xx>/<sha>.ndjson`, which new records land in first and which `runs2.ndjson` is extended from ([§3](#can-results-reach-the-rcc-branch-as-soon-as-they-exist)) |
@@ -46,8 +46,10 @@ so the working tree keeps its diff and the `clean` gate still fails the commit.
 This is why the `build` job needs `contents: write`.
 
 The commit status stays, and is now purely a display surface: nothing decides
-from it. `scripts/vendor-gate.sh`, which turned a window of statuses into one
-green/red/stale verdict for the daily vendoring run, went with the run it served
+from it. Selection reads the verdict store on the `rcc` branch instead (below),
+and `scripts/vendor-gate.sh` — the last consumer that decided anything from a
+status, turning a window of them into one green/red/stale verdict for the daily
+vendoring run — went with the run it served
 (D4 of [`../plan/PLAN-vendoring-simplification.md`](../plan/PLAN-vendoring-simplification.md)).
 
 The readers of the `rcc` branch did need a change, but a compatible one. Records
@@ -110,21 +112,34 @@ So the `workflow_run` hop was decorating the branch tip, not the commit under te
 The new path has no such hop, and `each-rcc` is not named `rcc`,
 so `R-CMD-check-status.yaml` does not fire for it at all.
 
-Two selection details are new, and both only fire in states the old path never produced:
+**Selection does not read any of this.** The status is written for the commit
+list to show, and a commit is planned or skipped according to the **verdict
+store** — the record the `rcc` branch holds at `runs2.d/<xx>/<sha>.ndjson`,
+which the deciding leg publishes within seconds
+([§3](#can-results-reach-the-rcc-branch-as-soon-as-they-exist)).
+`scripts/rcc-decided.sh` is that read, for the planner and for a resuming leg
+alike, and it is one tree-only fetch rather than a request per commit.
 
-- A `pending` status older than `PENDING_TTL_HOURS` (default 6) is treated as
-  abandoned and replanned. Previously a leg that died hard left a commit wedged
-  in `pending` forever. (The default was once matched to `MAX_AGE_HOURS` in
-  `vendor-gate.sh`; that script is gone, and the number now stands on its own.)
-- A commit missing from the status scan is replanned rather than skipped.
+Two stores answering the same question is what needed reconciling, and what
+made a `pending` status a problem at all: a leg that died hard left one wedged
+forever, so `PENDING_TTL_HOURS` existed to age it out. A store where a dead leg
+simply writes nothing needs no such rule — no record means undecided, which is
+the truth — and the TTL is gone with it.
+
+The remaining selection details:
+
+- A commit the store does not mention is planned rather than skipped: the
+  enumeration drives the decision, not the store's contents.
+- Reachability is not emptiness. A store that cannot be read stops the plan
+  rather than reporting nothing decided, which would replan the whole range.
 - A `retry-<S>-dev` branch — the series' own branch name with a prefix, see
   `.claude/skills/series-loop.md` — replans **its tip** even when that commit
   already carries a verdict, so one commit can be judged again on its own SHA
   instead of being amended and taking its descendants with it. The prefix is
   stripped to derive the series, so the scan anchors on `<S>-green` and needs no
   ref of its own; a retry branch naming a series with no green plans nothing at
-  all, because the fallback scan reaches into `main`, where nothing carries an
-  `rcc` status.
+  all, because the fallback scan reaches into `main`, where no commit has a
+  verdict.
 
 ---
 
@@ -133,7 +148,7 @@ Two selection details are new, and both only fire in states the old path never p
 ```
 plan  (1 job, ~30 s)
   ├─ git log --first-parent --after=$SINCE          → candidate commits
-  ├─ GraphQL, 100 commits per request               → existing rcc statuses
+  ├─ scripts/rcc-decided.sh (one tree-only fetch)   → verdicts already on `rcc`
   ├─ scripts/each-cost.py                           → objects each commit invalidates
   ├─ scripts/each-partition.py
   │    ├─ greedy contiguous fill under the leg deadline → fewest shards
@@ -161,12 +176,13 @@ Files:
 | Path | Role |
 |---|---|
 | `.github/workflows/each.yaml` | plan → build → harvest |
-| `scripts/each-plan.sh` | enumerate, read statuses, weigh, partition |
+| `scripts/each-plan.sh` | enumerate, read verdicts, weigh, partition |
 | `scripts/each-cost.py` | unity-object reach; the cost model's only input |
 | `scripts/each-partition.py` | the cost model, the greedy fill, and the rebalance pass |
 | `scripts/each-shard.sh` | one leg: many commits, one workspace |
 | `scripts/rcc-one.sh` | the per-commit gate, extracted from `rcc-smoke` |
 | `scripts/rcc-part-push.sh` | publish one commit's record from the leg that decided it |
+| `scripts/rcc-decided.sh` | the other direction: which commits the store has decided |
 | `scripts/rcc-merge.sh` | bring `runs2.ndjson` level with the per-commit records |
 | `scripts/rcc-consolidate.sh` | manual: make the layouts agree, GC old logs, squash the branch |
 | `scripts/each-harvest.sh` | fan-in: reconcile what the legs could not publish |

--- a/scripts/VENDORING.md
+++ b/scripts/VENDORING.md
@@ -591,12 +591,13 @@ git log -1 --grep="^vendor:" --format=%s   # upstream commit it came from
 
 - `scripts/vendor.sh` - Manual vendoring of one specific upstream state
 - `scripts/vendor-one.sh` - Commit-by-commit vendoring (used by the series loop)
-- `scripts/each-plan.sh` - Selects commits without an `rcc` status and shards them by predicted build cost
+- `scripts/each-plan.sh` - Selects commits with no verdict on the `rcc` branch and shards them by predicted build cost
 - `scripts/each-cost.py` - Counts the unity objects a commit invalidates, from the include graph
 - `scripts/each-shard.sh` - Builds one shard of commits in a single job
 - `scripts/rcc-one.sh` - The per-commit `rcc` gate
 - `scripts/each-harvest.sh` - Folds the shards' results onto the orphan `rcc` branch
 - `scripts/rcc-part-push.sh` - Publishes one commit's result to the `rcc` branch from the leg that decided it
+- `scripts/rcc-decided.sh` - Lists the commits the `rcc` branch has a verdict for; what work selection reads (see [`EACH.md`](EACH.md))
 - `scripts/rcc-merge.sh` - Brings `runs2.ndjson` level with the records in `runs2.d/`
 - `scripts/rcc-consolidate.sh` - Manual: makes the layouts agree, GCs logs older than a month, squashes the `rcc` branch
 - `scripts/rconfigure.py` - Regenerates `src/duckdb/`, `src/include/sources.mk`, `R/version.R`

--- a/scripts/each-plan.sh
+++ b/scripts/each-plan.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 # Plan the sharded per-commit `rcc` build for the checked-out branch.
 #
-# Selects the commits that have no `rcc` commit-status -- on a series branch
-# those in `<S>-green..HEAD`, elsewhere the first-parent history on or after
-# $SINCE -- and
+# Selects the undecided commits -- on a series branch those in
+# `<S>-green..HEAD` with no verdict on the `rcc` branch, elsewhere the
+# first-parent history on or after $SINCE without one -- and
 # partitions them into contiguous, cost-balanced shards (see
 # `scripts/each-partition.py`, which also decides how many shards are worth
 # paying for).
@@ -20,10 +20,13 @@
 #     typical adjacent vendor commit is ~98% cached (VENDORING-LOOP.md, A.2);
 #   * the whole batch is one workflow run: one thing to cancel, one set of logs.
 #
-# Statuses are read in GraphQL batches of $BATCH commits rather than one REST
-# call each. This matters: GITHUB_TOKEN is limited to 1000 REST requests per
-# hour per repository, so a 3000-commit backfill cannot be enumerated over REST
-# at all, while the same scan costs ~30 GraphQL requests.
+# "Undecided" is read from the **verdict store**, not from commit statuses: a
+# commit has been decided when the `rcc` branch carries a record for it, and the
+# whole scan is one tree-only fetch (`scripts/rcc-decided.sh`). Statuses are a
+# display surface on the commit list and decide nothing here -- which is what
+# removes the reconciliation between two stores that used to answer this same
+# question differently: no GraphQL scan, no `pending` state to age out, and
+# nothing that has to be true about the status API for a plan to be correct.
 #
 # Usage:
 #   GH_TOKEN=<token> scripts/each-plan.sh
@@ -33,14 +36,12 @@
 #   GH_TOKEN=$(gh auth token) OUT=/tmp/plan.json scripts/each-plan.sh
 #
 # Environment variables:
-#   GH_TOKEN            - token with statuses:read (required)
+#   GH_TOKEN            - token with contents:read (required)
 #   SINCE               - earliest commit date to consider (default: 2026-01-01)
 #   OUT                 - plan file to write (default: plan.json)
-#   FORCE               - if non-empty, ignore existing statuses and replan all
+#   FORCE               - if non-empty, ignore existing verdicts and replan all
 #                         (a `retry-<S>-dev` branch replans its tip that way
 #                         without this, which is the whole point of it)
-#   PENDING_TTL_HOURS   - a `pending` status older than this is treated as
-#                         abandoned and the commit is replanned (default: 6)
 #   SHARD_BUDGET_MINUTES- build-time target per leg, excluding job setup
 #                         (default: 300; the GitHub job limit is 360, and
 #                         scripts/each-shard.sh stops at its own deadline rather
@@ -71,7 +72,6 @@ set -euo pipefail
 SINCE="${SINCE:-2026-01-01}"
 OUT="${OUT:-plan.json}"
 FORCE="${FORCE:-}"
-PENDING_TTL_HOURS="${PENDING_TTL_HOURS:-6}"
 SHARD_BUDGET_MINUTES="${SHARD_BUDGET_MINUTES:-300}"
 MAX_SHARDS="${MAX_SHARDS:-250}"
 MAX_PARALLEL="${MAX_PARALLEL:-8}"
@@ -81,7 +81,6 @@ SETUP_MINUTES="${SETUP_MINUTES:-5}"
 FULL_BUILD_MINUTES="${FULL_BUILD_MINUTES:-40}"
 FLOOR_MINUTES="${FLOOR_MINUTES:-6}"
 OBJECT_SECONDS="${OBJECT_SECONDS:-9.7}"
-BATCH="${BATCH:-100}"
 
 here="$(cd "$(dirname "$0")" && pwd)"
 workdir="$(mktemp -d)"
@@ -145,7 +144,7 @@ case "${branch}" in
     elif [ -n "${retry}" ]; then
       # Without the anchor the scan would fall back to first-parent history
       # since SINCE, reach past the series' seed into `main`, and queue a build
-      # for every commit there that carries no `rcc` status. A retry branch
+      # for every commit there that has no verdict. A retry branch
       # naming a series that has no green is not a request anyone can serve.
       echo "Retry branch names series ${series}, which has no green -- planning nothing"
       plan_nothing
@@ -168,105 +167,49 @@ fi
 total="$(wc -l < "${workdir}/all" | tr -d ' ')"
 echo "Commits in range: ${total}"
 
-# ------------------------------------------------------------- read statuses --
-# One GraphQL request per $BATCH commits. Emits "<sha> <state> <age-seconds>";
-# state is lowercase, "none" when the commit carries no rcc status at all.
-read_statuses() {
-  local -a shas=()
-  local sha
-
-  flush_batch() {
-    [ "${#shas[@]}" -eq 0 ] && return 0
-
-    local query='query { repository(owner: "'"${owner}"'", name: "'"${repo}"'") {'
-    local i=0
-    for sha in "${shas[@]}"; do
-      query+=" c${i}: object(oid: \"${sha}\") { ... on Commit { oid status { context(name: \"rcc\") { state createdAt } } } }"
-      i=$(( i + 1 ))
-    done
-    query+=' } }'
-
-    gh api graphql -f query="${query}" --jq '
-      .data.repository
-      | to_entries[]
-      | select(.value != null)
-      | [ .value.oid,
-          (.value.status.context.state // "NONE" | ascii_downcase),
-          (.value.status.context.createdAt // "") ]
-      | @tsv'
-
-    shas=()
-  }
-
-  while IFS= read -r sha; do
-    shas+=("${sha}")
-    if [ "${#shas[@]}" -ge "${BATCH}" ]; then
-      flush_batch
-    fi
-  done
-  flush_batch
-}
-
-if [ -n "${EACH_STATES_FILE:-}" ]; then
-  # Offline hook for testing the planner without a token: lines of
-  # "<sha> <state> [<createdAt>]". Commits absent from the file count as
-  # having no status, which is also what a partial GraphQL response means.
-  echo "Reading rcc statuses from ${EACH_STATES_FILE}"
-  cp "${EACH_STATES_FILE}" "${workdir}/states"
+# ------------------------------------------------------------ read verdicts --
+# Every commit the `rcc` branch holds a record for, in one tree-only fetch. A
+# reachable store that says nothing about a commit is the answer "undecided";
+# a store that cannot be reached is not an answer at all, and
+# scripts/rcc-decided.sh exits non-zero for it rather than reporting an empty
+# one, which under `set -e` stops the plan instead of replanning the world.
+if [ -n "${EACH_DECIDED_FILE:-}" ]; then
+  # Offline hook for testing the planner without a remote: one SHA per line.
+  echo "Reading decided commits from ${EACH_DECIDED_FILE}"
+  cp "${EACH_DECIDED_FILE}" "${workdir}/decided"
 elif [ "${total}" -eq 0 ]; then
-  : > "${workdir}/states"
+  : > "${workdir}/decided"
 else
-  owner="${GITHUB_REPOSITORY%%/*}"
-  repo="${GITHUB_REPOSITORY##*/}"
-  if [ -z "${GITHUB_REPOSITORY:-}" ]; then
-    owner="$(gh repo view --json owner --jq .owner.login)"
-    repo="$(gh repo view --json name --jq .name)"
-  fi
-  read_statuses < "${workdir}/all" > "${workdir}/states"
+  "${here}/rcc-decided.sh" > "${workdir}/decided"
 fi
+echo "Verdicts on the rcc branch: $(wc -l < "${workdir}/decided" | tr -d ' ')"
 
 # ---------------------------------------------------------------- select ----
-# Keep a commit when it has no status, or a `pending` status old enough that the
-# run that wrote it is gone. Every other state (success, failure, error) is a
-# decision and is left alone, which is what keeps a rebase-and-force-push the
-# way to re-trigger a commit.
+# Keep a commit when the store has no record for it. A record is a decision and
+# is left alone -- which is what keeps a rebase-and-force-push the way to
+# re-trigger a commit, the SHA being what the record is keyed by.
 #
 # The tip of a `retry-<S>-dev` branch is the one exception: it is a decision the
 # push exists to overturn. Only the tip, and only on that branch -- the rest of
 # the range is the series' own history and keeps the ordinary rule.
 #
-# Driven by the enumeration, not by the status list, so a commit the status scan
-# did not report is replanned rather than silently dropped. Order stays
+# Driven by the enumeration, not by the record list, so a commit the store does
+# not mention is replanned rather than silently dropped. Order stays
 # oldest-first, which is what the partitioner and the shard driver rely on.
-now="$(date -u +%s)"
 retry_tip=""
 [ -n "${retry}" ] && retry_tip="$(git rev-parse HEAD)"
-awk -v now="${now}" -v ttl_hours="${PENDING_TTL_HOURS}" -v force="${FORCE}" \
-    -v retry_tip="${retry_tip}" '
-  function to_epoch(s,   cmd, out) {
-    # RFC 3339 -> epoch. GNU date first, BSD date second; "" when absent.
-    if (s == "") return 0
-    cmd = "date -u -d \"" s "\" +%s 2>/dev/null || date -u -j -f %Y-%m-%dT%H:%M:%SZ \"" s "\" +%s 2>/dev/null"
-    cmd | getline out
-    close(cmd)
-    return out + 0
-  }
-  # The FILENAME guard matters: with an empty status file, FNR == NR is still
+awk -v force="${FORCE}" -v retry_tip="${retry_tip}" '
+  # The FILENAME guard matters: with an empty record list, FNR == NR is still
   # true for the first record of the second file.
-  FNR == NR && FILENAME == ARGV[1] { state[$1] = $2; created[$1] = $3; next }
+  FNR == NR && FILENAME == ARGV[1] { decided[$1] = 1; next }
   {
     sha = $1
-    s = (sha in state) ? state[sha] : "none"
     if (force != "") { print sha, "replan-forced"; next }
     if (retry_tip != "" && sha == retry_tip) { print sha, "replan-retry"; next }
-    if (s == "none" || s == "expected") { print sha, "no-status"; next }
-    if (s == "pending" && now - to_epoch(created[sha]) > ttl_hours * 3600) {
-      print sha, "stale-pending"
-      next
-    }
-    print sha, "skip:" s
+    if (!(sha in decided)) { print sha, "no-record"; next }
+    print sha, "skip:decided"
   }
-' "${workdir}/states" "${workdir}/all" > "${workdir}/decisions"
+' "${workdir}/decided" "${workdir}/all" > "${workdir}/decisions"
 
 awk '$2 !~ /^skip:/ { print $1 }' "${workdir}/decisions" > "${workdir}/todo"
 

--- a/scripts/each-shard.sh
+++ b/scripts/each-shard.sh
@@ -25,9 +25,11 @@
 #
 #   * The leg *resumes*. Re-running a failed job replays its whole shard from
 #     plan.json, so without a check it would rebuild the commits it had already
-#     decided -- up to five hours of work to redo, on a cold cache. A commit that
-#     already carries a decided `rcc` status is therefore skipped here, which
-#     makes "Re-run failed jobs" cost only what was actually lost.
+#     decided -- up to five hours of work to redo, on a cold cache. A commit the
+#     verdict store already holds a record for is therefore skipped here, which
+#     makes "Re-run failed jobs" cost only what was actually lost. The store is
+#     what the planner selects from too (scripts/rcc-decided.sh), so the two
+#     cannot disagree about what "decided" means.
 #     Not every decided commit, though: a forced replan and the tip of a
 #     `retry-<S>-dev` branch are in the plan *because* they already have a
 #     verdict, and skipping those would make the retry a no-op. The planner
@@ -154,18 +156,24 @@ set_status() {
     -f "context=rcc" > /dev/null
 }
 
-# Is this commit already decided? `pending` deliberately does not count: that is
-# the wedged-commit state a killed leg leaves behind, and redoing it is exactly
-# what a re-run is for.
-decided() {
-  local state
-  state="$(gh api "repos/{owner}/{repo}/commits/$1/statuses" \
-    --jq '[.[] | select(.context == "rcc")] | .[0].state // ""' 2>/dev/null || true)"
-  case "${state}" in
-    success|failure|error) return 0 ;;
-    *) return 1 ;;
-  esac
-}
+# What the verdict store already holds, read once. The same source the planner
+# selects from (scripts/rcc-decided.sh), so "decided" means the same thing in
+# both places -- a record on the `rcc` branch, not a commit status, which is a
+# display surface and in particular carries the `pending` a killed leg leaves
+# behind.
+#
+# A snapshot at leg start is the right granularity: the commits this leg might
+# skip are the ones a *previous attempt* of it decided, and no other leg is
+# deciding a commit in this shard. Failing to read it is not fatal -- an empty
+# list rebuilds, which is what a leg with no store at all has always done.
+decided_file="${workdir}/decided"
+: > "${decided_file}"
+if ! "${here}/rcc-decided.sh" > "${decided_file}" 2>/dev/null; then
+  echo "Could not read the verdict store; nothing will be skipped as already decided."
+  : > "${decided_file}"
+fi
+
+decided() { grep -qxF -- "$1" "${decided_file}"; }
 
 # --------------------------------------------------------------- publisher ----
 # The run object, once. Every record this leg writes carries it, so the fan-in and
@@ -296,12 +304,12 @@ for sha in "${commits[@]}"; do
   now="$(date -u +%s)"
   remaining=$(( deadline - now ))
 
-  # Before anything expensive: has someone already decided this commit? On a
-  # first run nobody has, and this costs one REST read per commit. On a re-run of
-  # a leg that died it is the difference between redoing the lost commit and
+  # Before anything expensive: has this commit already been decided? On a first
+  # run nothing has, and the lookup is a grep over a list read once. On a re-run
+  # of a leg that died it is the difference between redoing the lost commit and
   # redoing the whole shard. A commit the planner deliberately replanned is
   # exempt -- its verdict is the thing being overturned.
-  if [ -z "${FORCE}" ] && [ -n "${GH_TOKEN:-}" ] \
+  if [ -z "${FORCE}" ] \
      && ! grep -qxF -- "${sha}" <<<"${replanned}" \
      && decided "${sha}"; then
     echo "${sha}: already decided, skipping (re-run of a partially built shard)"

--- a/scripts/rcc-decided.sh
+++ b/scripts/rcc-decided.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+# Print the SHA of every commit the verdict store has decided, one per line.
+#
+# The verdict store is the orphan `rcc` branch: one record per commit at
+# `runs2.d/<xx>/<sha>.ndjson`, published by the leg that decided it within
+# seconds of the verdict existing (scripts/rcc-part-push.sh, scripts/EACH.md
+# section 3). Presence is the whole question -- a commit with a record has been
+# decided, a commit without one has not -- so the answer is one `ls-tree` over a
+# tree-only fetch rather than a request per commit.
+#
+# This is what work selection reads: scripts/each-plan.sh to choose what to
+# build, scripts/each-shard.sh to skip what a previous attempt already decided.
+# Both used to read commit statuses instead, which made the record store and the
+# status store two answers to the same question that had to be reconciled --
+# newest-writer rules, a `PENDING_TTL_HOURS` heuristic, and a backstop that
+# derived records *from* statuses. One store needs none of that. Statuses stay,
+# as a display surface on the commit list.
+#
+# Parts only, no aggregate. Records that predate the per-commit layout live in
+# `runs2.ndjson` alone, and are not looked up here: every one of them belongs to
+# a commit decided before the sharded matrix existed, which is far below every
+# series' green, and green is what bounds the planner's range. Should one ever
+# fall inside a range, the cost is a rebuild rather than a wrong verdict, and
+# `BACKFILL=1 scripts/rcc-merge.sh` splits the pre-split records into parts once
+# and for good.
+#
+# Reachability is not the same question as emptiness, and the two exit
+# differently: no `rcc` branch on the remote means nothing has been decided yet
+# (empty output, success), while a remote that cannot be reached is an error --
+# answering "nothing is decided" there would replan every commit in range.
+#
+# Usage:
+#   scripts/rcc-decided.sh > decided.txt
+#
+# Environment variables:
+#   GH_TOKEN / GITHUB_TOKEN - token with contents:read on the repository
+#   GITHUB_REPOSITORY       - owner/repo (required unless RCC_REMOTE is set)
+#   GITHUB_SERVER_URL       - default: https://github.com
+#   RCC_REMOTE              - remote URL, overriding the two above; how the test
+#                             harness points this at a local bare repository
+#   RCC_READ_DIR            - where the branch clone is cached between calls
+#                             (default: $RUNNER_TEMP/rcc-read); must be outside
+#                             the workspace, which scripts/each-shard.sh wipes.
+#                             Deliberately not RCC_DIR: that one belongs to
+#                             scripts/rcc-part-push.sh, which configures a commit
+#                             identity in it that this script has no business
+#                             creating or depending on.
+#   BRANCH                  - default: rcc
+
+set -euo pipefail
+
+RCC_READ_DIR="${RCC_READ_DIR:-${RUNNER_TEMP:-/tmp}/rcc-read}"
+BRANCH="${BRANCH:-rcc}"
+
+# A blobless clone backfills on demand, and `ls-tree` is not supposed to trigger
+# any such demand. This turns a path that would quietly fetch ~220 MB of
+# harvested logs into a loud failure instead; see scripts/rcc-part-push.sh, which
+# pays for the same guard.
+export GIT_NO_LAZY_FETCH=1
+
+git_rcc() { git -C "${RCC_READ_DIR}" "$@"; }
+
+# The remote URL carries the token the way actions/checkout does. GITHUB_TOKEN is
+# a registered secret, so Actions masks it in the log; nothing here echoes it.
+remote_url() {
+  if [ -n "${RCC_REMOTE:-}" ]; then
+    printf '%s' "${RCC_REMOTE}"
+    return
+  fi
+  local base="${GITHUB_SERVER_URL:-https://github.com}"
+  local token="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+  local repo="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY or RCC_REMOTE is required}"
+  if [ -n "${token}" ]; then
+    printf 'https://x-access-token:%s@%s/%s' "${token}" "${base#https://}" "${repo}"
+  else
+    printf '%s/%s' "${base}" "${repo}"
+  fi
+}
+
+if [ ! -d "${RCC_READ_DIR}/.git" ]; then
+  mkdir -p "$(dirname "${RCC_READ_DIR}")"
+  git init -q "${RCC_READ_DIR}"
+  git_rcc remote add origin "$(remote_url)"
+else
+  git_rcc remote set-url origin "$(remote_url)"
+fi
+
+# `--exit-code` distinguishes the two: 2 is "no such branch", anything else
+# non-zero is "could not ask".
+rc=0
+git_rcc ls-remote --exit-code --heads origin "${BRANCH}" >/dev/null 2>&1 || rc=$?
+case "${rc}" in
+  0) ;;
+  2)
+    echo "rcc-decided: no ${BRANCH} branch on the remote -- nothing is decided yet" >&2
+    exit 0
+    ;;
+  *)
+    echo "rcc-decided: cannot reach the remote to read the ${BRANCH} branch" >&2
+    exit 1
+    ;;
+esac
+
+# `--filter=blob:none` is a server capability; a remote without it (or an old
+# client) still works, just with the blobs we did not want. Recorded so the
+# fallback is only paid once per caller rather than per call.
+fetch_tip() {
+  local filter="--filter=blob:none"
+  [ -f "${RCC_READ_DIR}/.no-filter" ] && filter=""
+  if git_rcc fetch -q --depth 1 ${filter} origin \
+       "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}" 2>/dev/null; then
+    return 0
+  fi
+  [ -n "${filter}" ] || return 1
+  : > "${RCC_READ_DIR}/.no-filter"
+  git_rcc fetch -q --depth 1 origin \
+    "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}" 2>/dev/null
+}
+
+if ! fetch_tip; then
+  echo "rcc-decided: could not fetch ${BRANCH} from the remote" >&2
+  exit 1
+fi
+
+# Anything that is not a well-formed part path is not a verdict, and is dropped
+# rather than guessed at.
+git_rcc ls-tree -r --name-only "refs/remotes/origin/${BRANCH}" -- runs2.d |
+  sed -n 's#^runs2\.d/[0-9a-f][0-9a-f]/\([0-9a-f]\{40\}\)\.ndjson$#\1#p'


### PR DESCRIPTION
**D1** of [`plan/PLAN-vendoring-simplification.md`](../blob/main/plan/PLAN-vendoring-simplification.md), Phase 2 — the cut for finding **F1**. Rebased onto current `main`; merges cleanly, and no longer conflicts with anything.

## The problem

Two stores answered "has this commit been decided?" — the commit statuses that selection read, and the records on the `rcc` branch that the loop reads.
Everything between them existed to make them agree: a GraphQL scan per plan, a REST read per commit in a resuming leg, newest-writer rules, a `PENDING_TTL_HOURS` heuristic for statuses a dead runner wedged, and a scheduled backstop that derives records *from* statuses.
None of that mechanism would exist with one store.

## The change

Selection reads the records.
`scripts/rcc-decided.sh` lists the commits the `rcc` branch holds a record for, in one tree-only fetch — presence is the whole question, because a leg publishes a record within seconds of deciding a commit — and **both** readers use it: the planner to choose what to build, a resuming leg to skip what a previous attempt decided.
"Decided" therefore means the same thing in both places.

Deleted: the GraphQL status scan and its batching, the REST status read per commit, `PENDING_TTL_HOURS`, and the wedged-`pending` state it was invented for.
A leg that dies hard now writes nothing, and nothing is what "undecided" looks like — the truth, needing no rule to age out.
`each-plan.sh` loses ~90 lines and its dependency on the status API being correct.

The new script is entered in the inventories that own it: `scripts/VENDORING.md`'s file list and `BRANCHES.md`'s tooling tree and table.

## What #2442 already settled

With the legacy dispatcher retired, statuses now decide nothing anywhere — `vendor-gate.sh` was their last deciding consumer, and the plan job no longer requests `statuses: read`. **This PR therefore touches no workflow at all**; that hunk disappeared in the rebase rather than being reconciled, which is why merging D4 first was the right order.

Statuses stay as the display surface on the commit list, which is what branch protection reads on ordinary pushes.

## Two properties worth checking closely

* **Reachability is not emptiness.** A store that cannot be read exits non-zero rather than reporting nothing decided, so the plan stops instead of replanning the entire range. (`ls-remote --exit-code` distinguishes "no such branch" — a legitimate empty answer on day one — from "could not ask".)
* **Parts only, no aggregate.** Records predating the per-commit layout live in `runs2.ndjson` alone, and belong to commits decided before the sharded matrix existed — far below every series' green, which bounds the planner. If one ever did fall inside a range the cost is a rebuild, not a wrong verdict.
  **Suggested before merge:** run `BACKFILL=1 scripts/rcc-merge.sh` once on the `rcc` branch; it splits the pre-split records into parts and removes the case entirely. This is the sweep D2 needs anyway.

## Deliberately left out

The rest of D1 inverts the scheduled backstop — it stops writing, and its schedule becomes the dispatcher for idle undecided work.
Until then it still reconstructs a record from a status for a leg that died before publishing. That is now a *repair path into the one store* rather than a second store being read — a coherent and strictly safer intermediate; the inversion is a separate change against `rcc-logs.sh` / `rcc-logs.yaml`.

## Verification

`each-plan.sh` run end to end against the repository after the rebase, with the offline `EACH_DECIDED_FILE` hook:

| scenario | result |
|---|---|
| nothing decided, 3 commits in range | 3 planned |
| 2 newest already decided | 1 planned, 2 skipped |
| `FORCE=1` | 3 planned, all 3 listed in `replanned_despite_verdict` |

`rcc-decided.sh` against a simulated `rcc` remote: no branch → empty + success; two records → both listed, non-record paths filtered; unreachable remote → error, exit 1.
Selection's awk exercised directly for the retry-tip and empty-store paths.
#2445's oldest-first shard ordering is preserved verbatim — checked in the emitted plan, not just in the diff.

## Rollback

A revert. Statuses are still written, so reading them again costs nothing.