### PR TITLE
feat(series): Make cutover a manual operation the loop only suggests

### DIFF
--- a/.claude/skills/series-forward.md
+++ b/.claude/skills/series-forward.md
@@ -103,7 +103,7 @@ A series that has cut over is no longer WIP:
 its green serves consumers,
 and moving it means a new forward series, not a rebase.
 
-## Cut over
+## Cut over — by hand, always
 
 When `<S>-fwd-green` vendors at least the upstream commit
 `<S>-green` vendors —
@@ -112,6 +112,16 @@ coverage may never regress — run
 ```sh
 scripts/series-cutover.sh <S> origin <upstream-clone>
 ```
+
+**A human runs this, never the loop.**
+The series loop reports a ready cutover and stops there
+(`series-loop.md`, stage 6),
+and the script refuses to run without a terminal
+and a typed confirmation.
+Pass the upstream clone:
+without it the coverage gate degrades to a warning,
+and a warning is not what should authorize
+retiring the lineage consumers are reading.
 
 It swaps all four refs in a single `git push --atomic`
 with a per-ref lease,

--- a/.claude/skills/series-loop.md
+++ b/.claude/skills/series-loop.md
@@ -81,7 +81,9 @@ Three scripts carry the mechanical parts:
 `scripts/series-check.sh`
 (read-only — walks every series, classifies from the harvest,
 prints one verdict each:
-ADVANCE / WAIT / RETRY `<sha>` / REPAIR `<sha>` / IDLE),
+ADVANCE / WAIT / RETRY `<sha>` / REPAIR `<sha>` / IDLE,
+plus a CUTOVER line for a forward series that has caught up —
+a suggestion for a human, stage 6),
 `scripts/series-advance.sh <S>`
 (stages 3 and 5 — fast-forwards `-green`,
 moves `-build-base` by vendored-SHA match,
@@ -417,6 +419,43 @@ verify and promote it, but do not extend it.
 `rcc-logs.yaml` harvests results to branch `rcc` every 30 minutes,
 which is below build time (~35 min).
 
+### 6. Suggest a cutover — never perform one
+
+A forward series that has caught up is **reported, not swapped**.
+When `<S>-fwd-green` vendors the upstream commit `<S>-green` vendors,
+`series-check.sh` says so beside that series' verdict,
+and the firing carries the line into its summary:
+
+```sh
+scripts/series-cutover.sh <S> origin <upstream-clone>
+```
+
+That is the whole stage.
+The routine does not run the script,
+and does not swap the four refs by hand instead.
+
+Cutover is the one move that retires a lineage consumers are reading.
+Everything else the loop does is bounded and recoverable:
+a bad repair is repaired again,
+a wrong extension is replayed,
+and `-green` only ever moves forward over commits CI called green.
+The swap moves a serving green *sideways*
+— the single sanctioned non-fast-forward of one (`series-forward.md`) —
+and it deletes the counterpart that would let it be undone.
+Its coverage gate is also the one gate the loop cannot fully evaluate:
+the ancestry check needs an upstream clone,
+and degrades to a warning without one,
+so an unattended firing would be authorizing the swap on a warning.
+Verification is mechanical, so the loop owns it;
+deciding that r-universe should build a different lineage today
+is not, so a human owns that.
+
+The script enforces its own half:
+it refuses to run without a terminal
+and takes the series name as confirmation,
+so a firing that tries anyway achieves nothing.
+Treat that refusal as the answer, not as an obstacle to route around.
+
 ## Rerun one commit: `retry-<S>-dev`
 
 Some runs fail for reasons the commit had no part in:
@@ -539,6 +578,11 @@ is what carries the automatic path into a forward series.
 ## Invariants
 
 - `<S>-green` and `<S>-build-base` move forward only.
+- Cutover is manual.
+  The loop reports that a forward series has caught up
+  and prints the command; it never runs it,
+  and never swaps the refs by another route.
+  Every other ref move in this skill is the routine's to make.
 - A base is advanced on completed, successful runs —
   never on absence of a failure.
 - Fixes are folded into the commit that needs them,

--- a/plan/PLAN-vendoring-simplification.md
+++ b/plan/PLAN-vendoring-simplification.md
@@ -146,8 +146,9 @@ with a status line each as the work lands:
   ref — `series-advance.sh` requires it and guards its own writes with a
   fast-forward check, `series-cutover.sh` swaps it atomically, the
   skills create it on day one — so "no script reads it back" was too
-  strong: it is written, guarded, and swapped by the loop, but it is an
-  input to nothing. Its consumer is the human: it is the ref that makes
+  strong: it is written and guarded by the loop, and swapped at cutover
+  (by hand — §3.1 rule 7), but it is an input to nothing.
+  Its consumer is the human: it is the ref that makes
   "how much is vendored but not yet verified" a clean linear range,
   `-build-base..-build`, renderable as a compare URL and as a badge
   (§3.4). The gap was that no document stated that contract,
@@ -225,7 +226,8 @@ as one checklist; this plan is analysis, not a routing node:
 6. A series is discovered from its refs, never configured.
 7. Rebasing or rerooting replays the vendor chain onto a fresh seed
    beside the serving series and re-verifies from scratch;
-   cutover is one atomic swap.
+   cutover is one atomic swap, and the one move the loop only suggests —
+   a human runs it, from a terminal.
 
 ### 3.2 Extensions that earn their keep
 

--- a/scripts/series-check.sh
+++ b/scripts/series-check.sh
@@ -11,6 +11,10 @@
 #   RETRY <sha> <why>  the oldest failure, and nothing in the commit caused it
 #   REPAIR <sha> <why>  the oldest failure and its classification
 #
+# A forward series that has caught up with the green it replaces additionally
+# gets a CUTOVER line: the command to run, for a human to run. The loop never
+# swaps a serving green itself (.claude/skills/series-loop.md).
+#
 # Classification is by positive evidence only (.claude/skills/series-loop.md);
 # "Job is waiting for a hosted runner" appears in every log and means nothing.
 #
@@ -133,11 +137,26 @@ for S in "${series[@]}"; do
   done
   # cutover litter: a forward series whose green is an ancestor of its base's
   # (the base moves on after cutover, so equality cannot be the test)
+  cutover=""
   case "$S" in *-fwd)
     base=${S%-fwd}
-    if git rev-parse -q --verify "$remote/$base-green" >/dev/null &&
-       git merge-base --is-ancestor "$green" "$remote/$base-green"; then
-      echo "$S: green is an ancestor of $base's — cutover litter, ignoring"; continue
+    if git rev-parse -q --verify "$remote/$base-green" >/dev/null; then
+      if git merge-base --is-ancestor "$green" "$remote/$base-green"; then
+        echo "$S: green is an ancestor of $base's — cutover litter, ignoring"; continue
+      fi
+      # Ready to cut over once the forward green vendors the upstream commit the
+      # base green vendors: coverage may never regress. Tested by subject, like
+      # every other equivalence here, and bounded by the mainline the forward
+      # seed was built on — `main`'s own vendor commits sit below that seed and
+      # must not answer for the forward chain. A base green that vendors nothing
+      # asks for no coverage, exactly as in series-cutover.sh.
+      base_up=$(vendored_sha "$remote/$base-green")
+      # Collected, not piped into grep: `grep -q` leaves early, and under
+      # `pipefail` the SIGPIPE it hands `git log` would read as a failed test.
+      fwd_vendored=$(git log --format=%s "$remote/main..$green" -- src/duckdb || true)
+      if [ -z "$base_up" ] || grep -q "duckdb@$base_up" <<<"$fwd_vendored"; then
+        cutover=$base
+      fi
     fi ;;
   esac
 
@@ -196,5 +215,14 @@ for S in "${series[@]}"; do
     echo "  IDLE   nothing in flight, buffer empty — vendor"
   else
     echo "  ADVANCE"
+  fi
+
+  # Suggested, never done: a firing reports a ready cutover and stops
+  # (.claude/skills/series-loop.md). Printed beside the verdict rather than as
+  # one, because it is orthogonal — a forward series that has caught up still
+  # needs repairing, advancing or waiting like any other.
+  if [ -n "$cutover" ]; then
+    echo "  CUTOVER  $S covers $cutover's green — a manual step, never a firing's:"
+    echo "           scripts/series-cutover.sh $cutover $remote <upstream-clone>"
   fi
 done

--- a/scripts/series-cutover.sh
+++ b/scripts/series-cutover.sh
@@ -8,6 +8,12 @@
 # half-replaced series. The swap is the one sanctioned non-fast-forward move
 # of a green ref.
 #
+# It is also the one move the series loop never makes: the loop reports a ready
+# cutover and stops (.claude/skills/series-loop.md), because retiring the
+# lineage r-universe builds from is a decision, not a stage. This script is the
+# mechanical half of that rule — it runs from a terminal, on a typed
+# confirmation, and nowhere else.
+#
 # A base series ref that does not exist yet is created rather than swapped:
 # a series that started as -fwd has no counterpart to replace.
 #
@@ -22,6 +28,15 @@ set -euo pipefail
 S=${1:?usage: series-cutover.sh <series> [remote] [upstream-clone]}
 remote=${2:-origin}
 upstream=${3:-}
+
+# Fail before the fetch, not after it: an unattended firing has no terminal, so
+# there is nothing for it to confirm with and no reason to do any work first.
+if [ ! -t 0 ] || [ ! -t 1 ]; then
+  echo "Error: cutover is a manual operation; run this script from a terminal." >&2
+  echo "  The series loop reports a ready cutover and stops; a human runs it." >&2
+  echo "  See .claude/skills/series-forward.md and series-loop.md." >&2
+  exit 1
+fi
 
 git fetch -q "$remote"
 
@@ -87,6 +102,7 @@ fi
 
 leases=()
 refspecs=()
+echo "refs to swap:"
 for r in build dev green build-base; do
   new=$(git rev-parse "refs/remotes/$remote/$S-fwd-$r")
   # An empty expected value leases the ref as "must not exist yet", which is
@@ -96,7 +112,17 @@ for r in build dev green build-base; do
   cur=$(git rev-parse -q --verify "refs/remotes/$remote/$S-$r") || cur=
   leases+=("--force-with-lease=refs/heads/$S-$r:$cur")
   refspecs+=("$new:refs/heads/$S-$r")
+  short=${cur:0:7}
+  printf '  %-20s %s -> %s\n' "$S-$r" "${short:-<new>}" "${new:0:7}"
 done
+
+# The gate above says the swap is allowed; this asks whether it is wanted. It
+# comes last so the operator confirms with the coverage lines and the four ref
+# moves on screen, and it takes the series name rather than a keystroke because
+# the mistake worth catching is cutting over the wrong series.
+printf 'Replace series %s with %s-fwd-*? Type the series name to confirm: ' "$S" "$S"
+read -r confirm
+[ "$confirm" = "$S" ] || { echo "Aborted; nothing was pushed."; exit 1; }
 
 git push --atomic "${leases[@]}" "$remote" "${refspecs[@]}"
 if [ ${#missing[@]} -eq 4 ]; then


### PR DESCRIPTION
Cutover is the one move that retires a lineage consumers are reading,
so the series loop now reports it and stops —
a human runs `series-cutover.sh`, from a terminal.

## Why

Everything else the loop does is bounded and recoverable:
a bad repair is repaired again,
a wrong extension is replayed,
and `-green` only ever moves forward over commits CI called green.
The swap moves a serving green *sideways* —
the single sanctioned non-fast-forward of one —
and it deletes the counterpart that would let it be undone.

Its coverage gate is also the one gate a firing cannot fully evaluate:
the ancestry check needs an upstream clone
and degrades to a warning without one,
so an unattended cutover would be authorizing the swap on a warning.
Verification is mechanical, so the loop owns it;
deciding that r-universe should build a different lineage today is not.

## The suggestion

`scripts/series-check.sh` prints a `CUTOVER` line beside the verdict
of a forward series that has caught up,
with the exact command:

```
=== main-fwd: 0 in flight, 12 buffered, green=abc1234 dev=abc1234
  ADVANCE
  CUTOVER  main-fwd covers main's green — a manual step, never a firing's:
           scripts/series-cutover.sh main origin <upstream-clone>
```

Readiness is tested the way every other equivalence here is tested —
by the `duckdb/duckdb@<sha>` subject:
the forward green must vendor the upstream commit the base green vendors.
The walk is bounded by the mainline the forward seed was built on,
so `main`'s own vendor commits below that seed
cannot answer for the forward chain,
and a base green that vendors nothing asks for no coverage,
exactly as in `series-cutover.sh`.
The line is printed beside the verdict rather than as one:
a forward series that has caught up
still needs repairing, advancing or waiting like any other.

## The enforcement

`scripts/series-cutover.sh` carries the mechanical half:

- it refuses to run unless stdin and stdout are a terminal,
  before the fetch, so an unattended firing gets nothing;
- it prints the four ref moves alongside the coverage lines;
- it takes the **series name** as confirmation before the atomic push —
  the mistake worth catching is cutting over the wrong series.

## Docs

`series-loop.md` gains stage 6 (suggest, never perform) and an invariant;
`series-forward.md`'s cutover section says a human runs it and why
the upstream clone should be passed;
the plan's rule 7 and the `-build-base` finding are corrected to match.

## Testing

Exercised on synthetic remotes:
`series-check.sh` reports `CUTOVER` when the forward green covers the base,
stays silent when it does not,
and is not fooled by a mainline vendor commit below the forward seed;
existing cutover-litter detection is unchanged.
`series-cutover.sh` refuses without a terminal (exit 1, nothing fetched),
aborts a wrong confirmation without pushing,
and swaps all four refs plus deletes the `-fwd-*` refs on a correct one.

---
_Generated by [Claude Code](https://claude.ai/code/session_0177rDhDoqMirV3knfCkgSq9)_