### PR TITLE
docs(handbook): Write the branches/flavors leaf

### DIFF
--- a/BRANCHES.md
+++ b/BRANCHES.md
@@ -1,5 +1,7 @@
 # Branching Strategy
 
+*Handbook: [`branches/flavors/`](/handbook/branches/flavors/README.md).*
+
 Version numbers are given at the time of writing (March 2026) and may be outdated by the time you read this.
 The branching strategy is expected to remain stable.
 
@@ -137,28 +139,11 @@ Numbers in `[brackets]` refer to the component list above.
 
 ## Why multiple R packages?
 
-DuckDB releases a new minor version approximately every four months.
-See <https://duckdb.org/docs/stable/dev/release_cycle> for a detailed description of the upstream release cycle.
-
-CRAN does not allow multiple versions of the same package to coexist, so each supported release line needs its own package name (`duckdb`, `duckdb.1.4`, etc.).
-LTS releases receive patch updates for one year — roughly three minor-release cycles — after which they are archived.
-The `.dev` packages on r-universe mirror the corresponding bleeding-edge upstream branches and let users test upcoming releases without waiting for CRAN.
+See [`handbook/branches/flavors/`](/handbook/branches/flavors/README.md).
 
 ## R Package Flavors
 
-Several packages are published, organised into three release lines:
-
-| Package          | Install from   | Branch (repo)                            | Description                                          |
-|------------------|----------------|------------------------------------------|------------------------------------------------------|
-| `duckdb`         | CRAN           | `main` (`duckdb/duckdb-r`)               | **Current stable release.**                          |
-| `duckdb`         | r-universe     | `main` (`duckdb/duckdb-r`)               | Current or upcoming release.                         |
-| `duckdb.1.5`     | Does not exist |                                          | v1.5 is not an LTS version.                          |
-| `duckdb.1.4`     | r-universe     | `v1.4-andium-lts` (`duckdb/duckdb-r`)    | **LTS — v1.4.** Receives only bug fixes.             |
-| `duckdb.dev`     | r-universe     | `main-dev` (`krlmlr/duckdb-r`)           | Bleeding-edge build of the next major/minor version. |
-| `duckdb.1.5.dev` | r-universe     | `v1.5-variegata-dev` (`krlmlr/duckdb-r`) | Bleeding-edge build on the v1.5 upstream.            |
-| `duckdb.1.4.dev` | r-universe     | `v1.4-andium-dev` (`krlmlr/duckdb-r`)    | Bleeding-edge build on the v1.4 upstream.            |
-
-Use `duckdb` unless you need to pin to a specific minor version (LTS) or want to test unreleased functionality (`.dev`).
+See [`handbook/branches/flavors/`](/handbook/branches/flavors/README.md).
 
 ## Overview
 
@@ -549,7 +534,8 @@ When upstream tags `v1.6.0`:
    - **If LTS**: create `v1.5-variegata-lts` from `v1.5-variegata`, apply `scripts/flavor.sh 1.5`
      to produce the `duckdb.1.5` branch, register `duckdb.1.5` on r-universe, and add it to the forward-port chain.
    - **If not LTS**: stop vendoring into its dev branch and archive both branches.
-4. Update the Branch Overview table and the R Package Flavors table in this document.
+4. Update the Branch Overview table in this document, and the flavor list in
+   [`handbook/branches/flavors/`](/handbook/branches/flavors/README.md).
 
 ### On LTS expiry (one year after designation)
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 # duckdb
 
+*Handbook: [`branches/flavors/`](/handbook/branches/flavors/README.md).*
+
 [DuckDB](https://duckdb.org/) is an in-process SQL OLAP database management system.
 It is designed to support analytical query workloads and is optimized for fast query execution.
 This repository contains the R bindings for DuckDB.
@@ -77,7 +79,9 @@ The badges track each `.dev` series:
 *ahead* counts commits ahead of the branch the series releases from,
 *in flight* counts commits in CI but not yet trusted,
 *buffered* counts commits vendored but not yet verified.
-See [`BRANCHES.md`](BRANCHES.md) for the full model.
+See [`handbook/branches/flavors/`](/handbook/branches/flavors/README.md)
+for what a flavor is and how it is produced,
+and [`BRANCHES.md`](BRANCHES.md) for the full branch model.
 
 ## User Guide
 

--- a/handbook/branches/flavors/README.md
+++ b/handbook/branches/flavors/README.md
@@ -1,18 +1,150 @@
 # Flavors
 
-*Stub — this leaf will own its topic;
-today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../meta/handbook/);
-the last section holds this leaf's parameters.*
+One source tree, published under several package names:
+`duckdb` on CRAN,
+and `duckdb.1.4`, `duckdb.dev`, `duckdb.1.5.dev`, `duckdb.1.4.dev`
+on r-universe.
+A flavor is a mechanical rename applied on top of a series' branch —
+nothing else distinguishes one published package from another.
 
-Scope: one source tree published under many names
-(`duckdb`, `duckdb.dev`, `duckdb.1.5.dev`, …).
+## Why more than one package
 
-Today:
+DuckDB cuts a new minor version roughly every four months
+(the [upstream release cycle](https://duckdb.org/docs/stable/dev/release_cycle)
+describes the schedule).
+CRAN carries only one version of a given package name at a time,
+so a release line that has to stay installable
+next to the current one needs a name of its own.
+LTS lines receive patch updates for a year —
+about three minor cycles — and are archived after that.
+The `.dev` names follow the bleeding edge of the matching upstream branch,
+so the next release can be tried out without waiting for CRAN.
 
-* [`BRANCHES.md`](../../../BRANCHES.md#r-package-flavors)
+Because the names differ, the flavors coexist in one R library:
+installing `duckdb.1.4` leaves `duckdb` alone.
 
-To write this leaf:
+## The flavors
 
-* absorb: `BRANCHES.md` § "R package flavors" and the flavor tooling
-  (`scripts/flavor.sh`, `flavor.patch`, `flavor-package-name.R`)
+| Flavor | Kind | Built from | Upstream series |
+|---|---|---|---|
+| `duckdb` | CRAN, also on r-universe | `main` in `duckdb/duckdb-r` | `v1.5-variegata` |
+| `duckdb.1.4` | LTS, r-universe | `v1.4-andium-lts` in `duckdb/duckdb-r` | `v1.4-andium` |
+| `duckdb.dev` | dev, r-universe | the `main` series in `krlmlr/duckdb-r` | `main` |
+| `duckdb.1.5.dev` | dev, r-universe | the `v1.5-variegata` series in `krlmlr/duckdb-r` | `v1.5-variegata` |
+| `duckdb.1.4.dev` | dev, r-universe | the `v1.4-andium` series in `krlmlr/duckdb-r` | `v1.4-andium` |
+
+Which ref inside a series r-universe builds,
+and how the series advance,
+is [`model/`](/handbook/branches/model/README.md)'s.
+Which flavor to install is
+[`usage/installation/`](/handbook/usage/installation/README.md)'s.
+
+There is no `duckdb.1.5`:
+v1.5 was not designated an LTS line,
+and the current release already ships as `duckdb`.
+A numbered flavor without the `.dev` suffix exists only for an LTS line,
+and so does the `-lts` branch it is built from.
+
+The set grows when a new series opens.
+The `Flavors` table in the root [`README.md`](/README.md)
+is the only place a new flavor is announced by hand;
+everything else about a series is discovered from its refs
+(`.claude/skills/series-open.md`).
+
+## What the rename touches
+
+The flavor lives in a handful of files,
+and the diff between an unflavored branch and its flavored counterpart
+is exactly this:
+
+* `DESCRIPTION` — the `Package:` field.
+* `R/duckdb-package.R` — the `@useDynLib` directive
+  and the `@name` of the package topic.
+  `NAMESPACE` and `man/duckdb-package.Rd` carry the same change,
+  patched directly rather than regenerated,
+  so no roxygen2 run is needed.
+* `src/include/rapi.hpp` — the `DUCKDB_PACKAGE_NAME` macro.
+* `inst/include/duckdb_types.hpp` — renamed,
+  with dots turned into underscores:
+  `duckdb_1_4_types.hpp`, `duckdb_1_5_dev_types.hpp`, `duckdb_dev_types.hpp`.
+  It is the public C++ header that downstream packages include by name.
+* `tests/testthat.R` — the `library()` call.
+* `README.md` — the CRAN and Posit Public Package Manager sections
+  collapse into a single sentence,
+  and the r-universe `install.packages()` call takes the new name.
+* `src/cpp11.cpp` and `R/cpp11.R` — regenerated rather than patched.
+  cpp11 derives the `.Call` symbol prefix from the package name,
+  so `_duckdb_rapi_connect` becomes `_duckdb_1_4_rapi_connect`,
+  and the generated include follows the renamed public header.
+
+Nothing else differs:
+no vendored engine source, no glue logic, no R logic.
+That the difference stays this small,
+and that the names inside a branch agree with each other,
+are stated as invariants in
+[`invariants/`](/handbook/branches/invariants/README.md).
+
+Everywhere else, the package asks for its own name at run time
+through `get_package_name()`,
+the seam described in
+[`architecture/r-layer/`](/handbook/architecture/r-layer/README.md).
+A name hard-coded outside the rename surface keeps pointing at `duckdb`
+under every other flavor,
+silently and usually only for the user;
+the scan that prevents that is
+[`testing/guards/`](/handbook/testing/guards/README.md)'s.
+
+## Producing a flavor
+
+[`scripts/flavor.sh`](/scripts/flavor.sh) takes the *suffix*, not the name:
+`1.4` yields `duckdb.1.4`, `1.5.dev` yields `duckdb.1.5.dev`,
+and `dev` yields `duckdb.dev`.
+It works on the branch that is checked out and leaves two commits:
+
+1. It rewrites [`scripts/flavor.patch`](/scripts/flavor.patch) in place,
+   replacing the `1.3` placeholder with the target suffix.
+   A single substitution covers both spellings —
+   `.1.3` in package names and `_1_3` in the header filename —
+   because it matches the separator in front of the number
+   and reuses it for every dot in the suffix.
+   Committed as `chore: Update flavor patch to <suffix>`.
+2. It applies the patch with `patch -p1`,
+   re-runs `cpp11::cpp_register()` to regenerate the two cpp11 files,
+   drops the `.orig` leftovers,
+   and commits everything as `chore: Update version to <suffix>`.
+
+The second commit's subject says "version",
+but the script never touches `Version:` —
+both commits are the rename.
+A series' dev branch carries a third commit on top of the pair
+to add the fifth version component; that one is
+[`operations/releases/versioning/`](/handbook/operations/releases/versioning/README.md)'s.
+
+## Limits
+
+* `flavor.sh` invokes `gsed`.
+  On a system where GNU sed is simply `sed` — most Linux —
+  the script fails unless `gsed` is on `PATH`.
+* The rewrite is one-shot.
+  `flavor.sh` edits the patch template in place and commits it,
+  so after the first run the placeholder is gone
+  and the branch's template names that flavor.
+  Re-flavoring means starting from an unflavored tree again,
+  which is why a series is rebased rather than reseeded.
+* The blurb the patch writes into `README.md` says
+  "This package contains the LTS version 1.3 of DuckDB".
+  The `1.3` there is preceded by a space rather than by `.` or `_`,
+  so the substitution does not reach it,
+  and every flavored branch's README claims 1.3 whatever the line —
+  visible today on the published `duckdb.1.4`.
+  The rest of the rename is unaffected.
+* The regenerated cpp11 symbols depend on
+  whichever cpp11 is installed when `flavor.sh` runs.
+  cpp11 0.5.5 replaces only the first dot of the package name,
+  producing `_duckdb_1.5.dev_rapi_connect`,
+  which is not a valid C identifier.
+  Compare `R/cpp11.R` against an existing series' seed
+  before trusting a fresh one (`.claude/skills/series-open.md`).
+* A flavor is a property of a branch, not a build-time option:
+  one tree produces one name,
+  and there is no environment variable or configure flag that selects it.

--- a/handbook/branches/flavors/README.md
+++ b/handbook/branches/flavors/README.md
@@ -2,8 +2,8 @@
 
 One source tree, published under several package names:
 `duckdb` on CRAN,
-and `duckdb.1.4`, `duckdb.dev`, `duckdb.1.5.dev`, `duckdb.1.4.dev`
-on r-universe.
+and numbered and `.dev` names on r-universe,
+tabulated under [The flavors](#the-flavors) below.
 A flavor is a mechanical rename applied on top of a series' branch —
 nothing else distinguishes one published package from another.
 
@@ -65,8 +65,8 @@ is exactly this:
   so no roxygen2 run is needed.
 * `src/include/rapi.hpp` — the `DUCKDB_PACKAGE_NAME` macro.
 * `inst/include/duckdb_types.hpp` — renamed,
-  with dots turned into underscores:
-  `duckdb_1_4_types.hpp`, `duckdb_1_5_dev_types.hpp`, `duckdb_dev_types.hpp`.
+  with dots turned into underscores,
+  so `duckdb.1.5.dev` gives `duckdb_1_5_dev_types.hpp`.
   It is the public C++ header that downstream packages include by name.
 * `tests/testthat.R` — the `library()` call.
 * `README.md` — the CRAN and Posit Public Package Manager sections


### PR DESCRIPTION
## What this leaf now owns

`handbook/branches/flavors/` explains one source tree published under many
package names: why more than one package exists (CRAN's one-version-per-name
rule, the four-month upstream minor cadence, one-year LTS support, `.dev` for
pre-CRAN testing), the flavor set that exists today and where each is built
from, the exact file surface the rename touches (`DESCRIPTION`, the
`@useDynLib` / `@name` pair with its patched `NAMESPACE` and `.Rd`,
`DUCKDB_PACKAGE_NAME`, the renamed public `duckdb_*_types.hpp`, `testthat.R`,
the README blurb, and the regenerated cpp11 pair), and the tooling that
produces it — `scripts/flavor.sh` and `scripts/flavor.patch` — with its limits.
Boundaries are linked, not restated: the `get_package_name()` seam is
`architecture/r-layer/`'s, the guard that enforces it is `testing/guards/`'s,
which flavor a user should install is `usage/installation/`'s, the series and
their refs are `branches/model/`'s, and the name-coherence and mechanical-rename
invariants are `branches/invariants/`'s.

## What moved

- **`BRANCHES.md`** — lost §§ "Why multiple R packages?" and "R Package
  Flavors"; both headings remain and now hold a one-line pointer to the leaf, so
  the `#r-package-flavors` anchor that `AGENTS.md` links keeps resolving. The
  "On new minor release" step that said to update the flavors table in that
  document now points at the leaf. Gained the visible handbook backreference
  line under its H1.
- **`README.md`** — gained the visible handbook backreference line under its H1,
  and the `Flavors` badge legend now routes to the leaf for what a flavor is and
  how it is produced, keeping the `BRANCHES.md` link for the branch model. The
  table itself is untouched.
- **`scripts/README.md`** — unchanged. It is generated, and its `flavor*` glob
  group already maps to `handbook/branches/flavors`, so no ownership edit and no
  regeneration were needed.

## Assumptions

- "Replace each absorbed heading with a one-line pointer" was read as *keep the
  heading, replace its body*, rather than deleting the heading outright.
  Deleting it would break `AGENTS.md`'s `BRANCHES.md#r-package-flavors` link and
  the three sibling leaves splitting the same file.
- The root `README.md` gained a backreference line under its H1 even though
  `usage/installation/` also serves that file; per the wave convention the two
  leaves merge into one line. `git apply --check --include=README.md
  scripts/flavor.patch` and a full `patch -p1 --dry-run` still pass with the
  extra line, and `flavor_package_name_offenders(".")` stays empty.
- The flavor table's "Built from" column names the branch for the two published
  stable flavors (`main`, `v1.4-andium-lts`) but only names the *series* for the
  `.dev` flavors, deferring which ref r-universe builds to `branches/model/`.
  `BRANCHES.md` says `-dev` while `.claude/skills/series-loop.md` says `-green`
  is what r-universe should build from; rather than pick, the leaf links.
- Three facts are documented as today's behavior, verified from source rather
  than from `BRANCHES.md`: `flavor.sh` requires `gsed` (absent on a plain
  Linux); the substitution does not reach the `1.3` in the README blurb the
  patch inserts, so every flavored branch's README says "LTS version 1.3"
  (confirmed on the published `v1.4-andium-lts`); and the cpp11 0.5.5
  first-dot-only symbol hazard from `.claude/skills/series-open.md`. None of
  these is filed as an issue — flagging them here in case they should be.
- `BRANCHES.md`'s tooling table calls `1.4` the `flavor.patch` placeholder; the
  file and the script's own comment both say `1.3`. The leaf states `1.3`. That
  table belongs to another leaf, so it was left alone.
- No `plan/` document covers flavors, so the leaf points at no intent document.

## Durability sweep

A follow-up pass over this leaf for facts a routine change invalidates.

**Out.** The opening no longer repeats every r-universe package name; it says
`duckdb` on CRAN plus numbered and `.dev` names on r-universe, and points at
the flavor table below. The set was written down twice, so a new series had to
be added in two places. The renamed public header is now shown with one
example (`duckdb.1.5.dev` → `duckdb_1_5_dev_types.hpp`) instead of one
filename per flavor, which was the same list in a third place.

**Stayed.** The flavor table itself — it names each flavor and the branch it is
built from, which is the *which*, not a count, and the leaf already says the
set grows when a series opens and where a new one is announced by hand. The
version identifiers `v1.4-andium-lts`, `cpp11 0.5.5` and the `1.3` placeholder
in `flavor.patch`, which identify a thing. "Two commits" and "the two cpp11
files" in `flavor.sh`'s description: the numbered list is the design, and
changing it would mean changing the script. The upstream cadence and LTS
support window, which are upstream policy rather than readings off this tree.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PD23hjFQFRWW62HFvru187)_