### PR TITLE
docs(handbook): Write the usage/installation leaf

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
 
 # duckdb
 
+*Handbook: [`usage/installation/`](/handbook/usage/installation/README.md) —
+choosing a repository to install from, and a flavor.*
+
 [DuckDB](https://duckdb.org/) is an in-process SQL OLAP database management system.
 It is designed to support analytical query workloads and is optimized for fast query execution.
 This repository contains the R bindings for DuckDB.

--- a/handbook/usage/installation/README.md
+++ b/handbook/usage/installation/README.md
@@ -1,18 +1,71 @@
 # Installation
 
-*Stub — this leaf will own its topic;
-today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../meta/handbook/);
-the last section holds this leaf's parameters.*
+Choosing where to install the package from, and which flavor to install.
+The exact commands stay in the root [`README.md`](/README.md):
+CRAN renders it, so it is the first thing a user sees,
+and it keeps the full install text and the `Flavors` table.
 
-Scope: installing from CRAN or r-universe, and choosing a flavor.
+## Where to install from
 
-Today:
+Four sources serve the package, and they differ in what they carry.
 
-* [`README.md`](../../../README.md) — the install commands and the `Flavors` table
+* **CRAN** publishes the released `duckdb`.
+  It is the recommended source for recent R versions on Windows and macOS,
+  which have binaries there.
+  For Linux or an older R it offers sources only,
+  and a source install may take up to an hour.
+* **The [Posit Public Package Manager](https://p3m.dev/)** serves binary
+  builds of the same CRAN release for a wide variety of platforms,
+  including Linux —
+  the way around the hour-long source build.
+  Setup instructions, a ManyLinux one-liner,
+  and the page that shows which binaries exist for a platform
+  are linked from the root `README.md`.
+* **[r-universe](https://duckdb.r-universe.dev)** serves development versions,
+  and it is where every flavor other than the CRAN `duckdb` is published.
+  Binaries are available for recent versions of R and for some platforms;
+  where they are not, the source install applies again.
+* **GitHub** installs the current state of this repository with
+  `pak::pak("duckdb/duckdb-r")`, always from source.
 
-To write this leaf:
+## Which flavor
 
-* source: `README.md` — the install commands and the `Flavors` table;
-  summarize and point — the root keeps the full text (CRAN renders it)
-  and gains a backreference to this leaf
+One source tree is published under several package names.
+Use `duckdb` unless you need to pin to a minor version
+or to test unreleased functionality:
+
+* `duckdb` — the current stable release, on CRAN and on r-universe.
+* `duckdb.1.4` — the LTS line, on r-universe, receiving bug fixes only.
+  There is no `duckdb.1.5`, because v1.5 is not an LTS version.
+* `duckdb.dev`, `duckdb.1.5.dev`, `duckdb.1.4.dev` — bleeding-edge builds
+  of the corresponding upstream branch, on r-universe.
+  They let you test what a release will contain without waiting for CRAN.
+
+Picking a flavor changes the package name and little else.
+The rename rewrites `DESCRIPTION`, the loaded shared library,
+and the name of the C++ header a downstream package links to,
+but no exported function or method,
+so code written against `duckdb` runs unchanged
+once `library()` names the flavor you installed.
+Because the names differ, a flavor installs alongside `duckdb`
+instead of replacing it.
+
+## Boundaries
+
+Only `duckdb` reaches CRAN;
+a flavored package's own `README.md` states that it is available
+from r-universe and GitHub only,
+and drops the CRAN and package-manager sections accordingly.
+Which flavors exist at a given time is the root `README.md` table;
+what a flavor *is* — one source tree, many names,
+and the series that produce them —
+belongs to [`branches/flavors/`](/handbook/branches/flavors/).
+
+Installing a published package is not the same as building the tree:
+compiling from a clone,
+and the switches that make that fast,
+are [`build/source-build/`](/handbook/build/source-build/)
+and [`build/fast-paths/`](/handbook/build/fast-paths/).
+Which DuckDB extensions an installed package can reach,
+and how further ones are obtained,
+is a separate question — see [`usage/extensions/`](/handbook/usage/extensions/).

--- a/handbook/usage/installation/README.md
+++ b/handbook/usage/installation/README.md
@@ -13,11 +13,12 @@ Four sources serve the package, and they differ in what they carry.
   It is the recommended source for recent R versions on Windows and macOS,
   which have binaries there.
   For Linux or an older R it offers sources only,
-  and a source install may take up to an hour.
+  and a source install compiles the whole vendored engine,
+  which takes tens of minutes rather than seconds.
 * **The [Posit Public Package Manager](https://p3m.dev/)** serves binary
   builds of the same CRAN release for a wide variety of platforms,
   including Linux —
-  the way around the hour-long source build.
+  the way around that source build.
   Setup instructions, a ManyLinux one-liner,
   and the page that shows which binaries exist for a platform
   are linked from the root `README.md`.


### PR DESCRIPTION
## What this leaf now owns

`handbook/usage/installation/` owns the two decisions a user makes before installing:
which repository to install from — CRAN, the [Posit Public Package Manager](https://p3m.dev/), r-universe, or GitHub — and which flavor to install.
It says what each source carries (released `duckdb` vs. development versions, binaries vs. a source build that compiles the whole vendored engine), when to pick a flavor other than `duckdb` (LTS pinning, testing unreleased functionality), and what picking one actually changes (the package name, the loaded library, the C++ header name — not a single exported function).
Deliberately **not** a move: the root `README.md` keeps the full install commands and the `Flavors` table because CRAN renders it, so the leaf summarizes and points there.
The branch-level meaning of flavors — one source tree, many names, and the series that produce them — is linked to [`branches/flavors/`](/handbook/branches/flavors/), not restated.

## What moved

* `README.md` — gains a visible italic handbook backreference line directly under the H1 (`# duckdb`), naming `usage/installation/`.
  Loses nothing: the install sections and the `Flavors` table stay verbatim.
  One line rather than one per section, placed at the top because it serves all four `## Installation from …` sections *and* `## Flavors`, and because that is the only spot in that region `scripts/flavor.patch` does not use as hunk context — `patch -p1 --dry-run &lt; scripts/flavor.patch` still applies cleanly (offset only) with the line in place.
  Placing it just above `## Installation from CRAN` would have broken the flavor rename.

## Assumptions

* Flavor names and repository URLs were taken from the root `README.md` `Flavors` table and `BRANCHES.md` § "R Package Flavors": `duckdb`, `duckdb.1.4`, `duckdb.dev`, `duckdb.1.5.dev`, `duckdb.1.4.dev`, and no `duckdb.1.5` (v1.5 is not an LTS line). Nothing invented.
* "Picking a flavor changes the package name and little else" is read off `scripts/flavor.patch`: it rewrites `DESCRIPTION:Package`, `@useDynLib`/`NAMESPACE`, `DUCKDB_PACKAGE_NAME`, the `inst/include/duckdb_*_types.hpp` filename, `tests/testthat.R`, and the package `.Rd` — no exported function or method. The conclusion that user code runs unchanged after `library()` is my inference from that patch, not a statement copied from a source.
* "A flavor installs alongside `duckdb` instead of replacing it" is inferred from `BRANCHES.md`'s rationale that distinct package names exist precisely because CRAN forbids coexisting versions of one name. It is not asserted verbatim anywhere; worth a maintainer's nod.
* The claim that a flavored package's README states it is available from r-universe and GitHub only, and drops the CRAN and package-manager sections, is verified against the README hunk in `scripts/flavor.patch`.
* Platform/binary availability claims (CRAN binaries for recent R on Windows and macOS, p3m binaries for a wide variety of platforms, r-universe binaries for recent R and some platforms) are the root `README.md`'s assertions, summarized rather than re-verified — no build was run, per the wave's rules. The root README's "up to an hour" source-build figure is no longer carried; see the durability sweep below.
* No issues were listed for this leaf, so none were drained.

## Durability sweep

A targeted pass for one defect class: facts a routine commit invalidates.

**Removed.** The "up to an hour" source-build claim, summarized from the root
`README.md`, is replaced by the mechanism that causes it — a source install
*compiles the whole vendored engine* — plus a qualitative order of magnitude,
"tens of minutes rather than seconds". The second mention, "the way around the
hour-long source build", becomes "the way around that source build" and now
refers back to the mechanism.

The judgment here: the *point* of the sentence is that a source build is slow
enough to make the binary worth seeking out, so the argument does need a sense
of scale and could not simply be cut. But a wall-clock figure read off one
machine cannot carry it — the same wave's `testing/suite/` leaf had the engine
build at "ten to fifteen minutes" locally, against this leaf's "up to an hour"
on a CRAN checker, which is exactly how such a figure rots. "Compiles the whole
vendored engine" is true on every machine and explains *why* it is slow;
"tens of minutes rather than seconds" survives the hardware getting faster.

**Kept.** "Four sources serve the package" is load-bearing: the four bullets
that follow are the distribution design, and a fifth channel would be a change
to that design rather than a routine commit. The flavor names stay for the same
reason the sweep spares version numbers — the point is *which* flavor, not how
many — and `Boundaries` already backstops them by naming the root `README.md`
table as the authority on which exist at a given time.

The root `README.md` was not touched by this sweep. `patch -p1 --dry-run` was
re-run against `scripts/flavor.patch` regardless: still applies, offsets only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PD23hjFQFRWW62HFvru187)_