### PR TITLE
docs(handbook): Write the build/fast-paths leaf

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # DuckDB R Package - Operational Instructions
 
+*Handbook: [`build/fast-paths/`](/handbook/build/fast-paths/README.md).*
+
 R package that contains a vendored copy of the DuckDB C++ library and glue code for R, including a DBI and a relational interface.
 
 ## Where to look
@@ -35,7 +37,7 @@ so the check reports "Found no calls to `R_registerRoutines`, `R_useDynamicSymbo
 and fails a package that registers its routines correctly.
 It saves ~10-20 s on this tree, so it is not worth carrying into CI at all.
 
-For an interactive edit-build-test loop, prefer the prebuilt-libduckdb fast path (seconds instead of 10-15 minutes) -- see ["Fast build with system libduckdb"](#fast-build-with-system-libduckdb-linuxmacos-opt-in) and ["Testing with prebuilt DuckDB"](#testing-with-prebuilt-duckdb-the-fast-iterate-loop) below.
+For an interactive edit-build-test loop, prefer the prebuilt-libduckdb fast path (seconds instead of 10-15 minutes) -- see [`build/fast-paths/`](/handbook/build/fast-paths/README.md).
 
 ### Run Tests
 
@@ -113,87 +115,11 @@ UserNM=true R CMD INSTALL . --no-byte-compile
 
 ### Fast build with system libduckdb (Linux/macOS, opt-in)
 
-For iteration during development (and for coding agent sessions), the R
-package can skip compiling the ~1700 vendored .cpp files and link
-against a system-installed libduckdb instead. Drops a clean
-`R CMD INSTALL .` from 10–15 minutes to about 5 seconds.
-
-```bash
-# One-time: install libduckdb matching the vendored DuckDB version
-sudo scripts/install-libduckdb.sh        # to /usr/local
-# or: scripts/install-libduckdb.sh --prefix "$HOME/.local"
-
-# Each install
-DUCKDB_R_USE_SYSTEM_LIB=1 R CMD INSTALL . --no-byte-compile
-```
-
-**What this mode actually does.** The R glue compiles against the
-**vendored headers** in `src/duckdb/src/include/` (the amalgamated
-`duckdb.hpp` shipped with libduckdb releases is missing ~37 of the 71
-internal C++ headers the glue needs — templates like `GenericExecutor`,
-the Arrow integration, core-functions extension internals). Only the
-**implementation** is swapped for the system-installed `libduckdb.so`
-/ `.dylib` at link time and at runtime.
-
-That is only safe if the vendored sources and the installed library
-were built from the **same commit**. `configure` extracts the
-`DUCKDB_SOURCE_ID` from the vendored `pragma_version.cpp`, greps for
-it inside the shared library, and aborts with a clear error if it is
-not present. Re-run `scripts/install-libduckdb.sh` after every
-vendoring bump.
-
-The opt-in only applies to `R CMD INSTALL .` — not to `R CMD build`,
-since the resulting installation depends on libduckdb being present at
-runtime. The installed `duckdb.so` carries an rpath pointing at the
-libduckdb directory; do not move libduckdb after installing.
+Moved to the handbook: [`build/fast-paths/`](/handbook/build/fast-paths/README.md).
 
 ### Testing with prebuilt DuckDB (the fast iterate loop)
 
-`pkgload::load_all()` / `devtools::load_all()` — and therefore
-`testthat::test_local()`, which loads the package the same way — honor
-`DUCKDB_R_USE_SYSTEM_LIB` too: they compile only the ~30 glue `.cpp`
-files in `src/` and link against the prebuilt libduckdb, exactly like
-`R CMD INSTALL .`. This is the recommended setup for any
-edit-build-test loop (including coding-agent sessions), because it turns
-the otherwise 10–15 minute first build into seconds.
-
-```bash
-# One-time, matching the vendored DuckDB version (see above)
-sudo scripts/install-libduckdb.sh          # or --prefix "$HOME/.local"
-
-# Then, in every shell that builds/tests the package:
-export DUCKDB_R_USE_SYSTEM_LIB=1
-export MAKEFLAGS="-j$(nproc)"
-
-R -q -e 'pkgload::load_all()'              # ~1 s warm, no source changes
-R -q -e 'testthat::test_local()'           # runs the suite against the glue
-```
-
-Measured on a clean container (R 4.5.3, ccache warm): a no-op
-`load_all()` takes about 1 second, and a `load_all()` after editing a
-single glue file (recompile one `.cpp` + relink) about 4 seconds —
-versus 10–15 minutes when the vendored sources are compiled. The same
-`configure` commit-match guard applies, so re-run
-`scripts/install-libduckdb.sh` after every vendoring bump; if it
-reports a `-dev` snapshot with no published prebuilt, drop
-`DUCKDB_R_USE_SYSTEM_LIB` and fall back to a source build.
-
-In CI, `.github/workflows/custom/before-install/action.yml` defaults all
-Linux/macOS builds (the smoke test and the regular matrix) to the fast
-path, except:
-
-* the `krlmlr/duckdb-r` fork, which hosts the vendoring pipeline and
-  must always build from source;
-* any matrix entry that pins `DUCKDB_R_USE_SYSTEM_LIB` itself through the
-  generic `env` field in `.github/versions-matrix.R`. That file carries a
-  dedicated "vendored build" entry (`DUCKDB_R_USE_SYSTEM_LIB=0`) so one
-  regular matrix build still compiles the bundled sources — the artifact
-  that ships to CRAN.
-
-The libduckdb that `scripts/install-libduckdb.sh` fetches matches the
-vendored commit: tagged versions come from the GitHub release assets,
-development snapshots (e.g. `v1.5.4-dev157`) from the DuckDB nightly
-staging bucket keyed by `DUCKDB_SOURCE_ID`.
+Moved to the handbook: [`build/fast-paths/`](/handbook/build/fast-paths/README.md).
 
 IMPORTANT: `.dd` files in `src/` are dependency tracking files for development (source files that need rebuilding when a header file changes) and should be kept in version control.
 These files are generated by the `%.dd: %.d` rule in `src/include/deps.mk`, which filters compiler-generated `.d` files to keep only local `include/` dependencies.

--- a/handbook/build/fast-paths/README.md
+++ b/handbook/build/fast-paths/README.md
@@ -1,22 +1,179 @@
 # Fast paths
 
-*Stub — this leaf will own its topic;
-today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](/handbook/meta/handbook/);
-the last section holds this leaf's parameters.*
+Linking a prebuilt `libduckdb` instead of compiling the vendored DuckDB
+sources: the `DUCKDB_R_USE_SYSTEM_LIB` opt-in, the commit-match guard
+that keeps it honest, and the claims it cannot support.
 
-Scope: linking a prebuilt libduckdb (`DUCKDB_R_USE_SYSTEM_LIB`)
-for seconds-long builds and test loops.
+A clean source install compiles about 1700 vendored `.cpp` files and
+takes 10–15 minutes
+([`source-build/`](/handbook/build/source-build/)).
+With the opt-in set, only the ~30 glue files in `src/` are compiled and
+everything else is resolved from an already-built shared library,
+which brings `R CMD INSTALL .` down to roughly five seconds.
+It is meant for interactive iteration, coding-agent sessions, and CI —
+never for a tarball that someone else installs.
+Linux and macOS only; `configure` refuses any other platform.
 
-Today:
+## Setting it up
 
-* [`AGENTS.md`](/AGENTS.md) — "Fast build with system libduckdb"
-* [`scripts/install-libduckdb.sh`](/scripts/install-libduckdb.sh)
+Install a `libduckdb` matching the vendored sources once,
+then set the variable in every shell that builds or tests the package:
 
-To write this leaf:
+```sh
+sudo scripts/install-libduckdb.sh              # into /usr/local
+# or: scripts/install-libduckdb.sh --prefix "$HOME/.local"
 
-* absorb: `AGENTS.md` §§ "Fast build with system libduckdb" and
-  "Testing with prebuilt DuckDB"; state the commit-match guard and
-  the rule that engine configuration is never verified on the fast
-  path (see `usage/extensions/`)
-* drain: #22
+export DUCKDB_R_USE_SYSTEM_LIB=1
+export MAKEFLAGS="-j$(nproc)"
+
+R CMD INSTALL . --no-byte-compile
+R -q -e 'pkgload::load_all()'
+R -q -e 'testthat::test_local()'
+```
+
+[`scripts/install-libduckdb.sh`](/scripts/install-libduckdb.sh) reads
+`DUCKDB_VERSION` and `DUCKDB_SOURCE_ID` out of the vendored
+`src/duckdb/src/function/table/version/pragma_version.cpp`,
+picks the platform archive (`linux-amd64`, `linux-arm64`,
+`osx-universal`),
+and installs the shared library plus `duckdb.h` and `duckdb.hpp`
+under `<prefix>/lib` and `<prefix>/include`.
+`--version` (or `DUCKDB_R_LIB_VERSION`) overrides the version,
+`--url` (or `DUCKDB_R_LIB_URL`) the whole download URL;
+`sudo` is invoked only when the prefix is not writable.
+
+`configure` finds the library through `DUCKDB_R_LIB_DIR` first,
+then `pkg-config --variable=libdir duckdb`,
+then the usual system directories,
+and aborts with instructions if none of them holds a `libduckdb`.
+
+The loop is not limited to `R CMD INSTALL`.
+`pkgload::load_all()` and `devtools::load_all()` — and therefore
+`testthat::test_local()`, which loads the package the same way —
+compile through the same `configure` and `src/Makevars`, so they honor
+the opt-in identically.
+Measured on a clean container (R 4.5.3, `ccache` warm),
+a no-op `load_all()` takes about a second
+and a `load_all()` after editing one glue file about four,
+against 10–15 minutes for the vendored sources.
+The suite itself is [`testing/suite/`](/handbook/testing/suite/)'s topic.
+
+## What is swapped, and what is not
+
+Only the *implementation* is swapped.
+The glue keeps compiling against the **vendored headers** in
+`src/duckdb/src/include/`,
+because it reaches into about 71 internal DuckDB C++ headers —
+templates such as `GenericExecutor`, the Arrow integration,
+core-functions extension internals —
+and roughly 37 of them are absent from the amalgamated `duckdb.hpp`
+that ships with a `libduckdb` release.
+
+Mechanically, `configure` writes `src/Makevars.system-lib`,
+which `src/Makevars` includes:
+it empties `SOURCES` and sets
+`PKG_LIBS=-L<dir> -lduckdb -Wl,-rpath,<dir>`.
+The file is git-ignored, and the rest of the build is untouched.
+Because of that rpath, moving or deleting the library after installing
+breaks the installed package at load time.
+
+Under `R CMD check` the package is first tarballed by `R CMD build`,
+which compresses `src/duckdb/` into `src/duckdb.tar.xz`;
+`configure` extracts it again before compiling, so the headers are there.
+
+## The commit-match guard
+
+Compiling against vendored internal headers while linking a foreign
+implementation is only safe if both were built from the same upstream
+commit, so `configure` hard-fails otherwise.
+It reads `DUCKDB_SOURCE_ID` from the vendored `pragma_version.cpp`
+and looks for that commit hash inside the installed
+`libduckdb.so` / `libduckdb.dylib` with `strings`
+(missing `strings` is itself a hard error — install `binutils`).
+The comparison uses the first ten hex characters:
+DuckDB truncates the hash to ten in the binary,
+while the vendored file sometimes carries eleven.
+
+On a mismatch the build stops and prints both commits —
+the one the headers expect and the one the library reports —
+and offers the two ways out:
+re-run the install script, or unset the variable and compile the
+vendored sources.
+That is the routine to remember after every vendoring bump:
+the library is stale the moment `src/duckdb/` moves,
+and the guard is what turns a silent ABI mismatch into a clear error.
+
+## The fast path proves nothing about the engine
+
+The extension set and the autoload / autoinstall defaults are
+properties of the linked library, not of the R glue.
+A vendored build compiles the engine with `parquet` and
+`core_functions` and with `-DDUCKDB_EXTENSION_AUTOLOAD_DEFAULT`;
+a release `libduckdb` links more than that — `icu`, `json`,
+`autocomplete` — and comes with a different
+`autoinstall_known_extensions` default.
+Under `DUCKDB_R_USE_SYSTEM_LIB=1` every engine symbol comes from the
+release library, so anything observed about extensions in that mode
+describes the release library and not the package that ships.
+Engine configuration is therefore **never** verified on the fast path;
+check it against a vendored build, and read
+[`usage/extensions/`](/handbook/usage/extensions/) for what the package
+actually ships.
+
+The failure mode this guards against is real enough that `configure`
+removes `src/Makevars.system-lib` on every run:
+a file left behind by an earlier fast build keeps emptying `SOURCES`
+and adding `-lduckdb`,
+so a plain `R CMD INSTALL .` silently stays on the fast path and
+produces a package that looks vendored while resolving its symbols —
+and its extension set — from the system library.
+
+## In CI
+
+`.github/workflows/custom/before-install/action.yml` defaults every
+non-Windows job, smoke test and regular matrix alike, to the fast path,
+unless the entry pinned `DUCKDB_R_USE_SYSTEM_LIB` itself or the
+repository is `krlmlr/duckdb-r`, which hosts the vendoring pipeline and
+must always build from source.
+It then runs the install script, and — if no library appeared, which is
+how a development snapshot manifests — sets `DUCKDB_R_USE_SYSTEM_LIB=0`
+so the job falls back to compiling the vendored tree.
+`.github/versions-matrix.R` pins `DUCKDB_R_USE_SYSTEM_LIB=0` on one
+Linux and one macOS entry, so the artifact that ships to CRAN is still
+built from source on every platform: Windows never takes the fast path
+at all.
+The workflows themselves are [`operations/ci/`](/handbook/operations/ci/)'s.
+
+## Limits
+
+* **Not for `R CMD build` or for users.**
+  The opt-in covers `R CMD INSTALL .` only.
+  The resulting installation depends on `libduckdb` staying present at
+  the path baked into its rpath,
+  and on an exact-commit match that no end user can be asked to
+  reproduce, so the package installed from CRAN or from a tarball
+  always compiles the vendored sources.
+  This is the answer to the standing request for an Arrow-style
+  prebuilt-library install
+  ([#22](https://github.com/duckdb/duckdb-r/issues/22)):
+  the mechanism exists and is used daily, but as a development and CI
+  opt-in, not as a distribution channel — the issue stays open for the
+  user-facing half.
+  The other speed-ups asked for there, `MAKEFLAGS` and `ccache`, are
+  build knobs and live in
+  [`configuration/`](/handbook/build/configuration/).
+* **No prebuilt exists between releases.**
+  The install script only resolves tagged versions, from the GitHub
+  release assets.
+  For a development snapshot such as `v1.5.4-dev157` it reports that no
+  matching prebuilt is published and exits without installing anything,
+  which is what lets a caller fall back cleanly;
+  supply `DUCKDB_R_LIB_URL` if a private build is at hand.
+  So on a `-dev` vendoring state the fast path is simply unavailable.
+* **Linux and macOS only.**
+  `configure` exits with an error on any other platform,
+  and CI does not offer the mode on Windows.
+* **`scripts/install-duckdb-cli.sh` is not part of this.**
+  It fetches the standalone DuckDB CLI matching the vendored sources so
+  the CLI-to-R end-to-end tests can run;
+  it installs no library and changes no build.

--- a/handbook/build/fast-paths/README.md
+++ b/handbook/build/fast-paths/README.md
@@ -4,12 +4,12 @@ Linking a prebuilt `libduckdb` instead of compiling the vendored DuckDB
 sources: the `DUCKDB_R_USE_SYSTEM_LIB` opt-in, the commit-match guard
 that keeps it honest, and the claims it cannot support.
 
-A clean source install compiles about 1700 vendored `.cpp` files and
-takes 10–15 minutes
+A clean source install compiles the whole vendored DuckDB tree and
+takes many minutes
 ([`source-build/`](/handbook/build/source-build/)).
-With the opt-in set, only the ~30 glue files in `src/` are compiled and
-everything else is resolved from an already-built shared library,
-which brings `R CMD INSTALL .` down to roughly five seconds.
+With the opt-in set, only the glue translation units in `src/` are
+compiled and everything else is resolved from an already-built shared
+library, which brings `R CMD INSTALL .` down to seconds.
 It is meant for interactive iteration, coding-agent sessions, and CI —
 never for a tarball that someone else installs.
 Linux and macOS only; `configure` refuses any other platform.
@@ -52,10 +52,9 @@ The loop is not limited to `R CMD INSTALL`.
 `testthat::test_local()`, which loads the package the same way —
 compile through the same `configure` and `src/Makevars`, so they honor
 the opt-in identically.
-Measured on a clean container (R 4.5.3, `ccache` warm),
-a no-op `load_all()` takes about a second
-and a `load_all()` after editing one glue file about four,
-against 10–15 minutes for the vendored sources.
+With `ccache` warm, a no-op `load_all()` and a `load_all()` after
+editing one glue file both finish in seconds rather than the minutes a
+vendored build takes.
 The suite itself is [`testing/suite/`](/handbook/testing/suite/)'s topic.
 
 ## What is swapped, and what is not
@@ -63,11 +62,13 @@ The suite itself is [`testing/suite/`](/handbook/testing/suite/)'s topic.
 Only the *implementation* is swapped.
 The glue keeps compiling against the **vendored headers** in
 `src/duckdb/src/include/`,
-because it reaches into about 71 internal DuckDB C++ headers —
+because it reaches into internal DuckDB C++ headers —
 templates such as `GenericExecutor`, the Arrow integration,
 core-functions extension internals —
-and roughly 37 of them are absent from the amalgamated `duckdb.hpp`
+and a large share of those are absent from the amalgamated `duckdb.hpp`
 that ships with a `libduckdb` release.
+The comment block at the top of `configure` records that reasoning,
+and `configure` is where the header tree is wired up.
 
 Mechanically, `configure` writes `src/Makevars.system-lib`,
 which `src/Makevars` includes:
@@ -138,8 +139,8 @@ must always build from source.
 It then runs the install script, and — if no library appeared, which is
 how a development snapshot manifests — sets `DUCKDB_R_USE_SYSTEM_LIB=0`
 so the job falls back to compiling the vendored tree.
-`.github/versions-matrix.R` pins `DUCKDB_R_USE_SYSTEM_LIB=0` on one
-Linux and one macOS entry, so the artifact that ships to CRAN is still
+`.github/versions-matrix.R` pins `DUCKDB_R_USE_SYSTEM_LIB=0` on a Linux
+and a macOS entry, so the artifact that ships to CRAN is still
 built from source on every platform: Windows never takes the fast path
 at all.
 The workflows themselves are [`operations/ci/`](/handbook/operations/ci/)'s.


### PR DESCRIPTION
## What this leaf now owns

`handbook/build/fast-paths/` explains linking a prebuilt `libduckdb`
instead of compiling the vendored sources:
the `DUCKDB_R_USE_SYSTEM_LIB` opt-in and how `scripts/install-libduckdb.sh`
resolves version, platform, and prefix;
the `pkgload::load_all()` / `testthat::test_local()` loop that honors the
same switch;
what the mode actually swaps (implementation only — the glue keeps
compiling against the vendored internal headers) and the
`src/Makevars.system-lib` + rpath mechanics;
the `configure` commit-match guard, including the ten-character hash
comparison and what it prints on a mismatch;
the CI default and the pinned `DUCKDB_R_USE_SYSTEM_LIB=0` matrix
entries that keep a vendored build on every OS;
and the limits — not for `R CMD build` or for users, no prebuilt between
releases, Linux and macOS only.
It states as a boundary that engine configuration is never verified on
the fast path, since the release `libduckdb` links extra extensions
(`icu`, `json`, `autocomplete`) and carries a different
`autoinstall_known_extensions` default, and links
`/handbook/usage/extensions/` for what the package actually ships.
[#22](https://github.com/duckdb/duckdb-r/issues/22) is answered in the
"Limits" section and left open for its user-facing half.

## What moved

* `AGENTS.md` — loses §§ "Fast build with system libduckdb (Linux/macOS,
  opt-in)" and "Testing with prebuilt DuckDB (the fast iterate loop)",
  each replaced by a one-line pointer to the leaf; gains the visible
  italic handbook backreference under its H1. Its cross-reference from
  "Bootstrap, Build, and Test the Repository" now links the leaf instead
  of the two removed anchors. The `.dd` dependency-file paragraph that
  sat inside the absorbed region stays put — it belongs to
  `build/source-build/`.

`scripts/README.md` needed no change: its generator already maps
`install-*.sh` to `handbook/build/fast-paths`, so the index carries that
backreference.

## Assumptions

* `AGENTS.md` claimed that development snapshots are fetched "from the
  DuckDB nightly staging bucket keyed by `DUCKDB_SOURCE_ID`". The code in
  `scripts/install-libduckdb.sh` does not do this: for a `*-dev*` version
  it prints that no prebuilt is published and exits 0 so the caller falls
  back to a source build. The leaf states the code's behavior. The
  script's own header comment (lines 13–17) still carries the stale
  claim; it is left untouched here, since this wave is documentation
  only and `scripts/` files take no hand-added backreference.
* `pkgload::load_all()` honoring the opt-in is stated on the mechanism —
  it compiles through the same `configure` and `src/Makevars`, and
  `src/Makevars` is what includes `Makevars.system-lib`. Not re-measured.
* `scripts/install-duckdb-cli.sh` also maps to this leaf through the
  generated index's `install-*.sh` glob, but is not a fast-path tool. The
  leaf names it in one sentence under "Limits" so a reader arriving from
  `scripts/README.md` is not stranded, rather than absorbing it; if the
  mapping should instead move to a testing leaf, that is a separate change.
* The root `README.md` was left alone: `AGENTS.md` is only partly
  absorbed and is not deleted, so its `## Documentation` entry still
  describes it correctly.
* No build was run, per the wave's rules; every behavioral claim is read
  off `configure`, `src/Makevars.in`, `scripts/install-libduckdb.sh`,
  `scripts/rconfigure.py`, `.github/versions-matrix.R`, and
  `.github/workflows/custom/before-install/action.yml`.

## Durability sweep

A follow-up pass removed the numbers a routine commit invalidates —
mostly figures this leaf had carried over unverified from `AGENTS.md`
and `configure`.

**Out**, replaced by the mechanism or by a qualitative form:

* "about 1700 vendored `.cpp` files", "10–15 minutes", "roughly five
  seconds" → the whole vendored tree, many minutes, seconds. The
  argument was always the order of magnitude, not the stopwatch.
* "~30 glue files" → "the glue translation units in `src/`".
* The `load_all()` measurement ("about a second", "about four") →
  "seconds rather than the minutes a vendored build takes".
* "about 71 internal DuckDB C++ headers", "roughly 37 of them" absent
  from `duckdb.hpp` → a pointer to the comment block at the top of
  `configure`, where the reasoning and the header wiring live. This also
  retires the assumption listed above: there is no longer a count to
  have recounted.
* "one Linux and one macOS entry" → "a Linux and a macOS entry"; the
  per-platform pinning is the fact, the entry count is incidental.

**Kept:** the ten/eleven hex characters of the commit-match comparison —
that is the guard's mechanism, and changing it would change the design.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PD23hjFQFRWW62HFvru187)_