### PR TITLE
fix(rcc): Do not restore the persistent ccache under R-devel

### DIFF
--- a/.github/workflows/custom/after-install/action.yml
+++ b/.github/workflows/custom/after-install/action.yml
@@ -18,14 +18,33 @@ runs:
         path: ${{ env.DUCKDB_R_PREBUILT_ARCHIVE }}
         key: ${{ env.DUCKDB_R_PREBUILT_ARCHIVE_GHA_CACHE_KEY }}
 
+    - name: Detect an unreleased R
+      run: |
+        ## -- Detect an unreleased R --
+        # The persistent ccache below is keyed on getRversion(), and that key is
+        # only honest for a released R, where the version number changes
+        # whenever the installation does. R-devel is rebuilt every day but keeps
+        # reporting the same number for months, so one cache entry ends up
+        # serving an arbitrary span of R-devel snapshots -- and restoring it in
+        # the rcc R-devel job has produced build failures. Skip the persistent
+        # cache there and build cold; ccache itself stays configured by the
+        # install action, so reuse within the job is unaffected.
+        #
+        # R.version$status is empty for a released R and non-empty for one that
+        # moves under a fixed version number ("Under development (unstable)" for
+        # R-devel, "Patched" for R-patched) -- exactly the builds the key cannot
+        # tell apart.
+        echo "DUCKDB_R_UNRELEASED=$(Rscript --vanilla -e 'cat(if (nzchar(R.version$status)) "1" else "0")')" | tee -a $GITHUB_ENV
+      shell: bash
+
     - name: Compute ccache key
-      if: env.DUCKDB_R_USE_SYSTEM_LIB != '1'
+      if: env.DUCKDB_R_USE_SYSTEM_LIB != '1' && env.DUCKDB_R_UNRELEASED != '1'
       run: |
         echo "GHA_CCACHE_KEY=${{ runner.os }}-$($(R CMD config CXX) --version | head -n 1 | sed -r 's/[, ]/-/g')-R-$(Rscript --vanilla -e 'cat(format(getRversion()))')" | tee -a $GITHUB_ENV
       shell: bash
 
     - name: Install persistent ccache
-      if: env.DUCKDB_R_USE_SYSTEM_LIB != '1'
+      if: env.DUCKDB_R_USE_SYSTEM_LIB != '1' && env.DUCKDB_R_UNRELEASED != '1'
       uses: hendrikmuhs/ccache-action@v1.2.14
       with:
         key: ${{ env.GHA_CCACHE_KEY }}


### PR DESCRIPTION
The persistent ccache in `.github/workflows/custom/after-install/action.yml` is keyed on `getRversion()`,
which is only an honest key for a released R,
where the version number changes whenever the installation does.
R-devel is rebuilt every day but keeps reporting the same number for months,
so a single cache entry ends up serving an arbitrary span of R-devel snapshots
— and restoring it in the rcc R-devel job has produced build failures.

## What changed

- A new step detects an unreleased R via `R.version$status`,
  which is empty for a released R and non-empty for one whose contents move under a fixed version number
  (`Under development (unstable)` for R-devel, `Patched` for R-patched),
  and exports the result as `DUCKDB_R_UNRELEASED`.
- `Compute ccache key` and `Install persistent ccache` now also require `DUCKDB_R_UNRELEASED != '1'`,
  so the `hendrikmuhs/ccache-action` restore/save is skipped entirely on those builds.

## Effect

R-devel (and R-patched) jobs build cold.
Every other matrix entry is unchanged.

ccache itself is still installed and wired into `~/.R/Makevars` by `.github/workflows/install`,
which runs before this action,
so reuse *within* a job — the `R CMD INSTALL` here and the later `R CMD check` install — is unaffected;
only the cross-run cache is dropped.
`Show ccache stats` keeps working for the same reason.

The guard lives in the custom after-install action rather than in `R-CMD-check.yaml`
because a composite action cannot read the matrix context,
and because the problem is the installed R, not the job:
the same guard covers `rcc dev`, `pkgdown`, and `copilot-setup-steps`,
none of which currently run on R-devel.

The neighbouring `duckdb.tar` archive cache is keyed on `getRversion()` too,
but its contents are the vendored DuckDB objects, which carry no R headers,
so it is left alone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NQDtgpKBU6tCwXQYfBD3Mg)_