### PR TITLE
ci(each): Queue the shards oldest first

### DIFF
--- a/.github/workflows/each.yaml
+++ b/.github/workflows/each.yaml
@@ -23,8 +23,9 @@
 # EACH_SPLIT_FACTOR times the runner minutes of the cheapest plan.
 #
 # Shards are numbered along the history -- shard 1 is the oldest slice, shard N
-# the branch tip -- and queued the other way round, so under max-parallel
-# throttling the tip is decided first. A leg that fails a commit quotes the tail
+# the branch tip -- and queued in that same order, so under max-parallel
+# throttling the oldest undecided slice is decided first, which is the only end
+# `<S>-green` can advance from. A leg that fails a commit quotes the tail
 # of every stage that failed into its job summary, so the run summary says what
 # broke without opening the log.
 #

--- a/scripts/EACH.md
+++ b/scripts/EACH.md
@@ -466,19 +466,20 @@ or a plan whose waves are already even.
 
 #### Numbering, and the order they are queued in
 
-These are two different things, and conflating them is what made the first
-version confusing to read.
+These are two separate decisions that happen to agree.
 
 A shard's **number** runs with the history: shard 1 holds the oldest commits of
 the plan, shard N the branch tip, and adjacent numbers are adjacent slices.
 So a leg's number reads the way its commits do, and the numbering starts at
 one rather than at zero.
 
-The **order** they are queued in is the reverse: newest shard first, so that
-under `max-parallel` throttling the branch tip — the thing the series loop and
-the release flow wait on — is decided first.
-The matrix therefore starts at shard N and finishes with shard 1.
-Within a shard, commits run oldest-first, for cache locality.
+The **order** they are queued in is the same: oldest shard first, so that
+under `max-parallel` throttling the oldest undecided slice is decided first.
+That is the end the series loop can actually move from — `<S>-green` advances
+over a *contiguous* run of green commits, so a decided tip sitting above an
+undecided gap advances nothing.
+The matrix therefore starts at shard 1 and finishes with shard N.
+Within a shard, commits run oldest-first too, for cache locality.
 
 Numbers are assigned after the matrix cap has dropped the oldest shards
 (§4), so shard 1 is the oldest shard *this run* will build,

--- a/scripts/each-partition.py
+++ b/scripts/each-partition.py
@@ -145,11 +145,11 @@ def greedy(items, model, budget):
 
 
 def makespan(shards, model, parallel):
-    """Wall clock of the whole matrix, newest shard submitted first."""
+    """Wall clock of the whole matrix, oldest shard submitted first."""
     if not shards:
         return 0.0
     slots = [0.0] * max(1, min(parallel, len(shards)))
-    for shard in reversed(shards):
+    for shard in shards:
         i = min(range(len(slots)), key=lambda j: slots[j])
         slots[i] += model.estimate_minutes(shard)
     return max(slots)

--- a/scripts/each-plan.sh
+++ b/scripts/each-plan.sh
@@ -10,8 +10,8 @@
 # One shard becomes one matrix leg in `.github/workflows/each.yaml`, and one
 # leg builds its whole slice sequentially in a single job (see
 # `scripts/each-shard.sh`). Shards are numbered along the history -- shard 1 is
-# the oldest slice, shard N the branch tip -- and emitted in the reverse order,
-# so the leg holding the tip is the one queued first.
+# the oldest slice, shard N the branch tip -- and emitted in that same order,
+# so the leg holding the oldest slice is the one queued first.
 #
 # Why shards instead of one dispatch per commit:
 #   * a leg pays the ~4 min R/dependency setup once for ~20 commits, not once
@@ -337,18 +337,19 @@ if [ "${dropped}" -gt 0 ]; then
   echo "Capped to ${MAX_SHARDS} shards; ${dropped} older commit(s) deferred to the next run"
 fi
 
-# Two independent things, deliberately not conflated:
+# Number and order now say the same thing:
 #
 #   * the *number* runs with history -- shard 1 holds the oldest commits of the
 #     plan and shard N the branch tip, so a shard number reads the way the
 #     commits do, and adjacent numbers are adjacent slices;
-#   * the *order* of the array is newest first, because that is the order
-#     GitHub starts the legs in, and under MAX_PARALLEL throttling the tip of
-#     the branch has to be decided first -- it is what scripts/vendor-gate.sh
-#     and the promotion flow wait on.
+#   * the *order* of the array is oldest first, because that is the order
+#     GitHub starts the legs in, and under MAX_PARALLEL throttling the oldest
+#     undecided slice has to be decided first -- `<S>-green` only ever advances
+#     over a contiguous run of green commits, so a decided tip above an
+#     undecided gap moves nothing.
 #
-# So the matrix starts shard N and finishes with shard 1.
-jq -r 'to_entries | map(.value + {index: (.key + 1)}) | reverse' \
+# So the matrix starts shard 1 and finishes with shard N.
+jq -r 'to_entries | map(.value + {index: (.key + 1)})' \
   "${workdir}/shards.json" > "${workdir}/shards.final.json"
 
 parallel="${MAX_PARALLEL}"
@@ -404,8 +405,8 @@ fi
 planned="$(jq '[.shards[].commits | length] | add // 0' "${OUT}")"
 
 echo "Plan written to ${OUT}: ${shards} shard(s), ${planned} commit(s), max-parallel ${parallel}"
-# Listed by number, which is oldest slice first; the legs are queued the other
-# way round.
+# Listed by number, which is oldest slice first, and that is also the order the
+# legs are queued in.
 jq -r '.shards | sort_by(.index)[]
        | "  shard \(.index): \(.commits | length) commits, ~\(.estimate_minutes) min"' "${OUT}"
 
@@ -445,7 +446,7 @@ if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
       jq -r '.shards | sort_by(.index)[]
              | "| \(.index) | \(.commits | length) | ~\(.estimate_minutes) min | \([.commits[].objects] | max) |"' "${OUT}"
       echo
-      echo "Shard 1 is the oldest slice; the legs are queued newest first, so shard ${shards} starts first."
+      echo "Shard 1 is the oldest slice; the legs are queued oldest first, so shard 1 starts first."
     fi
   } >> "${GITHUB_STEP_SUMMARY}"
 fi


### PR DESCRIPTION
Flips the scheduling order of the matrix legs in the `each-rcc` workflow.

## What changed

Shard **numbering** is unchanged: shard 1 is still the oldest slice of the plan, shard N the branch tip.
What changed is the **order the legs are queued in**.

`scripts/each-plan.sh` used to `reverse` the shard array before emitting the matrix,
so GitHub started at shard N and finished with shard 1.
The array is now emitted in numbering order, so the matrix starts at shard 1 and finishes with shard N.
Under `max-parallel` throttling, the oldest undecided slice is now the one decided first.

## Why

`<S>-green` advances over a *contiguous* run of green commits.
A decided tip sitting above an undecided gap advances nothing,
so deciding the oldest undecided slice first is what actually lets green move.

## Also updated

- `scripts/each-partition.py` — `makespan()` simulates the submission order to score candidate plans, so its slot assignment flips with the queue order.
- Comments in `.github/workflows/each.yaml` and `scripts/each-plan.sh`, the planner's log line and job summary, and the "Numbering, and the order they are queued in" section of `scripts/EACH.md`.

Shard selection inside a leg is by `.index` (`scripts/each-shard.sh`), not by array position, so nothing downstream depends on the emitted order.
Within a shard, commits still run oldest-first for cache locality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sxb54Dxk8hA12LNwPaUHPQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sxb54Dxk8hA12LNwPaUHPQ)_