### PR TITLE
docs(handbook): Write the series-loop leaf

### DIFF
--- a/.claude/skills/series-forward.md
+++ b/.claude/skills/series-forward.md
@@ -1,5 +1,7 @@
 # Forwarding a series to a newer base
 
+*Handbook: [`operations/vendoring/series-loop/`](/handbook/operations/vendoring/series-loop/README.md).*
+
 `main` moves under a series:
 R-side fixes, workflow changes, version bumps.
 The series' branches are built on yesterday's `main`,

--- a/.claude/skills/series-loop.md
+++ b/.claude/skills/series-loop.md
@@ -1,5 +1,7 @@
 # The series loop: vendor, promote, repair
 
+*Handbook: [`operations/vendoring/series-loop/`](/handbook/operations/vendoring/series-loop/README.md).*
+
 One routine drives **all** series:
 each firing enumerates every series and every existing forward (`-fwd`)
 counterpart and serves each in turn.

--- a/.claude/skills/series-open.md
+++ b/.claude/skills/series-open.md
@@ -1,5 +1,7 @@
 # Opening a new series
 
+*Handbook: [`operations/vendoring/series-loop/`](/handbook/operations/vendoring/series-loop/README.md).*
+
 When upstream cuts a release branch —
 v2.0 is released, upstream `main` becomes the 2.1 line —
 the release gets a series of its own.

--- a/.claude/skills/series-rebase.md
+++ b/.claude/skills/series-rebase.md
@@ -1,5 +1,7 @@
 # Rebasing a forward series onto a newer mainline
 
+*Handbook: [`operations/vendoring/series-loop/`](/handbook/operations/vendoring/series-loop/README.md).*
+
 Two different moves put a series on a newer base,
 and only one of them is a rebase.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ start there rather than searching.
 | Release process, modelled as a state machine | `RELEASE.md` |
 | Vendoring mechanics: scripts, invariants, troubleshooting | `scripts/VENDORING.md` |
 | Per-commit CI (sharded matrix): design and limits | `scripts/EACH.md` |
-| Operating the vendoring loop (routine playbooks) | `.claude/skills/`: `series-loop.md`, `series-forward.md`, `series-rebase.md`, `series-open.md` |
+| Operating the vendoring loop: what fires it, what its stages decide | [`handbook/operations/vendoring/series-loop/`](/handbook/operations/vendoring/series-loop/), which links the playbooks in `.claude/skills/` |
 | Designs, plans, and historical documents | `plan/README.md`, which names each by path |
 
 ## Working Effectively
@@ -92,7 +92,7 @@ For an interactive edit-build-test loop, prefer the prebuilt-libduckdb fast path
 
 The duckdb-r package vendors (includes a copy of) the DuckDB C++ core library. Key points:
 
-- **Automated Process**: Runs daily via GitHub Actions in `krlmlr/duckdb-r`, gated on the per-commit `rcc` build status
+- **Automated Process**: a scheduled agent routine — the series loop — vendors every series in `krlmlr/duckdb-r` and promotes on the per-commit `rcc` build status; no workflow drives it, see [`handbook/operations/vendoring/series-loop/`](/handbook/operations/vendoring/series-loop/)
 - **Branch Strategy**: one dev branch per upstream branch (`main-dev` ← `main`, `v1.5-variegata-dev` ← `v1.5-variegata`, `v1.4-andium-dev` ← `v1.4-andium`); see [BRANCHES.md](BRANCHES.md)
 - **One commit at a time**: each vendor commit corresponds to exactly one upstream commit, and must build and pass tests on its own — fold any required glue fix into that commit rather than adding a follow-up
 - **Never modify `src/duckdb/` directly** - changes will be overwritten by vendoring

--- a/handbook/operations/vendoring/series-loop/README.md
+++ b/handbook/operations/vendoring/series-loop/README.md
@@ -96,8 +96,10 @@ lacks, classified `TOOLING` / `MIXED` / `OTHER` / `VENDOR`, and applies all
 but `VENDOR`; conflicts and engine-incompatible commits stay judgement.
 
 **5. Extend `<S>-dev`** decides how much of the buffer is consumed —
-one chunk per firing, sized by `series-advance.sh`'s chunk argument,
+one chunk per firing — a hundred commits by default,
+overridable per call —
 and only when everything in flight is green.
+What the bound buys is [`branches/model/`](/handbook/branches/model/)'s to explain.
 A series with a live forward counterpart is being replaced, so it is
 verified and promoted but never extended.
 

--- a/handbook/operations/vendoring/series-loop/README.md
+++ b/handbook/operations/vendoring/series-loop/README.md
@@ -16,9 +16,8 @@ and the schedule lives with the routine that invokes the playbook,
 outside this tree.
 What the repository schedules is adjacent to the loop rather than part of it:
 [`sync.yaml`](/.github/workflows/sync.yaml) fast-forwards the fork's `main`
-hourly,
-[`rcc-logs.yaml`](/.github/workflows/rcc-logs.yaml) harvests run results
-onto the `rcc` branch twice an hour,
+and [`rcc-logs.yaml`](/.github/workflows/rcc-logs.yaml) harvests run results
+onto the `rcc` branch, each on the schedule its own `cron:` line sets,
 and [`each.yaml`](/.github/workflows/each.yaml) triggers on every push
 to a `*-dev` branch.
 Those cadences bound how fast a firing can learn anything;
@@ -30,7 +29,7 @@ the firing lists `refs/heads/*-build`,
 and every `<S>-build` with a sibling `<S>-dev` is a series it serves —
 base series and forward (`-fwd`) counterparts alike.
 Opening a series therefore takes no configuration change, only refs.
-The refs themselves, and what each of the four guarantees,
+The refs themselves, and what each of them guarantees,
 belong to [`branches/model/`](/handbook/branches/model/)
 and [`branches/invariants/`](/handbook/branches/invariants/).
 
@@ -97,7 +96,8 @@ lacks, classified `TOOLING` / `MIXED` / `OTHER` / `VENDOR`, and applies all
 but `VENDOR`; conflicts and engine-incompatible commits stay judgement.
 
 **5. Extend `<S>-dev`** decides how much of the buffer is consumed —
-up to 100 commits per firing, and only when everything in flight is green.
+one chunk per firing, sized by `series-advance.sh`'s chunk argument,
+and only when everything in flight is green.
 A series with a live forward counterpart is being replaced, so it is
 verified and promoted but never extended.
 

--- a/handbook/operations/vendoring/series-loop/README.md
+++ b/handbook/operations/vendoring/series-loop/README.md
@@ -1,22 +1,152 @@
 # The series loop
 
-*Stub — this leaf will own its topic;
-today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../../meta/handbook/);
-the last section holds this leaf's parameters.*
+The routine that vendors every series —
+what fires it, what its stages decide, and which playbook carries each one.
+The procedures themselves are machine-loaded from `.claude/skills/`
+and are linked here, never restated:
+a reader who wants to *run* the loop follows the link,
+a reader who wants to know what runs stays here.
 
-Scope: the scheduled routine that vendors every series —
-its stages, its playbooks, and when it fires.
+## What fires it
 
-Today:
+The loop is a **scheduled agent routine**, not a workflow.
+Nothing under [`.github/workflows/`](/.github/workflows/) starts it —
+there is no vendoring workflow in the repository at all —
+and the schedule lives with the routine that invokes the playbook,
+outside this tree.
+What the repository schedules is adjacent to the loop rather than part of it:
+[`sync.yaml`](/.github/workflows/sync.yaml) fast-forwards the fork's `main`
+hourly,
+[`rcc-logs.yaml`](/.github/workflows/rcc-logs.yaml) harvests run results
+onto the `rcc` branch twice an hour,
+and [`each.yaml`](/.github/workflows/each.yaml) triggers on every push
+to a `*-dev` branch.
+Those cadences bound how fast a firing can learn anything;
+they do not decide when a firing happens.
 
-* [`.claude/skills/series-loop.md`](../../../../.claude/skills/series-loop.md)
-* [`.claude/skills/`](../../../../.claude/skills) —
-  the sibling playbooks (`series-forward`, `series-rebase`, `series-open`),
-  machine-loaded from there
+A firing serves **all** series in one pass,
+and a series is discovered rather than configured:
+the firing lists `refs/heads/*-build`,
+and every `<S>-build` with a sibling `<S>-dev` is a series it serves —
+base series and forward (`-fwd`) counterparts alike.
+Opening a series therefore takes no configuration change, only refs.
+The refs themselves, and what each of the four guarantees,
+belong to [`branches/model/`](/handbook/branches/model/)
+and [`branches/invariants/`](/handbook/branches/invariants/).
 
-To write this leaf:
+## One firing
 
-* write a prose summary of the loop's stages and when it fires;
-  the procedures stay machine-loaded under `.claude/skills/` —
-  link, never copy
+Setup runs first and is never skipped;
+each numbered stage is skipped when it has nothing to do.
+
+**0. Setup** decides what the firing is allowed to believe.
+It fetches every branch, unshallowed, with tags —
+a narrowed clone enumerates zero series and reports a clean pass over nothing —
+and reads the open pull requests that touch `.github/`, `scripts/`
+or `.claude/`.
+Those are context, not instructions:
+an open PR is tooling the series does *not* have yet,
+so a failure it already documents is one to work around
+rather than diagnose again.
+
+**1. Vendor onto `<S>-build`** decides how far the buffer reaches.
+It runs `main`'s copy of `vendor-one.sh` against the buffer worktree,
+which is the one place the port stage below cannot reach:
+`-build` carries no ports by design.
+The script gates itself, syntax-checking the glue against the freshly
+vendored headers after each commit and stopping at the first break,
+so the stage's real work is fixing glue.
+`-build` is pushed unconditionally — no CI runs on it, and red never
+blocks the buffer.
+The vendoring mechanics are owned by
+[`vendoring/pipeline/`](/handbook/operations/vendoring/pipeline/).
+
+**2. Repair the oldest `<S>-dev` failure** decides whether a red commit
+is the tree's fault or the run's.
+Only the range `<S>-green..<S>-dev` is ever examined,
+and classification is by what a log positively contains, never by a
+missing marker.
+A commit the tree broke is repaired by folding the fix into the offending
+commit and replaying the tail, so every commit stays independently green;
+a commit the infrastructure broke is asked for again by pushing a
+`retry-<S>-dev` ref at it, which rewrites nothing and re-mints no
+descendants.
+That ref doubles as the ledger: already sitting on the commit, it means
+the one rerun was spent and the failure is real.
+The failure taxonomy — glue gate, base scans, dropped patches, stale
+snapshots — is owned by
+[`vendoring/troubleshooting/`](/handbook/operations/vendoring/troubleshooting/).
+
+**3. Advance `<S>-green` and `<S>-build-base`** decides how far the series
+is trusted.
+Green fast-forwards to the newest commit with a `success` run for
+everything below it, and `-build-base` follows to the equivalent buffer
+commit.
+Fast-forward only: if green cannot fast-forward, verified history was
+rewritten and the firing stops and says so.
+
+**4. Port from `main`** decides nothing — its goal is identity, not
+curation.
+After the stage, `.github/`, `scripts/` and `.claude/` on `<S>-dev` are
+byte-identical to `main`'s.
+Because CI reads workflows and scripts from the branch it checks, this is
+what puts a tooling fix into effect, and it is why a fix never waits for a
+forward.
+`scripts/series-port.sh` lists every commit `main` has that the series
+lacks, classified `TOOLING` / `MIXED` / `OTHER` / `VENDOR`, and applies all
+but `VENDOR`; conflicts and engine-incompatible commits stay judgement.
+
+**5. Extend `<S>-dev`** decides how much of the buffer is consumed —
+up to 100 commits per firing, and only when everything in flight is green.
+A series with a live forward counterpart is being replaced, so it is
+verified and promoted but never extended.
+
+**6. Suggest a cutover** decides only to report one.
+When a forward series has caught up, the firing prints the
+`series-cutover.sh` command and stops.
+The swap moves a serving green *sideways* and deletes the counterpart that
+would let it be undone, so a human owns it;
+the script enforces its own half by refusing to run without a terminal
+and a typed confirmation.
+
+**7. Open a pull request for whatever the tooling got wrong.**
+A firing that worked around a bug in a script or a workflow owes `main` a
+PR before it ends — one per cause, small, with the failing firing linked as
+evidence.
+The workaround is done by hand first, so the fix is never load-bearing for
+the firing that found it, and the routine never merges its own PR.
+Review is owned by [`operations/review/`](/handbook/operations/review/).
+
+## The playbooks
+
+| Playbook | When it is used |
+|---|---|
+| [`series-loop.md`](/.claude/skills/series-loop.md) | Every firing: the stages above, in order. |
+| [`series-open.md`](/.claude/skills/series-open.md) | Once per series, when upstream cuts a release branch. |
+| [`series-forward.md`](/.claude/skills/series-forward.md) | When `main` has moved far enough under a series that it needs a new base: a `-fwd` counterpart is built beside it and swapped in by hand. |
+| [`series-rebase.md`](/.claude/skills/series-rebase.md) | While a `-fwd` series is still work in progress, to move it onto a newer mainline. |
+
+The mechanical helpers the loop calls — `series-check.sh` for a read-only
+verdict per series, `series-advance.sh` for stages 3 and 5,
+`series-port.sh` for stage 4, `series-cutover.sh` for the manual swap —
+are listed under this leaf in the generated
+[`scripts/` index](/scripts/README.md).
+
+## Limits
+
+The loop owns verification and promotion, and nothing beyond that.
+It never performs a cutover, never merges a tooling PR, and never moves
+`-green` or `-build-base` anywhere but forward.
+It advances on completed, successful runs and never on the absence of a
+failure, so a commit missing from the harvest makes it wait rather than
+guess.
+It also keeps no state of its own: git alone is sufficient in principle,
+richer tools shorten diagnosis but are never depended on.
+
+Shard planning, the verdict store, and how a commit gets a run at all
+belong to [`ci/per-commit/`](/handbook/operations/ci/per-commit/).
+Why the engine is vendored one commit at a time is
+[`vendoring/model/`](/handbook/operations/vendoring/model/).
+Intent — where the loop is still heading, and which pieces are landed
+versus proposed — lives in
+[`plan/PLAN-vendoring-simplification.md`](/plan/PLAN-vendoring-simplification.md).


### PR DESCRIPTION
## What this leaf now owns

`handbook/operations/vendoring/series-loop/` explains the routine that vendors every series:
what fires it, what each of its stages decides, which playbook carries each move, and where the loop's limits are.
It stays a **pointer leaf** — the procedures remain machine-loaded under `.claude/skills/` and are linked, never copied.
The page states plainly that no workflow drives the loop (there is no vendoring workflow in the repository at all) and separates the repository's adjacent schedules — `sync.yaml`, `rcc-logs.yaml`, and `each.yaml` on pushes to `*-dev` — from the firing itself.
Boundaries are linked rather than absorbed: red runs to `vendoring/troubleshooting/`, the vendoring scripts to `vendoring/pipeline/`, shard mechanics and the verdict store to `ci/per-commit/`, the series refs to `branches/model/` and `branches/invariants/`, PR flow to `operations/review/`, and intent to `plan/PLAN-vendoring-simplification.md`.

## What moved

* `.claude/skills/series-loop.md` — gained a visible italic handbook backreference under its H1. Nothing removed; it stays the machine-loaded procedure.
* `.claude/skills/series-forward.md` — same backreference line.
* `.claude/skills/series-rebase.md` — same backreference line.
* `.claude/skills/series-open.md` — same backreference line.
* `AGENTS.md` — lost a stale schedule claim (vendoring does not run "daily via GitHub Actions"; the bullet now routes to the leaf that owns when the loop fires), and its routing row for the playbooks now names the leaf instead of the four skill files, which the leaf links in turn.
* `scripts/README.md` — unchanged. The generated index already groups `series-*.sh` under this leaf, so those scripts need no backreference of their own and the file-to-leaf mapping needed no edit.

Every behavioral claim on the page was checked against the source: `series-advance.sh` consumes at most one chunk per firing (`chunk=${2:-100}`), `series-check.sh` prints ADVANCE / WAIT / RETRY / REPAIR / IDLE plus a CUTOVER suggestion, `series-port.sh` classifies TOOLING / MIXED / OTHER / VENDOR and applies all but VENDOR, `series-cutover.sh` fails before the fetch when there is no terminal and takes the series name as confirmation.

## Assumptions

* **All four skills belong to this leaf.** The stub's `Today:` section listed `series-loop.md` plus the three siblings, and no other stub in the tree mentions `.claude/skills/`, so all four got the backreference. `series-open.md` is the closest call — opening a series is arguably `branches/model/` territory — but the loop is what discovers and then serves a new series, so it is listed here as the once-per-series playbook.
* **The schedule is genuinely outside the repository.** Nothing under `.github/workflows/` fires the loop and there is no `vendor.yaml`; `BRANCHES.md` and `plan/PLAN-vendoring-simplification.md` both call it "a scheduled Claude routine". The page says the schedule lives with the routine that invokes the playbook, outside this tree, rather than inventing a cadence. Confirm that is the intended framing.
* **`AGENTS.md`'s vendoring bullet was in scope.** Most of that section belongs to the `model/` and `pipeline/` leaves being written in parallel, so only the one bullet carrying the (false) trigger claim was touched. If the pipeline leaf rewrites the whole section, this edit is a trivial merge.
* **`BRANCHES.md` was left alone, and the contradiction it carries is now visible in the tree.** Its "Synchronization › Vendoring" paragraph says `-dev` is consumed "up to 25 commits at a time", which contradicts the verified default in `series-advance.sh` (`chunk=${2:-100}`). Since the leaf now states the hundred in prose (see the sweep below), the two documents disagree in the open. That file is owned by the `branches/` leaves, so the discrepancy is reported rather than fixed here.
* **Ref mechanics are named, not explained.** The series refs are named once so the stages read, with the model itself left to `branches/model/`; a reviewer should check the split lands where they expect.

## Durability sweep

A later pass removed the facts a routine commit would invalidate.

**Out, replaced by the mechanism:**

* "`sync.yaml` … hourly" and "`rcc-logs.yaml` … twice an hour" → "each on the
  schedule its own `cron:` line sets". Both workflows are already linked from
  that sentence, so a reader gets today's cadence from the file. The argument
  the sentence makes — those cadences bound how fast a firing can learn
  anything, but do not decide when it fires — is untouched.

**Out, because the count served no argument:** "what each of the four
guarantees" → "what each of them guarantees". The sentence only hands the refs
to `branches/model/`; counting them there and here invites the two to disagree.

**Kept:** the stage numbers 0–7. They are identifiers, not a tally — the leaf
says "stages 3 and 5" and "stage 4", and the playbooks use the same numbering.
The literal classifications `TOOLING` / `MIXED` / `OTHER` / `VENDOR` are values,
not a count. The single-retry rule ("the one rerun was spent") is the policy
itself.

## Correction after the sweep

The sweep had also replaced the extend cap, "up to 100 commits per firing",
with "one chunk per firing, sized by `series-advance.sh`'s chunk argument".
That went too far, and a follow-up commit put the value back. A default
governs behaviour, so a reader who must open the script to learn it has been
sent away for the thing they came for.

Stage 5 now reads **"one chunk per firing — a hundred commits by default,
overridable per call"**, and the sentence after it delegates the bound's
rationale — what the bound buys — to
[`branches/model/`](/handbook/branches/model/) rather than arguing it here.
The mechanism stays beside the value: the default is `chunk=${2:-100}` in
`series-advance.sh`. Only the chunk size was restored; the two cadence
pointers above stand as the sweep left them.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PD23hjFQFRWW62HFvru187)_