### PR TITLE
fix(configure): Drop a stale `Makevars.system-lib` so a vendored build is one

### DIFF
--- a/configure
+++ b/configure
@@ -22,6 +22,15 @@ cd "${PKG_ROOT}/src"
 echo DUCKDB_RSTRTMGR=1 > Makevars.rstrtmgr
 echo DUCKDB_RSTRTMGR_LIB= >> Makevars.rstrtmgr
 
+# Drop any Makevars.system-lib left behind by an earlier
+# DUCKDB_R_USE_SYSTEM_LIB build; the branch below rewrites it when the
+# opt-in is active. Without this, the stale file keeps emptying SOURCES
+# and adding -lduckdb, so a plain `R CMD INSTALL .` silently stays on the
+# fast path -- producing a package that resolves DuckDB symbols from the
+# system library (a different extension set and autoinstall default)
+# while looking like a vendored build.
+rm -f Makevars.system-lib
+
 
 # Opt-in mode: skip compilation of the ~1700 vendored .cpp files and
 # link the R package against a system-installed libduckdb instead.


### PR DESCRIPTION
## The bug

`configure` writes `src/Makevars.system-lib` when `DUCKDB_R_USE_SYSTEM_LIB` is set, and `src/Makevars.in` picks it up with a plain `include`. The file empties `SOURCES` and sets `PKG_LIBS=-lduckdb`.

Nothing ever removed it. Once a tree has done one fast-path build, **every later build in that tree keeps emptying `SOURCES` and linking `-lduckdb`, even with the variable unset** — while still appearing to compile the vendored sources, because make goes on building the objects it no longer links.

## Why it matters

The contaminated build is not merely slower or faster — it answers questions about engine configuration wrongly:

| | Vendored build | Release `libduckdb` |
|---|---|---|
| Statically linked | `core_functions`, `parquet` | also `icu`, `json`, `autocomplete` |
| `autoinstall_known_extensions` | `false` | `true` |
| `autoload_known_extensions` | `true` | `true` |

Both differences follow from `src/Makevars.in`, which compiles with `-DDUCKDB_EXTENSION_PARQUET_LINKED -DDUCKDB_EXTENSION_CORE_FUNCTIONS_LINKED` and defines `DUCKDB_EXTENSION_AUTOLOAD_DEFAULT` but not `DUCKDB_EXTENSION_AUTOINSTALL_DEFAULT` (see `src/duckdb/src/include/duckdb/main/settings.hpp`, where each default is `#if defined(...) && ...`).

So `duckdb_extensions()` in such a tree reports extensions that do not ship — including `icu`, which is the subject of #2306. This was found by trying to verify that issue's facts and getting the wrong answer from a build that looked vendored.

## The fix

`rm -f Makevars.system-lib` at the top of `configure`, before the opt-in branch that rewrites it when it applies.

## Verification

On Linux, both directions:

- **Variable unset** — installed `duckdb.so` is ~850 MB and `ldd` shows no `libduckdb` dependency. `duckdb_extensions()` reports `core_functions` and `parquet` `STATICALLY_LINKED`, `autoinstall_known_extensions` `false`, and `icu`/`json`/`autocomplete` absent.
- **Variable set** — the fast path still works: `configure` rewrites the file, the installed `duckdb.so` is ~52 MB and links `/usr/local/lib/libduckdb.so`.
- Test suite on the fast path: FAIL 0 | WARN 0 | SKIP 60 | PASS 1265.

## Known remaining issue, not fixed here

A stale `src/duckdb.so` can survive a mode switch in the *other* direction: with `SOURCES` empty it is newer than the 15 glue objects, so make relinks nothing and the fast path silently installs the vendored library. That cannot be fixed in `configure` — the remedy is `rm -f src/duckdb.so src/*.o` when switching modes. #2443 documents both traps in `BUILD.md`, and does not depend on this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_014tm3WuF973ZTogTJgaDmaV)_