### PR TITLE
docs(handbook): Write the vendoring model leaf

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,8 @@ start there rather than searching.
 | Build, test, and validate the package locally | this file (below) |
 | Branch model, package flavors, series invariants | `BRANCHES.md` |
 | Release process, modelled as a state machine | `RELEASE.md` |
-| Vendoring mechanics: scripts, invariants, troubleshooting | `scripts/VENDORING.md` |
+| Why the engine is vendored, and the one-commit-per-upstream-commit invariant | [`handbook/operations/vendoring/model/`](handbook/operations/vendoring/model/README.md) |
+| Vendoring mechanics: scripts, troubleshooting | `scripts/VENDORING.md` |
 | Per-commit CI (sharded matrix): design and limits | `scripts/EACH.md` |
 | Operating the vendoring loop (routine playbooks) | `.claude/skills/`: `series-loop.md`, `series-forward.md`, `series-rebase.md`, `series-open.md` |
 | Designs, plans, and historical documents | `plan/README.md`, which names each by path |
@@ -94,7 +95,7 @@ The duckdb-r package vendors (includes a copy of) the DuckDB C++ core library. K
 
 - **Automated Process**: Runs daily via GitHub Actions in `krlmlr/duckdb-r`, gated on the per-commit `rcc` build status
 - **Branch Strategy**: one dev branch per upstream branch (`main-dev` ← `main`, `v1.5-variegata-dev` ← `v1.5-variegata`, `v1.4-andium-dev` ← `v1.4-andium`); see [BRANCHES.md](BRANCHES.md)
-- **One commit at a time**: each vendor commit corresponds to exactly one upstream commit, and must build and pass tests on its own — fold any required glue fix into that commit rather than adding a follow-up
+- **One commit at a time**: the vendoring model — why the engine is vendored, and the invariant every vendor commit satisfies — is [`handbook/operations/vendoring/model/`](handbook/operations/vendoring/model/README.md)
 - **Never modify `src/duckdb/` directly** - changes will be overwritten by vendoring
 - **Patching**: Add files to the `patch/` directory to apply R-specific modifications to vendored code. Send patches upstream as pull requests every once in a while. A patch that no longer applies is deleted by the next vendor run.
 - **Manual vendoring**: Use `scripts/vendor.sh /path/to/duckdb/repo` for testing

--- a/BRANCHES.md
+++ b/BRANCHES.md
@@ -599,7 +599,7 @@ a **linear** first-parent history without merge commits,
 **one upstream commit per vendor commit** forming a contiguous first-parent walk of the tracked upstream branch,
 and a **green** build for every commit.
 These are stated as invariants, with the reasoning and the failure modes, in
-[Dev Branch Invariants](scripts/VENDORING.md#dev-branch-invariants).
+[`operations/vendoring/model/`](handbook/operations/vendoring/model/README.md).
 
 ### On release
 

--- a/handbook/operations/vendoring/model/README.md
+++ b/handbook/operations/vendoring/model/README.md
@@ -88,7 +88,7 @@ without invariant 3, the step cannot be tested at all.
 That is the whole reason a package repository replays upstream history
 commit by commit rather than jumping to the next release.
 
-The price is paid in four places:
+The price is paid in several places:
 
 * **Every vendorable upstream commit gets its own build and testsuite run.**
   A backlog of *n* commits costs *n* builds; there is no shortcut.
@@ -161,10 +161,10 @@ The enumeration then started from the v1.5 base,
 whose oldest entries are commits `main` accumulated
 after the fork point but *before* the release.
 The first mainline vendor commit therefore moved the vendored sources
-backwards in time — to a `main` commit two weeks older than `v1.5.0` —
-while simultaneously landing 101 first-parent commits past the fork point
-in a single step.
-Those hundred-odd upstream commits were never built against the glue,
+backwards in time — to a `main` commit predating the release —
+while simultaneously landing everything `main` had accumulated
+past the fork point, in a single step.
+None of that upstream work was ever built against the glue,
 and a bisect across that one commit answers nothing.
 
 The rule that avoids it:

--- a/handbook/operations/vendoring/model/README.md
+++ b/handbook/operations/vendoring/model/README.md
@@ -1,19 +1,213 @@
 # The model
 
-*Stub — this leaf will own its topic;
-today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../../meta/handbook/);
-the last section holds this leaf's parameters.*
+Why this package carries a complete copy of the DuckDB C++ engine,
+and why that copy advances one upstream commit at a time.
 
-Scope: why the engine is vendored,
-and the one-commit-per-upstream-commit invariant.
+Vendoring is keeping a dependency's sources inside the depending repository
+instead of resolving them at build time.
+`src/duckdb/` is that copy — the whole DuckDB C++ core —
+regenerated from an upstream clone by the vendoring scripts
+and never edited in place.
+What the engine is, and which commit of it is embedded, is
+[`architecture/engine/`](/handbook/architecture/engine/README.md);
+how the copy is produced is
+[`pipeline/`](/handbook/operations/vendoring/pipeline/README.md).
 
-Today:
+## Why vendor
 
-* [`scripts/VENDORING.md`](../../../../scripts/VENDORING.md)
+* **Self-contained builds.**
+  The package builds from source on a machine that has no DuckDB installed.
+* **Version compatibility.**
+  The glue is compiled against exactly the engine commit it was tested with.
+  This is not a preference:
+  the glue includes internal DuckDB C++ headers,
+  which are ABI-compatible only with the matching commit's library,
+  and `configure` refuses a mismatch outright.
+* **CRAN compliance.**
+  CRAN expects a package to be self-contained,
+  with no external library resolved at install time.
+* **Reproducible builds.**
+  Two builds of the same package version compile the same engine sources.
 
-To write this leaf:
+The one supported way to skip compiling those sources is
+`DUCKDB_R_USE_SYSTEM_LIB=1`,
+which links a prebuilt `libduckdb` instead.
+That is a developer fast path, not a second distribution model:
+`configure` compares the installed library's `DUCKDB_SOURCE_ID`
+against the vendored headers' and fails when they differ.
+See [`build/fast-paths/`](/handbook/build/fast-paths/README.md).
 
-* absorb: `scripts/VENDORING.md` §§ "What is Vendoring?" and
-  "Why Vendor DuckDB?", plus the one-commit-per-upstream-commit
-  invariant with its build-and-test requirement
+## The invariant
+
+Everything the pipeline does exists to keep four properties true
+for every `-dev` branch.
+They are what makes the history useful rather than merely present.
+
+1. **Linear.**
+   First-parent history only, no merge commits.
+   A merge lands a batch of changes as a single step
+   whose components were never built individually.
+2. **One upstream commit per vendor commit.**
+   Each vendor commit corresponds to exactly one upstream commit
+   on the tracked branch,
+   and the vendored SHAs form a contiguous first-parent walk
+   of that upstream branch — no gaps, no jumps, no going backwards.
+3. **Green per commit.**
+   Every commit builds and passes the testsuite on its own.
+   That is what `each.yaml` verifies.
+   If a vendor commit needs an R-side fix to build,
+   the fix is folded into that commit,
+   never added as a follow-up —
+   a follow-up leaves a red commit in the history forever.
+4. **Auditable R-side delta.**
+   Vendor commits touch only the mechanical path set
+   (`src/duckdb/`, `R/version.R`, `src/include/sources.mk`, `DESCRIPTION`).
+   Anything else in a vendor commit is a folded glue fix,
+   and must be reviewable as a path-filtered diff
+   ([`plan/history/vendoring-loop.md`](/plan/history/vendoring-loop.md) §3.4).
+
+Upstream commits that change nothing the vendored tree carries —
+test-only, CI-only, documentation, other clients —
+produce no vendor commit at all.
+The walk skips forward to the next one that does,
+which does not break the contiguity invariant 2 asks for:
+nothing vendorable happened in between.
+How that decision is made is
+[`pipeline/`](/handbook/operations/vendoring/pipeline/README.md).
+
+## What it buys, and what it costs
+
+It buys bisectability across the engine boundary.
+`git bisect` over a `-dev` branch lands on a single vendor commit,
+and that commit names a single upstream commit,
+so a regression is attributable either to that upstream change
+or to the glue fix folded in with it.
+Both halves are needed:
+without invariant 2, a bisect step spans an arbitrary batch of upstream work;
+without invariant 3, the step cannot be tested at all.
+That is the whole reason a package repository replays upstream history
+commit by commit rather than jumping to the next release.
+
+The price is paid in four places:
+
+* **Every vendorable upstream commit gets its own build and testsuite run.**
+  A backlog of *n* commits costs *n* builds; there is no shortcut.
+  Making that affordable is what the sharded per-commit CI is for
+  ([`ci/per-commit/`](/handbook/operations/ci/per-commit/README.md)),
+  and what the local ccache-warm replay loop is for
+  ([`pipeline/`](/handbook/operations/vendoring/pipeline/README.md)).
+* **A broken commit blocks the walk.**
+  The fix belongs in the commit that needs it, by amend,
+  so the walk stops until someone repairs it
+  rather than moving on and patching over it later
+  ([`troubleshooting/`](/handbook/operations/vendoring/troubleshooting/README.md)).
+* **The branch cannot be reshaped freely.**
+  No merges into it, no squashing vendor commits together,
+  no re-pointing it at a different upstream branch.
+* **Glue fixes lose their own history.**
+  Folding a fix into a vendor commit is what keeps every commit green,
+  but it also means the fix has no separate commit of its own;
+  invariant 4 is what keeps it reviewable anyway.
+
+Invariant 2 is the one that is easy to lose,
+and it is lost silently — see
+[starting a new dev line](#starting-a-new-dev-line).
+
+## The vendor commit is the record
+
+A vendor commit's subject is machine-readable state, not prose:
+
+```text
+vendor: Update vendored sources to duckdb/duckdb@<commit_hash>
+
+Date: <author date of the upstream commit>
+
+<subjects of the upstream first-parent commits since the previous one>
+```
+
+A commit that upstream tagged is marked in the same line:
+
+```text
+vendor: Update vendored sources (tag v1.x.x) to duckdb/duckdb@<commit_hash>
+```
+
+The `duckdb/duckdb@<sha>` in the subject is the *only* record
+of where a branch stands in upstream history.
+`vendor-one.sh`, `series-advance.sh`, `series-port.sh`
+and the repair playbooks under `.claude/skills/`
+all recover that position by parsing it back out of the commit message.
+So the subject is not free-form:
+do not reword it,
+and do not squash vendor commits together
+without keeping the newest SHA in the subject of the result.
+
+## Starting a new dev line
+
+When upstream cuts a release branch off `main`,
+the package gains a new dev line,
+and the tempting shortcut breaks invariant 2 without saying so:
+point an existing dev branch at the new upstream branch
+and let the walk catch up.
+It fails because the branch's recorded base is a commit
+on the *old* upstream line,
+so the enumeration spans two branches that diverged long ago.
+
+This is not hypothetical — it happened to `main-dev`,
+and the record of it is worth keeping.
+The branch was created from the v1.5-era package,
+vendoring the released `v1.5.0` tree,
+then re-pointed at upstream `main`.
+The enumeration then started from the v1.5 base,
+whose oldest entries are commits `main` accumulated
+after the fork point but *before* the release.
+The first mainline vendor commit therefore moved the vendored sources
+backwards in time — to a `main` commit two weeks older than `v1.5.0` —
+while simultaneously landing 101 first-parent commits past the fork point
+in a single step.
+Those hundred-odd upstream commits were never built against the glue,
+and a bisect across that one commit answers nothing.
+
+The rule that avoids it:
+
+> A new dev line starts with a vendor commit at the fork point
+> of the two upstream branches,
+> and walks forward from there, one upstream commit at a time.
+
+The fork point is the newest commit
+on the first-parent chain of *both* upstream branches.
+It is not `git merge-base`:
+upstream merges the release branch back into `main`,
+which drags the merge base forward
+to just after the most recent release.
+
+Seeding a line at that commit is a procedure, not a principle,
+and it lives elsewhere:
+the branch bootstrap is
+[`series-loop/`](/handbook/operations/vendoring/series-loop/README.md),
+and the scripts that seed and then walk are
+[`pipeline/`](/handbook/operations/vendoring/pipeline/README.md).
+
+## Boundaries
+
+This leaf owns the rationale and the invariant, nothing operational.
+
+* The engine itself, and how this build of it differs from a stock one —
+  [`architecture/engine/`](/handbook/architecture/engine/README.md).
+* The series-wide guarantees each branch of a series carries,
+  and what enforces them —
+  [`branches/invariants/`](/handbook/branches/invariants/README.md).
+  The four properties above are the vendoring side of the same story:
+  they say what a vendor commit must be,
+  not what a series promises.
+* The scripts, the regeneration, the patch stack, the version counters —
+  [`pipeline/`](/handbook/operations/vendoring/pipeline/README.md).
+* The routine that runs the walk, its stages and its schedule —
+  [`series-loop/`](/handbook/operations/vendoring/series-loop/README.md).
+* A red run —
+  [`troubleshooting/`](/handbook/operations/vendoring/troubleshooting/README.md).
+
+Intent lives under `plan/`:
+[`PLAN-vendoring-simplification.md`](/plan/PLAN-vendoring-simplification.md)
+carries the current direction of the vendoring system,
+and [`history/vendoring-loop.md`](/plan/history/vendoring-loop.md)
+the design notes that led to the commit-by-commit loop.

--- a/scripts/VENDORING.md
+++ b/scripts/VENDORING.md
@@ -1,8 +1,10 @@
 # DuckDB R Package Vendoring
 
 This document covers the mechanics of vendoring:
-what the scripts do, which invariants a dev branch must satisfy, how a new dev line is started,
+what the scripts do, how a new dev line is started,
 and how to troubleshoot a failing run.
+Why the engine is vendored at all, and the invariant the mechanics serve,
+are [`operations/vendoring/model/`](/handbook/operations/vendoring/model/README.md).
 For the branch strategy, the complete list of active branches, and the release process, see
 [BRANCHES.md](../BRANCHES.md), which is the authoritative source.
 For the historical design notes that led to the series loop,
@@ -11,15 +13,7 @@ see [history/vendoring-loop.md](../plan/history/vendoring-loop.md)
 
 ## What is Vendoring?
 
-Vendoring is the practice of including a copy of external dependencies directly in your source code repository.
-The duckdb-r package vendors (includes a complete copy of) the DuckDB C++ core library in the `src/duckdb/` directory.
-
-## Why Vendor DuckDB?
-
-- **Self-contained builds**: The R package can be built without requiring users to have DuckDB installed separately
-- **Version compatibility**: Ensures the R bindings work with a specific, tested version of the DuckDB core
-- **CRAN compliance**: Meets CRAN requirements for packages to be self-contained
-- **Reproducible builds**: Eliminates dependency on external DuckDB installations
+What vendoring is, and why this package does it, are [`operations/vendoring/model/`](/handbook/operations/vendoring/model/README.md).
 
 ## Active Dev Branches
 
@@ -40,31 +34,7 @@ the one routine discovers the series from its refs.
 
 ## Dev Branch Invariants
 
-Everything below exists to keep four properties true for every dev branch.
-They are what makes the history useful rather than merely present.
-
-1. **Linear.**
-   First-parent history only, no merge commits.
-   A merge lands a batch of changes as a single step whose components were never built individually.
-2. **One upstream commit per vendor commit.**
-   Each vendor commit corresponds to exactly one upstream commit on the tracked branch,
-   and the vendored SHAs form a **contiguous first-parent walk** of that upstream branch —
-   no gaps, no jumps, no going backwards.
-3. **Green per commit.**
-   Every commit builds and passes the testsuite on its own.
-   That is what `each.yaml` verifies, and what makes `git bisect` meaningful.
-   If a vendor commit needs an R-side fix to build, the fix is folded **into that commit**,
-   never added as a follow-up — a follow-up leaves a red commit in the history forever.
-4. **Auditable R-side delta.**
-   Vendor commits touch only the mechanical path set
-   (`src/duckdb/`, `R/version.R`, `src/include/sources.mk`, `DESCRIPTION`).
-   Anything else in a vendor commit is a folded glue fix,
-   and must be reviewable as a path-filtered diff (see [history/vendoring-loop.md](../plan/history/vendoring-loop.md) §3.4).
-
-Invariant 2 is the one that is easy to lose.
-It is violated the moment a dev branch is re-pointed at a different upstream branch
-without re-basing its vendored history — see
-[Starting a new dev line](#starting-a-new-dev-line-the-fork-point-rule).
+The four properties every dev branch keeps — linear, one upstream commit per vendor commit, green per commit, auditable R-side delta — are stated and reasoned in [`operations/vendoring/model/`](/handbook/operations/vendoring/model/README.md), which keeps this numbering.
 
 ## The Vendoring Scripts
 
@@ -119,7 +89,7 @@ Shared behaviour, in the order it happens:
    the fifth component of `Version:` in `DESCRIPTION` is incremented
    (`1.5.4.9005` → `1.5.4.9005.1` → `…9005.2`),
    so every vendor commit is installable as a distinct version on r-universe.
-8. **Commit** with the message described in [Understanding Vendor Commits](#understanding-vendor-commits).
+8. **Commit** with the message format described in [`operations/vendoring/model/`](/handbook/operations/vendoring/model/README.md).
 
 `vendor-one.sh --commits N` repeats steps 3–8 up to `N` times (the routine uses 100),
 stopping early on a tag or when no candidates remain.
@@ -359,33 +329,14 @@ the `cleanup` script runs `git clean -fdx src` and packs `src/duckdb/` into `src
 
 When upstream cuts a release branch (say `v2.0-<codename>` off `main`),
 the R package gains a new dev line.
-The tempting shortcut — point an existing dev branch at the new upstream branch
-and let `vendor-one.sh` catch up — silently breaks invariant 2,
-because the branch's recorded base is a commit on the *old* upstream line.
+The rule that governs how it starts — a seed vendor commit at the fork point
+of the two upstream branches, then a forward walk one upstream commit at a time —
+is [`operations/vendoring/model/`](/handbook/operations/vendoring/model/README.md),
+together with what goes wrong when a dev branch is re-pointed instead
+and why the fork point is not `git merge-base`.
+Below is how to carry the rule out.
 
-What happens then is worth spelling out, because it happened to `main-dev`:
-
-* `main-dev` was created from the v1.5-era package (vendoring the released `v1.5.0` tree)
-  and re-pointed at upstream `main`.
-* `vendor-one.sh` enumerated `<v1.5 base>..main`,
-  whose oldest entries are the commits `main` accumulated
-  **after the fork point but before the release**.
-  So the first mainline vendor commit moved the vendored sources *backwards* in time —
-  from released `v1.5.0` to a `main` commit two weeks older —
-  while simultaneously skipping ahead:
-  it landed 101 first-parent commits past the fork point in a single step.
-* Those ~100 upstream commits were never built against the R glue,
-  and a `git bisect` across that one commit answers nothing.
-
-The rule that avoids this:
-
-> **A new dev line starts with a vendor commit at the fork point of the two upstream branches,
-> and walks forward from there, one upstream commit at a time.**
-
-The fork point is the newest commit on the **first-parent chain of both** upstream branches.
-It is not `git merge-base`:
-upstream merges the release branch back into `main`,
-which drags the merge base forward to just after the most recent release.
+Computing the fork point, the newest commit on the first-parent chain of both branches:
 
 ```bash
 cd ~/duckdb
@@ -445,28 +396,7 @@ at a point the package already builds against, so it needs no rewind.
 
 ## Understanding Vendor Commits
 
-Vendor commits follow a specific format:
-
-```text
-vendor: Update vendored sources to duckdb/duckdb@<commit_hash>
-
-Date: <author date of the upstream commit>
-
-<subjects of the upstream first-parent commits since the previously vendored commit>
-```
-
-For tagged releases:
-
-```text
-vendor: Update vendored sources (tag v1.x.x) to duckdb/duckdb@<commit_hash>
-```
-
-The subject line is machine-readable state:
-`vendor-one.sh`, `series-advance.sh`, `series-port.sh` and the repair skills
-all recover "where is this branch in upstream history"
-by parsing `duckdb/duckdb@<sha>` out of it.
-Do not reword it, and do not squash vendor commits together
-without keeping the newest SHA in the subject.
+The vendor commit message format, and why the subject line is machine-readable state, are [`operations/vendoring/model/`](/handbook/operations/vendoring/model/README.md).
 
 ## Troubleshooting
 


### PR DESCRIPTION
## What this leaf now owns

`handbook/operations/vendoring/model/` explains why this package carries a complete copy of the DuckDB C++ engine and why that copy advances one upstream commit at a time. It states the four dev-branch properties with their original numbering preserved (linear, one upstream commit per vendor commit, green per commit, auditable R-side delta), what the invariant buys — bisectability across the engine boundary, where a `git bisect` step lands on one vendor commit naming one upstream commit — and what it costs: one build per vendorable commit with no shortcut for a backlog, a walk that stops at a broken commit rather than patching over it, a branch that cannot be merged into or re-pointed, and glue fixes that lose their own commit. It also owns the vendor commit subject as the only record of where a branch stands in upstream history, and the fork-point rule together with the `main-dev` failure that motivates it. The engine itself, the series-wide guarantees, the scripts, the routine, and red runs are linked, not absorbed.

## What moved

* `scripts/VENDORING.md` — lost §§ "What is Vendoring?", "Why Vendor DuckDB?", "Dev Branch Invariants", "Understanding Vendor Commits", and the rationale, rule, and fork-point definition from "Starting a New Dev Line". It keeps all its mechanics; each absorbed heading is retained with a one-line pointer to the leaf, so the inbound anchors elsewhere in the file still resolve. Its intro sentence no longer claims to cover the invariants. The file is not deleted — the absorption is partial, with `pipeline/` and `troubleshooting/` splitting the rest in parallel.
* `AGENTS.md` — gained a "Where to look" row routing the model to the leaf, and its Vendoring section's restated "one commit at a time" bullet became a pointer instead of a second copy of the invariant. The mechanics row was narrowed to "scripts, troubleshooting".
* `BRANCHES.md` — its §Vendoring pointer to `scripts/VENDORING.md#dev-branch-invariants` now names the leaf, since that anchor no longer holds the content.
* `scripts/README.md` and `.claude/skills/docs-consistency/docs-readme.R` — **unchanged, deliberately.** `VENDORING.md` maps to the internal node `handbook/operations/vendoring`, and with three leaves splitting the file that parent node is still the correct owner: it routes to all three. Remapping it to any single leaf would be wrong, so the `globs =` groups stayed as they are and no regeneration was needed (`docs-readme.R --check` reports the index current). Per the wave convention, no italic backreference line was added to `VENDORING.md` — the generated index carries it.

## Assumptions

* **The fork-point boundary.** I read the *rule* as model and the *procedure* as mechanics. The leaf takes why re-pointing a dev branch breaks invariant 2, the `main-dev` narrative, the rule itself, and the definition of the fork point (newest commit on the first-parent chain of both branches, not `git merge-base`). `VENDORING.md` keeps the `git rev-list`/`awk` snippet that computes it and the day-one steps, since those are the procedure, and the seeding procedure is `series-loop/`'s.
* **The numbered invariants stay whole here, including 1 and 4.** `branches/invariants/` owns the C-numbered series guarantees from `BRANCHES.md`; this list is `VENDORING.md`'s own, cited by number from `VENDORING.md` itself ("invariant 3") and previously from `BRANCHES.md`, so splitting it would break those citations. The leaf's Boundaries section says explicitly that these four say what a vendor commit must be, not what a series promises, and links `branches/invariants/`.
* **Two headings collapsed into one pointer.** "What is Vendoring?" and "Why Vendor DuckDB?" were adjacent and both fully absorbed, so `VENDORING.md` keeps the first heading with a single pointer rather than two consecutive pointer lines. Nothing links to `#why-vendor-duckdb`.
* **`AGENTS.md` got no italic H1 backreference.** Its own "Where to look" table is its backreference mechanism, and several leaves serve the file; a line naming only this leaf would be misleading. A reviewer may prefer the italic line once the other leaves land.
* **The `main-dev` figures are gone** (see the durability sweep below). They came from `scripts/VENDORING.md` and could not be re-derived here, since the `-dev` branches live in the fork and are not reachable from this checkout. Everything else is verified against source: the commit subject formats against `scripts/vendor.sh` and `scripts/vendor-one.sh`, the SHA parsing against `vendor-one.sh`, `series-advance.sh`, and `series-port.sh`, the `DUCKDB_SOURCE_ID` mismatch refusal against `configure`, and per-commit green against `.github/workflows/each.yaml`.
* **`DUCKDB_R_USE_SYSTEM_LIB=1` is framed as a boundary, not a feature of this leaf** — a developer fast path, not a second distribution model — and linked to `build/fast-paths/`. Per the wave rules no build was run under it.
* Pre-existing `../` links in the files I edited were left alone; the separate sweep PR converts them. Links I wrote are root-absolute where they leave their directory, relative where they descend (`AGENTS.md` and `BRANCHES.md` sit at the repository root).

## Durability sweep

A later pass removed the facts a routine commit would invalidate.

**Out, reduced to the qualitative claim the argument needs:** the two `main-dev`
figures — "a `main` commit two weeks older than `v1.5.0`" and "101 first-parent
commits past the fork point", plus the "hundred-odd upstream commits" that
echoed it. They were carried over from `scripts/VENDORING.md` and were the one
thing in the leaf that could not be verified from this checkout, so they were
both unverifiable and stale-prone. The narrative now says the vendored sources
moved backwards to "a `main` commit predating the release" while landing
"everything `main` had accumulated past the fork point, in a single step" —
which is the point: the batch was large enough that a bisect across it answers
nothing.

**Out, because nothing cites it:** "The price is paid in four places" →
"in several places". The bullets are not referenced by number.

**Kept, deliberately:** the four numbered invariants and both mentions of
"four properties". The numbers are identifiers — the leaf itself says
"invariant 2", "invariant 3", "invariant 4", and `scripts/VENDORING.md` points
here saying it keeps this numbering. The set is the design: a fifth property
would be a change to the model, not drift. Also kept: `v1.5.0` and
`v1.4-andium`-style names (which version, not how many), and
"A backlog of *n* commits costs *n* builds", which is a relation rather than
a measurement.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PD23hjFQFRWW62HFvru187)_