### PR TITLE
docs(scripts): Give every script an extractable one-line header

### DIFF
--- a/scripts/flavor.sh
+++ b/scripts/flavor.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Apply a package flavor: rewrite scripts/flavor.patch to the target name
+# (say, duckdb.dev), apply it, and commit the rename; see BRANCHES.md.
 
 set -euxo pipefail
 

--- a/scripts/format.py
+++ b/scripts/format.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-# this script is used to format the source directory
+# Format the source directory; driven by the Makefile's format-* targets.
 
 import os
 import time

--- a/scripts/python_helpers.py
+++ b/scripts/python_helpers.py
@@ -1,3 +1,5 @@
+# Shared file helpers for the Python scripts in this directory
+# (imported by format.py).
 def open_utf8(fpath, flags):
     import sys
     if sys.version_info[0] < 3:

--- a/scripts/rconfigure.py
+++ b/scripts/rconfigure.py
@@ -1,3 +1,6 @@
+# Regenerate the vendored build configuration from a DuckDB checkout:
+# src/duckdb/, src/include/sources.mk, and R/version.R.
+# Called by vendor.sh and vendor-one.sh with DUCKDB_PATH set.
 import os
 import sys
 import shutil

--- a/scripts/rethrow.R
+++ b/scripts/rethrow.R
@@ -1,3 +1,5 @@
+# Generate R/rethrow-gen.R from R/cpp11.R: wrap each rapi_* binding
+# to rethrow errors with call context; sourced by .Rprofile on repo load.
 rethrow_generate <- function() {
   if (Sys.getenv("CI") != "") {
     return()

--- a/scripts/setup-makeflags.R
+++ b/scripts/setup-makeflags.R
@@ -1,6 +1,6 @@
 #!/usr/bin/env Rscript
 
-# Setup MAKEFLAGS for parallel compilation
+# Setup MAKEFLAGS for parallel compilation.
 # Based on the approach used by Apache Arrow R package
 # Only sets MAKEFLAGS if not already set (respects user preferences)
 

--- a/scripts/vendor-one.sh
+++ b/scripts/vendor-one.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Vendors DuckDB sources commit-by-commit from upstream repository
+# Vendors DuckDB sources commit-by-commit from the upstream repository.
 # Used by the series loop (.claude/skills/series-loop.md)
 # See scripts/VENDORING.md for complete documentation
 # https://unix.stackexchange.com/a/654932/19205

--- a/scripts/vendor-rfuns.sh
+++ b/scripts/vendor-rfuns.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# Vendor the rfuns extension: copy sources from a duckdb-rfuns checkout
+# into src/ and commit with the upstream log, one commit per import.
 
 set -e
 set -x

--- a/scripts/vendor.sh
+++ b/scripts/vendor.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Vendors DuckDB sources from upstream repository (manual vendoring)
+# Vendors DuckDB sources from the upstream repository (manual vendoring).
 # For manual testing and development use
 # See scripts/VENDORING.md for complete documentation
 # https://unix.stackexchange.com/a/654932/19205


### PR DESCRIPTION
## What this is

Split out of #2447 so the comment-only changes can merge on their own.

Every file in `scripts/` gets a first comment line that states what it is,
extractable as a one-line description by the directory index
proposed in #2447 — and useful on its own to anyone opening the file.

Five scripts had no leading comment at all
(`flavor.sh`, `rconfigure.py`, `rethrow.R`,
`python_helpers.py`, `vendor-rfuns.sh`);
four more had a first line without sentence punctuation,
so a first-sentence extractor reads them as a run-on
(`vendor.sh`, `vendor-one.sh`, `setup-makeflags.R`, `format.py`).

Comment-only; no behavior change.
`^scripts$` is in `.Rbuildignore`, so nothing reaches the tarball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193eYv8K8VQQnTyDKjDN68r