### PR TITLE
docs(handbook): Write the vendoring troubleshooting leaf

### DIFF
--- a/handbook/operations/vendoring/troubleshooting/README.md
+++ b/handbook/operations/vendoring/troubleshooting/README.md
@@ -1,21 +1,244 @@
 # Troubleshooting
 
-*Stub — this leaf will own its topic;
-today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../../meta/handbook/);
-the last section holds this leaf's parameters.*
+When a vendoring run goes red:
+how to tell the failure modes apart, what causes each one, and what it needs.
+The repair procedures themselves are playbooks the series loop runs
+([`series-loop/`](/handbook/operations/vendoring/series-loop/README.md));
+what follows is how to reach the right one.
 
-Scope: when a run is red —
-the glue gate, base scans, dropped patches,
-stuck shards, stale snapshots.
+## Where to look first
 
-Today:
+[`scripts/series-check.sh`](/scripts/series-check.sh) is the read-only diagnosis.
+For every series it walks `<S>-green..<S>-dev`,
+looks each commit up in the harvest on branch `rcc`,
+and prints one verdict —
+`ADVANCE`, `WAIT`, `RETRY <sha>`, `REPAIR <sha>`, or `IDLE` —
+beside the in-flight and buffered counts.
+It takes no arguments, discovers the series from the refs,
+and changes nothing, so it is always safe to run first.
 
-* [`scripts/VENDORING.md`](../../../../scripts/VENDORING.md)
-* [`scripts/EACH.md`](../../../../scripts/EACH.md)
+The harvest it reads lives on the orphan branch `rcc`:
+one record per commit at `runs2.d/<xx>/<sha>.ndjson`,
+a failing commit's whole log at `logs2/<sha>.log`,
+and `runs2.ndjson` holding the same records concatenated
+for commits that predate the per-commit layout.
+A matrix leg publishes its record within seconds of deciding a commit,
+and `rcc-logs.yaml` sweeps every 30 minutes for whatever a leg could not publish.
+The record is what decides whether a commit counts as judged;
+the `rcc` commit status is a display surface on the commit list.
+The store's shape and its writers belong to
+[`ci/per-commit/`](/handbook/operations/ci/per-commit/README.md).
 
-To write this leaf:
+Three commands answer "what is vendored here, and when did it last move":
 
-* absorb: the troubleshooting section of `scripts/VENDORING.md`;
-  glue gate, base scans, dropped patches;
-  stuck shards belong to `ci/per-commit/` — link
+```bash
+grep duckdb_version R/version.R            # the DuckDB version string
+git log -1 --grep="^vendor:" --format=%s   # the upstream commit it came from
+git log --oneline --grep="^vendor:" -10    # the last ten vendor commits
+```
+
+## The script refuses to start
+
+Both [`vendor.sh`](/scripts/vendor.sh) and
+[`vendor-one.sh`](/scripts/vendor-one.sh) abort with
+`Error: working directory not clean` before touching anything:
+`git status --porcelain` must be empty.
+Commit or stash first.
+A dirty *upstream* clone is only a warning.
+`vendor-one.sh` additionally refuses unless the working directory
+is the root of its own git worktree.
+
+## The base scan comes up empty
+
+```
+Error: no duckdb/duckdb@ subject among the newest N src/duckdb commit(s)
+```
+
+Both scripts recover where the branch stands in upstream history
+by scanning back over recent commits that touched `src/duckdb/`
+and taking the first `duckdb/duckdb@<sha>` they find in a subject.
+The pathspec narrows the walk and the subject decides,
+so patch-stack fixes — which edit the vendored tree in place and carry no
+upstream SHA — are looked past, twenty commits deep by default.
+
+Coming up empty is not an answer, and neither script guesses.
+An empty base makes the enumeration read `..<HEAD>`,
+whose missing left side git resolves to the upstream clone's `HEAD` —
+a range nobody chose, silently vendoring the wrong span —
+so both refuse and name the bound they hit.
+
+Two causes, with different fixes:
+
+* **A vendor subject was reworded or squashed away.**
+  The subject line is the only record of the base,
+  so restore a well-formed `vendor: … duckdb/duckdb@<sha>` subject;
+  its exact format is
+  [`pipeline/`](/handbook/operations/vendoring/pipeline/README.md)'s.
+* **The branch genuinely stacks more than twenty non-vendoring commits
+  under `src/duckdb/`.**
+  Raise `BASE_SCAN_DEPTH`.
+  The message says the scan hit its bound only when it actually did,
+  so its absence points at the first cause instead.
+  The same bound is written into `series-advance.sh` and `series-check.sh`
+  as a literal twenty, so a branch that needs a raise here needs them changed too.
+
+## The glue gate stops the walk
+
+`vendor-one.sh` syntax-checks the R glue against the freshly vendored headers
+after each commit it makes, and stops at the first failure with exit status 3:
+
+```
+=== GLUE BROKEN by <sha> (upstream <commit>) ===
+Files: ...
+```
+
+The gate runs *after* the commit, so the breaking vendor commit is already at
+`HEAD`, and the upstream clone is kept rather than removed
+so the walk can resume once the glue is fixed.
+The failing files are also left in `/tmp/vendor-one-glue-failures.txt`.
+
+The check is `g++ -fsyntax-only` over `src/*.cpp`, four files at a time,
+with the compile flags derived from `R CMD SHLIB -n` so they match the local setup.
+It costs about twenty seconds, links nothing and starts no R session,
+which is what makes it affordable once per commit.
+Nearly every upstream break is a C++ API change the glue has to follow,
+and the gate catches it here rather than fifteen minutes into a build.
+
+Fix the glue in `src/*.cpp` and `src/include/`, never in `src/duckdb/`,
+run `clang-format`, amend into `HEAD` appending an `R-side fix` section
+that names the upstream change and what was adapted, then rerun the script.
+The fix has to land *in* the vendor commit that needs it:
+a follow-up leaves a commit that never built in the history forever
+([`branches/invariants/`](/handbook/branches/invariants/README.md)).
+The full procedure — including what to do when no glue fix can help
+because the vendored tree is broken at that commit — is stage 1 of the
+series loop.
+
+One misreading is worth guarding against.
+An empty `Files:` list next to
+`Error: could not derive glue compile flags (R CMD SHLIB -n)`
+means the flags could not be derived, not that every glue file is broken.
+Deriving them needs `src/Makevars.rstrtmgr`, which only `./configure` writes;
+the gate runs `./configure` itself when the file is missing,
+so this is a broken local setup rather than an upstream change.
+`--no-check-glue` turns the gate off.
+
+## A patch disappeared from `patch/`
+
+That is by design.
+Each vendor run applies every `patch/*.patch` in order,
+and a patch whose dry run no longer applies is deleted —
+`Removing patch <file>` in the log — with the deletion committed
+as part of the vendor commit.
+The assumption is that the fix landed upstream.
+
+Verify that assumption rather than trusting it.
+If the patch is still needed, restore it and rebase it against the new sources.
+The patch stack's lifecycle is
+[`pipeline/`](/handbook/operations/vendoring/pipeline/README.md)'s,
+and its rules are [Patch Stack](/BRANCHES.md#patch-stack) in `BRANCHES.md`.
+
+## A commit on `-dev` is red
+
+`series-check.sh` names the oldest failure and classifies it
+from what its harvested log contains.
+`RETRY` means nothing in the commit caused it;
+`REPAIR` means the commit has to change.
+
+| in the log | what it is | where it goes |
+|---|---|---|
+| `Updating snapshots: '…'` | engine output drifted | [`testing/snapshots/`](/handbook/testing/snapshots/README.md) |
+| `Error ('test-….R:N:M')` | a real test failure | fix at origin, fold into the commit |
+| `Changes detected in workflow_dispatch build` | style or roxygen drift | fix at origin, fold into the commit |
+| a refused or reset connection while the tests passed | infrastructure | rerun the commit |
+| `exceeded its …s budget -- presumed stuck` | a gate ran out of time | not a flake; rerunning buys the same kill |
+
+Never classify by the absence of a marker:
+`Job is waiting for a hosted runner` appears in every log and means nothing.
+
+Repair the oldest failure first — later reds usually inherit it.
+Snapshot drift after a vendor commit is the class most often mistaken for a
+regression: an engine whose error wording or type list changed makes the
+recorded output stale rather than wrong, and the corrected files are already
+published on the `snapshot-<sha>-rcc-smoke-null` branch the snapshots gate wrote.
+When to accept and when accepting hides a regression is
+[`testing/snapshots/`](/handbook/testing/snapshots/README.md)'s call.
+
+A build failure straight after vendoring is almost always a DuckDB C++ API
+change: adapt the glue and fold the fix into the vendor commit that broke.
+If the R-specific build configuration is at fault instead,
+`rconfigure.py` is what changes.
+Folding, replaying the tail, and force-pushing `<S>-dev` is stage 2 of the
+series loop.
+
+## A commit has no verdict at all
+
+Missing is not failed, and `series-check.sh` says `WAIT` rather than `REPAIR`.
+Rule out the cheap explanations from what git can see before doing anything:
+the harvest may be stale — compare the age of the `rcc` branch tip against its
+thirty-minute schedule — and the run may simply be queued behind a large push.
+
+Only then is the run presumed lost.
+The series loop's rule is twelve hours, and its recovery is the
+`retry-<S>-dev` ref, which re-judges one commit on its own SHA
+instead of amending it and re-minting every descendant.
+
+Nothing schedules a replan.
+`each.yaml` fires on push, `workflow_dispatch` and `workflow_call`,
+so after a leg dies its undecided commits wait for someone to push to the branch
+or dispatch the workflow.
+Shards, budgets and what a dead leg leaves behind are
+[`ci/per-commit/`](/handbook/operations/ci/per-commit/README.md)'s.
+
+## Diffs that are not changes
+
+`src/*.dd` files that change on every build are spurious;
+revert them with `git checkout -- src/*.dd`.
+They should only change when a `.cpp` file gains or loses a *local* `#include`,
+because `src/include/deps.mk` filters everything under `duckdb/`
+out of the recorded dependencies.
+
+Two vendorings of the same upstream commit from different clones
+differ in one line of `src/function/table/version/pragma_version.cpp`
+and nowhere else;
+[`pipeline/`](/handbook/operations/vendoring/pipeline/README.md) explains why,
+and why nothing downstream breaks.
+
+## Re-vendoring from scratch
+
+When a tree has to be rebuilt from a known upstream state
+rather than repaired commit by commit:
+
+```bash
+git clone https://github.com/duckdb/duckdb.git /tmp/duckdb-vendor
+git -C /tmp/duckdb-vendor checkout v1.4-andium   # the series' upstream branch
+scripts/vendor.sh /tmp/duckdb-vendor
+R CMD INSTALL .
+```
+
+This produces exactly one vendor commit, at that upstream branch's `HEAD`.
+It is a seed, not a catch-up.
+A single commit that carries a series forward over however many upstream
+commits it skipped breaks the one-commit-per-upstream-commit rule,
+and `git bisect` across it answers nothing
+([`model/`](/handbook/operations/vendoring/model/README.md)).
+Use it to seed a new line or to inspect a tree,
+and let `vendor-one.sh` walk a series forward.
+
+## Limits
+
+Two stores still answer "has this commit been judged".
+Selection and the loop both read the record on `rcc`,
+but the `rcc` commit status is written per commit and shown on the commit list,
+and a `pending` status left behind by a leg that died reads like work in
+progress when it is not.
+Nothing decides from it: a commit without a *record* is undecided
+and gets replanned, so the status is safe to disbelieve.
+Collapsing the two into one is finding F1 of
+[`plan/PLAN-vendoring-simplification.md`](/plan/PLAN-vendoring-simplification.md);
+[`meta/plans/`](/handbook/meta/plans/README.md) tracks what is live.
+
+`scripts/vendor-gate.sh`, which turned a window of `rcc` statuses into one
+`green`/`red`/`stale`/`undecided` verdict for the daily vendoring run,
+was retired with the rest of the legacy dispatch path.
+`series-check.sh` is what replaced it, and its verdicts are the ones above.

--- a/handbook/operations/vendoring/troubleshooting/README.md
+++ b/handbook/operations/vendoring/troubleshooting/README.md
@@ -60,7 +60,8 @@ by scanning back over recent commits that touched `src/duckdb/`
 and taking the first `duckdb/duckdb@<sha>` they find in a subject.
 The pathspec narrows the walk and the subject decides,
 so patch-stack fixes — which edit the vendored tree in place and carry no
-upstream SHA — are looked past, as deep as `BASE_SCAN_DEPTH` allows.
+upstream SHA — are looked past, as deep as `BASE_SCAN_DEPTH` allows,
+which is twenty commits unless the environment says otherwise.
 
 Coming up empty is not an answer, and neither script guesses.
 An empty base makes the enumeration read `..<HEAD>`,
@@ -80,7 +81,7 @@ The causes, with their different fixes:
   Raise `BASE_SCAN_DEPTH`.
   The message says the scan hit its bound only when it actually did,
   so its absence points at the first cause instead.
-  The same bound is hard-coded in `series-advance.sh` and `series-check.sh`,
+  The same twenty is hard-coded in `series-advance.sh` and `series-check.sh`,
   which read no such variable,
   so a branch that needs a raise here needs them changed too.
 
@@ -182,7 +183,7 @@ the harvest may be stale — compare the age of the `rcc` branch tip against
 large push.
 
 Only then is the run presumed lost.
-The series loop's playbook sets how long to wait before that,
+The series loop's playbook waits twelve hours before that,
 and its recovery is the `retry-<S>-dev` ref,
 which re-judges one commit on its own SHA
 instead of amending it and re-minting every descendant.

--- a/handbook/operations/vendoring/troubleshooting/README.md
+++ b/handbook/operations/vendoring/troubleshooting/README.md
@@ -22,14 +22,15 @@ one record per commit at `runs2.d/<xx>/<sha>.ndjson`,
 a failing commit's whole log at `logs2/<sha>.log`,
 and `runs2.ndjson` holding the same records concatenated
 for commits that predate the per-commit layout.
-A matrix leg publishes its record within seconds of deciding a commit,
-and `rcc-logs.yaml` sweeps every 30 minutes for whatever a leg could not publish.
+A matrix leg publishes its record as soon as it has decided a commit,
+and [`rcc-logs.yaml`](/.github/workflows/rcc-logs.yaml) sweeps on its own
+schedule for whatever a leg could not publish.
 The record is what decides whether a commit counts as judged;
 the `rcc` commit status is a display surface on the commit list.
 The store's shape and its writers belong to
 [`ci/per-commit/`](/handbook/operations/ci/per-commit/README.md).
 
-Three commands answer "what is vendored here, and when did it last move":
+These commands answer "what is vendored here, and when did it last move":
 
 ```bash
 grep duckdb_version R/version.R            # the DuckDB version string
@@ -59,7 +60,7 @@ by scanning back over recent commits that touched `src/duckdb/`
 and taking the first `duckdb/duckdb@<sha>` they find in a subject.
 The pathspec narrows the walk and the subject decides,
 so patch-stack fixes — which edit the vendored tree in place and carry no
-upstream SHA — are looked past, twenty commits deep by default.
+upstream SHA — are looked past, as deep as `BASE_SCAN_DEPTH` allows.
 
 Coming up empty is not an answer, and neither script guesses.
 An empty base makes the enumeration read `..<HEAD>`,
@@ -67,20 +68,21 @@ whose missing left side git resolves to the upstream clone's `HEAD` —
 a range nobody chose, silently vendoring the wrong span —
 so both refuse and name the bound they hit.
 
-Two causes, with different fixes:
+The causes, with their different fixes:
 
 * **A vendor subject was reworded or squashed away.**
   The subject line is the only record of the base,
   so restore a well-formed `vendor: … duckdb/duckdb@<sha>` subject;
   its exact format is
   [`pipeline/`](/handbook/operations/vendoring/pipeline/README.md)'s.
-* **The branch genuinely stacks more than twenty non-vendoring commits
-  under `src/duckdb/`.**
+* **The branch genuinely stacks more non-vendoring commits under
+  `src/duckdb/` than the scan reaches.**
   Raise `BASE_SCAN_DEPTH`.
   The message says the scan hit its bound only when it actually did,
   so its absence points at the first cause instead.
-  The same bound is written into `series-advance.sh` and `series-check.sh`
-  as a literal twenty, so a branch that needs a raise here needs them changed too.
+  The same bound is hard-coded in `series-advance.sh` and `series-check.sh`,
+  which read no such variable,
+  so a branch that needs a raise here needs them changed too.
 
 ## The glue gate stops the walk
 
@@ -97,12 +99,12 @@ The gate runs *after* the commit, so the breaking vendor commit is already at
 so the walk can resume once the glue is fixed.
 The failing files are also left in `/tmp/vendor-one-glue-failures.txt`.
 
-The check is `g++ -fsyntax-only` over `src/*.cpp`, four files at a time,
+The check is `g++ -fsyntax-only` over `src/*.cpp`, several files in parallel,
 with the compile flags derived from `R CMD SHLIB -n` so they match the local setup.
-It costs about twenty seconds, links nothing and starts no R session,
+It costs seconds, links nothing and starts no R session,
 which is what makes it affordable once per commit.
 Nearly every upstream break is a C++ API change the glue has to follow,
-and the gate catches it here rather than fifteen minutes into a build.
+and the gate catches it here rather than deep into a full build.
 
 Fix the glue in `src/*.cpp` and `src/include/`, never in `src/duckdb/`,
 run `clang-format`, amend into `HEAD` appending an `R-side fix` section
@@ -175,12 +177,14 @@ series loop.
 
 Missing is not failed, and `series-check.sh` says `WAIT` rather than `REPAIR`.
 Rule out the cheap explanations from what git can see before doing anything:
-the harvest may be stale — compare the age of the `rcc` branch tip against its
-thirty-minute schedule — and the run may simply be queued behind a large push.
+the harvest may be stale — compare the age of the `rcc` branch tip against
+`rcc-logs.yaml`'s sweep schedule — and the run may simply be queued behind a
+large push.
 
 Only then is the run presumed lost.
-The series loop's rule is twelve hours, and its recovery is the
-`retry-<S>-dev` ref, which re-judges one commit on its own SHA
+The series loop's playbook sets how long to wait before that,
+and its recovery is the `retry-<S>-dev` ref,
+which re-judges one commit on its own SHA
 instead of amending it and re-minting every descendant.
 
 Nothing schedules a replan.

--- a/scripts/VENDORING.md
+++ b/scripts/VENDORING.md
@@ -1,8 +1,9 @@
 # DuckDB R Package Vendoring
 
 This document covers the mechanics of vendoring:
-what the scripts do, which invariants a dev branch must satisfy, how a new dev line is started,
-and how to troubleshoot a failing run.
+what the scripts do, which invariants a dev branch must satisfy, and how a new dev line is started.
+Diagnosing a failing run is
+[`operations/vendoring/troubleshooting/`](/handbook/operations/vendoring/troubleshooting/README.md).
 For the branch strategy, the complete list of active branches, and the release process, see
 [BRANCHES.md](../BRANCHES.md), which is the authoritative source.
 For the historical design notes that led to the series loop,
@@ -470,59 +471,8 @@ without keeping the newest SHA in the subject.
 
 ## Troubleshooting
 
-### Vendoring stopped working
-
-1. **Check the harvest**: read `runs2.d/<xx>/<sha>.ndjson` and `logs2/` on branch
-   `rcc` — `runs2.ndjson` accumulates the same records in one file
-   (`scripts/series-check.sh` prints a per-series verdict, reading whichever of
-   the two holds the commit).
-2. **Gate says `red` or `stale`**: a commit near the tip is failing `rcc`, or never got a result.
-   Repair the failing commit first (see the skills in `.claude/skills/`);
-   vendoring resumes on its own once a green base is back in the window.
-3. **Clean working directory**: both scripts abort on any uncommitted change.
-4. **The base is unparseable**: if the recent commits touching `src/duckdb/`
-   no longer carry a `duckdb/duckdb@<sha>` subject (e.g. after a manual squash),
-   the script has no base and tries to vendor from the beginning of time.
-   Restore a well-formed vendor subject.
-
-### Manual recovery
-
-```bash
-# 1. Clone fresh DuckDB repository
-git clone https://github.com/duckdb/duckdb.git /tmp/duckdb-vendor
-
-# 2. Checkout target branch
-cd /tmp/duckdb-vendor
-git checkout v1.4-andium   # adjust to target series
-
-# 3. Run manual vendor
-cd /path/to/duckdb-r
-scripts/vendor.sh /tmp/duckdb-vendor
-
-# 4. Test build
-R CMD INSTALL .
-```
-
-### Common issues
-
-**Issue**: `Error: working directory not clean`
-**Solution**: Commit or stash all changes before vendoring.
-
-**Issue**: A patch silently disappeared from `patch/`
-**Solution**: That is by design —
-a patch that no longer applies is deleted by the vendor run,
-on the assumption that the fix landed upstream.
-Verify that assumption; if the patch is still needed, restore and rebase it against the new sources.
-See [Patch Stack](../BRANCHES.md#patch-stack).
-
-**Issue**: Build failures after vendoring
-**Solution**: Usually a DuckDB C++ API change;
-adapt the glue code in `src/*.cpp` / `src/include/` and fold the fix into the vendor commit.
-If the R-specific build configuration is at fault, update `scripts/rconfigure.py`.
-
-**Issue**: `src/*.dd` files change on every build
-**Solution**: Spurious — revert with `git checkout -- src/*.dd`.
-They should only change when a `.cpp` file gains or loses a local `#include`.
+Moved to the handbook:
+[`operations/vendoring/troubleshooting/`](/handbook/operations/vendoring/troubleshooting/README.md).
 
 ## Monitoring Vendoring
 
@@ -561,29 +511,10 @@ which is the drill-down.
 An upstream-lag badge ("how far behind `duckdb/duckdb` itself")
 is not expressible this way — the comparison would cross repositories.
 
-### GitHub Actions
+### Where a run stands
 
-- The routine reports each firing; branch `rcc` holds the harvested
-  per-commit results (`runs2.d/<xx>/<sha>.ndjson`, `logs2/<sha>.log`, and
-  `runs2.ndjson`), published within seconds of each commit being decided
-- Check for `rcc` statuses on the individual commits of each `-dev` branch
-
-### Commit history
-
-Look for recent vendor commits:
-
-```bash
-git log --oneline --grep="^vendor:" -10
-```
-
-### Version tracking
-
-Check what DuckDB version is currently vendored:
-
-```bash
-grep duckdb_version R/version.R            # DuckDB version string
-git log -1 --grep="^vendor:" --format=%s   # upstream commit it came from
-```
+Reading the harvest, the vendor commits, and the vendored version:
+[`operations/vendoring/troubleshooting/`](/handbook/operations/vendoring/troubleshooting/README.md).
 
 ## Files and Directories
 


### PR DESCRIPTION
## What this leaf now owns

`handbook/operations/vendoring/troubleshooting/` is the page you open when a
vendoring run is red. It is organized by symptom rather than by subsystem:
where to look first (`series-check.sh`, the harvest on `rcc`, what is
vendored), a script refusing to start, an empty base scan, the glue gate
stopping the walk, a patch that disappeared from `patch/`, a red commit on
`{S}-dev` and how its log classifies, a commit with no verdict at all, diffs that
are not changes, re-vendoring from scratch, and the limits. Every claim is
checked against `scripts/vendor.sh`, `scripts/vendor-one.sh`,
`scripts/series-check.sh`, `scripts/rcc-one.sh`, `scripts/rcc-decided.sh`,
`src/include/deps.mk` and `.github/workflows/each.yaml`. Stuck shards and the
verdict store point at `operations/ci/per-commit/`, snapshot acceptance at
`testing/snapshots/`, the patch-stack lifecycle at `operations/vendoring/pipeline/`,
and the repair playbooks at `operations/vendoring/series-loop/` — linked, not
absorbed.

(Series refs are written `{S}-dev` here. The leaf itself uses angle brackets;
GitHub deletes those from a pull-request body even inside backticks.)

## What moved

- **`scripts/VENDORING.md`** — lost its whole `## Troubleshooting` section
  ("Vendoring stopped working", "Manual recovery", "Common issues") and the
  diagnostic half of `## Monitoring Vendoring` ("GitHub Actions",
  "Commit history", "Version tracking"); each is replaced by a one-line pointer
  to the leaf. `### Ahead/behind badges` stays untouched, and the intro sentence
  now routes troubleshooting to the handbook instead of claiming it. No
  backreference line was added: `VENDORING.md` is covered by the generated
  `scripts/README.md` index, whose ownership row is unchanged (verified with
  `docs-readme.R --check`).

`scripts/EACH.md` was **not** edited — another leaf owns it.

## Assumptions

- **`## Monitoring Vendoring` was split rather than taken whole.** The work
  order named it as a source, but `### Ahead/behind badges` is about series
  display and `README.md` upkeep (shields.io within one repository, release
  branches mirrored into the fork), not about a red run, so it was left in
  `VENDORING.md` for whichever leaf claims it. The three diagnostic subsections
  were absorbed.
- **The retired `vendor-gate.sh` verdicts were replaced, not repeated.**
  `VENDORING.md` still spoke of a gate saying `red` or `stale`; that script no
  longer exists in the tree. The leaf states today's verdicts —
  `series-check.sh`'s `ADVANCE` / `WAIT` / `RETRY` / `REPAIR` / `IDLE` — and
  records the retirement under **Limits** so a reader who remembers the old
  vocabulary lands somewhere.
- **`PENDING_TTL_HOURS` is treated as gone.** It appears in no script or
  workflow (`rcc-decided.sh`'s header says selection now reads records, not
  statuses), so the leaf says a commit without a *record* is undecided and a
  `pending` status is safe to disbelieve. `scripts/EACH.md` still names
  `PENDING_TTL_HOURS` in its §3 table and its failure-mode table; that looks
  stale, and it belongs to the `operations/ci/per-commit/` leaf to fix.
- **The failure-class table is a recognition aid, not the repair playbook.**
  Its rows come from `series-check.sh`'s `classify()` and stage 2 of
  `.claude/skills/series-loop.md`; the actions column points onward rather than
  restating the fold-and-replay procedure.
- **The manual-recovery snippet gained a caveat.** `VENDORING.md` presented
  `vendor.sh` as recovery without saying what it does to a `{S}-dev`
  branch; the leaf keeps the procedure and states that it produces one commit
  and is a seed, not a catch-up.
- Nothing named in a recovery procedure was found missing: `vendor.sh`,
  `vendor-one.sh`, `series-check.sh`, `snapshot-accept.sh`, `rconfigure.py`,
  `each.yaml`, `rcc-logs.yaml` all exist as described.

## Durability sweep

A later pass removed the facts a routine commit would invalidate.

**Out, replaced by the mechanism:**

- "looked past, twenty commits deep by default" → "as deep as
  `BASE_SCAN_DEPTH` allows". The variable is already the fix the section
  recommends. *(Partly reversed — see below.)*
- "The same bound is written into `series-advance.sh` and `series-check.sh` as
  a literal twenty" → "hard-coded in `series-advance.sh` and `series-check.sh`,
  which read no such variable". The coupling — raising the depth here means
  editing them too — is the durable fact; the literal is not.
  *(Partly reversed — see below.)*
- "`rcc-logs.yaml` sweeps every 30 minutes" and "compare the age of the `rcc`
  branch tip against its thirty-minute schedule" → the workflow's own sweep
  schedule, with the workflow now linked so the cadence is one click away.
  This one stands: the leaf still names the schedule rather than quoting it.
- "The series loop's rule is twelve hours" → "The series loop's playbook sets
  how long to wait before that". The playbook owns the rule and is linked from
  the top of the leaf. *(Reversed — see below.)*

**Out, as timings nobody will re-measure:** "It costs about twenty seconds" →
"It costs seconds"; "rather than fifteen minutes into a build" → "rather than
deep into a full build". Both served the same point — the gate is cheap enough
to run once per commit — which survives without the stopwatch. "four files at
a time" became "several files in parallel", which is also a more accurate
reading of `xargs -P`.

**Out, because the count only restated what followed:** "Three commands answer
…" → "These commands answer …"; "Two causes, with different fixes" → "The
causes, with their different fixes".

**Kept:** the failure-class table in full — it names each class, which is the
durable form. Exit status 3, the `ADVANCE` / `WAIT` / `RETRY` / `REPAIR` /
`IDLE` verdicts, and the store paths are values, not counts. "Both scripts"
(`vendor.sh` and `vendor-one.sh`, named in the same breath), "exactly one
vendor commit" from a re-vendor (the seed-not-catch-up point), the one line of
`pragma_version.cpp` that differs between clones, and the "two stores" of
finding F1 all stay: in each, changing the number would mean changing the
design.

## Operational defaults put back

The sweep went one step too far on three of its removals, and a later commit
restored them. A default *governs behaviour*: a reader sent to open the script
for the number has been sent away for the thing they came for. The mechanism
stays beside the value in each case.

- **The base scan depth is twenty again** — "as deep as `BASE_SCAN_DEPTH`
  allows, which is twenty commits unless the environment says otherwise".
  Verified: `scripts/vendor.sh` and `scripts/vendor-one.sh` both read
  `${BASE_SCAN_DEPTH:-20}`.
- **The hard-coded twenty is named as the same twenty** — "The same twenty is
  hard-coded in `series-advance.sh` and `series-check.sh`, which read no such
  variable, so a branch that needs a raise here needs them changed too." That
  those two scripts hard-code *the same* number is exactly why the coupling
  bites; naming it is what makes the sentence checkable. Verified: `git log -n
  20` and an `-ge 20` bound in both scripts, neither of which mentions
  `BASE_SCAN_DEPTH`.
- **The playbook's wait is twelve hours again** — "The series loop's playbook
  waits twelve hours before that", with the playbook still linked as the owner
  of the rule.

The `rcc-logs.yaml` cadence was *not* put back: it is a workflow schedule one
click away in a file the leaf links, not a knob the reader is being asked to
reason about.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PD23hjFQFRWW62HFvru187)_
