### PR TITLE
docs(handbook): Write the branches/model leaf

### DIFF
--- a/BRANCHES.md
+++ b/BRANCHES.md
@@ -1,5 +1,7 @@
 # Branching Strategy
 
+*Handbook: [`branches/model/`](/handbook/branches/model/README.md).*
+
 Version numbers are given at the time of writing (March 2026) and may be outdated by the time you read this.
 The branching strategy is expected to remain stable.
 
@@ -162,150 +164,19 @@ Use `duckdb` unless you need to pin to a specific minor version (LTS) or want to
 
 ## Overview
 
-Three moving parts work together to produce the published R packages:
-
-```txt
-duckdb/duckdb        krlmlr/duckdb-r         duckdb/duckdb-r       CRAN / r-universe
-(upstream C++)       (CI/CD fork)            (canonical R pkg)
-──────────────       ──────────────          ───────────────       ─────────────────
-main            ──►  main-dev           ──►  main               ──►  duckdb (r-universe)
-                     main-dev-base                                   duckdb.dev
-v1.5-variegata  ──►  v1.5-variegata-dev ──►  main               ──►  duckdb (CRAN)
-                     v1.5-variegata-dev-base                         duckdb.1.5.dev (r-universe)
-v1.4-andium     ──►  v1.4-andium-dev    ──►  v1.4-andium        ──►  duckdb.1.4 (r-universe)
-                     v1.4-andium-dev-base    v1.4-andium-lts         duckdb.1.4.dev (r-universe)
-
-   │              ^        ^       │                ^
-   │  vendor      │        │       │ during release │
-   │  (daily)     │        │       │  preparation   │
-   │  + patches   │        │       │     only       │
-   │  from patch/ │        │       └────────────────┘
-   └──────────────┘        │
-                    sync.yaml (hourly FF of krlmlr/main from duckdb/main)
-```
-
-The arrow from upstream to the CI/CD fork represents automated vendoring; the arrow from the fork to the canonical repo represents the release merge. Patches from `patch/` are applied to the vendored C++ code during every vendor run (see [Patch Stack](#patch-stack) below).
+Moved to [`branches/model/`](/handbook/branches/model/README.md).
 
 ## Repositories
 
-This package lives in two GitHub repositories:
-
-- **`duckdb/duckdb-r`** — the canonical repository. Stable and flavor branches are published to CRAN and r-universe from here.
-- **`krlmlr/duckdb-r`** — a disconnected fork used exclusively for CI/CD, so that automated runs do not consume the `duckdb` organization's GitHub Actions quota. Development ("dev") branches live here.
-
-The C++ database engine is vendored from **`duckdb/duckdb`** (referred to as *upstream*) into `krlmlr/duckdb-r`. The R glue code that wraps it lives in `duckdb/duckdb-r` and is synchronized with the dev branches.
+Moved to [`branches/model/`](/handbook/branches/model/README.md).
 
 ## Branch Overview
 
-Each supported DuckDB minor version has a **series of four branches** organised into two repos.
-The table below shows the complete set at the time of writing.
-The `dev`/`dev-base` pair is the legacy vendoring layout;
-as each series is reseeded into the series loop
-(see [Vendoring](#vendoring) below),
-that pair gives way to the loop's four refs —
-`<S>-build`, `<S>-dev`, `<S>-green`, `<S>-build-base`.
-
-| Branch                    | Repo              | `Package:`       | Purpose                                                    |
-|---------------------------|-------------------|------------------|------------------------------------------------------------|
-| `main`                    | `duckdb/duckdb-r` | `duckdb`         | Source of truth for glue code, R code, tests, CI/CD, cpp11 |
-| `main-dev`                | `krlmlr/duckdb-r` | `duckdb`         | Vendored dev (upstream `main`); published as `duckdb.dev`  |
-| `main-dev-base`           | `krlmlr/duckdb-r` | `duckdb`         | Stable base for `main-dev`; marks the last reviewed point  |
-| `v1.5-variegata`          | `duckdb/duckdb-r` | `duckdb`         | Stable baseline for current release                        |
-| `v1.5-variegata-lts`      |                   |                  | Does not exist, v1.5 is not an LTS                         |
-| `v1.5-variegata-dev`      | `krlmlr/duckdb-r` | `duckdb.1.5.dev` | Bleeding edge on v1.5 upstream                             |
-| `v1.5-variegata-dev-base` | `krlmlr/duckdb-r` | `duckdb.1.5.dev` | Stable base for `v1.5-variegata-dev`                       |
-| `v1.4-andium`             | `duckdb/duckdb-r` | `duckdb`         | Stable baseline for LTS release                            |
-| `v1.4-andium-lts`         | `duckdb/duckdb-r` | `duckdb.1.4`     | `v1.4-andium` + one rename commit; published to r-universe |
-| `v1.4-andium-dev`         | `krlmlr/duckdb-r` | `duckdb.1.4.dev` | Bleeding edge on v1.4 upstream                             |
-| `v1.4-andium-dev-base`    | `krlmlr/duckdb-r` | `duckdb.1.4.dev` | Stable base for `v1.4-andium-dev`                          |
-
-### Branch series structure
-
-Within each minor version, the four branches form a linear stack, illustrated here for v1.4:
-
-```
-duckdb/duckdb-r                         krlmlr/duckdb-r
-───────────────                         ───────────────
-
-v1.4-andium  ────────────────────────────────────►
- │  Package: duckdb                              │
- │  Baseline: glue code + vendored C++           │
- │                                               ▼
- │                                      v1.4-andium-dev-base
- │                                      Package: duckdb.1.4.dev
- │                                      v1.4-andium + rename + version suffix
- │                                               │
- │                                               │  vendor commits land here first
- │                                               ▼
- ▼                                      v1.4-andium-dev          ← bleeding edge
-v1.4-andium-lts                         Package: duckdb.1.4.dev
- Package: duckdb.1.4                    Always a descendant of dev-base
- v1.4-andium + one rename commit
- Published to r-universe
-```
-
-The pending changes between `dev-base` and `dev` can be inspected at any time:
-
-```
-https://github.com/krlmlr/duckdb-r/compare/v1.4-andium-dev-base...v1.4-andium-dev
-```
-
-The same structure applies to v1.5 and to `main`/`main-dev`/`main-dev-base`.
-The `-lts`-suffixed branch only exists when the minor version is designated an LTS release.
-
-Stable branches (`duckdb/duckdb-r`) track released R package versions and are the source for CRAN
-releases and numbered r-universe releases (without the `.dev` suffix).
-Dev branches (`krlmlr/duckdb-r`) track the corresponding bleeding-edge upstream branches and are
-published as `.dev` packages.
+Moved to [`branches/model/`](/handbook/branches/model/README.md), together with the series structure.
 
 ## Source of Truth
 
-`main` in `duckdb/duckdb-r` is the **source of truth** for four of the seven components:
-
-| Component                | Source of truth                   | Notes                                             |
-|--------------------------|-----------------------------------|---------------------------------------------------|
-| DuckDB core              | `duckdb/duckdb` upstream          | Vendored independently into each branch           |
-| Flavor                   | Per-branch (via `flavor.sh`)      | Applied mechanically on top of the baseline       |
-| **Glue code**            | **`main`**                        | Forward-ported to all `-andium` / `-dev` branches |
-| **R code and tests**     | **`main`**                        | Forward-ported to all `-andium` / `-dev` branches |
-| **CI/CD infrastructure** | **`main`**                        | Forward-ported to all `-andium` / `-dev` branches |
-| **cpp11**                | **`main`**                        | Forward-ported to all `-andium` / `-dev` branches |
-| R core                   | External (`r-devel`, CRAN policy) | Monitored; fixes land in `main` first             |
-
-### Keeping derived branches in sync with main
-
-The forward-port order for non-vendor commits is always from newer to older:
-
-```
-duckdb/duckdb-r@main ─────────────────────────────►
-        │                                         │
-        ▼                                         ▼
-krlmlr/duckdb-r@main-dev                duckdb/duckdb-r@v1.4-andium
-        │
-        ▼
-krlmlr/duckdb-r@v1.5-variegata-dev
-        │
-        ▼
-krlmlr/duckdb-r@v1.4-andium-dev
-```
-
-Never port in reverse. Proposed patterns to keep this consistent:
-
-1. **PR-per-branch**: After any non-vendor commit merges to `main`, open a PR for each active
-   `-dev` branch. `sync.yaml` already handles `krlmlr/main` automatically; the remaining branches
-   require a manual or script-assisted step.
-
-2. **`scripts/sync-to-derived.sh`** *(proposed — see §Tooling)*: A script that identifies commits
-   in `main` not yet reachable from a given `-dev` branch and prints the `git cherry-pick` commands
-   needed to bring it up to date.
-
-3. **Stale-branch CI check** *(proposed — see §Tooling)*: A scheduled workflow that computes
-   `git merge-base --is-ancestor main <branch>` for each active `-dev` branch and posts a status
-   summary to flag forward-porting debt early.
-
-4. **Mandatory merge-base label**: PRs to any `-dev` branch that target glue-code or R-code files
-   are labeled `needs-forward-port` automatically by a label action, reminding maintainers to
-   propagate the change toward `main` before the next release.
+Moved to [`branches/model/`](/handbook/branches/model/README.md), together with how derived branches are kept in sync.
 
 ## Series Invariants
 
@@ -468,106 +339,11 @@ release.
 
 ## Release Cycle Mapping
 
-The upstream release cycle is documented at <https://duckdb.org/docs/stable/dev/release_cycle>.
-This section summarises the parts that are relevant to the R package and describes what actions to take at each phase.
-This assumes v1.5-variegata is the current release, v1.6 is in development, and v1.4-andium is current LTS; adjust branch names as needed for future cycles.
-(These numbers are for illustrative purposes only; at the time of writing, the next release is expected to be v2.0.0.)
-
-### Phase 1: Mid-Cycle (≈75% of the time)
-
-Upstream active branches: `main`, `v1.5-variegata`, `v1.4-andium`.
-
-This is business-as-usual.
-The series loop vendors on its schedule with no manual intervention required.
-
-- Upstream patch releases (`v1.5.z`) cut from `v1.5-variegata` are picked up automatically by the corresponding `-dev` branch.
-- When a patch release is tagged upstream, run the [On patch release](#on-patch-release-v145) flow for that branch.
-- Forward-port glue code changes from `main` toward older branches as usual.
-
-### Phase 2: Pre-Release
-
-Upstream active branches: `main`, `v1.5-variegata`, `v1.6-codename` (newly created), `v1.4-andium`.
-
-When the upstream team creates the new `v1.6-codename` branch, the R package temporarily becomes a three-branch extension:
-
-```txt
-  duckdb/duckdb branches          R package branches to create
-  ──────────────────────          ────────────────────────────
-  main                            (existing) krlmlr/duckdb-r@main-dev
-  v1.4-andium                     (existing) krlmlr/duckdb-r@v1.4-andium-dev
-  v1.5-variegata                  (existing) krlmlr/duckdb-r@v1.5-variegata-dev
-  v1.6-codename  (new)  ──►       krlmlr/duckdb-r@v1.6-codename-{build,dev,green,build-base}  (create)
-                                  duckdb/duckdb-r@v1.6-codename      (create)
-```
-
-Actions:
-
-1. Create `v1.6-codename` in `duckdb/duckdb-r` (the future stable branch) from `main`.
-2. Open the `v1.6-codename` series in `krlmlr/duckdb-r`
-   following `.claude/skills/series-open.md`:
-   seed from `main` with `scripts/flavor.sh 1.6.dev`
-   plus the separate fifth-component commit,
-   create the four series refs equal at the seed tip,
-   and populate `v1.6-codename-build` starting from the fork-point tree.
-   The routine discovers the new series from its refs;
-   no CI configuration is needed.
-3. Add the new dev branch to the front of the forward-port chain:
-
-```txt
-duckdb/duckdb-r@main  →  krlmlr/duckdb-r@main-dev  →  krlmlr/duckdb-r@v1.6-codename-dev
-                                                    ↘  krlmlr/duckdb-r@v1.5-variegata-dev  →  …
-```
-
-4. **The `main` series needs nothing.**
-   Under the series loop it keeps walking upstream `main`'s
-   first-parent chain, which passes through the fork point,
-   so nothing jumps and nothing is re-seeded
-   (the legacy `main-dev` layout needed an explicit fork-point re-seed here —
-   that hazard is what the loop's one-commit-at-a-time walk removes).
-   The fork point matters for the *new* series instead:
-   `v1.6-codename-build` starts from the fork-point tree,
-   computed as in
-   [Starting a new dev line](scripts/VENDORING.md#starting-a-new-dev-line-the-fork-point-rule)
-   (it is *not* `git merge-base`),
-   with the glue rewound as far as that tree requires.
-
-### Phase 3: Feature Freeze
-
-Upstream active branches: `main`, `v1.5-variegata`, `v1.6-codename`
-
-From the R package perspective, this phase is identical to Pre-Release.
-Only bug fixes flow into `v1.6-codename`; new features target `main`.
-No additional branch management is required.
-
-### On new minor release (`v1.6.0`)
-
-When upstream tags `v1.6.0`:
-
-1. Run the [On release](#on-release) flow: merge `krlmlr/duckdb-r@v1.6-codename-dev` → `duckdb/duckdb-r@v1.6-codename`.
-2. Publish the new `duckdb` CRAN package from `duckdb/duckdb-r@v1.6-codename`.
-3. Decide whether `v1.5-variegata` is designated as an LTS release:
-   - **If LTS**: create `v1.5-variegata-lts` from `v1.5-variegata`, apply `scripts/flavor.sh 1.5`
-     to produce the `duckdb.1.5` branch, register `duckdb.1.5` on r-universe, and add it to the forward-port chain.
-   - **If not LTS**: stop vendoring into its dev branch and archive both branches.
-4. Update the Branch Overview table and the R Package Flavors table in this document.
-
-### On LTS expiry (one year after designation)
-
-TBD.
+Moved to [`branches/model/`](/handbook/branches/model/README.md) — the phases, a new minor, LTS expiry, and a patch release.
 
 ### On patch release (`v1.4.5`)
 
-This is the most common release event, and it is described in full as the
-**CUT** and **RESET** clusters of the release FSM in
-[`RELEASE.md`](RELEASE.md#cut--release-execution). In summary, once upstream tags
-`v1.4.5`: the daily vendoring lands the tagged commit on `v1.4-andium-dev`
-(state 1), `each.yaml` proves it green, the pending window is reviewed (state 2),
-`dev-base` is fast-forwarded to the tagged commit (state 3), the commit is merged
-to `v1.4-andium` with `fledge::bump_version("1.4.5")` and the `-lts` branch
-rebased (state 4), the release is tagged and published to r-universe / CRAN
-(state 5), and finally `dev`/`dev-base` are re-baselined via `scripts/flavor.sh
-1.4.dev` (RESET). The pre-release reverse-dependency work that precedes the tag
-is the **STABILIZE** cluster.
+Moved to [`branches/model/`](/handbook/branches/model/README.md); the procedure is the **CUT** and **RESET** clusters of the release FSM in [`RELEASE.md`](RELEASE.md#cut--release-execution).
 
 ## Synchronization
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ The badges track each `.dev` series:
 *ahead* counts commits ahead of the branch the series releases from,
 *in flight* counts commits in CI but not yet trusted,
 *buffered* counts commits vendored but not yet verified.
-See [`BRANCHES.md`](BRANCHES.md) for the full model.
+See [`handbook/branches/model/`](/handbook/branches/model/README.md)
+for the full model: the series, their refs, and how each one advances.
 
 ## User Guide
 
@@ -92,8 +93,10 @@ and coding agents.
 
 * [`AGENTS.md`](AGENTS.md) — working on the package:
   build, test, and where to look for everything else
-* [`BRANCHES.md`](BRANCHES.md) — branch model, package flavors,
-  series invariants
+* [`handbook/branches/`](/handbook/branches/README.md) — the branch model:
+  [the series and their refs](/handbook/branches/model/README.md),
+  package flavors, series invariants
+  (what is not yet moved is still in [`BRANCHES.md`](BRANCHES.md))
 * [`RELEASE.md`](RELEASE.md) — the release process
 * [`scripts/VENDORING.md`](scripts/VENDORING.md) — vendoring mechanics
 * [`plan/README.md`](plan/README.md) — designs, plans, and historical

--- a/handbook/branches/model/README.md
+++ b/handbook/branches/model/README.md
@@ -71,7 +71,8 @@ so vendoring can run ahead — red or not —
 while CI works through what has already been consumed.
 Consumption is bounded:
 [`scripts/series-advance.sh`](/scripts/series-advance.sh)
-appends at most 100 `-build` commits to `-dev` in one pass by default.
+appends at most one chunk of `-build` commits to `-dev` per pass,
+the chunk size an optional argument whose default the script names.
 
 Which `-build` commit corresponds to which `-dev` commit
 is decided by the `duckdb/duckdb@<sha>` reference in the commit subject,
@@ -102,10 +103,10 @@ and never runs it
 
 ### What exists today
 
-Three base series — `main`, `v1.5-variegata`, `v1.4-andium` —
-each with all four refs in `krlmlr/duckdb-r`,
+The base series are `main`, `v1.5-variegata` and `v1.4-andium`,
+each with its refs in `krlmlr/duckdb-r`,
 and `main` additionally with a live forward counterpart, `main-fwd`.
-In `duckdb/duckdb-r`: `main`, the two parked baselines, and `v1.4-andium-lts`.
+In `duckdb/duckdb-r`: `main`, the parked baselines, and `v1.4-andium-lts`.
 There is no `v1.5-variegata-lts`; v1.5 is not an LTS line.
 
 Every series also still carries a `<S>-dev-base` ref

--- a/handbook/branches/model/README.md
+++ b/handbook/branches/model/README.md
@@ -1,19 +1,288 @@
 # The model
 
-*Stub — this leaf will own its topic;
-today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](../../meta/handbook/);
-the last section holds this leaf's parameters.*
+Each DuckDB minor line the R package follows gets a **series** of branches.
+The series and its refs are the branch model:
+what a series is, where its branches live,
+what each ref means and how far it may move,
+which branch is the source of truth for the code that is not vendored,
+and what the upstream release cycle asks of all of this at each phase.
 
-Scope: the series and their `-dev` / `-build` / `-green` refs,
-and how they advance.
+## A series
 
-Today:
+A series is one upstream branch of `duckdb/duckdb` —
+`main`, `v1.5-variegata`, `v1.4-andium` —
+together with the R package branches that carry it.
+Upstream cuts a branch per minor version
+and ships a new minor roughly every four months
+(<https://duckdb.org/docs/stable/dev/release_cycle>);
+each such branch the R package still follows is a series here.
 
-* [`BRANCHES.md`](../../../BRANCHES.md)
+A series is *discovered*, not configured.
+The vendoring routine lists `refs/heads/*-build`
+and serves every one that has a sibling `-dev`,
+so opening a series is a matter of creating its refs and nothing else —
+no CI configuration, and no list anywhere to keep up to date.
+The birth certificate is
+[`.claude/skills/series-open.md`](/.claude/skills/series-open.md);
+the routine that then serves it is
+[`operations/vendoring/series-loop/`](/handbook/operations/vendoring/series-loop/README.md).
 
-To write this leaf:
+## Two repositories
 
-* absorb: the branch model from `BRANCHES.md` — series,
-  `-dev` / `-build` / `-green` refs, and how they advance;
-  flavors and invariants go to the sibling leaves, not here
+`duckdb/duckdb-r` is canonical.
+It holds `main`, the parked stable baselines
+(`v1.5-variegata`, `v1.4-andium`),
+and the LTS flavor branch `v1.4-andium-lts`.
+CRAN and the numbered r-universe packages are published from here.
+
+`krlmlr/duckdb-r` is a disconnected fork used only for CI/CD,
+so that the automated per-commit builds
+do not consume the `duckdb` organization's GitHub Actions quota.
+Every series' working refs live there.
+[`.github/workflows/sync.yaml`](/.github/workflows/sync.yaml)
+keeps the fork's `main` level with the canonical one:
+hourly, it clones `duckdb/duckdb-r` and fast-forwards — never merges.
+
+The C++ engine is vendored from `duckdb/duckdb` into the fork's series refs;
+the R code that wraps it is written on `duckdb/duckdb-r@main`
+and travels the other way.
+Why the engine is vendored at all is
+[`operations/vendoring/model/`](/handbook/operations/vendoring/model/README.md).
+
+## The four refs
+
+Each series `<S>` carries four refs in `krlmlr/duckdb-r`:
+
+| Ref | Moves by | What it is |
+|---|---|---|
+| `<S>-build` | append; force-push to repair | The buffer: every upstream first-parent commit vendored one to one, with the glue compiling at each. No CI runs here. |
+| `<S>-dev` | append; force-push | What CI judges, commit by commit: `-build` commits consumed in chunks, with test, R and patch adaptations folded into the commit that needs them, plus what was forward-ported from `main`. |
+| `<S>-green` | fast-forward only | The trusted frontier — the newest commit such that every commit in `<S>-green..it` has a successful run. What r-universe should build from. |
+| `<S>-build-base` | forward only | The `-build` commit equivalent to `-green`. Marks how much of the buffer has been consumed and verified. |
+
+All four exist from a series' first day, equal at its seed tip,
+so there is never a "no green yet" state
+and every walk the routine makes is bounded below by `<S>-green`.
+
+The buffer is deliberately untested.
+[`each.yaml`](/.github/workflows/each.yaml) triggers on `*-dev` and `each-*`,
+never on `*-build`,
+so vendoring can run ahead — red or not —
+while CI works through what has already been consumed.
+Consumption is bounded:
+[`scripts/series-advance.sh`](/scripts/series-advance.sh)
+appends at most 100 `-build` commits to `-dev` in one pass by default.
+
+Which `-build` commit corresponds to which `-dev` commit
+is decided by the `duckdb/duckdb@<sha>` reference in the commit subject,
+never by the paths a commit touched:
+the patch stack is applied to the vendored tree in place,
+so commits that change `src/duckdb/` while vendoring nothing are routine.
+
+The gaps between these refs are what the badges
+in the root [`README.md`](/README.md) count:
+*ahead* is what `-green` has over the branch the series releases from,
+*in flight* what `-dev` has over `-green` — consumed, not yet all green —
+and *buffered* what `-build` has over `-build-base` — vendored, not yet consumed.
+
+### Forward counterparts
+
+`main` moves under a series.
+Rebasing a series in place would rewrite `<S>-green`,
+the one ref consumers read,
+so the rebase happens beside it:
+a counterpart series `<S>-fwd` is built with the same four refs,
+verified from scratch by the same routine,
+and swapped in once it has caught up.
+That swap — a cutover — is the single sanctioned sideways move
+of a serving `-green`, and it is always a human's call:
+the routine reports that a counterpart has caught up and prints the command,
+and never runs it
+([`operations/vendoring/series-loop/`](/handbook/operations/vendoring/series-loop/README.md)).
+
+### What exists today
+
+Three base series — `main`, `v1.5-variegata`, `v1.4-andium` —
+each with all four refs in `krlmlr/duckdb-r`,
+and `main` additionally with a live forward counterpart, `main-fwd`.
+In `duckdb/duckdb-r`: `main`, the two parked baselines, and `v1.4-andium-lts`.
+There is no `v1.5-variegata-lts`; v1.5 is not an LTS line.
+
+Every series also still carries a `<S>-dev-base` ref
+from the layout that preceded the loop,
+in which `-dev` was vendored into directly
+and `-dev-base` marked the last released point.
+No script and no workflow in the tree reads it any more.
+It survives because the release state machine still models it —
+moving it is a release step, not a loop step —
+so two layouts describe the same branches at once,
+and which one answers depends on the question:
+the four refs for what is vendored and verified,
+`-dev-base` for what was released
+([`operations/releases/process/`](/handbook/operations/releases/process/README.md)).
+
+Beside these the fork carries litter from retired designs —
+`broken-<sha>-dev` branches from a repair mechanism that was never made to work,
+a stray `retry-<sha>-green`, `main-dev-old`, `main-rewind-*`.
+Only `retry-<S>-dev` is live:
+it is how a single commit is asked for a second verdict
+without rewriting anything.
+
+## The source of truth
+
+`duckdb/duckdb-r@main` is the source of truth
+for everything the package does not vendor:
+the glue code (`src/*.cpp`, `src/include/`),
+the R code and the tests,
+the CI/CD infrastructure (`.github/`, `scripts/`, `.claude/`),
+and the vendored cpp11 headers.
+The engine comes from upstream, per series;
+the published package name is applied mechanically per branch
+([`branches/flavors/`](/handbook/branches/flavors/README.md));
+and the R API itself is external —
+it constrains what the glue may do rather than being owned anywhere here.
+
+The consequence is a direction.
+Glue is never *born* on a `-dev` branch;
+it is written on `main` and carried down.
+The one exception is the preview line that tracks upstream `main`,
+where an adaptation forced by a new upstream C++ API has nowhere else to be born,
+because `main` does not yet carry that upstream version.
+As a checkable guarantee this is invariant S4 —
+[`branches/invariants/`](/handbook/branches/invariants/README.md).
+
+### Keeping derived branches in sync
+
+The order is always newer to older:
+
+```txt
+duckdb/duckdb-r@main
+  →  krlmlr/duckdb-r@main-dev
+  →  krlmlr/duckdb-r@v1.5-variegata-dev
+  →  krlmlr/duckdb-r@v1.4-andium-dev
+```
+
+with `duckdb/duckdb-r@v1.4-andium` fed from `main` at release time.
+Never in reverse.
+A new series joins at the front of the chain, directly below `main-dev`.
+
+Keeping it that way is automated.
+[`scripts/series-port.sh`](/scripts/series-port.sh) lists every commit
+`main` has that the series lacks, by patch-id, oldest first,
+classifies each as TOOLING, MIXED, OTHER or VENDOR by what it touches,
+and cherry-picks all but VENDOR —
+`main`'s engine is not this series' engine,
+and the series' own vendoring owns that strand.
+Picks are whole commits, never split.
+Whatever the commit walk cannot explain
+is closed by one sync commit taking `main`'s tooling tree verbatim,
+so the goal is identity rather than curation:
+afterwards `.github/`, `scripts/` and `.claude/` on `<S>-dev`
+are byte-identical to `main`'s.
+
+A series never keeps its own fork of the tooling.
+Where a series genuinely needs different behavior,
+the difference is made conditional on `main`
+and ported down like anything else.
+
+Three mechanisms proposed for this before the port stage existed
+were never built, and are not planned:
+a `scripts/sync-to-derived.sh` that would print `git cherry-pick` commands,
+a scheduled stale-branch workflow that would flag forward-porting debt,
+and a `needs-forward-port` label on pull requests to `-dev` branches.
+The port stage runs every firing and leaves no debt,
+so there is nothing left for a reminder to remind about.
+
+## The release cycle
+
+Upstream ships a new minor roughly every four months
+and patches an LTS line for a year — about three minor cycles —
+after which it is archived.
+What the branches do at each phase:
+
+**Mid-cycle**, which is most of the time.
+Nothing to manage: each firing of the loop vendors and consumes,
+upstream patch releases land on the series that follows them,
+and forward-porting happens in the same firing.
+
+**Pre-release**, when upstream creates the next minor's branch.
+Two things are created:
+the future stable branch in `duckdb/duckdb-r`, from `main`;
+and the series in `krlmlr/duckdb-r` —
+seeded from `main` with `scripts/flavor.sh` for the new `.dev` flavor
+plus the separate fifth-component commit,
+its four refs equal at that seed tip,
+and `-build` populated starting from the fork-point tree
+([`.claude/skills/series-open.md`](/.claude/skills/series-open.md)).
+The new series then joins the front of the forward-port chain.
+
+The `main` series needs nothing here.
+Under the loop it keeps walking upstream `main`'s first-parent chain,
+which passes through the fork point,
+so nothing jumps and nothing is re-seeded;
+the layout that preceded the loop needed an explicit fork-point re-seed
+at exactly this moment,
+and the one-commit-at-a-time walk is what removed that hazard.
+The fork point matters for the *new* series instead,
+and it is not `git merge-base` —
+it is the newest commit on the first-parent chain of both upstream branches,
+computed as in
+[`scripts/VENDORING.md`](/scripts/VENDORING.md#starting-a-new-dev-line-the-fork-point-rule).
+
+**Feature freeze** is indistinguishable from pre-release on the R side:
+only bug fixes flow into the new branch, new features target `main`,
+and no branch management is required.
+
+**On a new minor release.**
+The new series' verified content is brought onto its stable branch
+in `duckdb/duckdb-r`, and `duckdb` is published to CRAN from there.
+Then the outgoing line is either designated LTS —
+create its `-lts` branch from the stable branch,
+apply `scripts/flavor.sh` for the numbered flavor,
+register that package on r-universe,
+and add the line to the forward-port chain —
+or it is not, in which case vendoring into its series stops
+and its branches are archived.
+
+**On a patch release**, the most common release event.
+In ref terms: the tagged upstream commit reaches `-dev` by ordinary vendoring,
+CI proves it green, `-green` advances to it,
+the commit is merged onto the stable branch with the release version set by
+`fledge`, the `-lts` branch is rebased on top, and the tag is pushed.
+The states, gates and rollbacks of that sequence belong to the release state
+machine —
+[`operations/releases/process/`](/handbook/operations/releases/process/README.md);
+the version numbers it sets belong to
+[`operations/releases/versioning/`](/handbook/operations/releases/versioning/README.md).
+
+**On LTS expiry** — undecided, and undecided since the model was written.
+What becomes of `v1.4-andium-lts`, of its r-universe registration
+and of its series a year after designation
+is written down nowhere, here or elsewhere.
+
+## Limits
+
+The model says which ref *should* be published, and cannot say which one is.
+The mapping from an r-universe package to the branch it is built from
+lives in the r-universe registry, outside this repository,
+so a change there is invisible in the tree;
+[`branches/flavors/`](/handbook/branches/flavors/README.md)
+names the intended mapping.
+
+How often the refs move is likewise not visible here.
+Nothing in `.github/workflows/` fires the series loop:
+it is a scheduled Claude routine,
+and its cadence is configured outside the repository.
+The workflows that do carry a schedule serve other jobs —
+`sync.yaml` hourly, `rcc-logs.yaml` twice an hour, `fledge.yaml` daily.
+
+How the refs are actually moved — the routine's stages,
+its repairs, its judgement calls — is
+[`operations/vendoring/series-loop/`](/handbook/operations/vendoring/series-loop/README.md),
+and the mechanics of a single vendor commit are
+[`operations/vendoring/pipeline/`](/handbook/operations/vendoring/pipeline/README.md).
+
+Intent for how this model is meant to shrink —
+one owner per fact, the vendoring re-tellings collapsed —
+is carried in
+[`plan/PLAN-vendoring-simplification.md`](/plan/PLAN-vendoring-simplification.md).

--- a/handbook/branches/model/README.md
+++ b/handbook/branches/model/README.md
@@ -72,7 +72,10 @@ while CI works through what has already been consumed.
 Consumption is bounded:
 [`scripts/series-advance.sh`](/scripts/series-advance.sh)
 appends at most one chunk of `-build` commits to `-dev` per pass,
-the chunk size an optional argument whose default the script names.
+a hundred by default, overridable per call.
+The bound is what keeps a pass reviewable
+and keeps a red run from stranding an unbounded backlog;
+`BRANCHES.md` long said twenty-five, which was never the default.
 
 Which `-build` commit corresponds to which `-dev` commit
 is decided by the `duckdb/duckdb@<sha>` reference in the commit subject,


### PR DESCRIPTION
## What this leaf now owns

`handbook/branches/model/` now explains the series and their refs: what a series is and why it is discovered from its refs rather than configured, which of the two repositories holds what, the four refs a series carries (`{S}-build`, `{S}-dev`, `{S}-green`, `{S}-build-base`) with what each means and how far each may move, forward counterparts and why a cutover is a human's call, the source-of-truth rule with the forward-port chain and how it is kept, and the release-cycle mapping — mid-cycle, pre-release, feature freeze, a new minor, a patch release, and LTS expiry. Facts belonging to siblings are linked, not repeated: flavors, the numbered invariants, version counters, the pipeline, the loop, and the release state machine.

(Refs are written `{S}-build` here. The leaf itself uses angle brackets; GitHub deletes those from a pull-request body even inside backticks.)

## What moved

* `BRANCHES.md` — lost §§ "Overview", "Repositories", "Branch Overview" (with "Branch series structure"), "Source of Truth" (with "Keeping derived branches in sync with main"), and "Release Cycle Mapping" (with its phase subsections). Each heading is **kept**, carrying a one-line pointer to the leaf, so the `#source-of-truth`, `#release-cycle-mapping` and `#on-patch-release-v145` anchors that `scripts/VENDORING.md` and `BRANCHES.md`'s own § "Synchronization" link still resolve. Gained the visible handbook backreference under its H1. The rest of the file — package components, flavors, series invariants, synchronization/vendoring, patch stack, version numbering, tooling — belongs to leaves still being written and is untouched.
* `README.md` — the "See `BRANCHES.md` for the full model" line under § Flavors now points at the leaf, and the § Documentation entry now names `handbook/branches/` (with the leaf named inside it) instead of `BRANCHES.md`, which it still mentions as the not-yet-moved remainder.

## Assumptions

* **"Replace each absorbed heading with a one-line pointer" read as: keep the heading, replace its body.** Deleting the headings outright would have broken five inbound anchor links from `scripts/VENDORING.md` and from a `BRANCHES.md` section owned by another leaf, and fixing those would have meant editing another leaf's text. Confirm this is the intended shape; if not, the headings can be dropped and the inbound anchors retargeted in a follow-up.
* **The "Ongoing" forward-port chain in `BRANCHES.md` § Synchronization was left in place** even though the leaf now owns that chain. § Synchronization belongs to `operations/vendoring/pipeline/`, so its owner should retire that paragraph rather than this PR reaching into it.
* **`BRANCHES.md` § Synchronization says `{S}-dev` is consumed "up to 25 commits at a time"; the default in `scripts/series-advance.sh` is a hundred.** The leaf now states the hundred and records that `BRANCHES.md` long said twenty-five, which was never the default — see "The chunk size, restated" below. The stale sentence in `BRANCHES.md` itself sits outside this leaf's absorption and is left for § Synchronization's owner. (Reported independently by the agent writing `operations/vendoring/series-loop/`.)
* **The verified state of the refs is stated as of today, in a "What exists today" subsection.** The loop refs exist for `main`, `v1.5-variegata` and `v1.4-andium`; `main` has a live `main-fwd` counterpart; the legacy `{S}-dev-base` refs still exist but no script or workflow in the tree reads them — only the release FSM in `RELEASE.md` still models them. The leaf says so plainly rather than presenting either layout as the whole truth. Checked with `git ls-remote` against `krlmlr/duckdb-r` and the GitHub API against `duckdb/duckdb-r`.
* **The loop's cadence is stated as not visible in the repository.** Nothing in `.github/workflows/` fires the series loop or `vendor-one.sh`; it is a scheduled Claude routine configured elsewhere. The leaf says that rather than repeating a cadence it cannot check.
* **The three proposed sync mechanisms are recorded as declined, not merely absent.** `scripts/sync-to-derived.sh`, a stale-branch workflow and a `needs-forward-port` label do not exist in the tree, and `scripts/series-port.sh` covers what they were for. If any of them is still wanted, that verdict needs correcting.
* **r-universe's package-to-branch mapping is stated as unverifiable from here** (it lives in the registry), so the leaf says `{S}-green` is what *should* be built, matching `.claude/skills/series-loop.md`, and points at `branches/flavors/` for the intended mapping.
* No issues were listed for this leaf, so none were drained. No build was run; every claim is from the refs, the scripts and the workflows.

## Durability sweep

A follow-up pass over this leaf for facts a routine change invalidates.

**Out.** The counts in "What exists today": "three base series", "all four refs",
"the two parked baselines". The series and the refs are still named, which is
what a reader came for; opening a series no longer falsifies a sentence.

The sweep also removed the chunk size, on the grounds that it is a default in a
script. That one was put back — see below.

**Stayed.** The four refs as a design — the section heading, the table, and
"all four exist from a series' first day, equal at its seed tip". Changing that
number would mean changing the model, so it is a fact and not a hostage. The
`{S}-dev-base` paragraph in full: it is an observation framed as one and it
carries the argument that a ref nothing reads is still a live boundary between
two layouts. The `TOOLING / MIXED / OTHER / VENDOR` classes in
`series-port.sh`, likewise the design. The upstream cadence and LTS window,
which are upstream policy. The workflow schedules in § Limits, which name
which workflow does what rather than counting anything.

## The chunk size, restated

The sweep replaced "at most 100 commits per pass" with a pointer to the
script's default. A later commit reversed that: a default that governs
behaviour is a fact worth stating, the same way each build knob's default is
stated in `build/configuration/`. It bounds how much a single pass can move,
which is how a reader reasons about the loop.

The leaf now says that `scripts/series-advance.sh` appends at most one chunk of
`{S}-build` commits to `{S}-dev` per pass, **a hundred by default, overridable
per call**, and says what the bound buys: it keeps a pass reviewable and keeps a
red run from stranding an unbounded backlog. It also records that `BRANCHES.md`
long said twenty-five, which was never the default, so the wrong number does
not come back.

Verified against the script: `series-advance.sh` documents
`series-advance.sh {series} [chunk-size]` with "chunk default 100" and takes
`chunk=${2:-100}`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PD23hjFQFRWW62HFvru187)_
