### PR TITLE
docs(handbook): Write the operations/releases/cran leaf

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,7 @@
 # R Package Release Process
 
+*Handbook: [`operations/releases/cran/`](/handbook/operations/releases/cran/README.md).*
+
 This document describes the release process for one DuckDB release line as a
 **finite state machine (FSM)**. It is the operational companion to
 [`BRANCHES.md`](BRANCHES.md), which defines the branch model, the package
@@ -219,12 +221,7 @@ git rebase origin/L && git push origin L-lts
 
 ### WinBuilder + final checks
 
-Obtain the source tarball from the CI build artifact (`r-package-source`) or the
-post-CI GitHub release (`duckdb_<version>.tar.gz`). Build it from
-`duckdb/duckdb@main` rather than a fork, so the git revision ids used to fetch
-extensions are correct. Upload to WinBuilder (R-devel):
-<https://win-builder.r-project.org/upload.aspx>. Apart from the known
-package-size NOTE, warnings and notes are blockers.
+See [`operations/releases/cran/`](/handbook/operations/releases/cran/README.md).
 
 ### 5 PUBLISHED — tag & publish
 
@@ -235,12 +232,10 @@ git tag vX.Y.Z origin/L-lts   # or origin/L per series convention
 git push origin vX.Y.Z
 ```
 
-For the **current** line (the CRAN `duckdb` package), submit the source tarball at
-<https://cran.r-project.org/submit.html>. The maintainer (currently Hannes)
-confirms the upload, after which CRAN's automated checks run. CRAN acceptance is
-**asynchronous** — it can take days and overlaps RESET and the next TRACK. If CRAN
-rejects, fix on `stable` and re-enter CUT as a follow-up patch. LTS lines publish
-to r-universe only and have no CRAN tail.
+For the **current** line (the CRAN `duckdb` package), the submission itself —
+and the asynchronous acceptance tail that overlaps RESET and the next TRACK —
+is [`operations/releases/cran/`](/handbook/operations/releases/cran/README.md).
+LTS lines publish to r-universe only and have no CRAN tail.
 
 ## RESET — re-baseline
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,5 +1,7 @@
 duckdb 1.5.5
 
+*Handbook: [`operations/releases/cran/`](/handbook/operations/releases/cran/README.md).*
+
 ## Cran Repository Policy
 
 - [x] Reviewed CRP last edited 2026-05-31.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,7 +1,5 @@
 duckdb 1.5.5
 
-*Handbook: [`operations/releases/cran/`](/handbook/operations/releases/cran/README.md).*
-
 ## Cran Repository Policy
 
 - [x] Reviewed CRP last edited 2026-05-31.

--- a/handbook/operations/releases/cran/README.md
+++ b/handbook/operations/releases/cran/README.md
@@ -81,6 +81,16 @@ file — version, timestamp, and commit SHA of a submitted release —
 that `devtools` writes after a successful upload.
 No such file is in the tree.
 
+The link to `cran-comments.md` is deliberately one-way:
+it carries no backreference to here,
+because it is outbound correspondence rather than documentation of a
+topic, and its whole text reaches a CRAN maintainer verbatim.
+The backreference convention exists so that a reader standing in the
+source tree finds the page explaining what they are looking at;
+nobody browses `cran-comments.md` for that,
+and its actual audience should not be reading our internal routing.
+The asymmetry is correct, not an orphan.
+
 ## Policy constraints
 
 ### No warning suppression
@@ -108,15 +118,22 @@ so fmt's `std_string_view` alias became a struct that derives from
 and `char32_t`, and is empty otherwise —
 the deprecated template is never instantiated.
 
-Two patches fall short of the rule and are debt, not precedent.
+**Two patches in the current stack break the rule while passing the
+check, and that is unresolved.**
 `patch/0003-Try-to-ignore-clang-warnings.patch` adds
 `-Wgnu-anonymous-struct`, `-Wnested-anon-types` and `-Wdtor-name`
-suppressions to re2 headers written as `#  pragma`,
-and `patch/0016-Avoid-mbedtls-diagnostic-pragmas.patch` respaces
-mbedtls's existing `-Wredundant-decls` pragmas as
+suppressions to two re2 headers, written as `#  pragma`;
+`patch/0016-Avoid-mbedtls-diagnostic-pragmas.patch` keeps mbedtls's
+existing `-Wredundant-decls` suppressions but respaces them as
 `#pragma  GCC  diagnostic  ignored`.
-Both forms fall outside the single-space pattern the check greps for,
-so the compiler still honours them while the check does not see them.
+The regex above matches only `#pragma` with single spaces,
+so neither form is seen by `R CMD check` —
+while the compiler honours both, exactly as if they had been written
+normally.
+These are warnings silenced rather than fixed,
+which is the thing the policy forbids;
+they are debt awaiting a root-cause fix or a deletion,
+not a precedent to copy.
 
 How the glue in `src/` honours the rule as a source convention is
 [`architecture/glue/`](/handbook/architecture/glue/README.md)'s.

--- a/handbook/operations/releases/cran/README.md
+++ b/handbook/operations/releases/cran/README.md
@@ -1,19 +1,172 @@
 # CRAN
 
-*Stub — this leaf will own its topic;
-today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](/handbook/meta/handbook/);
-the last section holds this leaf's parameters.*
+How a release reaches CRAN —
+the checks that run before a submission, the submission itself,
+and `cran-comments.md` —
+together with the CRAN policy constraints
+the source tree lives under year-round.
+Only the current line ships to CRAN, as the `duckdb` package;
+every other flavor publishes to r-universe and has no CRAN tail
+([`branches/flavors/`](/handbook/branches/flavors/README.md)).
+Where a submission sits in the release state machine belongs to
+[`operations/releases/process/`](/handbook/operations/releases/process/README.md).
 
-Scope: submission mechanics and CRAN policy constraints.
+## The final checks
 
-Today:
+What goes to CRAN is a source tarball built from `duckdb/duckdb@main`
+rather than from a fork,
+so that the git revision ids the build embeds for fetching extensions
+are correct.
+Take it from the upstream R workflow's `r-package-source` artifact,
+or from the post-CI GitHub release asset (`duckdb_<version>.tar.gz`);
+this repository's own workflows do not produce a source tarball.
 
-* [`RELEASE.md`](/RELEASE.md)
-* [`cran-comments.md`](/cran-comments.md)
+Upload that tarball to WinBuilder against R-devel
+(<https://win-builder.r-project.org/upload.aspx>).
+The bar there is the same as on the
+[CRAN checks page](https://cran.r-project.org/web/checks/check_results_duckdb.html)
+and in the upstream R workflow's `R CMD check`:
+apart from the known package-size NOTE
+and the "Note to CRAN Maintainers",
+every error, warning, and note is a blocker.
 
-To write this leaf:
+A `cran-*` branch is the other pre-submission surface:
+pushing one triggers [`.github/workflows/rhub.yaml`](/.github/workflows/rhub.yaml),
+R-hub's own generic workflow, which checks the package on R-hub's
+platforms.
+It also runs on demand, taking the platform list as an input
+(`linux,windows,macos` by default).
+The workflow inventory itself belongs to
+[`operations/ci/workflows/`](/handbook/operations/ci/workflows/README.md).
 
-* split from `RELEASE.md`: CRAN policy constraints
-  (no warning suppression, tarball size, non-standard files)
-  and `cran-comments.md` mechanics
+## Submitting
+
+Upload the tarball at <https://cran.r-project.org/submit.html>.
+The form carries four things:
+the maintainer's name and address — the `cre` entry in `DESCRIPTION` —
+the tarball, the text of `cran-comments.md`,
+and an acknowledgement of the CRAN Repository Policy.
+The maintainer then confirms the upload from a link CRAN mails to that
+address, after which CRAN's automated incoming checks run.
+
+Acceptance is asynchronous.
+It can take days, and it overlaps the next development cycle,
+so the release is tagged and published to r-universe
+without waiting for it.
+A rejection is not a rollback:
+the fix lands on the release branch
+and re-enters the release process as a follow-up patch.
+
+## `cran-comments.md`
+
+[`cran-comments.md`](/cran-comments.md) is the note that accompanies a
+submission — the free-text comment field of the submission form,
+kept in the repository so that it is reviewable and has a history.
+It is `.Rbuildignore`d and never ships in the tarball.
+
+It holds two things today:
+the name and version being submitted (`duckdb 1.5.5`),
+and a ticked checkbox recording that the CRAN Repository Policy
+was reviewed at its stated last-edited date (`2026-05-31`).
+Keeping it means updating both at each submission:
+bump the version line to the version actually being uploaded,
+and re-read the policy, replacing the date with the one the policy
+currently carries.
+The date is the point of the checkbox —
+it records *which revision* of the policy was read,
+not merely that some revision was.
+
+The `CRAN-SUBMISSION` entry in `.Rbuildignore` anticipates the companion
+file — version, timestamp, and commit SHA of a submitted release —
+that `devtools` writes after a successful upload.
+No such file is in the tree.
+
+## Policy constraints
+
+### No warning suppression
+
+CRAN rejects packages that silence compiler warnings
+instead of fixing what causes them,
+and `R CMD check --as-cran` enforces it mechanically:
+`tools:::.check_pragmas` scans `src/` and `inst/include/`
+for lines matching `^\s*#pragma (GCC|clang) diagnostic ignored`,
+reporting any hit and escalating a subset —
+`-Wuninitialized`, `-Wfloat-equal`, `-Warray-bound`, `-Wformat`,
+and a long list of GCC-only, non-portable warning names.
+
+The rule reaches the vendored engine too, even though that code is not
+ours: the fix goes into [`patch/`](/patch) and upstream as a pull request,
+so the patch can eventually be retired.
+Two examples in the current stack.
+`patch/0008-Avoid-pragma-for-zstd.patch` deletes a
+`-Wshorten-64-to-32` suppression outright, leaving a comment in its place.
+`patch/0033-clang-macos.patch` fixes a root cause instead:
+`-Wdeprecated-declarations` fired on `char_traits<T>` in libc++
+for non-standard `T`,
+so fmt's `std_string_view` alias became a struct that derives from
+`std::basic_string_view<Char>` only for `char`, `wchar_t`, `char16_t`
+and `char32_t`, and is empty otherwise —
+the deprecated template is never instantiated.
+
+Two patches fall short of the rule and are debt, not precedent.
+`patch/0003-Try-to-ignore-clang-warnings.patch` adds
+`-Wgnu-anonymous-struct`, `-Wnested-anon-types` and `-Wdtor-name`
+suppressions to re2 headers written as `#  pragma`,
+and `patch/0016-Avoid-mbedtls-diagnostic-pragmas.patch` respaces
+mbedtls's existing `-Wredundant-decls` pragmas as
+`#pragma  GCC  diagnostic  ignored`.
+Both forms fall outside the single-space pattern the check greps for,
+so the compiler still honours them while the check does not see them.
+
+How the glue in `src/` honours the rule as a source convention is
+[`architecture/glue/`](/handbook/architecture/glue/README.md)'s.
+
+### Package size
+
+The vendored engine is large — `src/duckdb/` alone is about 42 MB of C++
+sources — and `R CMD check` notes an installed size above 5 Mb,
+so the package-size NOTE is permanent.
+It is the one note tolerated at every gate above.
+CI does not even raise it:
+[`.github/workflows/custom/before-install/action.yml`](/.github/workflows/custom/before-install/action.yml)
+sets `_R_CHECK_PKG_SIZES_=FALSE`,
+which switches the installed-size check off altogether
+so that a size NOTE cannot fail a matrix run.
+
+### What ships in the tarball
+
+`R CMD check` notes non-standard files and directories at the top level,
+so [`.Rbuildignore`](/.Rbuildignore) keeps the whole maintenance surface
+out of the build.
+What survives it at the top level is the standard set and nothing else:
+`DESCRIPTION`, `NAMESPACE`, `LICENSE`, `NEWS.md`, `README.md`,
+`configure` and `configure.win`, `cleanup` and `cleanup.win`,
+the `R/`, `src/`, `man/`, `inst/` and `tests/` directories,
+and the `.Rbuildignore` and `.gitignore` dotfiles.
+Excluded are `AGENTS.md`, `BRANCHES.md`, `RELEASE.md`, `cran-comments.md`,
+`Makefile`, `CMakeLists.txt`, `_pkgdown.yml`, `docker-compose.yml`,
+the `.Rproj` file, and the `handbook/`, `plan/`, `scripts/`, `patch/`,
+`revdep/`, `docker/`, `pkgdown/`, `.github/` and `.claude/` directories.
+
+The practical consequence: a new top-level file needs its `.Rbuildignore`
+entry in the same change, unless it is genuinely meant to ship.
+That `handbook/` is among the exclusions is also why a source file's
+backreference into the handbook is a plain `#` comment and never a
+roxygen `#'` line — a generated `.Rd` cross-reference would dangle for
+every installed user
+([`meta/handbook/`](/handbook/meta/handbook/README.md)).
+
+### What CRAN does not run, and what it may not touch
+
+CRAN's check farm cannot carry the engine's test suite,
+so the tests and the runnable examples are gated off there
+and enabled automatically on GitHub Actions and r-universe instead;
+that guard is [`testing/guards/`](/handbook/testing/guards/README.md)'s.
+CRAN policy also constrains where an installed package may write —
+which is what shapes the extension and secret storage locations;
+[`usage/storage/`](/handbook/usage/storage/README.md) owns that,
+with the intent in [`plan/PLAN-storage-locations.md`](/plan/PLAN-storage-locations.md).
+And because policy requires contacting affected maintainers well before
+a release, the reverse-dependency checks run ahead of the upstream tag,
+not after it — see
+[`testing/revdep/`](/handbook/testing/revdep/README.md).

--- a/handbook/operations/releases/cran/README.md
+++ b/handbook/operations/releases/cran/README.md
@@ -118,22 +118,53 @@ so fmt's `std_string_view` alias became a struct that derives from
 and `char32_t`, and is empty otherwise —
 the deprecated template is never instantiated.
 
-**Two patches in the current stack break the rule while passing the
-check, and that is unresolved.**
-`patch/0003-Try-to-ignore-clang-warnings.patch` adds
-`-Wgnu-anonymous-struct`, `-Wnested-anon-types` and `-Wdtor-name`
-suppressions to two re2 headers, written as `#  pragma`;
-`patch/0016-Avoid-mbedtls-diagnostic-pragmas.patch` keeps mbedtls's
-existing `-Wredundant-decls` suppressions but respaces them as
-`#pragma  GCC  diagnostic  ignored`.
-The regex above matches only `#pragma` with single spaces,
-so neither form is seen by `R CMD check` —
-while the compiler honours both, exactly as if they had been written
+The regex above matches only `#pragma` spelled with single spaces,
+which leaves a loophole:
+a pragma written as `#  pragma` or as
+`#pragma  GCC  diagnostic  ignored` is invisible to `R CMD check`
+while the compiler honours it exactly as if it had been written
 normally.
-These are warnings silenced rather than fixed,
-which is the thing the policy forbids;
-they are debt awaiting a root-cause fix or a deletion,
-not a precedent to copy.
+Two patches used to sit in that loophole.
+Both have now been dealt with, one fully and one in part.
+
+`patch/0003-Fix-clang-warnings-in-re2.patch` — formerly
+`Try-to-ignore-clang-warnings` — fixes the warnings it used to hide.
+`-Wnested-anon-types` came from two unnamed structs declared inside
+anonymous unions in `re2/prog.h`;
+they are now named and hoisted out of the union, layout-identical.
+`-Wdtor-name` came from `Regexp::Walker<T>::~Walker()` in
+`re2/walker-inl.h`, now spelled `Regexp::Walker<T>::Walker::~Walker()`
+as clang's own fix-it suggests.
+`-Wgnu-anonymous-struct` never fired at all.
+The suppressions were also costing something in their own right:
+`#pragma clang` is unknown to GCC,
+so each one raised a `-Wunknown-pragmas` warning per translation unit
+there.
+Alongside it, the `-Wredundant-decls` suppression that
+`patch/0016-Avoid-mbedtls-diagnostic-pragmas.patch` used to respace in
+`third_party/mbedtls/library/constant_time_impl.h` is deleted outright:
+that warning is in neither `-Wall` nor `-pedantic`,
+and no includer produces it in this C++ build even when it is asked
+for explicitly.
+
+What remains is one hunk of
+`patch/0016-Avoid-mbedtls-diagnostic-pragmas.patch`:
+mbedtls's own `-Wvla` suppression in
+`third_party/mbedtls/library/platform_util.cpp`,
+around the `asm volatile ("" : : "m" (*(char (*)[len]) buf) :)` barrier
+that stops `mbedtls_platform_zeroize()` from being optimised away.
+That warning is real — both GCC and clang emit it under `-pedantic`
+once the pragmas are removed —
+and the only pragma-free fix is to weaken the operand to a full
+`"memory"` clobber,
+which changes the codegen of a hardening primitive in vendored crypto
+code.
+So the suppression stays, still spelled
+`#pragma  GCC  diagnostic  ignored`,
+and `R CMD check` still does not report it.
+Whether to leave it that way, or to normalise the spelling and accept
+the resulting check output, is a maintainer decision, not a precedent
+to copy.
 
 How the glue in `src/` honours the rule as a source convention is
 [`architecture/glue/`](/handbook/architecture/glue/README.md)'s.


### PR DESCRIPTION
## Documentation only — the code moved to #2492

This branch was rebuilt to carry the three `docs(handbook)` commits and
nothing else. `fix(patch): Fix the re2 and mbedtls warnings instead of hiding
them` — everything under `patch/` and `src/duckdb/`, including the careful
account of the re2 fixes, the `patch/0016` split, and the three options for
the `-Wvla` hunk — is now in **#2492**.

**#2492 merges first.** The leaf below records those fixes as done and cites
`patch/0003-Fix-clang-warnings-in-re2.patch` by its new name. Merged the
other way round, it describes a state the tree is not in.

The two branches together reproduce this PR's pre-split tree byte-for-byte;
checked with `git merge-tree --write-tree` against the original tip.

## What this leaf now owns

`handbook/operations/releases/cran/` owns the CRAN-facing half of a release:
how the source tarball is obtained (built from `duckdb/duckdb@main` so the
embedded revision ids are right) and checked before submission — WinBuilder
against R-devel, the CRAN checks page, R-hub via a push to a `cran-*` branch —
what the submission form actually carries, what `cran-comments.md` is for and
how it is kept, and the CRAN policy constraints the source tree lives under
year-round: no warning suppression, the permanent package-size NOTE, and what
`.Rbuildignore` keeps out of the tarball. Boundaries are linked, not repeated:
the state machine to `operations/releases/process/`, the C++ source convention
to `architecture/glue/`, the CRAN test guard to `testing/guards/`, storage
locations to `usage/storage/`, and reverse-dependency checks to
`testing/revdep/`.

## The pragma finding, recorded here and fixed in #2492

Writing the leaf turned up a defect: `tools:::.check_pragmas` greps `src/`
and `inst/include/` for `^\s*#pragma (GCC|clang) diagnostic ignored` — single
spaces, and no space between `#` and `pragma`. Two patches in the stack wrote
their suppressions just outside that pattern, as `#  pragma` and as
`#pragma  GCC  diagnostic  ignored`. The compiler honours both exactly as if
written normally; `R CMD check` sees neither. The stated policy —
`AGENTS.md`, and now this leaf — is that warnings get fixed, not silenced.

**#2492 resolves most of it**, with the evidence: `patch/0003` renamed and
fixed at the source (re2's nested anonymous types and destructor spelling),
`patch/0016`'s `-Wredundant-decls` hunk removed outright, and its `-Wvla`
hunk kept, deliberately, in the invisible spelling. That last one **needs a
maintainer decision** and #2492 lays out three options; this leaf documents
whichever holds, and today says plainly that the spelling is why `R CMD
check` stays quiet.

For contrast the leaf also records the two patches that already honour the
rule: `patch/0008-Avoid-pragma-for-zstd.patch` deletes a suppression
outright, and `patch/0033-clang-macos.patch` fixes the root cause of
`-Wdeprecated-declarations` in fmt.

## What moved

* `RELEASE.md` — lost the whole `### WinBuilder + final checks` section and
  the CRAN-submission paragraph of `### 5 PUBLISHED`, each replaced by a
  one-line pointer to the leaf; gained the visible italic handbook
  backreference under its H1. The rest of the file is untouched — the state
  machine, versioning, and revdep material belong to sibling leaves being
  written in parallel.

`cran-comments.md` is deliberately **not** changed. It briefly gained a
backreference and it was reverted: that file is outbound correspondence, not
documentation of a topic, and its whole text is uploaded verbatim as the
submission comment. The backreference convention exists so a reader standing
in the source tree finds the leaf explaining what they are looking at; nobody
browses `cran-comments.md` for that, and its actual audience is a CRAN
maintainer who should not be reading our internal routing. An HTML comment
would be no better — CRAN receives the raw text. The leaf links to it one-way
and records why that asymmetry is correct rather than an orphan.

## Assumptions

* **`RELEASE.md` is deliberately not deleted.** This is a partial absorption:
  two of the three leaves splitting it are on sibling branches. Conflicts in
  `RELEASE.md` on merge are expected.
* **`r-package-source` is read as an upstream artifact.** `RELEASE.md` calls
  it "the CI build artifact"; no workflow in this repository produces a
  source tarball, and the preflight bullet points at `duckdb/duckdb`'s
  `R.yml`, so the leaf says "the upstream R workflow's `r-package-source`
  artifact". Worth confirming.
* **The maintainer is named by role, not by person.** `RELEASE.md` said "the
  maintainer (currently Hannes) confirms the upload", but `DESCRIPTION`
  currently lists Kirill Müller as `cre` and CRAN mails the confirmation to
  the `Maintainer:` address of the submitted tarball. The leaf therefore says
  "the `cre` entry in `DESCRIPTION`" and drops the name. Whether the old
  wording was stale or described a real hand-off is being confirmed with the
  maintainer separately.
* **The tarball inventory was computed, not assumed** — every top-level entry
  matched against `.Rbuildignore` in R rather than by running `R CMD build`
  (the wave is documentation-only, no builds). `.gitignore` and
  `.Rbuildignore` survive that filter and are listed as surviving; `R CMD
  build`'s own built-in exclusions were not modelled.
* **`RELEASE.md`'s "CRAN rejection" failure-table row was left in place.** It
  restates a fact the leaf now owns, but the table is the process leaf's
  inventory, so it was not edited.
* **The root `README.md` was not touched.** Its `## Documentation` entry
  still points at `RELEASE.md`, which still exists and is still accurate;
  `cran-comments.md` was never listed there.
* **The `Preflight` bullets in `RELEASE.md` were left alone** even though
  they state the same "only the package-size NOTE is tolerated" rule the leaf
  now owns — that section belongs to `operations/releases/process/`.
* **CRAN itself was not reachable** from this environment (the proxy refuses
  `cran.r-project.org`), so the published check results and tarball size were
  not fetched. No claim in the leaf depends on them; the 5 Mb installed-size
  threshold comes from R's own documentation for
  `_R_CHECK_PKG_SIZES_THRESHOLD_`.
* **No durability sweep was run on this leaf.** The numbers it quotes —
  `sizeof(Prog)`, the translation-unit counts, the compiler versions — are
  measurements of a specific investigation rather than inventory of the tree,
  so there was nothing of that class to remove. The investigation itself, and
  the caveat that its compiler evidence is Linux/x86-64 only, is in #2492.

## Verification

`Rscript .claude/skills/docs-consistency/docs-readme.R --check` and the
handbook link check (no dangling target, none starting with `../`) are clean
on this branch. `R CMD check` and a full package build were not run — not
feasible in this environment — and no claim here depends on them.
`tools:::.check_pragmas(".")` returns `character(0)` both before and after
#2492, so neither PR changes what that check reports today.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PD23hjFQFRWW62HFvru187)_