### PR TITLE
docs(handbook): Write the versioning leaf

### DIFF
--- a/.github/workflows/fledge.yaml
+++ b/.github/workflows/fledge.yaml
@@ -1,3 +1,4 @@
+# Handbook: handbook/operations/releases/versioning/
 name: fledge
 
 on:

--- a/BRANCHES.md
+++ b/BRANCHES.md
@@ -1,5 +1,7 @@
 # Branching Strategy
 
+*Handbook: [`operations/releases/versioning/`](/handbook/operations/releases/versioning/README.md).*
+
 Version numbers are given at the time of writing (March 2026) and may be outdated by the time you read this.
 The branching strategy is expected to remain stable.
 
@@ -651,40 +653,7 @@ If a vendor run fails because a patch no longer applies cleanly, update the patc
 
 ## Version Numbering
 
-The package version in `DESCRIPTION` carries up to five dot-separated components. Two of them are
-independent counters that advance on different strands:
-
-| Component | Example | Counter | Advanced by |
-|-----------|---------|---------|-------------|
-| 1–3 (`major.minor.patch`) | `1.5.3` | Release line identity | Matches the upstream DuckDB tag |
-| 4th | `…​.9006` | **R-client counter** | `fledge` on the source-of-truth strand (`main`) |
-| 5th | `…​.9006.42` | **vendor counter** | `scripts/vendor-one.sh`, one bump per vendor commit on a `-dev` branch |
-
-A released version is the bare three-component prefix (`1.5.4`). The `-dev` branches never touch
-`NEWS.md`; only `DESCRIPTION:Version` differs between the strands.
-
-### The DESCRIPTION merge driver
-
-Because the two counters advance on the same line, a plain forward-port, rebase, or release merge
-conflicts on `DESCRIPTION:Version` at essentially every commit. The merge driver in
-`scripts/merge-version.sh` resolves that line by taking the **component-wise maximum** of the two
-sides, **gated on an equal `major.minor.patch` prefix**:
-
-- Within a release line, the max keeps the 4th component from the strand that owns it (the R-client
-  strand) and the 5th from the strand that owns it (the vendor strand). E.g.
-  `1.5.3.9008` merged with `1.5.3.9006.42` → `1.5.3.9008.42`. The result is direction-agnostic.
-- Across release lines (different prefix, e.g. forward-porting a fix from `1.5.x` onto the `1.4.x`
-  LTS), the driver keeps **ours** unchanged and never inherits a foreign prefix.
-
-The rest of `DESCRIPTION` still gets a normal 3-way merge, so a genuine concurrent edit
-(e.g. two branches touching `Imports:`) still raises a real conflict. The authoritative release
-version is set by `fledge::bump_version()` at the tip after the operation completes — the driver's
-only job is to stop the version line from halting a rebase.
-
-**Setup.** The `merge=ours-version` attribute is committed in `.gitattributes`, but the driver's
-name→command mapping must live in `.git/config`. Run `scripts/setup-git.sh` once per clone — and as
-the first step of any CI job that rebases, cherry-picks, or merges — to register the driver, enable
-`rerere`, and pin `rebase.backend=merge` (the patch/`am` backend bypasses merge drivers).
+Moved to the handbook: [`operations/releases/versioning/`](/handbook/operations/releases/versioning/README.md) owns the two version counters, `fledge`, `NEWS.md`, and why the counters need a merge driver.
 
 ## Tooling
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,7 @@
 # R Package Release Process
 
+*Handbook: [`operations/releases/versioning/`](/handbook/operations/releases/versioning/README.md).*
+
 This document describes the release process for one DuckDB release line as a
 **finite state machine (FSM)**. It is the operational companion to
 [`BRANCHES.md`](BRANCHES.md), which defines the branch model, the package
@@ -198,17 +200,13 @@ Bring the tagged `dev` content onto `stable` **linearly — never as a merge
 commit** (invariant **L**): fast-forward or rebase the tagged range onto
 `stable`, dropping the `flavor.sh` flavor rename. The `DESCRIPTION` version conflict
 is resolved automatically by the merge driver (see
-[BRANCHES.md → Version Numbering](BRANCHES.md#version-numbering)); run
+[`operations/releases/versioning/`](/handbook/operations/releases/versioning/README.md)); run
 `scripts/setup-git.sh` first if this is a fresh clone or CI runner. Because
 `release-content ⊑ dev-base ⊑ dev` (invariant **A1**), the only rewriting is
 dropping the rename commit.
 
-The package version is **not** derived from the git tag — set it explicitly so
-`DESCRIPTION` matches the upstream tag:
-
-```r
-fledge::bump_version("X.Y.Z")
-```
+Then set the release version with `fledge` — it is not derived from the git tag;
+see [`operations/releases/versioning/`](/handbook/operations/releases/versioning/README.md).
 
 Then rebase the `lts` branch (one rename commit on top of `stable`):
 
@@ -254,9 +252,8 @@ git push krlmlr L-dev-base --force-with-lease
 git push krlmlr L-dev-base:L-dev --force-with-lease
 ```
 
-The glue source of truth (`main`) separately moves to its ongoing development
-version (4th component, e.g. `X.Y.Z.9000`) via `fledge`; the `dev` branches then
-resume bumping the 5th (vendor) component from the new baseline.
+The version counters move on afterwards too; see
+[`operations/releases/versioning/`](/handbook/operations/releases/versioning/README.md).
 
 ## Multi-line coordination
 

--- a/handbook/operations/releases/versioning/README.md
+++ b/handbook/operations/releases/versioning/README.md
@@ -17,7 +17,7 @@ that advance on different strands and never interfere:
 | 4th | `1.5.5.9004` | **R-client counter** | `fledge`, on the glue source of truth (`main`) |
 | 5th | `1.5.3.9006.42` | **vendor counter** | `scripts/vendor-one.sh`, once per vendor commit |
 
-`main`'s `Version: 1.5.5.9004` is exactly that shape:
+A `main` version such as `1.5.5.9004` is exactly that shape:
 the released prefix `1.5.5`,
 the R-client counter at `9004`,
 and no fifth component at all,
@@ -83,8 +83,8 @@ from the new baseline.
 The bare prefix is the rule, not a guarantee.
 When the R layer needs a fix and upstream has not tagged,
 the package ships a release carrying a low 4th component instead:
-`v1.5.4.1`, `v1.5.4.2`, and `v1.5.4.3` were cut that way,
-and `NEWS.md` records them as releases between `1.5.4` and `1.5.5`.
+the tag list shows `v1.5.4.1`, `v1.5.4.2` and `v1.5.4.3` cut that way,
+recorded in `NEWS.md` as releases between `1.5.4` and `1.5.5`.
 Such a number is below the 9000 block the R-client counter uses,
 so it never collides with a development version.
 
@@ -97,11 +97,11 @@ not here.
 ## fledge
 
 [fledge](https://fledge.cynkra.com) owns the 4th component and `NEWS.md`.
-`.github/workflows/fledge.yaml` runs it daily at 00:30 UTC,
+`.github/workflows/fledge.yaml` runs it on a daily schedule,
 on manual dispatch,
 and on any push to `main` that touches the workflow file itself.
 
-Two guards run before anything is bumped.
+Guards run before anything is bumped.
 The workflow skips forks outright,
 and skips `krlmlr/duckdb-r` by name —
 so no branch in the CI/CD fork ever receives a version bump
@@ -143,8 +143,8 @@ at release they fold into the release's own heading.
 Below the current development block
 `NEWS.md` therefore carries release headings only,
 even though every intermediate bump was also tagged
-(`v1.5.4.9000` through `v1.5.4.9013` exist as tags
-with no heading of their own).
+(the tag list shows `v1.5.4.9000` and the bumps that followed it,
+none with a heading of its own).
 
 The `-dev` branches never touch `NEWS.md`.
 Between the strands only `DESCRIPTION:Version` differs,

--- a/handbook/operations/releases/versioning/README.md
+++ b/handbook/operations/releases/versioning/README.md
@@ -1,18 +1,206 @@
 # Versioning
 
-*Stub — this leaf will own its topic;
-today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../../meta/handbook/);
-the last section holds this leaf's parameters.*
+The package version lives in exactly one place —
+`Version:` in `DESCRIPTION`.
+Versioning owns what its components mean,
+which of them advance on their own,
+how `fledge` advances one of them and writes `NEWS.md`,
+and what number a release finally carries.
 
-Scope: the version counters, fledge, and `NEWS.md`.
+The version has up to five dot-separated components.
+Two of them are independent counters
+that advance on different strands and never interfere:
 
-Today:
+| Component | Example | Meaning | Advanced by |
+|-----------|---------|---------|-------------|
+| 1–3 (`major.minor.patch`) | `1.5.5` | release-line identity — the upstream DuckDB tag | set explicitly at release |
+| 4th | `1.5.5.9004` | **R-client counter** | `fledge`, on the glue source of truth (`main`) |
+| 5th | `1.5.3.9006.42` | **vendor counter** | `scripts/vendor-one.sh`, once per vendor commit |
 
-* [`RELEASE.md`](../../../../RELEASE.md)
+`main`'s `Version: 1.5.5.9004` is exactly that shape:
+the released prefix `1.5.5`,
+the R-client counter at `9004`,
+and no fifth component at all,
+because vendor commits do not land on `main`.
 
-To write this leaf:
+## The R-client counter
 
-* split from `RELEASE.md`: the two version counters, fledge,
-  `NEWS.md`; the merge driver itself is
-  `operations/vendoring/pipeline/`'s — link it
+The 4th component free-runs on `main`,
+which is where every glue, R, test, and CI change is born.
+It counts development on the R side of the package
+and says nothing about the engine.
+
+On a `-dev` branch the 4th component is inherited and then frozen:
+each strand owns one counter and freezes the other,
+which is the property the merge driver below depends on.
+The per-branch statements of this
+— what each branch's version must look like at any moment —
+are the version invariants at
+[`branches/invariants/`](/handbook/branches/invariants/README.md).
+
+## The vendor counter
+
+`scripts/vendor-one.sh` bumps the 5th component once per vendor commit,
+filling any missing intermediate component with zero:
+`1.2.3` becomes `1.2.3.0.1`,
+`1.2.3.9000` becomes `1.2.3.9000.1`,
+and `1.2.3.9000.4` becomes `1.2.3.9000.5`.
+The point is that every vendor commit is installable
+as a distinct version on r-universe.
+
+The 5th component is a dev-branch affair.
+`scripts/flavor.sh` never stamps it,
+and a regular LTS flavor keeps a four-component version.
+Under the series loop the seed carries a separate
+`chore: Add fifth version component` commit
+that stamps the counter's zero,
+so every commit on the series is orderable by version
+from the first one onward.
+It orders, it does not count:
+when a broken vendor commit is folded into the commit that fixes it,
+the gap it leaves in the counter is accepted.
+
+## What a release carries
+
+A released version is normally the bare three-component prefix,
+matching the upstream tag.
+It is **not** derived from git —
+the tag follows `DESCRIPTION`, never the other way round —
+so it is set explicitly when the tagged content reaches the stable branch:
+
+```r
+fledge::bump_version("X.Y.Z")
+```
+
+Where that happens in the release sequence is
+[`process/`](/handbook/operations/releases/process/README.md)'s;
+what happens afterwards is versioning's.
+`main` moves on to its next development version
+(the prefix plus a fresh 4th component, e.g. `X.Y.Z.9000`) via `fledge`,
+and the series' dev branches resume the vendor counter
+from the new baseline.
+
+The bare prefix is the rule, not a guarantee.
+When the R layer needs a fix and upstream has not tagged,
+the package ships a release carrying a low 4th component instead:
+`v1.5.4.1`, `v1.5.4.2`, and `v1.5.4.3` were cut that way,
+and `NEWS.md` records them as releases between `1.5.4` and `1.5.5`.
+Such a number is below the 9000 block the R-client counter uses,
+so it never collides with a development version.
+
+The vendored engine's own version string is a separate surface:
+`R/version.R` is generated and carries `duckdb_version`.
+It belongs to
+[`operations/vendoring/pipeline/`](/handbook/operations/vendoring/pipeline/README.md),
+not here.
+
+## fledge
+
+[fledge](https://fledge.cynkra.com) owns the 4th component and `NEWS.md`.
+`.github/workflows/fledge.yaml` runs it daily at 00:30 UTC,
+on manual dispatch,
+and on any push to `main` that touches the workflow file itself.
+
+Two guards run before anything is bumped.
+The workflow skips forks outright,
+and skips `krlmlr/duckdb-r` by name —
+so no branch in the CI/CD fork ever receives a version bump
+or a `NEWS.md` entry from it.
+It also skips unless the first line of `NEWS.md` mentions fledge,
+which is what the maintenance banner at the top of that file is for:
+remove the banner and the automation stops.
+
+The bump itself is
+`fledge::bump_version(which = "dev", no_change_behavior = "noop")`
+followed by `fledge::finalize_version(push = TRUE)`.
+`noop` means a day with nothing new produces nothing.
+Because `main` is protected,
+the run pushes a `fledge` branch instead of committing to `main`,
+opens a pull request,
+triggers the `rcc` workflow on the head commit,
+and enables squash auto-merge;
+what lands reads `fledge: Bump version to 1.5.5.9004 (#2448)`.
+A final step calls `fledge:::release_after_cran_built_binaries()`,
+fledge's own post-CRAN hook —
+its behavior belongs to fledge, not to this repository.
+
+## `NEWS.md`
+
+`NEWS.md` is generated, not written.
+Its first line says so and tells contributors not to edit it.
+The way to influence an entry is therefore to word the commit well:
+fledge reads Conventional Commits subjects from `main` and maps
+the type to a `##` section,
+the scope to a `###` sub-heading,
+and the subject to a bullet.
+`ci(each): Queue the shards oldest first (#2445)` arrives as
+`- Queue the shards oldest first (#2445).`
+under `## Continuous integration` → `### each`.
+
+Each bump opens a heading for the new development version.
+Those headings are provisional:
+at release they fold into the release's own heading.
+Below the current development block
+`NEWS.md` therefore carries release headings only,
+even though every intermediate bump was also tagged
+(`v1.5.4.9000` through `v1.5.4.9013` exist as tags
+with no heading of their own).
+
+The `-dev` branches never touch `NEWS.md`.
+Between the strands only `DESCRIPTION:Version` differs,
+which is what makes the merge driver a complete answer
+to the recurring conflict.
+
+## Why the counters need a merge driver
+
+Both counters live on the same `Version:` line,
+and both strands advance constantly:
+`main` bumps the 4th daily,
+every vendor commit bumps the 5th.
+So a forward-port, a rebase, or a release merge
+conflicts on that one line at essentially every commit —
+replaying a pending window of hundreds of commits
+would stop hundreds of times,
+on a line whose correct value is mechanical.
+
+The resolution is a git merge driver on `DESCRIPTION`.
+It takes the component-wise maximum of the two sides,
+gated on an equal `major.minor.patch` prefix.
+Within a release line each strand keeps the counter it owns,
+because it freezes the other:
+`1.5.3.9008` merged with `1.5.3.9006.42` gives `1.5.3.9008.42`,
+in either direction.
+Across release lines —
+forward-porting a `1.5.x` fix onto the `1.4.x` LTS —
+the prefix gate keeps ours,
+so a foreign prefix is never inherited.
+The rest of `DESCRIPTION` still gets a normal three-way merge,
+so two branches genuinely editing `Imports:` still conflict.
+
+The driver never decides a release version.
+Its only job is to stop the version line from halting a rebase;
+the authoritative number is set by `fledge::bump_version()`
+at the tip once the operation completes.
+
+The mechanism — `scripts/merge-version.sh`,
+the `merge=ours-version` attribute in `.gitattributes`,
+and `scripts/setup-git.sh`,
+which registers the driver per clone
+and must run first in any job that rebases, cherry-picks, or merges —
+belongs to
+[`operations/vendoring/pipeline/`](/handbook/operations/vendoring/pipeline/README.md).
+
+## Limits
+
+* There is no automatic path from an upstream tag to `DESCRIPTION`.
+  A release version is typed out once, by hand, through `fledge`.
+* The counters carry no meaning beyond ordering.
+  Neither the 4th nor the 5th component is a change count,
+  and gaps in either are expected.
+* fledge is an external tool.
+  What this repository configures is the workflow file and the banner;
+  how a bump or a `NEWS.md` entry is computed is fledge's own behavior.
+* The version invariants that make the scheme checkable per branch —
+  prefix lock, patch ordering, counter ownership, release shape —
+  are stated at [`branches/invariants/`](/handbook/branches/invariants/README.md),
+  not here.


### PR DESCRIPTION
## What this leaf now owns

`handbook/operations/releases/versioning/` explains the version in `DESCRIPTION` once: the three-component release-line prefix, the 4th component as the R-client counter that `fledge` free-runs on `main`, and the 5th as the vendor counter that `scripts/vendor-one.sh` bumps once per vendor commit on a `-dev` branch. It covers what number a release carries (set explicitly through `fledge`, never derived from the git tag), how `.github/workflows/fledge.yaml` gates and drives the daily bump, how `NEWS.md` is generated from Conventional Commits subjects and folded at release, and *why* two counters on one line need a `DESCRIPTION` merge driver — the driver itself (`scripts/merge-version.sh`, `scripts/setup-git.sh`, the `.gitattributes` attribute) stays with `operations/vendoring/pipeline/`, which the leaf links. Limits and the per-branch version invariants are stated as boundaries, the latter linking `branches/invariants/`.

## What moved

- **`BRANCHES.md`** — lost § "Version Numbering" and its "The `DESCRIPTION` merge driver" subsection, replaced by a one-line pointer to the leaf. Gained the visible italic handbook backreference under its H1. The rest of the file is untouched; three sibling leaves are splitting it in parallel.
- **`RELEASE.md`** — lost the `fledge::bump_version("X.Y.Z")` paragraph and code block in § "4 MERGED" and the post-RESET paragraph about `main` moving to `X.Y.Z.9000`, both replaced by pointers. Its `BRANCHES.md#version-numbering` link, whose anchor this PR removes, now points at the leaf. Gained the italic handbook backreference under its H1. Two sibling leaves are splitting the rest.
- **`.github/workflows/fledge.yaml`** — gained a plain `# Handbook: handbook/operations/releases/versioning/` comment above `name:`.

## Assumptions

- The stub said "the two version counters, fledge, and `NEWS.md`". I read the merge-driver material in `BRANCHES.md` § "Version Numbering" as *motivation* that belongs here (why the counters conflict) with the *mechanism* left to `operations/vendoring/pipeline/`, so § "The `DESCRIPTION` merge driver" is summarized in the leaf and its scripts are linked rather than described.
- The 4th-component shape was read off `main`'s `DESCRIPTION`: a bare prefix plus the 4th component and no 5th. The leaf carries `1.5.5.9004` as an **example** of that shape rather than as `main`'s current version — see the durability sweep below, and note that `main` has since bumped to `1.5.5.9005`, which is exactly the rot the sweep was guarding against. The claim that the 4th component is frozen on `-dev` branches is not checkable from this branch; it is taken from `scripts/merge-version.sh`'s own reasoning ("each strand owns exactly one counter and freezes the other") and the per-branch form is delegated to `branches/invariants/`.
- The leaf records that the bare-three-component rule has exceptions: `v1.5.4.1` through `v1.5.4.3` were released with a low 4th component (verified from the tag list and from `NEWS.md`, which carries headings for all three between `1.5.4` and `1.5.5`). Tags `v1.5.4.9901`–`9903` also exist; I could not determine the rule that produced them, so the leaf says nothing about them.
- "At release the development headings fold into the release heading" is inferred from evidence, not from fledge's docs: `NEWS.md` carries no `1.5.4.9xxx` heading although `v1.5.4.9000` and the bumps that followed it are all tagged. Worth a maintainer's confirmation.
- `fledge:::release_after_cran_built_binaries()` is named as the workflow's last step but its behavior is attributed to fledge rather than described, since it is an internal function of an external package.
- `NEWS.md` did **not** get a backreference line: it is generated and its banner tells contributors not to edit it. The root `README.md` § "Documentation" entries for `BRANCHES.md` and `RELEASE.md` were also left alone, because both absorptions are partial and five sibling branches touch those same bullets.

## Durability sweep

A follow-up pass over the leaf for facts a routine change would invalidate.

**Removed or reframed**

* "`main`'s `Version: 1.5.5.9004` is exactly that shape" → "A `main` version such as `1.5.5.9004`". fledge bumps that counter daily, so asserting the current value made the leaf wrong by the next morning. The paragraph was illustrating the *shape*, which the example still does. (`main` has bumped since; the reframed sentence is still true.)
* The upper end of the intermediate tag range, `v1.5.4.9013`. A range endpoint is a count of tags wearing a version number: it grows with every bump. Now "the tag list shows `v1.5.4.9000` and the bumps that followed it".
* fledge's exact cron minute ("daily at 00:30 UTC" → "on a daily schedule"). The sentence already names `.github/workflows/fledge.yaml`, which carries the schedule and is correct on the day it is read.
* The count in "Two guards run before anything is bumped" — the guards follow immediately, so the number argued nothing.

**Kept**

* **`v1.5.4.1`, `v1.5.4.2` and `v1.5.4.3`.** These are the evidence that the bare-prefix rule has exceptions, and they are anchored to specific version identifiers, so they age honestly. Reworded to say the *tag list shows* them rather than presenting them as the current set — a fourth such release would not falsify the sentence.
* **The two counters, the five components, the 9000 block.** These are the design; changing the count would mean changing the scheme.
* **The worked merge examples** (`1.5.3.9008` ⊔ `1.5.3.9006.42` = `1.5.3.9008.42`, and the `1.2.3` → `1.2.3.0.1` fill) — arithmetic demonstrations, not readings off the tree.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PD23hjFQFRWW62HFvru187)_