### PR TITLE
docs(handbook): Record the forms the first wave of leaves assumes

### DIFF
--- a/handbook/meta/handbook/README.md
+++ b/handbook/meta/handbook/README.md
@@ -66,7 +66,8 @@ and it is written for an agent starting with clean context:
   a root `README.md` section, a reference page,
   a directory index — gains a backreference to the leaf.
   Free-floating `.md` files shrink as their content lands here;
-  a fully absorbed file becomes a one-line tombstone.
+  a fully absorbed file goes away, and its directory's in-place
+  `README.md` — the index GitHub renders there — routes on in its place.
 * **Verify before you state.**
   Check every behavioral claim against the ground truth the stub
   names; check engine-configuration claims against a vendored
@@ -85,6 +86,64 @@ and it is written for an agent starting with clean context:
   Delete the "To write this leaf" section and the stub notice;
   keep internal nodes navigation-only;
   leave no dangling links.
+
+## The forms
+
+The rules above say what a page must do;
+these are the shapes the tree has settled on for doing it.
+They exist so that leaves written independently read as one document.
+
+**A written leaf** opens with its H1
+and then a scope sentence in ordinary prose —
+no `Scope:` label, that scaffolding belongs to stubs —
+and continues with the content.
+The scope sentence survives the stub because the tree's shape
+depends on every leaf declaring its boundary.
+A one-screen leaf needs no headings; a longer one uses `##`.
+
+**An absorbed file goes away.**
+There are no tombstones:
+a `.md` whose content has landed in a leaf is deleted,
+not left behind as a one-line redirect.
+What replaces it is the **in-place `README.md`** —
+the index GitHub renders when someone browses to that directory.
+The index is generated, one row per file,
+grouped by the handbook leaf that owns each file's topic
+([`scripts/README.md`](../../../scripts/README.md) is the worked example);
+regenerating it is how it stays true,
+and the generator's file-to-leaf mapping is what a change edits,
+never the rendered table.
+A file only partly absorbed keeps its remaining sections,
+and each absorbed heading becomes a one-line pointer to the leaf.
+
+**A backreference is how a leaf is discovered from the source tree.**
+Someone standing in `scripts/` finds the leaf that explains what they
+are looking at without knowing the handbook exists —
+which is the whole point, and the reason absorbing content
+never strands the reader who goes looking at the old address.
+The generated index carries the backreference for every file it covers —
+today that is `scripts/` alone,
+and extending the generator to the other directories that hold
+documentation is open work, not a settled shape.
+Where no index covers a document, it carries its own:
+
+* *Markdown* — a visible italic line directly under the H1,
+  linking the leaf by repo-relative path.
+  Several leaves serving one file share the one line.
+  This holds for the root `README.md` too,
+  which already links `AGENTS.md` and `plan/README.md` the same way
+  even though CRAN renders it from a tarball
+  where `.Rbuildignore` has removed them.
+* *Source files* — a plain source comment,
+  above the roxygen block or below the script's one-line header.
+  Never a roxygen `#'` line:
+  `handbook/` is `.Rbuildignore`d,
+  so a reference page linking into it would be broken for users.
+
+Prose absorbed into a leaf may be rewritten —
+the handbook's voice is tighter than its sources' —
+but a rewrite that loses a fact is a regression, not an edit.
+All prose in the tree uses [semantic line breaks](https://sembr.org).
 
 ## Enforcement
 


### PR DESCRIPTION
Groundwork for a wave of one-PR-per-stub leaf writes.
The rules said what a page must *do* but not what the doing *looks like*,
so leaves written independently would each settle their own shape.
This fixes the three shapes that recur, as a new `## The forms` section
in `handbook/meta/handbook/`, plus one correction to the rules above it.

## What this changes

**A written leaf** opens with its H1, then a scope sentence in ordinary
prose — no `Scope:` label, that scaffolding belongs to stubs — then the
content. The scope sentence survives the stub because the tree's shape
depends on every leaf declaring its boundary.

**A fully absorbed `.md` goes away.** No tombstones. The in-place
`README.md` that GitHub renders in that directory routes on in its
place: generated, one row per file, grouped by the owning leaf — the way
[`scripts/README.md`](scripts/README.md) already does it. A change edits
the generator's file-to-leaf mapping, never the rendered table. A file
only *partly* absorbed keeps its remaining sections, and each absorbed
heading becomes a one-line pointer.

This corrects the "Move, don't copy" bullet, which previously said a
fully absorbed file becomes a one-line tombstone.

**A backreference is how a leaf is discovered from the source tree.**
Someone standing in `scripts/` finds the leaf that explains what they
are looking at without knowing the handbook exists — which is why
absorbing content never strands the reader who goes to the old address.
The generated index carries it where one exists; the document carries
its own where none does:

* Markdown — a visible italic line under the H1, repo-relative link.
  This holds for the root `README.md` too, which already links
  `AGENTS.md` and `plan/README.md` that way even though CRAN renders it
  from a tarball where `.Rbuildignore` has removed them.
* Source files — a plain source comment, above the roxygen block or
  below the script's one-line header. Never a roxygen `#'` line:
  `handbook/` is `.Rbuildignore`d, so a reference page linking into it
  would be broken for users.

## Assumptions a reviewer should confirm

* **Index coverage is `scripts/` only today.** The section says so
  in the text rather than hiding it — extending `docs-readme.R` to the
  other directories that hold documentation is called out as open work,
  not a settled shape. Root-level `.md` files therefore have no
  generated index to route on their behalf yet.
* **Root `README.md` gets a visible link, not an HTML comment.** It
  ships to CRAN, where a relative link into `.Rbuildignore`d
  `handbook/` does not resolve — but the file already links `AGENTS.md`,
  `BRANCHES.md`, and `plan/README.md` exactly that way, so a hidden
  backreference would have been a new and inconsistent rule.
* **Semantic line breaks** are stated as the tree's prose convention.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PD23hjFQFRWW62HFvru187)_