### PR TITLE
docs(handbook): Write the testing/snapshots leaf

### DIFF
--- a/handbook/testing/snapshots/README.md
+++ b/handbook/testing/snapshots/README.md
@@ -1,17 +1,148 @@
 # Snapshots
 
-*Stub — this leaf will own its topic;
-today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../meta/handbook/);
-the last section holds this leaf's parameters.*
+How the suite records expected output as snapshot files,
+and how a changed snapshot is accepted —
+deliberately, because accepting one asserts that the new output is correct.
 
-Scope: snapshot tests, and accepting changed snapshots deliberately.
+## What a snapshot records
 
-Today:
+Snapshot expectations are testthat's.
+About sixty `expect_snapshot()` calls (and one `expect_snapshot_error()`)
+are spread over `tests/testthat/`,
+and the text they captured lives in `tests/testthat/_snaps/<file>.md` —
+one Markdown file per test file,
+one section per test, holding the code and its printed output.
+Running them is running the suite
+([`testing/suite/`](/handbook/testing/suite/README.md));
+whether they run at all under CRAN's rules is
+[`testing/guards/`](/handbook/testing/guards/README.md).
 
-* [`scripts/snapshot-accept.sh`](../../../scripts/snapshot-accept.sh) — its header is the procedure
+Much of the recorded text comes from the engine rather than from R:
+error messages and the position they point at, type names,
+`EXPLAIN` plans, the storage summary.
+A snapshot therefore drifts whenever a vendored DuckDB changes its output,
+which is why snapshot repair is a routine part of vendoring
+([`operations/vendoring/series-loop/`](/handbook/operations/vendoring/series-loop/README.md)).
 
-To write this leaf:
+The one thing a snapshot must not record is the package's own name.
+Every flavor but the mainline one ships under a different name
+([`branches/flavors/`](/handbook/branches/flavors/README.md)),
+and anything derived from `get_package_name()` carries that name into
+the output it produces —
+the session storage home most visibly.
+`scripts/lts.patch` deliberately does not rewrite `tests/testthat/_snaps/`,
+so a file recorded on one flavor could never match another.
+`tests/testthat/helper-snapshot.R` normalises at capture time instead:
+pass `transform = transform_package_name` to any expectation
+whose output can contain the package name,
+and every flavor records the same text.
 
-* absorb: the procedure in `scripts/snapshot-accept.sh`'s header;
-  say when accepting is right and when it hides a regression
+## Accepting a changed snapshot
+
+Every route ends in `testthat::snapshot_accept()`,
+which promotes the output of the last run to be the recorded one.
+They differ in who reads the diff, and when.
+
+**By hand.**
+Run the failing test, call `testthat::snapshot_accept("<name>")`,
+run it again to confirm it holds.
+
+**In CI.**
+`.github/workflows/update-snapshots/` is a composite action
+wired into the R-CMD-check jobs
+([`operations/ci/workflows/`](/handbook/operations/ci/workflows/README.md)).
+It greps `tests/testthat/test-*.R` for the literal string `snapshot`,
+runs `testthat::test_local()` over just those files
+with `TESTTHAT_PARALLEL=FALSE`,
+and if any of them failed *or warned*
+calls `testthat::snapshot_accept()` with no argument —
+accepting all of them at once.
+Where the result goes depends on the event.
+Outside a pull request it opens a pull request
+from `snapshot-<base>-<job>-<matrix>`
+carrying nothing but `tests/testthat/_snaps`,
+and then fails the job on purpose,
+so a red build is what announces the drift.
+On a pull request it opens nothing:
+the accepted files stay in the working tree
+for the later `commit` step,
+which pushes them onto the branch,
+or — for a pull request from a fork —
+uploads them as a patch artifact and fails.
+A custom build opts out by setting `SKIP_UPDATE_SNAPSHOTS=true`.
+Per-commit builds mirror the same step
+and publish the accepted files as a `snapshot-<sha>-rcc-smoke-null` branch
+([`operations/ci/per-commit/`](/handbook/operations/ci/per-commit/README.md)).
+
+**For one commit deep in a series.**
+`scripts/snapshot-accept.sh <commit-ish> <snapshot-name>...`
+is the fallback when no `snapshot-<sha>-rcc-smoke-null` branch exists,
+or when its diff does not survive review.
+It checks the commit out detached —
+a probe must never move a branch ref —
+wipes `src/` with `git clean -fdx`,
+because a stale object for a source that upstream has since folded
+into a unity file links as a duplicate-symbol error,
+installs, runs the suite,
+accepts each named snapshot,
+and re-runs to confirm the accepted files hold.
+It leaves them under `tests/testthat/_snaps/` in the working tree
+and prints them;
+folding them into the offending commit is the caller's job.
+
+## When accepting is right, and when it hides a regression
+
+Accepting is right when the diff reads as the change that caused it.
+A vendored engine commit that reworded an error,
+moved a reported error position,
+renamed a type, or changed a plan's layout
+should show up in `_snaps/` as exactly that and nothing more.
+Folding the accepted files into the commit that changed the behaviour
+then keeps the history honest:
+the commit that moved the output is the commit that carries
+the new expectation.
+Accepting is accepting new behaviour as correct,
+so it deserves the same scrutiny as a code review.
+
+Accepting hides a regression when:
+
+* **A snapshot file, or a section of one, disappears.**
+  Recorded output is only dropped when its test stopped running —
+  a skip that now fires, an error raised before the expectation,
+  a helper that no longer loads.
+  That is a failure in its own right,
+  and accepting it deletes the evidence.
+* **The diff is wider than its cause.**
+  A change to one operator that moves snapshots
+  of tests it has no business touching
+  is a signal to find out why, not to record it.
+* **Output turned into an error, or an error lost its detail.**
+  A message that keeps its class but drops its position or its context
+  is a regression wearing the shape of a rewording.
+* **Nothing explains it.**
+  Output that moved with no engine change behind it
+  is an R-layer change nobody made on purpose.
+* **The text differs only by the package name.**
+  That is a missing `transform = transform_package_name`,
+  not drift;
+  accepting it records a file that is wrong on every other flavor.
+* **The output is not deterministic.**
+  A one-shot warning fires for whichever test reaches it first,
+  so its snapshot depends on test order,
+  and accepting simply freezes one run's ordering.
+  The repair is to make the output stable —
+  by excluding the case, or by pinning the order —
+  not to re-record it after every reshuffle.
+
+CI's blanket accept is a diff producer, not a verdict.
+It accepts everything that failed or warned,
+real failures included,
+and then fails the build precisely so that a person reads the result.
+A `snapshot-…` pull request is never merged unread.
+If the diff is surprising in any way, do not fold it blind:
+rebuild locally with `scripts/snapshot-accept.sh` and compare.
+When a reviewed fold may skip the local pass
+is the series loop's call
+([`operations/vendoring/series-loop/`](/handbook/operations/vendoring/series-loop/README.md));
+reading snapshot drift out of a red run is
+[`operations/vendoring/troubleshooting/`](/handbook/operations/vendoring/troubleshooting/README.md).

--- a/handbook/testing/snapshots/README.md
+++ b/handbook/testing/snapshots/README.md
@@ -7,8 +7,7 @@ deliberately, because accepting one asserts that the new output is correct.
 ## What a snapshot records
 
 Snapshot expectations are testthat's.
-About sixty `expect_snapshot()` calls (and one `expect_snapshot_error()`)
-are spread over `tests/testthat/`,
+`expect_snapshot()` calls are spread over `tests/testthat/`,
 and the text they captured lives in `tests/testthat/_snaps/<file>.md` —
 one Markdown file per test file,
 one section per test, holding the code and its printed output.

--- a/scripts/snapshot-accept.sh
+++ b/scripts/snapshot-accept.sh
@@ -1,14 +1,9 @@
 #!/bin/bash
 # Rebuild a commit, run the suite, accept the named snapshots, re-run to
-# confirm they hold. The fallback for snapshot repair when no
-# snapshot-<sha>-rcc-smoke-null branch exists, or when its diff does not
-# survive review (.claude/skills/series-loop.md).
+# confirm they hold.
 #
 # Usage: snapshot-accept.sh <commit-ish> <snapshot-name>...
 #   snapshot-accept.sh abc1234 sql types
-#
-# Leaves the corrected files under tests/testthat/_snaps/ in the working tree
-# and prints them; folding them into the offending commit is the caller's job.
 
 set -euo pipefail
 


### PR DESCRIPTION
## What this leaf now owns

`handbook/testing/snapshots/` explains snapshot testing in this package:
what `tests/testthat/_snaps/*.md` records and why so much of it is engine output rather than R output;
the package-name normalisation in `tests/testthat/helper-snapshot.R` that keeps one recorded file valid on every flavor, given that `scripts/lts.patch` deliberately leaves `_snaps/` alone;
the three routes to accepting a changed snapshot (by hand, the `update-snapshots` composite action in CI, and `scripts/snapshot-accept.sh` for one commit deep in a series);
and the judgment no script header stated — when accepting is right, and the six shapes of diff where accepting hides a regression.
Running the suite stays [`testing/suite/`](/handbook/testing/suite/README.md)'s topic, the CRAN gate stays [`testing/guards/`](/handbook/testing/guards/README.md)'s, and consuming snapshot branches during vendoring stays [`operations/vendoring/series-loop/`](/handbook/operations/vendoring/series-loop/README.md)'s; all are linked, not repeated.

## What moved

- `scripts/snapshot-accept.sh` — lost the two explanatory paragraphs of its header: its role as the fallback for snapshot repair when no snapshot-&lt;sha&gt;-rcc-smoke-null branch exists or its diff does not survive review, and the note that it leaves the corrected files in the working tree for the caller to fold. Both now live in the leaf. It keeps the extractable one-line summary that `scripts/README.md` is built from (#2453), plus its usage block. It gained nothing: `scripts/` has a generated index that already carries the backreference.

`scripts/README.md` is unchanged and verified current (`Rscript .claude/skills/docs-consistency/docs-readme.R --check`) — the `globs =` mapping in `.claude/skills/docs-consistency/docs-readme.R` already assigns `snapshot-accept.sh` to `testing/snapshots/`, and shrinking the header did not touch its first sentence.

## Assumptions

- The stub's "absorb the procedure in the header" was read as *move the explanation, keep the operating instructions*: the one-line summary and the `Usage:` block stayed in the script, everything else moved. If the intent was to strip the usage too, say so.
- The `update-snapshots` action's own comment says a pull request "will use reviewdog/action-suggester in the commit action". That is stale — `.github/workflows/commit/action.yml` contains no reviewdog step; reviewdog only appears in `format-suggest.yaml`. The leaf therefore states what the code actually does on a PR: the accepted files stay in the working tree, and the later `commit` step pushes them onto the branch, or uploads a patch artifact and fails for a fork PR. Worth confirming that the stale comment (not the leaf) is what should be fixed.
- The action is invoked from `R-CMD-check.yaml` (both `rcc-smoke` and `rcc-full`) and `R-CMD-check-dev.yaml`, with slightly different fork guards per job. The leaf says "the R-CMD-check jobs" and links [`operations/ci/workflows/`](/handbook/operations/ci/workflows/README.md) rather than enumerating them, on the grounds that the workflow inventory is that leaf's topic.
- "The output is not deterministic" is grounded in a real case from `plan/history/main-dev-review-2026-07.md`: a one-shot nanosecond-coercion warning (`std::call_once`) made the `types.md` snapshot order-dependent, and the fix was to exclude the type from `test_all_types()`, not to re-record. The leaf states the hazard generically without linking that historical review, since it is a review record rather than intent.
- No `plan/` document carries intent for snapshots, so the leaf points at none.
- ~~The suite has 63 `expect_snapshot()` calls and one `expect_snapshot_error()` across 12 recorded files; the leaf says "about sixty" so the number cannot rot.~~ Superseded by the durability sweep below — the count is gone from the leaf entirely.

## Durability sweep

A targeted pass for one defect class: facts a routine commit invalidates.

**Removed.** "About sixty `expect_snapshot()` calls (and one
`expect_snapshot_error()`)" is now plainly "`expect_snapshot()` calls".
Rounding to "about sixty" did not save it: the next contributor who adds a
snapshot file makes it wrong anyway, and the figure carried no argument. The
sentence exists to say where the expectations live and where the text they
capture is recorded, and it still names both `tests/testthat/` and the
per-test-file Markdown under `tests/testthat/_snaps/` — so a reader who wants
the number counts it, and is right on the day they look.

**Kept.** "One Markdown file per test file, one section per test" is the
recording format, not a tally; it is what a reader needs in order to find a
given snapshot. The six shapes of hiding-a-regression diff are a taxonomy of
judgment, not a count of things in the tree.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PD23hjFQFRWW62HFvru187)_