### PR TITLE
docs(handbook): Write the where-to-help leaf

### DIFF
--- a/handbook/contributors/where-to-help/README.md
+++ b/handbook/contributors/where-to-help/README.md
@@ -1,20 +1,132 @@
 # Where to help
 
-*Stub — this leaf will own its topic;
-today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../meta/handbook/);
-the last section holds this leaf's parameters.*
+Finding something worth doing in this repository:
+the label vocabulary on the issue tracker,
+how to turn that vocabulary into a live list of entry points,
+and where longer-range intent is written down.
 
-Scope: finding work — the labels, good entry points, the roadmap.
+## The invitation
 
-Today:
+One label invites outside work: `help wanted ❤️`,
+whose description on the tracker is the whole of its definition —
+"we'd love your help!".
+It marks work the maintainers would welcome from someone else;
+whether a given issue earns it is a triage verdict, not a rule
+([`operations/triage/`](/handbook/operations/triage/README.md)).
+Start from the query, not from a list:
 
-* the `help wanted ❤️` and `upstream 🐟` labels on the issue tracker
+* [open issues labelled `help wanted ❤️`](https://github.com/duckdb/duckdb-r/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted+%3Aheart%3A%22)
 
-To write this leaf:
+The tracker is the list.
+No curated selection of starter issues is kept here,
+because such a selection is wrong within a week
+and nothing forces it to be corrected —
+a saved query is never wrong.
+There is no `good first issue` label either:
+the tracker does not grade issues by difficulty.
 
-* explain the label vocabulary
-  (`operations/triage/` owns the verdicts behind it)
-  and where the roadmap lives (`meta/plans/`)
-* state how to find entry points by label
-  rather than keeping a list that rots
+The emoji in a label name is not always the character it looks like.
+GitHub renders the shortcode `:heart:` in a label name as ❤️,
+so this label reads `help wanted ❤️` on screen
+but has to be typed as `label:"help wanted :heart:"` in a search box
+or on a command line.
+`upstream 🐟` and `duckplyr 🗜️` carry the emoji character itself
+and can be pasted verbatim.
+
+## The vocabulary
+
+The authoritative set is the tracker's own
+[label index](https://github.com/duckdb/duckdb-r/labels);
+what each label says:
+
+| Label | What it says |
+|---|---|
+| `help wanted ❤️` | we'd love your help! |
+| `bug` | an unexpected problem or unintended behavior |
+| `feature` | a feature request or enhancement |
+| `documentation` | the answer is a documentation change |
+| `upkeep` | maintenance, infrastructure, and similar |
+| `reprex` | needs a minimal reproducible example |
+| `reproduced` | the report has been reproduced |
+| `upstream 🐟` | the cause is in the DuckDB engine, not in the R glue |
+| `duckplyr 🗜️` | support for the duckplyr R package |
+
+Six of these carry that wording as their own description on GitHub;
+`documentation`, `reproduced` and `upstream 🐟` carry none,
+and the table records how they are used.
+`reproduced` is rare in practice.
+The labels are an issue vocabulary:
+open pull requests carry none.
+
+`upstream 🐟` is the boundary that matters most when choosing work.
+It says the cause lies in the vendored DuckDB C++ engine
+rather than in this package's R and C++ glue,
+so the fix belongs in
+[`duckdb/duckdb`](https://github.com/duckdb/duckdb)
+and reaches this package only when the vendoring pipeline
+picks up the commit that carries it —
+see [`operations/vendoring/`](/handbook/operations/vendoring/README.md)
+and [`architecture/engine/`](/handbook/architecture/engine/README.md).
+A window-function binder failure closed this way
+([#2357](https://github.com/duckdb/duckdb-r/issues/2357))
+is the shape to expect.
+`src/duckdb/` is never edited here.
+
+`reprex` marks a report that is not yet actionable.
+Producing the missing reproducible example
+is help in its own right, and needs no build of the package.
+
+## Narrowing the search
+
+Combine a label with the ordinary GitHub qualifiers.
+Each of these is a query to paste into the tracker's search box:
+
+```
+is:issue is:open label:"help wanted :heart:" label:bug
+is:issue is:open label:"help wanted :heart:" -label:"upstream 🐟"
+is:issue is:open label:documentation
+is:issue is:open label:reprex
+is:issue is:open no:label
+```
+
+The first narrows to bugs;
+the second drops what will be fixed upstream.
+The third finds issues whose answer is a page of this handbook,
+which is the cheapest kind of contribution to finish.
+The last finds issues nobody has classified yet;
+reproducing one on a current build and saying so in a comment is useful,
+but the verdict that follows is the maintainer's —
+[`operations/triage/`](/handbook/operations/triage/README.md)
+owns what a label means to apply and what closing an issue requires.
+
+Nothing in the vocabulary records who is working on what,
+so comment on the issue before you start.
+A working development environment is
+[`contributors/setup/`](/handbook/contributors/setup/README.md);
+branching, testing and opening the pull request are
+[`contributors/workflow/`](/handbook/contributors/workflow/README.md);
+what a maintainer then checks is
+[`operations/review/`](/handbook/operations/review/README.md).
+
+## Reporting instead of fixing
+
+A report that can be reproduced is worth more than one that cannot,
+and there is no template to fill in:
+this repository has no `.github/ISSUE_TEMPLATE/`,
+so the form is yours to choose.
+A report that does not attract the `reprex` label carries
+a self-contained example that fails,
+the `sessionInfo()` it fails under,
+which flavor and version of the package was installed
+([`branches/flavors/`](/handbook/branches/flavors/README.md)),
+and — when the behavior changed — the last version that worked.
+
+## The roadmap
+
+There is no dated roadmap.
+Intent lives as a plan document under `plan/`,
+and what is live, in which order, is that directory's table;
+[`meta/plans/`](/handbook/meta/plans/README.md) owns it.
+An issue covered by a plan is one to read the plan for first:
+the design decision is already made there,
+and the remaining work is to implement it.

--- a/handbook/contributors/where-to-help/README.md
+++ b/handbook/contributors/where-to-help/README.md
@@ -51,12 +51,10 @@ what each label says:
 | `upstream 🐟` | the cause is in the DuckDB engine, not in the R glue |
 | `duckplyr 🗜️` | support for the duckplyr R package |
 
-Six of these carry that wording as their own description on GitHub;
+Most carry that wording as their own description on GitHub;
 `documentation`, `reproduced` and `upstream 🐟` carry none,
 and the table records how they are used.
-`reproduced` is rare in practice.
-The labels are an issue vocabulary:
-open pull requests carry none.
+The labels are an issue vocabulary, not a pull-request one.
 
 `upstream 🐟` is the boundary that matters most when choosing work.
 It says the cause lies in the vendored DuckDB C++ engine


### PR DESCRIPTION
## What this leaf now owns

`handbook/contributors/where-to-help/` explains how a contributor finds work in this repository: the issue tracker's label vocabulary, how to turn it into a live list of entry points, and where longer-range intent is written down. It documents the labels that actually exist today — `help wanted ❤️`, `bug`, `feature`, `documentation`, `upkeep`, `reprex`, `reproduced`, `upstream 🐟`, `duckplyr 🗜️` — records that `help wanted ❤️` is stored as the shortcode `help wanted :heart:` and so must be typed that way in a search, and gives search queries rather than a curated issue list that would rot. The boundaries stay where they belong: the verdict behind a label and what closing an issue requires are `operations/triage/`'s, the roadmap is `meta/plans/`'s, the mechanics of making a change are `contributors/workflow/`'s, and an `upstream 🐟` issue is fixed in `duckdb/duckdb` and arrives by vendoring.

## What moved

Nothing. The stub named no file to absorb — its "Today" line pointed at the labels on the issue tracker, not at a document — and no secondary document outside `handbook/` serves this leaf, so no file outside `handbook/` changed and no backreference was added.

## Assumptions

* The label set was read from the live repository (`get_label` / issue listings), not from a document. `good first issue`, `needs-info`, `docs-candidate`, `roadmap`, `enhancement`, `question`, `wip`, `wontfix` and `duplicate` do not exist, and the leaf states the absence of `good first issue` as a boundary. `needs-forward-port`, named in `BRANCHES.md` §Forward-porting, does not exist either — it is described there as a *proposed* pattern, so it is left out.
* Three labels carry no description of their own on GitHub (`documentation`, `reproduced`, `upstream 🐟`). The table gives the meaning their use implies, and the paragraph under it says plainly that these are read from usage rather than from a description. The `upstream 🐟` reading is backed by #2357, a DuckDB binder internal error closed under that label.
* The leaf says the repository has no `.github/ISSUE_TEMPLATE/` and therefore describes what a good report contains in prose. If templates land later — `operations/triage/`'s work order lists them as a guardrail to write — that paragraph is the one to replace with a link.
* Links are root-absolute and point at `README.md` explicitly (`/handbook/operations/triage/README.md`) rather than at the directory, so they resolve as blobs on any branch.

## Durability sweep

A pass over the leaf for facts a routine change would invalidate.

**Out:**

* "Six of these carry that wording as their own description on GitHub" — arithmetic
  over today's label set, wrong the first time a label is added. Now "Most".
  The three labels that carry no description of their own are still named:
  naming them is what tells the reader which rows are the handbook's paraphrase
  rather than GitHub's own words.
* "`reproduced` is rare in practice" — a census of how many issues carry a label,
  which rots immediately and served no argument. Cut.
* "The labels are an issue vocabulary: open pull requests carry none" — the same
  census over pull requests, and true only of the pull requests open on the day it
  was checked. Now states the durable half: "an issue vocabulary, not a
  pull-request one".

**Kept:** the table naming each label, and "One label invites outside work".
A vocabulary is the content, not a count of it — the table names the terms, and the
tracker's [label index](https://github.com/duckdb/duckdb-r/labels) is linked as the
authority for the set. That a single label carries the invitation is the design the
section rests on, not an incidental tally. The saved queries stay for the same reason
they were written: a query is never out of date.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PD23hjFQFRWW62HFvru187)_