### PR TITLE
docs: Write every upward link from the repository root

### DIFF
--- a/.claude/skills/docs-consistency/SKILL.md
+++ b/.claude/skills/docs-consistency/SKILL.md
@@ -1,7 +1,7 @@
 # Documentation consistency
 
 The enforcement arm of the handbook rules
-([`handbook/meta/handbook/`](../../../handbook/meta/handbook/README.md)):
+([`handbook/meta/handbook/`](/handbook/meta/handbook/README.md)):
 the checks that keep the documentation system whole.
 Run it when a change touches documentation —
 handbook pages, free-floating `.md` files, script headers,
@@ -29,7 +29,10 @@ Helpers are not entry points of their own.
    and a `To write this leaf` section last.
 
 2. **Link integrity** (mechanical).
-   Every relative link under `handbook/` resolves.
+   Every link under `handbook/` resolves,
+   and no link traverses upward with `../`
+   (the rules, "The forms": a link that leaves its own directory
+   is written from the repository root).
 
    ```sh
    python3 - <<'EOF'
@@ -40,8 +43,13 @@ Helpers are not entry points of their own.
            p = os.path.join(dirpath, f)
            for m in re.finditer(r"\]\(([^)#]+?)\)", open(p).read()):
                t = m.group(1)
-               if not t.startswith("http") and not os.path.exists(
-                       os.path.normpath(os.path.join(dirpath, t))):
+               if t.startswith("http"):
+                   continue
+               if t.startswith(".."):
+                   print("UPWARD", p, t); bad += 1
+                   continue
+               base = "." if t.startswith("/") else dirpath
+               if not os.path.exists(os.path.normpath(base + "/" + t)):
                    print("DANGLING", p, t); bad += 1
    sys.exit(1 if bad else 0)
    EOF
@@ -66,7 +74,7 @@ Helpers are not entry points of their own.
    report it with a proposed leaf address —
    an unaddressable path is a defect of the tree,
    per the address rule in
-   [`handbook/operations/triage/`](../../../handbook/operations/triage/README.md).
+   [`handbook/operations/triage/`](/handbook/operations/triage/README.md).
 
 5. **Backreferences** (judgment).
    The tree is the single source of truth;
@@ -94,5 +102,5 @@ Helpers are not entry points of their own.
 
 The rules define, this skill enforces:
 when the two disagree,
-[`handbook/meta/handbook/`](../../../handbook/meta/handbook/README.md)
+[`handbook/meta/handbook/`](/handbook/meta/handbook/README.md)
 is the authority, and the fix lands there first.

--- a/.claude/skills/docs-consistency/docs-readme.R
+++ b/.claude/skills/docs-consistency/docs-readme.R
@@ -180,7 +180,7 @@ owner_heading <- function(g) {
     stop("dangling owner: ", g$owner)
   }
   name <- paste0(sub("^handbook/", "", g$owner), "/")
-  rel <- paste0("../", g$owner, "/")
+  rel <- paste0("/", g$owner, "/")
   paste0("## [`", name, "`](", rel, ")")
 }
 
@@ -201,8 +201,8 @@ out <- c(
   "with the purpose taken from the file's own header line",
   "and the grouping from the handbook leaf that owns the topic —",
   "ownership by topic, navigation by place",
-  "([the rules](../handbook/meta/handbook/README.md)).",
-  "Root of the documentation tree: [`handbook/`](../handbook/).",
+  "([the rules](/handbook/meta/handbook/README.md)).",
+  "Root of the documentation tree: [`handbook/`](/handbook/).",
   ""
 )
 

--- a/.claude/skills/series-loop.md
+++ b/.claude/skills/series-loop.md
@@ -206,7 +206,7 @@ nothing at or before `<S>-green` is ever re-examined.
 A commit **missing** from the harvest has not completed —
 wait, do not guess.
 `each.yaml`'s legs publish a record within seconds of deciding a commit
-(see [`EACH.md`](../../scripts/EACH.md) §3),
+(see [`EACH.md`](/scripts/EACH.md) §3),
 so missing now means undecided, not merely uncollected.
 
 If a commit is still missing after **12 hours**, presume its run lost —

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
 # GitHub Copilot Instructions for duckdb Package
 
-Read and follow the development guidelines outlined in [AGENTS.md](../AGENTS.md).
+Read and follow the development guidelines outlined in [AGENTS.md](/AGENTS.md).
 
 ## Working Effectively
 

--- a/handbook/architecture/engine/README.md
+++ b/handbook/architecture/engine/README.md
@@ -2,7 +2,7 @@
 
 *Stub — this leaf will own its topic;
 today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../meta/handbook/);
+The writing protocol is in [`meta/handbook/`](/handbook/meta/handbook/);
 the last section holds this leaf's parameters.*
 
 Scope: the DuckDB engine embedded in `src/duckdb/`:
@@ -15,10 +15,10 @@ Today:
   the engine's own documentation, which this tree does not duplicate
 * [duckdb/duckdb](https://github.com/duckdb/duckdb) —
   the upstream sources and internals
-* [`R/version.R`](../../../R/version.R) —
+* [`R/version.R`](/R/version.R) —
   the embedded engine version, generated at vendor time
 * how the embedded copy is maintained is
-  [`operations/vendoring/`](../../operations/vendoring/), not here
+  [`operations/vendoring/`](/handbook/operations/vendoring/), not here
 
 To write this leaf:
 

--- a/handbook/architecture/glue/README.md
+++ b/handbook/architecture/glue/README.md
@@ -2,7 +2,7 @@
 
 *Stub — this leaf will own its topic;
 today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../meta/handbook/);
+The writing protocol is in [`meta/handbook/`](/handbook/meta/handbook/);
 the last section holds this leaf's parameters.*
 
 Scope: the translation units bridging R and DuckDB —
@@ -12,9 +12,9 @@ formatting, and the no-warning-suppression policy.
 
 Today:
 
-* [`AGENTS.md`](../../../AGENTS.md) — "C++ Glue Code Conventions"
+* [`AGENTS.md`](/AGENTS.md) — "C++ Glue Code Conventions"
   and "C++ Warning Policy"
-* [`scripts/format.py`](../../../scripts/format.py) —
+* [`scripts/format.py`](/scripts/format.py) —
   formats `src/`, driven by the Makefile's `format-*` targets
 
 To write this leaf:

--- a/handbook/architecture/r-layer/README.md
+++ b/handbook/architecture/r-layer/README.md
@@ -2,7 +2,7 @@
 
 *Stub — this leaf will own its topic;
 today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../meta/handbook/);
+The writing protocol is in [`meta/handbook/`](/handbook/meta/handbook/);
 the last section holds this leaf's parameters.*
 
 Scope: the file-per-method layout, generated files,
@@ -11,7 +11,7 @@ and deferred S3 registration.
 
 Today:
 
-* [`AGENTS.md`](../../../AGENTS.md) — "Never Hard-Code the Package Name"
+* [`AGENTS.md`](/AGENTS.md) — "Never Hard-Code the Package Name"
 
 To write this leaf:
 

--- a/handbook/branches/flavors/README.md
+++ b/handbook/branches/flavors/README.md
@@ -2,7 +2,7 @@
 
 *Stub — this leaf will own its topic;
 today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../meta/handbook/);
+The writing protocol is in [`meta/handbook/`](/handbook/meta/handbook/);
 the last section holds this leaf's parameters.*
 
 Scope: one source tree published under many names
@@ -10,7 +10,7 @@ Scope: one source tree published under many names
 
 Today:
 
-* [`BRANCHES.md`](../../../BRANCHES.md#r-package-flavors)
+* [`BRANCHES.md`](/BRANCHES.md#r-package-flavors)
 
 To write this leaf:
 

--- a/handbook/branches/invariants/README.md
+++ b/handbook/branches/invariants/README.md
@@ -2,14 +2,14 @@
 
 *Stub — this leaf will own its topic;
 today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../meta/handbook/);
+The writing protocol is in [`meta/handbook/`](/handbook/meta/handbook/);
 the last section holds this leaf's parameters.*
 
 Scope: what every series guarantees: green, bisectable, vendorable.
 
 Today:
 
-* [`BRANCHES.md`](../../../BRANCHES.md)
+* [`BRANCHES.md`](/BRANCHES.md)
 
 To write this leaf:
 

--- a/handbook/branches/model/README.md
+++ b/handbook/branches/model/README.md
@@ -2,7 +2,7 @@
 
 *Stub — this leaf will own its topic;
 today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../meta/handbook/);
+The writing protocol is in [`meta/handbook/`](/handbook/meta/handbook/);
 the last section holds this leaf's parameters.*
 
 Scope: the series and their `-dev` / `-build` / `-green` refs,
@@ -10,7 +10,7 @@ and how they advance.
 
 Today:
 
-* [`BRANCHES.md`](../../../BRANCHES.md)
+* [`BRANCHES.md`](/BRANCHES.md)
 
 To write this leaf:
 

--- a/handbook/build/configuration/README.md
+++ b/handbook/build/configuration/README.md
@@ -2,7 +2,7 @@
 
 *Stub — this leaf will own its topic;
 today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../meta/handbook/);
+The writing protocol is in [`meta/handbook/`](/handbook/meta/handbook/);
 the last section holds this leaf's parameters.*
 
 Scope: the build knobs: `MAKEFLAGS`, ccache, `UserNM`,
@@ -10,7 +10,7 @@ and the extension flags.
 
 Today:
 
-* [`AGENTS.md`](../../../AGENTS.md)
+* [`AGENTS.md`](/AGENTS.md)
 
 To write this leaf:
 

--- a/handbook/build/fast-paths/README.md
+++ b/handbook/build/fast-paths/README.md
@@ -2,7 +2,7 @@
 
 *Stub — this leaf will own its topic;
 today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../meta/handbook/);
+The writing protocol is in [`meta/handbook/`](/handbook/meta/handbook/);
 the last section holds this leaf's parameters.*
 
 Scope: linking a prebuilt libduckdb (`DUCKDB_R_USE_SYSTEM_LIB`)
@@ -10,8 +10,8 @@ for seconds-long builds and test loops.
 
 Today:
 
-* [`AGENTS.md`](../../../AGENTS.md) — "Fast build with system libduckdb"
-* [`scripts/install-libduckdb.sh`](../../../scripts/install-libduckdb.sh)
+* [`AGENTS.md`](/AGENTS.md) — "Fast build with system libduckdb"
+* [`scripts/install-libduckdb.sh`](/scripts/install-libduckdb.sh)
 
 To write this leaf:
 

--- a/handbook/build/source-build/README.md
+++ b/handbook/build/source-build/README.md
@@ -2,7 +2,7 @@
 
 *Stub — this leaf will own its topic;
 today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../meta/handbook/);
+The writing protocol is in [`meta/handbook/`](/handbook/meta/handbook/);
 the last section holds this leaf's parameters.*
 
 Scope: `configure`, `src/Makevars.in` and the `.mk` includes,
@@ -10,7 +10,7 @@ Scope: `configure`, `src/Makevars.in` and the `.mk` includes,
 
 Today:
 
-* [`AGENTS.md`](../../../AGENTS.md) — "Bootstrap, Build, and Test the Repository"
+* [`AGENTS.md`](/AGENTS.md) — "Bootstrap, Build, and Test the Repository"
 
 To write this leaf:
 

--- a/handbook/contributors/setup/README.md
+++ b/handbook/contributors/setup/README.md
@@ -2,7 +2,7 @@
 
 *Stub — this leaf will own its topic;
 today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../meta/handbook/);
+The writing protocol is in [`meta/handbook/`](/handbook/meta/handbook/);
 the last section holds this leaf's parameters.*
 
 Scope: a working development environment in minutes —
@@ -10,7 +10,7 @@ clone, fast build, test loop.
 
 Today:
 
-* [`AGENTS.md`](../../../AGENTS.md) — the bootstrap and fast-path sections
+* [`AGENTS.md`](/AGENTS.md) — the bootstrap and fast-path sections
 
 To write this leaf:
 

--- a/handbook/contributors/where-to-help/README.md
+++ b/handbook/contributors/where-to-help/README.md
@@ -2,7 +2,7 @@
 
 *Stub — this leaf will own its topic;
 today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../meta/handbook/);
+The writing protocol is in [`meta/handbook/`](/handbook/meta/handbook/);
 the last section holds this leaf's parameters.*
 
 Scope: finding work — the labels, good entry points, the roadmap.

--- a/handbook/contributors/workflow/README.md
+++ b/handbook/contributors/workflow/README.md
@@ -2,7 +2,7 @@
 
 *Stub — this leaf will own its topic;
 today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../meta/handbook/);
+The writing protocol is in [`meta/handbook/`](/handbook/meta/handbook/);
 the last section holds this leaf's parameters.*
 
 Scope: making a change, from branch to merged pull request.
@@ -10,7 +10,7 @@ Scope: making a change, from branch to merged pull request.
 Today:
 
 * no single owner today;
-  [`.github/copilot-instructions.md`](../../../.github/copilot-instructions.md)
+  [`.github/copilot-instructions.md`](/.github/copilot-instructions.md)
   carries a fragment
 
 To write this leaf:

--- a/handbook/meta/handbook/README.md
+++ b/handbook/meta/handbook/README.md
@@ -20,7 +20,7 @@ has exactly one place in this tree.
   "Can it do X?" is answered at X's leaf, whichever way it goes.
 * **Full cover.**
   Every fact is reachable by walking down from
-  [`handbook/`](../../README.md);
+  [`handbook/`](/handbook/README.md);
   a topic with no place in the tree is a defect of the tree,
   not of the topic.
 * **Pointer leaves are legitimate.**
@@ -109,7 +109,7 @@ What replaces it is the **in-place `README.md`** —
 the index GitHub renders when someone browses to that directory.
 The index is generated, one row per file,
 grouped by the handbook leaf that owns each file's topic
-([`scripts/README.md`](../../../scripts/README.md) is the worked example);
+([`scripts/README.md`](/scripts/README.md) is the worked example);
 regenerating it is how it stays true,
 and the generator's file-to-leaf mapping is what a change edits,
 never the rendered table.
@@ -139,6 +139,23 @@ Where no index covers a document, it carries its own:
   Never a roxygen `#'` line:
   `handbook/` is `.Rbuildignore`d,
   so a reference page linking into it would be broken for users.
+
+**A link that leaves its own directory is written from the repository
+root**, with a leading `/` — `/handbook/usage/types/`, not
+`../../usage/types/`. GitHub resolves such a link against the
+repository root and rewrites it for whatever branch the reader is on,
+so it works unchanged on `main`, on a pull request head, and in a fork.
+Same-directory and downward links stay relative, as they are already
+correct and already short.
+The tree is four levels deep in places,
+and a `../../../../` chain is both unreadable and wrong the moment a
+page moves — which, in a hierarchy that is still settling, it will.
+This follows the
+[Google Markdown style guide](https://google.github.io/styleguide/docguide/style.html#links),
+which discourages exactly the upward form and nothing else.
+The cost is that such a link does not resolve in a local Markdown
+preview, which has no notion of a repository root;
+the handbook is read on GitHub, and that is the trade taken.
 
 Prose absorbed into a leaf may be rewritten —
 the handbook's voice is tighter than its sources' —

--- a/handbook/meta/handbook/README.md
+++ b/handbook/meta/handbook/README.md
@@ -66,7 +66,8 @@ and it is written for an agent starting with clean context:
   a root `README.md` section, a reference page,
   a directory index — gains a backreference to the leaf.
   Free-floating `.md` files shrink as their content lands here;
-  a fully absorbed file becomes a one-line tombstone.
+  a fully absorbed file goes away, and its directory's in-place
+  `README.md` — the index GitHub renders there — routes on in its place.
 * **Verify before you state.**
   Check every behavioral claim against the ground truth the stub
   names; check engine-configuration claims against a vendored
@@ -85,6 +86,64 @@ and it is written for an agent starting with clean context:
   Delete the "To write this leaf" section and the stub notice;
   keep internal nodes navigation-only;
   leave no dangling links.
+
+## The forms
+
+The rules above say what a page must do;
+these are the shapes the tree has settled on for doing it.
+They exist so that leaves written independently read as one document.
+
+**A written leaf** opens with its H1
+and then a scope sentence in ordinary prose —
+no `Scope:` label, that scaffolding belongs to stubs —
+and continues with the content.
+The scope sentence survives the stub because the tree's shape
+depends on every leaf declaring its boundary.
+A one-screen leaf needs no headings; a longer one uses `##`.
+
+**An absorbed file goes away.**
+There are no tombstones:
+a `.md` whose content has landed in a leaf is deleted,
+not left behind as a one-line redirect.
+What replaces it is the **in-place `README.md`** —
+the index GitHub renders when someone browses to that directory.
+The index is generated, one row per file,
+grouped by the handbook leaf that owns each file's topic
+([`scripts/README.md`](../../../scripts/README.md) is the worked example);
+regenerating it is how it stays true,
+and the generator's file-to-leaf mapping is what a change edits,
+never the rendered table.
+A file only partly absorbed keeps its remaining sections,
+and each absorbed heading becomes a one-line pointer to the leaf.
+
+**A backreference is how a leaf is discovered from the source tree.**
+Someone standing in `scripts/` finds the leaf that explains what they
+are looking at without knowing the handbook exists —
+which is the whole point, and the reason absorbing content
+never strands the reader who goes looking at the old address.
+The generated index carries the backreference for every file it covers —
+today that is `scripts/` alone,
+and extending the generator to the other directories that hold
+documentation is open work, not a settled shape.
+Where no index covers a document, it carries its own:
+
+* *Markdown* — a visible italic line directly under the H1,
+  linking the leaf by repo-relative path.
+  Several leaves serving one file share the one line.
+  This holds for the root `README.md` too,
+  which already links `AGENTS.md` and `plan/README.md` the same way
+  even though CRAN renders it from a tarball
+  where `.Rbuildignore` has removed them.
+* *Source files* — a plain source comment,
+  above the roxygen block or below the script's one-line header.
+  Never a roxygen `#'` line:
+  `handbook/` is `.Rbuildignore`d,
+  so a reference page linking into it would be broken for users.
+
+Prose absorbed into a leaf may be rewritten —
+the handbook's voice is tighter than its sources' —
+but a rewrite that loses a fact is a regression, not an edit.
+All prose in the tree uses [semantic line breaks](https://sembr.org).
 
 ## Enforcement
 

--- a/handbook/meta/plans/README.md
+++ b/handbook/meta/plans/README.md
@@ -2,17 +2,17 @@
 
 *Stub — this leaf will own its topic;
 today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../meta/handbook/);
+The writing protocol is in [`meta/handbook/`](/handbook/meta/handbook/);
 the last section holds this leaf's parameters.*
 
 Scope: active designs, superseded records, and the roadmap —
-intent lives as a plan under [`plan/`](../../../plan),
+intent lives as a plan under [`plan/`](/plan),
 and what is live, in which order, is its README's table;
 each affected leaf points at the plan that concerns it.
 
 Today:
 
-* [`plan/README.md`](../../../plan/README.md)
+* [`plan/README.md`](/plan/README.md)
 
 To write this leaf:
 

--- a/handbook/operations/ci/matrix/README.md
+++ b/handbook/operations/ci/matrix/README.md
@@ -2,15 +2,15 @@
 
 *Stub — this leaf will own its topic;
 today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../../meta/handbook/);
+The writing protocol is in [`meta/handbook/`](/handbook/meta/handbook/);
 the last section holds this leaf's parameters.*
 
-Scope: [`.github/versions-matrix.R`](../../../../.github/versions-matrix.R):
+Scope: [`.github/versions-matrix.R`](/.github/versions-matrix.R):
 platforms, R versions, and the fast-path defaults.
 
 Today:
 
-* [`AGENTS.md`](../../../../AGENTS.md) — "Testing with prebuilt DuckDB"
+* [`AGENTS.md`](/AGENTS.md) — "Testing with prebuilt DuckDB"
 
 To write this leaf:
 

--- a/handbook/operations/ci/per-commit/README.md
+++ b/handbook/operations/ci/per-commit/README.md
@@ -2,14 +2,14 @@
 
 *Stub — this leaf will own its topic;
 today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../../meta/handbook/);
+The writing protocol is in [`meta/handbook/`](/handbook/meta/handbook/);
 the last section holds this leaf's parameters.*
 
 Scope: the sharded per-commit build system and its verdict store.
 
 Today:
 
-* [`scripts/EACH.md`](../../../../scripts/EACH.md)
+* [`scripts/EACH.md`](/scripts/EACH.md)
 
 To write this leaf:
 

--- a/handbook/operations/ci/workflows/README.md
+++ b/handbook/operations/ci/workflows/README.md
@@ -2,10 +2,10 @@
 
 *Stub — this leaf will own its topic;
 today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../../meta/handbook/);
+The writing protocol is in [`meta/handbook/`](/handbook/meta/handbook/);
 the last section holds this leaf's parameters.*
 
-Scope: the inventory under [`.github/workflows/`](../../../../.github/workflows):
+Scope: the inventory under [`.github/workflows/`](/.github/workflows):
 what each gates, and where it runs.
 
 Today:

--- a/handbook/operations/releases/cran/README.md
+++ b/handbook/operations/releases/cran/README.md
@@ -2,15 +2,15 @@
 
 *Stub — this leaf will own its topic;
 today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../../meta/handbook/);
+The writing protocol is in [`meta/handbook/`](/handbook/meta/handbook/);
 the last section holds this leaf's parameters.*
 
 Scope: submission mechanics and CRAN policy constraints.
 
 Today:
 
-* [`RELEASE.md`](../../../../RELEASE.md)
-* [`cran-comments.md`](../../../../cran-comments.md)
+* [`RELEASE.md`](/RELEASE.md)
+* [`cran-comments.md`](/cran-comments.md)
 
 To write this leaf:
 

--- a/handbook/operations/releases/process/README.md
+++ b/handbook/operations/releases/process/README.md
@@ -2,14 +2,14 @@
 
 *Stub — this leaf will own its topic;
 today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../../meta/handbook/);
+The writing protocol is in [`meta/handbook/`](/handbook/meta/handbook/);
 the last section holds this leaf's parameters.*
 
 Scope: the release process, modelled as a state machine.
 
 Today:
 
-* [`RELEASE.md`](../../../../RELEASE.md)
+* [`RELEASE.md`](/RELEASE.md)
 
 To write this leaf:
 

--- a/handbook/operations/releases/versioning/README.md
+++ b/handbook/operations/releases/versioning/README.md
@@ -2,14 +2,14 @@
 
 *Stub — this leaf will own its topic;
 today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../../meta/handbook/);
+The writing protocol is in [`meta/handbook/`](/handbook/meta/handbook/);
 the last section holds this leaf's parameters.*
 
 Scope: the version counters, fledge, and `NEWS.md`.
 
 Today:
 
-* [`RELEASE.md`](../../../../RELEASE.md)
+* [`RELEASE.md`](/RELEASE.md)
 
 To write this leaf:
 

--- a/handbook/operations/review/README.md
+++ b/handbook/operations/review/README.md
@@ -2,7 +2,7 @@
 
 *Stub — this leaf will own its topic;
 today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../meta/handbook/);
+The writing protocol is in [`meta/handbook/`](/handbook/meta/handbook/);
 the last section holds this leaf's parameters.*
 
 Scope: pull-request flow —
@@ -12,7 +12,7 @@ and the stewardship routines that watch open pull requests.
 Today:
 
 * no single owner today;
-  [`.github/copilot-instructions.md`](../../../.github/copilot-instructions.md)
+  [`.github/copilot-instructions.md`](/.github/copilot-instructions.md)
   carries a fragment
 
 To write this leaf:

--- a/handbook/operations/triage/README.md
+++ b/handbook/operations/triage/README.md
@@ -2,7 +2,7 @@
 
 *Stub — this leaf will own its topic;
 today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../meta/handbook/);
+The writing protocol is in [`meta/handbook/`](/handbook/meta/handbook/);
 the last section holds this leaf's parameters.*
 
 Scope: issue intake —

--- a/handbook/operations/vendoring/model/README.md
+++ b/handbook/operations/vendoring/model/README.md
@@ -2,7 +2,7 @@
 
 *Stub — this leaf will own its topic;
 today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../../meta/handbook/);
+The writing protocol is in [`meta/handbook/`](/handbook/meta/handbook/);
 the last section holds this leaf's parameters.*
 
 Scope: why the engine is vendored,
@@ -10,7 +10,7 @@ and the one-commit-per-upstream-commit invariant.
 
 Today:
 
-* [`scripts/VENDORING.md`](../../../../scripts/VENDORING.md)
+* [`scripts/VENDORING.md`](/scripts/VENDORING.md)
 
 To write this leaf:
 

--- a/handbook/operations/vendoring/pipeline/README.md
+++ b/handbook/operations/vendoring/pipeline/README.md
@@ -2,7 +2,7 @@
 
 *Stub — this leaf will own its topic;
 today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../../meta/handbook/);
+The writing protocol is in [`meta/handbook/`](/handbook/meta/handbook/);
 the last section holds this leaf's parameters.*
 
 Scope: `vendor-one.sh`, `rconfigure.py`, the patch stack,
@@ -11,8 +11,8 @@ mergeable across vendor commits.
 
 Today:
 
-* [`scripts/VENDORING.md`](../../../../scripts/VENDORING.md)
-* [`scripts/merge-version.sh`](../../../../scripts/merge-version.sh)
+* [`scripts/VENDORING.md`](/scripts/VENDORING.md)
+* [`scripts/merge-version.sh`](/scripts/merge-version.sh)
 * a generated `scripts/` directory index is proposed in
   [#2447](https://github.com/duckdb/duckdb-r/pull/2447)
 

--- a/handbook/operations/vendoring/series-loop/README.md
+++ b/handbook/operations/vendoring/series-loop/README.md
@@ -2,7 +2,7 @@
 
 *Stub — this leaf will own its topic;
 today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../../meta/handbook/);
+The writing protocol is in [`meta/handbook/`](/handbook/meta/handbook/);
 the last section holds this leaf's parameters.*
 
 Scope: the scheduled routine that vendors every series —
@@ -10,8 +10,8 @@ its stages, its playbooks, and when it fires.
 
 Today:
 
-* [`.claude/skills/series-loop.md`](../../../../.claude/skills/series-loop.md)
-* [`.claude/skills/`](../../../../.claude/skills) —
+* [`.claude/skills/series-loop.md`](/.claude/skills/series-loop.md)
+* [`.claude/skills/`](/.claude/skills) —
   the sibling playbooks (`series-forward`, `series-rebase`, `series-open`),
   machine-loaded from there
 

--- a/handbook/operations/vendoring/troubleshooting/README.md
+++ b/handbook/operations/vendoring/troubleshooting/README.md
@@ -2,7 +2,7 @@
 
 *Stub — this leaf will own its topic;
 today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../../meta/handbook/);
+The writing protocol is in [`meta/handbook/`](/handbook/meta/handbook/);
 the last section holds this leaf's parameters.*
 
 Scope: when a run is red —
@@ -11,8 +11,8 @@ stuck shards, stale snapshots.
 
 Today:
 
-* [`scripts/VENDORING.md`](../../../../scripts/VENDORING.md)
-* [`scripts/EACH.md`](../../../../scripts/EACH.md)
+* [`scripts/VENDORING.md`](/scripts/VENDORING.md)
+* [`scripts/EACH.md`](/scripts/EACH.md)
 
 To write this leaf:
 

--- a/handbook/testing/guards/README.md
+++ b/handbook/testing/guards/README.md
@@ -2,15 +2,15 @@
 
 *Stub — this leaf will own its topic;
 today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../meta/handbook/);
+The writing protocol is in [`meta/handbook/`](/handbook/meta/handbook/);
 the last section holds this leaf's parameters.*
 
 Scope: the CRAN test guard and the flavor-name guard.
 
 Today:
 
-* [`scripts/flavor-package-name.R`](../../../scripts/flavor-package-name.R)
-* [`AGENTS.md`](../../../AGENTS.md)
+* [`scripts/flavor-package-name.R`](/scripts/flavor-package-name.R)
+* [`AGENTS.md`](/AGENTS.md)
 
 To write this leaf:
 

--- a/handbook/testing/revdep/README.md
+++ b/handbook/testing/revdep/README.md
@@ -2,14 +2,14 @@
 
 *Stub — this leaf will own its topic;
 today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../meta/handbook/);
+The writing protocol is in [`meta/handbook/`](/handbook/meta/handbook/);
 the last section holds this leaf's parameters.*
 
 Scope: reverse-dependency checks ahead of a release.
 
 Today:
 
-* [`RELEASE.md`](../../../RELEASE.md)
+* [`RELEASE.md`](/RELEASE.md)
 
 To write this leaf:
 

--- a/handbook/testing/snapshots/README.md
+++ b/handbook/testing/snapshots/README.md
@@ -2,14 +2,14 @@
 
 *Stub — this leaf will own its topic;
 today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../meta/handbook/);
+The writing protocol is in [`meta/handbook/`](/handbook/meta/handbook/);
 the last section holds this leaf's parameters.*
 
 Scope: snapshot tests, and accepting changed snapshots deliberately.
 
 Today:
 
-* [`scripts/snapshot-accept.sh`](../../../scripts/snapshot-accept.sh) — its header is the procedure
+* [`scripts/snapshot-accept.sh`](/scripts/snapshot-accept.sh) — its header is the procedure
 
 To write this leaf:
 

--- a/handbook/testing/suite/README.md
+++ b/handbook/testing/suite/README.md
@@ -2,7 +2,7 @@
 
 *Stub — this leaf will own its topic;
 today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../meta/handbook/);
+The writing protocol is in [`meta/handbook/`](/handbook/meta/handbook/);
 the last section holds this leaf's parameters.*
 
 Scope: the `tests/testthat/` layout and helpers,
@@ -10,7 +10,7 @@ running one file, and the fast edit-test loop.
 
 Today:
 
-* [`AGENTS.md`](../../../AGENTS.md) — "Run Tests"
+* [`AGENTS.md`](/AGENTS.md) — "Run Tests"
 
 To write this leaf:
 

--- a/handbook/usage/connections/README.md
+++ b/handbook/usage/connections/README.md
@@ -2,7 +2,7 @@
 
 *Stub — this leaf will own its topic;
 today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../meta/handbook/);
+The writing protocol is in [`meta/handbook/`](/handbook/meta/handbook/);
 the last section holds this leaf's parameters.*
 
 Scope: `dbConnect()` semantics: instance caching, `config` and `read_only`,

--- a/handbook/usage/data-import/README.md
+++ b/handbook/usage/data-import/README.md
@@ -2,7 +2,7 @@
 
 *Stub — this leaf will own its topic;
 today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../meta/handbook/);
+The writing protocol is in [`meta/handbook/`](/handbook/meta/handbook/);
 the last section holds this leaf's parameters.*
 
 Scope: `duckdb_read_csv()` versus the SQL readers, globs,

--- a/handbook/usage/extensions/README.md
+++ b/handbook/usage/extensions/README.md
@@ -2,7 +2,7 @@
 
 *Stub — this leaf will own its topic;
 today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../meta/handbook/);
+The writing protocol is in [`meta/handbook/`](/handbook/meta/handbook/);
 the last section holds this leaf's parameters.*
 
 Scope: the bundled extension set, autoload vs autoinstall,

--- a/handbook/usage/installation/README.md
+++ b/handbook/usage/installation/README.md
@@ -2,14 +2,14 @@
 
 *Stub — this leaf will own its topic;
 today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../meta/handbook/);
+The writing protocol is in [`meta/handbook/`](/handbook/meta/handbook/);
 the last section holds this leaf's parameters.*
 
 Scope: installing from CRAN or r-universe, and choosing a flavor.
 
 Today:
 
-* [`README.md`](../../../README.md) — the install commands and the `Flavors` table
+* [`README.md`](/README.md) — the install commands and the `Flavors` table
 
 To write this leaf:
 

--- a/handbook/usage/integrations/README.md
+++ b/handbook/usage/integrations/README.md
@@ -2,7 +2,7 @@
 
 *Stub — this leaf will own its topic;
 today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../meta/handbook/);
+The writing protocol is in [`meta/handbook/`](/handbook/meta/handbook/);
 the last section holds this leaf's parameters.*
 
 Scope: the dbplyr backend and Arrow interchange.
@@ -10,7 +10,7 @@ Scope: the dbplyr backend and Arrow interchange.
 Today:
 
 * `?backend-duckdb` — the dbplyr backend reference
-* [`plan/PLAN-dbSendQueryArrow.md`](../../../plan/PLAN-dbSendQueryArrow.md) — the DBI Arrow API plan
+* [`plan/PLAN-dbSendQueryArrow.md`](/plan/PLAN-dbSendQueryArrow.md) — the DBI Arrow API plan
 
 To write this leaf:
 

--- a/handbook/usage/memory/README.md
+++ b/handbook/usage/memory/README.md
@@ -2,7 +2,7 @@
 
 *Stub — this leaf will own its topic;
 today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../meta/handbook/);
+The writing protocol is in [`meta/handbook/`](/handbook/meta/handbook/);
 the last section holds this leaf's parameters.*
 
 Scope: what `memory_limit` bounds and what it does not,

--- a/handbook/usage/storage/README.md
+++ b/handbook/usage/storage/README.md
@@ -2,15 +2,15 @@
 
 *Stub — this leaf will own its topic;
 today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../meta/handbook/);
+The writing protocol is in [`meta/handbook/`](/handbook/meta/handbook/);
 the last section holds this leaf's parameters.*
 
 Scope: where extensions and secrets live on disk, and how to move them.
 
 Today:
 
-* `?duckdb_storage` ([`R/storage.R`](../../../R/storage.R)),
-  backed by [`plan/PLAN-storage-locations.md`](../../../plan/PLAN-storage-locations.md)
+* `?duckdb_storage` ([`R/storage.R`](/R/storage.R)),
+  backed by [`plan/PLAN-storage-locations.md`](/plan/PLAN-storage-locations.md)
 
 To write this leaf:
 

--- a/handbook/usage/types/README.md
+++ b/handbook/usage/types/README.md
@@ -2,7 +2,7 @@
 
 *Stub — this leaf will own its topic;
 today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../meta/handbook/);
+The writing protocol is in [`meta/handbook/`](/handbook/meta/handbook/);
 the last section holds this leaf's parameters.*
 
 Scope: the R ↔ DuckDB edges: UTF-8 strictness, geometry via WKB,

--- a/plan/README.md
+++ b/plan/README.md
@@ -4,17 +4,17 @@ This directory holds documents that are *not* part of the routing tree's
 description of how the system works today:
 plans for work that is not finished,
 and records of designs and reviews that have been superseded.
-Both roots — [`README.md`](../README.md) for users and
-[`AGENTS.md`](../AGENTS.md) for maintainers and coding agents — point here,
+Both roots — [`README.md`](/README.md) for users and
+[`AGENTS.md`](/AGENTS.md) for maintainers and coding agents — point here,
 and this file is what names the contents,
 so nothing under `plan/` is an orphan.
 
 What is current lives elsewhere, and is owned there:
-[`BRANCHES.md`](../BRANCHES.md) for the branch model,
-[`RELEASE.md`](../RELEASE.md) for the release process,
-[`scripts/VENDORING.md`](../scripts/VENDORING.md) for vendoring mechanics,
-[`scripts/EACH.md`](../scripts/EACH.md) for per-commit CI,
-and [`.claude/skills/`](../.claude/skills/) for the routine's playbooks.
+[`BRANCHES.md`](/BRANCHES.md) for the branch model,
+[`RELEASE.md`](/RELEASE.md) for the release process,
+[`scripts/VENDORING.md`](/scripts/VENDORING.md) for vendoring mechanics,
+[`scripts/EACH.md`](/scripts/EACH.md) for per-commit CI,
+and [`.claude/skills/`](/.claude/skills/) for the routine's playbooks.
 A document here may describe something that has since changed;
 when the two disagree, the owner above is right.
 

--- a/plan/history/main-dev-review-2026-07.md
+++ b/plan/history/main-dev-review-2026-07.md
@@ -4,7 +4,7 @@ Status: **historical** — a one-off review artifact from 2026-07,
 kept for the findings it records about the R-side delta of a series.
 It is a snapshot of one branch at one moment, not a description of the
 system: the loop is owned by `.claude/skills/series-loop.md`,
-its mechanics by [`scripts/VENDORING.md`](../../scripts/VENDORING.md).
+its mechanics by [`scripts/VENDORING.md`](/scripts/VENDORING.md).
 
 **Range:** `main-dev-base..main-dev` (`krlmlr/duckdb-r`), 242 first-parent
 commits, of which **16 carry non-vendored (R-side) changes**.

--- a/plan/history/vendoring-loop.md
+++ b/plan/history/vendoring-loop.md
@@ -5,8 +5,8 @@ Status: **historical** — superseded by the series loop
 kept as design context.
 It lives under `plan/` because it is history, not routing:
 what the pipeline does *today* is owned by
-[`scripts/VENDORING.md`](../../scripts/VENDORING.md) (mechanics),
-[`scripts/EACH.md`](../../scripts/EACH.md) (per-commit CI),
+[`scripts/VENDORING.md`](/scripts/VENDORING.md) (mechanics),
+[`scripts/EACH.md`](/scripts/EACH.md) (per-commit CI),
 and the skills in `.claude/skills/` (procedure).
 Nothing here is current except the measurements in Appendix A,
 which the sharded matrix still cites.
@@ -14,7 +14,7 @@ References to `vendor.yaml` and the `rcc-smoke-fix` /
 `advance-green-dev` skills below describe artifacts
 that no longer exist.
 Target repo for implementation: `krlmlr/duckdb-r` (the CI/CD fork; see
-[`BRANCHES.md`](../../BRANCHES.md)). Source-of-truth CI/CD lives in
+[`BRANCHES.md`](/BRANCHES.md)). Source-of-truth CI/CD lives in
 `duckdb/duckdb-r@main` and is forward-ported.
 Author context: drafted on branch `claude/vibrant-ride-i4b5r2`.
 
@@ -22,8 +22,8 @@ This document proposes a re-architecture of the DuckDB-R vendoring pipeline as
 a **modular agentic loop**: Claude drives the creative steps, while GitHub
 Actions runs the predictable, parallelisable work and serves as the single
 **ground truth** for build results. It builds directly on the existing system
-documented in [`BRANCHES.md`](../../BRANCHES.md) and
-[`scripts/VENDORING.md`](../../scripts/VENDORING.md), and supersedes parts of the
+documented in [`BRANCHES.md`](/BRANCHES.md) and
+[`scripts/VENDORING.md`](/scripts/VENDORING.md), and supersedes parts of the
 three repair skills in `.claude/skills/`.
 
 ---
@@ -33,10 +33,10 @@ three repair skills in `.claude/skills/`.
 | Concern | Today | Mechanism |
 |---|---|---|
 | **Vendor** upstream C++ into `*-dev` | hourly, commit-by-commit, ≤30/run | `vendor.yaml` → `scripts/vendor-one.sh ./duckdb --commits 30` |
-| **Trigger** per-commit CI | fire-and-forget dispatch, no cap | `each.yaml` → `scripts/each-rcc.sh` → `gh workflow run rcc -f ref=<sha>` (since superseded by the sharded matrix, [`scripts/EACH.md`](../../scripts/EACH.md)) |
+| **Trigger** per-commit CI | fire-and-forget dispatch, no cap | `each.yaml` → `scripts/each-rcc.sh` → `gh workflow run rcc -f ref=<sha>` (since superseded by the sharded matrix, [`scripts/EACH.md`](/scripts/EACH.md)) |
 | **Build / smoke-test** a commit | one independent `rcc` run per commit | `R-CMD-check.yaml` (job *Smoke test: stock R*) |
 | **Record** the result marker | commit-status `rcc` = pending/success/failure | `R-CMD-check-status.yaml` (via `workflow_run`) |
-| **Harvest** logs to ground truth | **delayed**, 4×/day | `rcc-logs.yaml` → `scripts/rcc-logs.sh` → orphan branch `rcc` (`runs2.ndjson`, `logs2/<sha>.log`). Since [`scripts/EACH.md`](../../scripts/EACH.md) §3 the `each-rcc` legs publish their own records as each commit is decided, and this is the backstop. |
+| **Harvest** logs to ground truth | **delayed**, 4×/day | `rcc-logs.yaml` → `scripts/rcc-logs.sh` → orphan branch `rcc` (`runs2.ndjson`, `logs2/<sha>.log`). Since [`scripts/EACH.md`](/scripts/EACH.md) §3 the `each-rcc` legs publish their own records as each commit is decided, and this is the backstop. |
 | **Repair** a red commit | fork `broken-<sha>-dev`, amend the failing commit, **cherry-pick (replay) the whole tail**, force-push | skill `rcc-smoke-fix.md` |
 | **Advance** a repaired branch | cherry-pick next 30 vendor commits, matched by vendored upstream SHA | skill `advance-green-dev.md` |
 | **Self-heal** transient breaks | squash (window 1) / transient patch (≥2) | skill `rcc-smoke-fix-self-heal.md` |
@@ -180,7 +180,7 @@ Invariants:
 
 > **Landed, in narrower form.** This primitive is now implemented inside the
 > existing `each.yaml` rather than as a separate `rcc-matrix.yaml`, because the
-> commit-selection semantics were already there. See [`scripts/EACH.md`](../../scripts/EACH.md) for
+> commit-selection semantics were already there. See [`scripts/EACH.md`](/scripts/EACH.md) for
 > what was built, the GitHub Actions limits it works within, and two corrections
 > to the analysis below: within-shard reuse comes from **ccache**, not
 > incremental `make` (§4.2), and the reverse-include estimator of §4.3 exists as

--- a/scripts/EACH.md
+++ b/scripts/EACH.md
@@ -7,7 +7,7 @@ The cost model's constants are no longer borrowed —
 they are fitted to measured legs; see [§3, *Can we compute breakpoints efficiently, and evenly?*](#can-we-compute-breakpoints-efficiently-and-evenly).
 
 `.github/workflows/each.yaml` proves invariant **C1** from
-[`BRANCHES.md`](../BRANCHES.md#ci--green):
+[`BRANCHES.md`](/BRANCHES.md#ci--green):
 every commit on a `*-dev` branch is green, so the branch is bisectable end to end.
 It used to do that by dispatching one `rcc` workflow run per commit.
 It now plans contiguous, cost-balanced **shards** and gives each shard one job,
@@ -50,7 +50,7 @@ from it. Selection reads the verdict store on the `rcc` branch instead (below),
 and `scripts/vendor-gate.sh` — the last consumer that decided anything from a
 status, turning a window of them into one green/red/stale verdict for the daily
 vendoring run — went with the run it served
-(D4 of [`../plan/PLAN-vendoring-simplification.md`](../plan/PLAN-vendoring-simplification.md)).
+(D4 of [`../plan/PLAN-vendoring-simplification.md`](/plan/PLAN-vendoring-simplification.md)).
 
 The readers of the `rcc` branch did need a change, but a compatible one. Records
 are now one file per commit, with `runs2.ndjson` extended from them
@@ -237,7 +237,7 @@ Timestamp-based incremental `make` cannot cross a commit boundary here.
 What does survive is **ccache**, which is content-addressed
 and lives outside the workspace for the whole job.
 A typical adjacent vendor commit recompiles ~5 of 341 unity objects — ~98% hits
-(measured: [`history/vendoring-loop.md` Appendix A.2](../plan/history/vendoring-loop.md#a2-ccache-behaviour-on-adjacent-commits-8-consecutive-v15-commits)).
+(measured: [`history/vendoring-loop.md` Appendix A.2](/plan/history/vendoring-loop.md#a2-ccache-behaviour-on-adjacent-commits-8-consecutive-v15-commits)).
 Cleaning the workspace also means every commit's verdict is identical to one from a fresh checkout,
 which is what keeps the semantics honest.
 
@@ -324,7 +324,7 @@ and Actions being disabled on the account that tried it.
 A 3000-job run would be unreadable exactly when a red commit needs finding.
 
 There is also a maintenance cost: `R-CMD-check.yaml` is forward-ported
-from `duckdb/duckdb-r@main` (see [`BRANCHES.md`](../BRANCHES.md)),
+from `duckdb/duckdb-r@main` (see [`BRANCHES.md`](/BRANCHES.md)),
 so a repo-specific `workflow_call` interface there is a permanent merge tax.
 
 ### Can a job have multiple tasks that each do a `workflow_call`?
@@ -630,7 +630,7 @@ so the `plan` job's second upload of `each-plan` was rejected as a conflict.
 **The documented recovery discards good results.**
 This is the one that actually looks like "self-healing restarts everything", and it
 is not in this workflow at all — it is in the series loop.
-[`series-loop.md`](../.claude/skills/series-loop.md) says that a commit still
+[`series-loop.md`](/.claude/skills/series-loop.md) says that a commit still
 missing from the harvest after 12 hours should be presumed lost, and repaired by
 amending it and replaying the tail. Replaying mints a new SHA for every commit
 after it, so one lost leg costs a rebuild of every *already-green* commit newer
@@ -777,7 +777,7 @@ work:
 
 Everything routine is additive. The three destructive operations — making the
 layouts agree, deleting logs, discarding history — belong to one manually
-dispatched workflow ([`rcc-consolidate.yaml`](../.github/workflows/rcc-consolidate.yaml)),
+dispatched workflow ([`rcc-consolidate.yaml`](/.github/workflows/rcc-consolidate.yaml)),
 where they happen once and under supervision.
 
 #### Consolidation
@@ -1116,12 +1116,12 @@ it with no separating context.
 `each.yaml` runs the scripts from the *branch it is checking*,
 so a `*-dev` branch picks up the sharded path only once the new scripts are forward-ported to it —
 the same constraint every CI change in this repository has
-(invariant **G1** in [`BRANCHES.md`](../BRANCHES.md#source-of-truth-cross-series)).
+(invariant **G1** in [`BRANCHES.md`](/BRANCHES.md#source-of-truth-cross-series)).
 Until then that branch's copy of `each.yaml` is the old dispatcher, and keeps working.
 (The series loop automates this forward-port:
 stage 4 — `scripts/series-port.sh` — brings each `-dev` level with `main`;
 the wider simplification is
-[`plan/PLAN-vendoring-simplification.md`](../plan/PLAN-vendoring-simplification.md).)
+[`plan/PLAN-vendoring-simplification.md`](/plan/PLAN-vendoring-simplification.md).)
 
 `vendor.yaml` no longer exists — the series loop
 (`.claude/skills/series-loop.md`) replaced it — and neither does the dispatcher
@@ -1210,7 +1210,7 @@ Honest list, in rough order of risk:
 ## 8. Relation to the vendoring loop plan
 
 This is a concrete, narrower implementation of primitive **B** in
-[`history/vendoring-loop.md` §3.2](../plan/history/vendoring-loop.md#b-build-primitive--synchronous-sharded-matrix-ci-new-rcc-matrixyaml) —
+[`history/vendoring-loop.md` §3.2](/plan/history/vendoring-loop.md#b-build-primitive--synchronous-sharded-matrix-ci-new-rcc-matrixyaml) —
 plan, sharded matrix, `if: always()` fan-in — landed inside the existing `each-rcc`
 instead of as a new `rcc-matrix.yaml`, because the selection semantics are already right there.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -9,23 +9,23 @@ One row per file,
 with the purpose taken from the file's own header line
 and the grouping from the handbook leaf that owns the topic —
 ownership by topic, navigation by place
-([the rules](../handbook/meta/handbook/README.md)).
-Root of the documentation tree: [`handbook/`](../handbook/).
+([the rules](/handbook/meta/handbook/README.md)).
+Root of the documentation tree: [`handbook/`](/handbook/).
 
-## [`architecture/glue/`](../handbook/architecture/glue/)
+## [`architecture/glue/`](/handbook/architecture/glue/)
 
 | File | Purpose |
 |---|---|
 | [`format.py`](format.py) | Format the source directory; driven by the Makefile's format-* targets. |
 | [`python_helpers.py`](python_helpers.py) | Shared file helpers for the Python scripts in this directory (imported by format.py). |
 
-## [`architecture/r-layer/`](../handbook/architecture/r-layer/)
+## [`architecture/r-layer/`](/handbook/architecture/r-layer/)
 
 | File | Purpose |
 |---|---|
 | [`rethrow.R`](rethrow.R) | Generate R/rethrow-gen.R from R/cpp11.R: wrap each rapi_* binding to rethrow errors with call context; sourced by .Rprofile on repo load. |
 
-## [`branches/flavors/`](../handbook/branches/flavors/)
+## [`branches/flavors/`](/handbook/branches/flavors/)
 
 | File | Purpose |
 |---|---|
@@ -33,26 +33,26 @@ Root of the documentation tree: [`handbook/`](../handbook/).
 | [`flavor.patch`](flavor.patch) | — |
 | [`flavor.sh`](flavor.sh) | Apply a package flavor: rewrite scripts/flavor.patch to the target name (say, duckdb.dev), apply it, and commit the rename; see BRANCHES.md. |
 
-## [`build/configuration/`](../handbook/build/configuration/)
+## [`build/configuration/`](/handbook/build/configuration/)
 
 | File | Purpose |
 |---|---|
 | [`setup-makeflags.R`](setup-makeflags.R) | Setup MAKEFLAGS for parallel compilation. |
 
-## [`build/fast-paths/`](../handbook/build/fast-paths/)
+## [`build/fast-paths/`](/handbook/build/fast-paths/)
 
 | File | Purpose |
 |---|---|
 | [`install-duckdb-cli.sh`](install-duckdb-cli.sh) | Download the standalone DuckDB CLI matching the vendored DuckDB sources under src/duckdb/. |
 | [`install-libduckdb.sh`](install-libduckdb.sh) | Install the libduckdb prebuilt binary matching the vendored DuckDB sources under src/duckdb/. |
 
-## [`meta/handbook/`](../handbook/meta/handbook/)
+## [`meta/handbook/`](/handbook/meta/handbook/)
 
 | File | Purpose |
 |---|---|
 | [`README.md`](README.md) | (this index) |
 
-## [`operations/ci/per-commit/`](../handbook/operations/ci/per-commit/)
+## [`operations/ci/per-commit/`](/handbook/operations/ci/per-commit/)
 
 | File | Purpose |
 |---|---|
@@ -72,13 +72,13 @@ Root of the documentation tree: [`handbook/`](../handbook/).
 | [`rcc-push.sh`](rcc-push.sh) | Commit the orphan `rcc` worktree and push it, re-deriving on conflict. |
 | [`rcc-run-fields.jq`](rcc-run-fields.jq) | The subset of a GitHub workflow-run object that a record on the `rcc` branch carries, applied to `gh api repos/{owner}/{repo}/actions/runs/<id>`. |
 
-## [`operations/vendoring/`](../handbook/operations/vendoring/)
+## [`operations/vendoring/`](/handbook/operations/vendoring/)
 
 | File | Purpose |
 |---|---|
 | [`VENDORING.md`](VENDORING.md) | DuckDB R Package Vendoring |
 
-## [`operations/vendoring/pipeline/`](../handbook/operations/vendoring/pipeline/)
+## [`operations/vendoring/pipeline/`](/handbook/operations/vendoring/pipeline/)
 
 | File | Purpose |
 |---|---|
@@ -89,7 +89,7 @@ Root of the documentation tree: [`handbook/`](../handbook/).
 | [`vendor-rfuns.sh`](vendor-rfuns.sh) | Vendor the rfuns extension: copy sources from a duckdb-rfuns checkout into src/ and commit with the upstream log, one commit per import. |
 | [`vendor.sh`](vendor.sh) | Vendors DuckDB sources from the upstream repository (manual vendoring). |
 
-## [`operations/vendoring/series-loop/`](../handbook/operations/vendoring/series-loop/)
+## [`operations/vendoring/series-loop/`](/handbook/operations/vendoring/series-loop/)
 
 | File | Purpose |
 |---|---|
@@ -99,7 +99,7 @@ Root of the documentation tree: [`handbook/`](../handbook/).
 | [`series-forward-build.sh`](series-forward-build.sh) | Populate `<S>-fwd-build`: replay every vendor commit of the old `<S>-build` onto HEAD, which must be the freshly flavored seed on current `main` (.claude/ski... |
 | [`series-port.sh`](series-port.sh) | Bring a series' -dev branch level with `main` — stage 4 of the series loop (.claude/skills/series-loop.md). |
 
-## [`testing/snapshots/`](../handbook/testing/snapshots/)
+## [`testing/snapshots/`](/handbook/testing/snapshots/)
 
 | File | Purpose |
 |---|---|

--- a/scripts/VENDORING.md
+++ b/scripts/VENDORING.md
@@ -4,9 +4,9 @@ This document covers the mechanics of vendoring:
 what the scripts do, which invariants a dev branch must satisfy, how a new dev line is started,
 and how to troubleshoot a failing run.
 For the branch strategy, the complete list of active branches, and the release process, see
-[BRANCHES.md](../BRANCHES.md), which is the authoritative source.
+[BRANCHES.md](/BRANCHES.md), which is the authoritative source.
 For the historical design notes that led to the series loop,
-see [history/vendoring-loop.md](../plan/history/vendoring-loop.md)
+see [history/vendoring-loop.md](/plan/history/vendoring-loop.md)
 (superseded by `.claude/skills/series-loop.md`).
 
 ## What is Vendoring?
@@ -59,7 +59,7 @@ They are what makes the history useful rather than merely present.
    Vendor commits touch only the mechanical path set
    (`src/duckdb/`, `R/version.R`, `src/include/sources.mk`, `DESCRIPTION`).
    Anything else in a vendor commit is a folded glue fix,
-   and must be reviewable as a path-filtered diff (see [history/vendoring-loop.md](../plan/history/vendoring-loop.md) §3.4).
+   and must be reviewable as a path-filtered diff (see [history/vendoring-loop.md](/plan/history/vendoring-loop.md) §3.4).
 
 Invariant 2 is the one that is easy to lose.
 It is violated the moment a dev branch is re-pointed at a different upstream branch
@@ -105,7 +105,7 @@ Shared behaviour, in the order it happens:
    For each candidate, check it out, regenerate `src/duckdb/`,
    then apply every `patch/*.patch` in order.
    **A patch that no longer applies is deleted**, and the deletion becomes part of the vendor commit —
-   see [Patch Stack](../BRANCHES.md#patch-stack).
+   see [Patch Stack](/BRANCHES.md#patch-stack).
 6. **Decide whether the commit is worth vendoring.**
    * If `git describe --tags <commit>` resolves to an exact tag (a release), it is **always** vendored,
      the subject gets a `(tag vX.Y.Z)` marker, and `vendor-one.sh` stops afterwards.
@@ -215,12 +215,12 @@ and the routine judges conflicts
 (`scripts/series-port.sh`,
 stage 4 of `.claude/skills/series-loop.md`;
 the wider simplification is
-[`plan/PLAN-vendoring-simplification.md`](../plan/PLAN-vendoring-simplification.md)).
+[`plan/PLAN-vendoring-simplification.md`](/plan/PLAN-vendoring-simplification.md)).
 The next forward retires the ported commits,
 whose content the new seed already carries.
 
 `scripts/vendor-gate.sh` has been retired with the rest of the legacy dispatch
-path ([`plan/PLAN-vendoring-simplification.md`](../plan/PLAN-vendoring-simplification.md), D4).
+path ([`plan/PLAN-vendoring-simplification.md`](/plan/PLAN-vendoring-simplification.md), D4).
 It turned the `rcc` commit-status of a branch tip and the five commits before it
 into one verdict for the daily vendoring run:
 
@@ -315,7 +315,7 @@ Three things make this affordable:
   Adjacent vendor commits change a median of two `.cpp` files and no headers,
   so a warm ccache turns a ~15 minute cold build into a couple of minutes;
   wide-header commits are the exception, not the rule
-  (measured in [history/vendoring-loop.md](../plan/history/vendoring-loop.md) Appendix A).
+  (measured in [history/vendoring-loop.md](/plan/history/vendoring-loop.md) Appendix A).
   Point R at it via `~/.R/Makevars` (`CXX = ccache g++`, …)
   and give it a cache large enough to hold several trees (`ccache --max-size=20G`).
   Note that ccache reads `$CCACHE_DIR/ccache.conf` (i.e. `~/.ccache/ccache.conf`)
@@ -345,7 +345,7 @@ The cheap mode is a commit that changes only `.cpp` files;
 the expensive mode is a commit touching a widely-included header,
 which invalidates a large share of the ~345 unity objects at once.
 Note that the mix depends on *which* branch is being replayed:
-Appendix A of [history/vendoring-loop.md](../plan/history/vendoring-loop.md) measured a release branch,
+Appendix A of [history/vendoring-loop.md](/plan/history/vendoring-loop.md) measured a release branch,
 where 66 % of commits touch no header at all,
 whereas a mainline window in active pre-release development
 runs closer to a 57/43 split — plan bulk replays off the pessimistic figure.
@@ -402,7 +402,7 @@ and the four refs created equal at the seed tip — is
 this list is the sources-and-glue side it drives):
 
 1. Create the new dev branch from the current package `main`
-   (glue code, R code, CI — the [source of truth](../BRANCHES.md#source-of-truth)),
+   (glue code, R code, CI — the [source of truth](/BRANCHES.md#source-of-truth)),
    and apply its flavor with `scripts/flavor.sh`,
    as the **first** commits of the branch —
    the rename touches the shared-object name and every `.Call()` entry point,
@@ -513,7 +513,7 @@ R CMD INSTALL .
 a patch that no longer applies is deleted by the vendor run,
 on the assumption that the fix landed upstream.
 Verify that assumption; if the patch is still needed, restore and rebase it against the new sources.
-See [Patch Stack](../BRANCHES.md#patch-stack).
+See [Patch Stack](/BRANCHES.md#patch-stack).
 
 **Issue**: Build failures after vendoring
 **Solution**: Usually a DuckDB C++ API change;
@@ -546,7 +546,7 @@ https://img.shields.io/github/commits-difference/krlmlr/duckdb-r?base=<S>-green&
 https://img.shields.io/github/commits-difference/krlmlr/duckdb-r?base=<S>-build-base&head=<S>-build&label=buffered
 ```
 
-The live table is the `Flavors` section of [`README.md`](../README.md) —
+The live table is the `Flavors` section of [`README.md`](/README.md) —
 one row per flavor, these two badges
 plus an *ahead* badge against the branch the series releases from,
 and version badges for the CRAN and LTS rows.
@@ -605,7 +605,7 @@ git log -1 --grep="^vendor:" --format=%s   # upstream commit it came from
 - `scripts/merge-version.sh` - The merge driver itself (see [Version counters and the merge driver](#version-counters-and-the-merge-driver))
 - `.github/workflows/each.yaml` - Per-commit CI as a sharded matrix (see [`EACH.md`](EACH.md))
 - `patch/*.patch` - R-specific patches applied to vendored code
-  (see [Patch Stack](../BRANCHES.md#patch-stack))
+  (see [Patch Stack](/BRANCHES.md#patch-stack))
 
 ### Vendored content
 
@@ -643,7 +643,7 @@ patch -p1 < patch/00NN-my-fix.patch
 ## Release Considerations
 
 Which branch is released, and when, is governed by
-[Release Cycle Mapping](../BRANCHES.md#release-cycle-mapping) in `BRANCHES.md`.
+[Release Cycle Mapping](/BRANCHES.md#release-cycle-mapping) in `BRANCHES.md`.
 In short: CRAN releases come from the stable branches in `duckdb/duckdb-r`,
 the `.dev` packages on r-universe are built from the dev branches in `krlmlr/duckdb-r`,
 and the version in `DESCRIPTION` must match the upstream tag at release time.


### PR DESCRIPTION
Adopts the [Google Markdown style guide](https://google.github.io/styleguide/docguide/style.html#links)
rule on link paths, and sweeps the tree to match.

## The rule

A link that leaves its own directory is written from the repository
root, with a leading `/` — `/handbook/usage/types/`, not
`../../usage/types/`. Same-directory and downward links are untouched:
Google discourages *exactly* the upward form and nothing else, and
those links are already short and already right.

The handbook is four levels deep in places, so `../../../../` chains
had appeared. They are unreadable, and they break silently the moment a
page moves — which, in a hierarchy still settling, they will.

## Does it render on GitHub?

Yes. GitHub's docs are explicit that links *"beginning with `/` are
relative to the repository root"*, and that GitHub *"will automatically
transform your relative link… based on whatever branch you're currently
on, so that the link always works"* — so one written form works on
`main`, on this PR's head, and in a fork, with no rewriting.

The one known wart is [github/markup#1502](https://github.com/github/markup/issues/1502):
a link to the repository root *itself* (`/` alone) 404s. We never write
one. Directory links one level in and deeper (`/handbook/usage/`) go
through the same blob→tree resolution that today's relative directory
links already rely on.

**Worth eyeballing in the rendered diff before merge:** click a couple
of the converted directory links (say the ones in `scripts/README.md`)
to confirm the blob→tree redirect behaves as expected on a PR head.

## Blast radius

136 links across 47 files, all mechanical, plus the two places that
would otherwise reintroduce `../`:

* `scripts/README.md` is **generated** — the generator
  (`docs-consistency/docs-readme.R`) now emits root-absolute links, and
  the regenerated index matches the sweep exactly.
* The link-integrity check in the `docs-consistency` skill now resolves
  a leading `/` against the repo root, and flags any `../` that comes
  back as `UPWARD`. So the rule is enforced, not just written down.

Verified: zero dangling and zero upward links across every tracked
`.md` outside `src/duckdb/`.

## Assumptions a reviewer should confirm

* **Local Markdown preview is the cost.** A root-absolute link does not
  resolve in VS Code's or RStudio's preview, which has no notion of a
  repository root. The handbook is read on GitHub; the PR takes that
  trade explicitly and says so in the rules.
* **The root `README.md` is untouched.** It had no upward links to
  begin with, so the question of how CRAN resolves them from a tarball
  where `.Rbuildignore` has removed `handbook/` never arises.
* **`plan/history/` was swept too.** Those are superseded records; the
  sweep treated them as ordinary Markdown rather than leaving them in
  the old style as historical artifacts. Say the word and I'll exclude
  them.
* **Depends on #2457**, folded in here as its own commit so this PR
  stands alone; it drops out cleanly once #2457 merges.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PD23hjFQFRWW62HFvru187)_