### PR TITLE
docs(handbook): Write the contributors/setup leaf

### DIFF
--- a/handbook/contributors/setup/README.md
+++ b/handbook/contributors/setup/README.md
@@ -56,7 +56,8 @@ parallelism and `ccache` among them,
 are [`build/configuration/`](/handbook/build/configuration/README.md).
 
 The sequence assumes a toolchain that is already working —
-R 4.2.0 or newer, a C++ compiler, `make` —
+the R version `DESCRIPTION` names in `Depends`,
+a C++ compiler, `make` —
 and installs none of it.
 It also assumes Linux or macOS:
 `configure` rejects `DUCKDB_R_USE_SYSTEM_LIB` on any other system,

--- a/handbook/contributors/setup/README.md
+++ b/handbook/contributors/setup/README.md
@@ -1,21 +1,71 @@
 # Setup
 
-*Stub — this leaf will own its topic;
-today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../meta/handbook/);
-the last section holds this leaf's parameters.*
+Getting from a fresh clone to a running test suite,
+in the order a first-time contributor needs it —
+each knob named below is explained by the leaf that owns it,
+not here.
 
-Scope: a working development environment in minutes —
-clone, fast build, test loop.
+Start with the clone:
 
-Today:
+```sh
+git clone https://github.com/duckdb/duckdb-r.git
+cd duckdb-r
+```
 
-* [`AGENTS.md`](../../../AGENTS.md) — the bootstrap and fast-path sections
+The R-level dependencies are the ones `DESCRIPTION` declares;
+`pak::pak()` run inside the clone installs them,
+`testthat` among them.
 
-To write this leaf:
+The default build compiles the vendored DuckDB sources,
+which takes far too long for an edit-test loop,
+so the next step is to opt out of it.
+`scripts/install-libduckdb.sh` downloads the prebuilt libduckdb
+that matches the vendored sources —
+into `/usr/local`,
+or into a user-writable location with `--prefix "$HOME/.local"` —
+and `DUCKDB_R_USE_SYSTEM_LIB=1` makes the build link against it
+instead of compiling the engine:
 
-* route, don't duplicate: the fast build is `build/fast-paths/`'s,
-  the test loop `testing/suite/`'s —
-  this leaf sequences them for a first-time contributor
-* keep it to one screen:
-  clone, install libduckdb, `load_all()`, `test_local()`
+```sh
+scripts/install-libduckdb.sh
+export DUCKDB_R_USE_SYSTEM_LIB=1
+```
+
+From there the loop is two calls:
+
+```sh
+R -q -e 'pkgload::load_all()'
+R -q -e 'testthat::test_local()'
+```
+
+`load_all()` compiles only the glue sources in `src/`,
+and `test_local()` loads the package the same way before running
+the suite,
+so both stay in the seconds range.
+
+What the fast path costs and guards —
+the check that the installed library was built from the same commit
+as the vendored sources,
+and the re-install that every vendoring bump therefore requires —
+is [`build/fast-paths/`](/handbook/build/fast-paths/README.md).
+The suite's layout,
+and running one file rather than all of them,
+is [`testing/suite/`](/handbook/testing/suite/README.md).
+The remaining build knobs,
+parallelism and `ccache` among them,
+are [`build/configuration/`](/handbook/build/configuration/README.md).
+
+The sequence assumes a toolchain that is already working —
+R 4.2.0 or newer, a C++ compiler, `make` —
+and installs none of it.
+It also assumes Linux or macOS:
+`configure` rejects `DUCKDB_R_USE_SYSTEM_LIB` on any other system,
+and `configure.win` has no such branch at all.
+On Windows,
+and whenever no prebuilt libduckdb matches the vendored commit,
+the only route is the full build from the vendored sources,
+which [`build/source-build/`](/handbook/build/source-build/README.md)
+documents together with the toolchain bootstrap.
+Making the change once the environment works —
+branching, style, what a pull request needs —
+is [`contributors/workflow/`](/handbook/contributors/workflow/README.md).


### PR DESCRIPTION
## What this leaf now owns

`handbook/contributors/setup/` owns the *order* of a first working development environment,
and nothing else:
clone, install the R-level dependencies, install a prebuilt libduckdb and export
`DUCKDB_R_USE_SYSTEM_LIB=1`, then `pkgload::load_all()` and `testthat::test_local()`.
It deliberately explains none of those knobs — the fast path's commit-match guard and
re-install rule belong to [`build/fast-paths/`](https://github.com/duckdb/duckdb-r/blob/claude/handbook-contributors-setup-zayxqn/handbook/build/fast-paths/README.md),
the suite to [`testing/suite/`](https://github.com/duckdb/duckdb-r/blob/claude/handbook-contributors-setup-zayxqn/handbook/testing/suite/README.md),
parallelism and `ccache` to [`build/configuration/`](https://github.com/duckdb/duckdb-r/blob/claude/handbook-contributors-setup-zayxqn/handbook/build/configuration/README.md),
and the from-source route to [`build/source-build/`](https://github.com/duckdb/duckdb-r/blob/claude/handbook-contributors-setup-zayxqn/handbook/build/source-build/README.md).
The page states its boundary explicitly: it assumes a working toolchain (the R version `DESCRIPTION` names in `Depends`, a C++ compiler, `make`)
and installs none of it, and the fast path is Linux/macOS only —
`configure` rejects `DUCKDB_R_USE_SYSTEM_LIB` on any other system and `configure.win` has no such branch,
so Windows (and any vendored commit with no published prebuilt) goes through the source build.

## What moved

Nothing. This leaf sequences rather than absorbs, so no section left `AGENTS.md`
and no file outside `handbook/` changed — which also means `AGENTS.md` is owed no
backreference from this leaf. `build/*` and `testing/suite/` do that absorbing.

## Assumptions

* The commands are the ones `AGENTS.md` documents, re-verified against the tree:
  `scripts/install-libduckdb.sh` really defaults to `/usr/local` and takes `--prefix`,
  and `configure` really hard-fails `DUCKDB_R_USE_SYSTEM_LIB` outside Linux/macOS.
  `MAKEFLAGS` was dropped from the quoted block on purpose: with only the glue
  files compiling it buys little, and it is `build/configuration/`'s knob to explain.
* One line mentions `pak::pak()` for the R-level dependencies. That command also lives
  in the root `README.md`'s "Building" section, which is left untouched — a first-timer
  cannot get to `test_local()` without it, so this is a deliberate small overlap rather
  than an absorption. Say the word if it should instead be a bare link.
* "Install libduckdb" is written without `sudo`, because the script elevates itself only
  when the prefix is not writable; `AGENTS.md` shows `sudo scripts/install-libduckdb.sh`.
* Sibling leaves (`build/fast-paths/`, `build/source-build/`, `testing/suite/`,
  `build/configuration/`, `contributors/workflow/`) are still stubs on `main`; they are
  linked as the eventual owners, as instructed.
* No behavioral claim here was verified by building — this wave is documentation only.

## Durability sweep

A pass over the leaf for facts a routine commit would invalidate.

**Out:** the hard-coded minimum R version. `R 4.2.0 or newer` was read off
`DESCRIPTION` and is wrong the day `Depends` is bumped, so the leaf now names the
mechanism — "the R version `DESCRIPTION` names in `Depends`" — and a reader who
needs the number reads it where it is maintained.

**Kept:** "both stay in the seconds range" for `load_all()` and `test_local()`.
It is an order-of-magnitude claim rather than a measurement, it is the entire point
of opting out of the engine build, and it carries no figure that drifts.
"the loop is two calls" likewise stays: it counts the code block directly below it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PD23hjFQFRWW62HFvru187)_