### PR TITLE
docs(handbook): Write the testing/guards leaf

### DIFF
--- a/.claude/skills/docs-consistency/docs-readme.R
+++ b/.claude/skills/docs-consistency/docs-readme.R
@@ -129,7 +129,7 @@ groups <- list(
   ),
   list(
     owner = "handbook/branches/flavors",
-    globs = c("flavor*")
+    globs = c("flavor.sh", "flavor.patch")
   ),
   list(
     owner = "handbook/build/fast-paths",
@@ -146,6 +146,10 @@ groups <- list(
   list(
     owner = "handbook/architecture/r-layer",
     globs = c("rethrow.R")
+  ),
+  list(
+    owner = "handbook/testing/guards",
+    globs = c("flavor-package-name.R")
   ),
   list(
     owner = "handbook/testing/snapshots",

--- a/BRANCHES.md
+++ b/BRANCHES.md
@@ -1,5 +1,7 @@
 # Branching Strategy
 
+*Handbook: [`testing/guards/`](/handbook/testing/guards/README.md).*
+
 Version numbers are given at the time of writing (March 2026) and may be outdated by the time you read this.
 The branching strategy is expected to remain stable.
 
@@ -25,12 +27,8 @@ The seven components are:
    name variant (`duckdb`, `duckdb.1.4`, `duckdb.1.4.dev`, …).
    Managed via `scripts/flavor.patch` and `scripts/flavor.sh`; also covers the `@useDynLib` directive and
    the `DUCKDB_PACKAGE_NAME` C++ macro.
-   `scripts/flavor-package-name.R` guards the boundary: it fails as soon as the package name is hard-coded —
-   as a namespace qualifier or as a quoted string — in code or docs anywhere the patch does not rewrite it.
-   Code asks for the name at run time with `get_package_name()` instead, and docs do not namespace-qualify
-   our own objects. CI runs the scan from `.github/workflows/custom/after-install`;
-   `tests/testthat/test-flavor-package-name.R` wraps it for `testthat::test_local()` and skips under
-   `R CMD check`, which works from a tarball that carries neither the sources nor `scripts/`.
+   The flavor-name guard keeps the rename honest — see
+   [`testing/guards/`](/handbook/testing/guards/README.md).
 
 3. **Glue code** (`src/*.cpp`, `src/include/`): the C++ bridge between R and the DuckDB C++ API.
    Glue code may change when DuckDB's C++ API shifts, so it is updated together with vendoring commits.

--- a/R/cran-guard.R
+++ b/R/cran-guard.R
@@ -1,3 +1,4 @@
+# Handbook: handbook/testing/guards/
 # CRAN guard
 #
 # DuckDB ships its own large C++ engine. Running the test suite or the runnable

--- a/handbook/testing/guards/README.md
+++ b/handbook/testing/guards/README.md
@@ -56,7 +56,7 @@ the `skip_on_*()` helpers that decide individual tests
 belong to the suite's helpers, not here.
 
 That the gate actually holds is checked, not assumed.
-One matrix entry builds the engine with a tripwire
+A matrix entry builds the engine with a tripwire
 (`-DDUCKDB_R_POISON_ENGINE`, declared in `src/include/rapi.hpp`)
 and forces `DUCKDB_R_RUN_TESTS=false`,
 so any test or example that still reaches the engine aborts the check —

--- a/handbook/testing/guards/README.md
+++ b/handbook/testing/guards/README.md
@@ -1,19 +1,135 @@
 # Guards
 
-*Stub — this leaf will own its topic;
-today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../meta/handbook/);
-the last section holds this leaf's parameters.*
+Two checks that fail loudly rather than let a defect ship:
+the CRAN guard, which keeps DuckDB's bundled C++ engine
+out of CRAN's check farm,
+and the flavor-name guard, which keeps the package name
+from being written down anywhere the flavor rename cannot reach.
 
-Scope: the CRAN test guard and the flavor-name guard.
+## The CRAN guard
 
-Today:
+The suite and the runnable examples both start the bundled engine.
+That is too heavy for CRAN's check farm in time and in memory,
+and past checks there were fragile in ways we could not reproduce.
+The guard prevents a submission that spends the farm's budget on the engine —
+and, symmetrically, it prevents a green local `R CMD check`
+that quietly ran no tests at all,
+because whenever it declines it says so in a framed message
+that names the environment variable to set.
 
-* [`scripts/flavor-package-name.R`](../../../scripts/flavor-package-name.R)
-* [`AGENTS.md`](../../../AGENTS.md)
+The decision is not testthat's usual `NOT_CRAN` dance.
+`tests/testthat.R` decides for itself whether to call `test_check()` at all:
 
-To write this leaf:
+* `DUCKDB_R_RUN_TESTS` always wins.
+  A true-ish value (`true`, `1`, `yes`, `on`, case- and space-insensitive)
+  runs the suite; a false-ish value (`false`, `0`, `no`, `off`) forces it off.
+* With no explicit setting,
+  the suite runs when `GITHUB_ACTIONS` is `true`
+  or when `MY_UNIVERSE` is non-empty —
+  our own CI and r-universe respectively,
+  both of which are GitHub Actions.
+* Everywhere else, including CRAN, nothing runs.
 
-* own: the CRAN guard (tests auto-enable on GitHub Actions) and the
-  flavor-name guard (`scripts/flavor-package-name.R`,
-  `tests/testthat/test-flavor-package-name.R`)
+The same decision exists a second time in `R/cran-guard.R`
+as `duckdb_run_tests_enabled()`,
+which gates the runnable examples through `examples_enabled()` —
+the condition behind every
+`@examplesIf simulate_duckdb()$env$examples_enabled()` in `R/`.
+The duplication is deliberate:
+`tests/testthat.R` inlines the logic
+so that the guard is self-contained and readable
+without loading the package it is about to test.
+Both halves emit a message when they decline,
+so a skipped example is as visible as a skipped suite.
+
+Boundaries.
+`NOT_CRAN` plays no part in the decision:
+setting it alone does not run the suite.
+`scripts/snapshot-accept.sh` sets `NOT_CRAN=true` and `DUCKDB_R_RUN_TESTS=true`
+together, and it is the second of the two that opens this gate.
+The guard lives in `tests/testthat.R`,
+which `testthat::test_local()` never reads,
+so the local fast loop is never gated —
+see [`testing/suite/`](/handbook/testing/suite/README.md).
+And the guard is a gate on the whole suite, not a per-test skip;
+the `skip_on_*()` helpers that decide individual tests
+belong to the suite's helpers, not here.
+
+That the gate actually holds is checked, not assumed.
+One matrix entry builds the engine with a tripwire
+(`-DDUCKDB_R_POISON_ENGINE`, declared in `src/include/rapi.hpp`)
+and forces `DUCKDB_R_RUN_TESTS=false`,
+so any test or example that still reaches the engine aborts the check —
+see [`operations/ci/matrix/`](/handbook/operations/ci/matrix/README.md).
+
+## The flavor-name guard
+
+Every flavor but the mainline one ships this package under a different name,
+so a literal `duckdb` written into the sources
+keeps pointing at the mainline package in those builds.
+It works on `main`, breaks everywhere else, and breaks silently —
+usually noticed by a user rather than by CI.
+The rename itself is
+[`branches/flavors/`](/handbook/branches/flavors/README.md)'s topic;
+the run-time seam that code is supposed to use instead,
+`get_package_name()`, is
+[`architecture/r-layer/`](/handbook/architecture/r-layer/README.md)'s.
+The guard is what makes ignoring the seam impossible to do by accident.
+
+`flavor_package_name_offenders()` in `scripts/flavor-package-name.R`
+scans the tree and returns every hard-coded occurrence
+as a `path:line: content` string.
+It reads the allowlist out of `scripts/flavor.patch` itself —
+the trimmed `-` lines of each hunk, keyed by path —
+so what the rename already accounts for cannot drift
+from what the scan tolerates.
+The R-level surface (`R/`, `man/`, `tests/`, `vignettes/`,
+and the Markdown files at the top level)
+is scanned for `duckdb::`, `duckdb:::`, and `"duckdb"`;
+the C++ glue (`src/`, `inst/include/`, excluding the vendored `src/duckdb/`)
+only for the quoted form,
+because `duckdb::` there is the engine's own C++ namespace
+and has nothing to do with the R package name.
+
+A new hit is meant to be resolved, not silenced.
+In code, ask for the name at run time with `get_package_name()`.
+In docs, do not qualify our own objects at all.
+If the literal really names something else that happens to be spelled the same —
+the DuckDB CLI executable, say —
+write it in two pieces as `paste0("duck", "db")` so it reads as what it is.
+Otherwise, teach `scripts/flavor.patch` to rewrite it.
+
+The scan is deliberately base R only
+and does not need the package loaded,
+because CI runs it straight against a plain checkout:
+a step in `.github/workflows/custom/after-install`,
+restricted to the `rcc-smoke` job.
+It reads the checkout and nothing else,
+so every other matrix entry would return the same answer
+and running it once is enough.
+
+`tests/testthat/test-flavor-package-name.R` wraps the same function
+for `testthat::test_local()`,
+and skips when `scripts/flavor-package-name.R` is not next to the sources.
+That skip is not a fallback — it is the reason the CI step exists.
+`R CMD check` runs the tests from a built tarball,
+and `scripts/` is `.Rbuildignore`d,
+so neither the scan nor the patch it reads is present there
+and the test can only skip.
+Delete the CI step and the guard is gone
+in the one place it would ever have fired;
+delete the guard entirely
+and a hard-coded `duckdb:::` reaches the wrong package,
+or no package at all,
+in every flavored build.
+
+Limits.
+The scan is a text search over a fixed file list,
+so it cannot tell a deliberate literal from a mistake —
+hence the `paste0()` convention rather than an inline exemption.
+Only the top-level Markdown files are scanned,
+which leaves `handbook/` and `scripts/*.md` uncovered;
+both are `.Rbuildignore`d and ship to nobody,
+but a handbook page that qualifies our own objects with `duckdb::`
+would still be wrong on every flavor and the guard will not say so.
+Snapshots under `tests/testthat/_snaps/` are outside the scan as well.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -29,7 +29,6 @@ Root of the documentation tree: [`handbook/`](../handbook/).
 
 | File | Purpose |
 |---|---|
-| [`flavor-package-name.R`](flavor-package-name.R) | Guard for the flavor rename. |
 | [`flavor.patch`](flavor.patch) | — |
 | [`flavor.sh`](flavor.sh) | Apply a package flavor: rewrite scripts/flavor.patch to the target name (say, duckdb.dev), apply it, and commit the rename; see BRANCHES.md. |
 
@@ -98,6 +97,12 @@ Root of the documentation tree: [`handbook/`](../handbook/).
 | [`series-cutover.sh`](series-cutover.sh) | Atomically replace a series with its forward counterpart. |
 | [`series-forward-build.sh`](series-forward-build.sh) | Populate `<S>-fwd-build`: replay every vendor commit of the old `<S>-build` onto HEAD, which must be the freshly flavored seed on current `main` (.claude/ski... |
 | [`series-port.sh`](series-port.sh) | Bring a series' -dev branch level with `main` — stage 4 of the series loop (.claude/skills/series-loop.md). |
+
+## [`testing/guards/`](../handbook/testing/guards/)
+
+| File | Purpose |
+|---|---|
+| [`flavor-package-name.R`](flavor-package-name.R) | Guard for the flavor rename. |
 
 ## [`testing/snapshots/`](../handbook/testing/snapshots/)
 

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -9,6 +9,7 @@
 library(testthat)
 library(duckdb)
 
+# Handbook: handbook/testing/guards/
 # CRAN guard
 #
 # The duckdb test suite exercises DuckDB's bundled C++ engine, which is too heavy

--- a/tests/testthat/test-flavor-package-name.R
+++ b/tests/testthat/test-flavor-package-name.R
@@ -1,3 +1,5 @@
+# Handbook: handbook/testing/guards/
+#
 # The flavored builds ship this package under a different name, and scripts/flavor.patch
 # is what renames it. This test fails when the name is hard-coded somewhere the
 # patch does not rewrite; scripts/flavor-package-name.R explains the rules and holds


### PR DESCRIPTION
## What this leaf now owns

`handbook/testing/guards/` explains the two checks that fail loudly rather than let a defect ship, and — as the work order asked — what each one *prevents*, not just what it runs. The CRAN guard section describes the real mechanism: `tests/testthat.R` decides for itself whether to call `test_check()` at all, from `DUCKDB_R_RUN_TESTS` (explicit, always wins) falling back to `GITHUB_ACTIONS` and `MY_UNIVERSE` — no `NOT_CRAN`, no top-level `skip_on_cran()`; the same decision lives a second time in `R/cran-guard.R` as `duckdb_run_tests_enabled()`, gating runnable examples through `examples_enabled()`. The flavor-name guard section describes `flavor_package_name_offenders()`, its patch-derived allowlist, the `rcc-smoke` CI step, and why `tests/testthat/test-flavor-package-name.R` can only ever skip under `R CMD check` — the point being that deleting the CI step removes the guard from the one place it would fire. The flavor model and the `get_package_name()` seam are linked, not explained.

## What moved

* `BRANCHES.md` — loses the six-line description of the flavor-name guard from &#34;Package Components&#34; item 2, replaced by a one-line pointer to the leaf; the flavor definition itself stays for `branches/flavors/`. Gains a `*Handbook: …*` backreference line under the H1.
* `.claude/skills/docs-consistency/docs-readme.R` — the `flavor*` glob under `handbook/branches/flavors` is narrowed to `flavor.sh` / `flavor.patch`, and a new `handbook/testing/guards` group claims `flavor-package-name.R`. Narrowing was required: groups are matched first-match-wins in owner order, so the broad glob would have kept the file and raised a `double-owned` warning.
* `scripts/README.md` — regenerated (not hand-edited); `flavor-package-name.R` moves to a new `testing/guards/` section.
* `R/cran-guard.R` — gains `# Handbook: handbook/testing/guards/`.
* `tests/testthat.R` — gains `# Handbook: handbook/testing/guards/` above the CRAN guard block.
* `tests/testthat/test-flavor-package-name.R` — gains `# Handbook: handbook/testing/guards/` (not covered by any generated index).

`scripts/flavor-package-name.R` itself is untouched: the generated index carries its backreference.

## Assumptions

* **Ownership of `scripts/flavor-package-name.R` moved to `testing/guards/`.** The two stubs disagreed: `branches/flavors/` lists it as &#34;flavor tooling&#34; to absorb, while `testing/guards/` says `own:` it by name. I read `own:` as the stronger claim, and the file is a check that runs in CI and in the suite rather than part of the rename mechanism (`flavor.sh` + `flavor.patch`), which stays with `branches/flavors/`. Worth confirming with whoever writes that leaf.
* **The CRAN guard section covers runnable examples too.** The scope line says &#34;CRAN test guard&#34;, but `R/cran-guard.R` gates tests and examples through one variable and one predicate, and no other leaf claims examples. Splitting them would have meant explaining the same decision twice.
* **`R/cran-guard.R` is claimed by this leaf** even though the stub&#39;s `Today:` list named only `scripts/flavor-package-name.R` and `AGENTS.md`. It is where the guard actually lives, so it got the backreference; `architecture/r-layer/` owns `R/` generally.
* **`AGENTS.md` was not touched.** Its only relevant section, &#34;Never Hard-Code the Package Name&#34;, is the `get_package_name()` seam, which `architecture/r-layer/`&#39;s work order absorbs. Nothing in it describes either guard.
* **`src/include/rapi.hpp` got no backreference** despite carrying the `DUCKDB_R_POISON_ENGINE` tripwire. It belongs to `architecture/glue/`, and it is a flavor-patched file whose hunk already applies at maximum fuzz — editing it risked breaking `scripts/flavor.sh`. The leaf links it in prose instead. (`scripts/flavor.patch` was dry-run after every edit here and still applies.)
* **Limits stated in the leaf that a reviewer may want to sanity-check:** the flavor scan reads only *top-level* `.md` files, so `handbook/` and `scripts/*.md` are uncovered; `_snaps/` is uncovered; the scan reported no offenders when this branch was written.

## Durability sweep

A follow-up pass over the leaf for facts a routine change would invalidate. This leaf needed almost nothing.

**Removed or reframed**

* &#34;**One** matrix entry builds the engine with a tripwire&#34; → &#34;**A** matrix entry&#34;. The original asserted that exactly one entry carries `-DDUCKDB_R_POISON_ENGINE`, which an ordinary edit to the CI matrix would falsify. The durable fact is that the poisoned build exists and what it proves, not how many entries there are; the matrix itself is `operations/ci/matrix/`&#39;s subject and is linked.

**Checked and left alone**

* The leaf never counts tests, test files, or offenders. The flavor guard is described by its *mechanism* — the surfaces it scans, and the allowlist it derives from the `-` lines of `scripts/flavor.patch` — so it needs no number to be complete, and a reader who wants today&#39;s offender list runs `flavor_package_name_offenders()`. (The &#34;zero offenders&#34; observation above is a note on this PR, not a claim in the leaf.)
* **The two guards** and **the two halves of the CRAN decision** (`tests/testthat.R` inlining what `R/cran-guard.R` also computes). Both are structural: a third guard, or a third copy of the decision, would mean rewriting the leaf, so the counts are design rather than description.
* **The environment-variable literals** (`true`, `1`, `yes`, `on`, `false`, `0`, `no`, `off`) — the accepted values, quoted as code.

No non-handbook file needed a change, so `.claude/skills/docs-consistency/docs-readme.R` is untouched by the sweep; `Rscript .claude/skills/docs-consistency/docs-readme.R --check` still reports `scripts/README.md is current`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PD23hjFQFRWW62HFvru187)_