### PR TITLE
docs(handbook): Write the testing/suite leaf

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # DuckDB R Package - Operational Instructions
 
+*Handbook: [`testing/suite/`](/handbook/testing/suite/README.md).*
+
 R package that contains a vendored copy of the DuckDB C++ library and glue code for R, including a DBI and a relational interface.
 
 ## Where to look
@@ -39,23 +41,11 @@ For an interactive edit-build-test loop, prefer the prebuilt-libduckdb fast path
 
 ### Run Tests
 
-- `R -q -e "testthat::test_local()"` -- runs all tests. Takes about 45 seconds. NEVER CANCEL: set timeout to 5+ minutes.
-- `R -q -e "testthat::test_local(filter = '^name$')"` -- runs specific test file by name
+See [`testing/suite/`](/handbook/testing/suite/README.md).
 
 ### Manual Validation
 
-- ALWAYS test basic DuckDB functionality after making changes by running a complete scenario
-- Test connection, table creation, data insertion, and querying:
-
-    ```r
-    library(duckdb)
-    con <- dbConnect(duckdb())
-    dbExecute(con, "CREATE TABLE test (id INTEGER, name VARCHAR)")
-    dbExecute(con, "INSERT INTO test VALUES (1, 'Alice'), (2, 'Bob')")
-    result <- dbGetQuery(con, "SELECT * FROM test ORDER BY id")
-    print(result)
-    dbDisconnect(con, shutdown=TRUE)
-    ```
+See [`testing/suite/`](/handbook/testing/suite/README.md).
 
 ### Format Checking (Optional - Has Known Issues)
 
@@ -203,30 +193,15 @@ The root cause of spurious regeneration was a bug in `deps.mk` where the filter 
 
 ## Running Tests
 
-```bash
-# Run all tests
-R -q -e "testthat::test_local()"
-
-# Run specific test file (replace 'array' with the test name, or use more complex regex)
-R -q -e "testthat::test_local(filter = '^array$')"
-```
+See [`testing/suite/`](/handbook/testing/suite/README.md).
 
 ## Manual Testing Scripts
 
-```bash
-# Run bug reproduction script
-R -q -f bug.R
-
-# Run any R script
-R -q -f script_name.R
-R
-```
+See [`testing/suite/`](/handbook/testing/suite/README.md).
 
 ## Test Development
 
-- Test files located in `tests/testthat/`
-- Use `testthat::test_local(filter = "name")` for running specific test files
-- Always add tests when fixing bugs to prevent regression
+See [`testing/suite/`](/handbook/testing/suite/README.md).
 
 ## Code Style Guidelines
 

--- a/handbook/testing/suite/README.md
+++ b/handbook/testing/suite/README.md
@@ -1,20 +1,190 @@
 # The suite
 
-*Stub — this leaf will own its topic;
-today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](/handbook/meta/handbook/);
-the last section holds this leaf's parameters.*
+How the package's own tests are laid out under `tests/`,
+and how to run them —
+the whole suite, one file, or the edit-and-test loop.
 
-Scope: the `tests/testthat/` layout and helpers,
-running one file, and the fast edit-test loop.
+## Layout
 
-Today:
+`tests/testthat.R` is the entry point `R CMD check` runs.
+It attaches testthat and the package,
+decides whether the suite runs at all,
+and hands the run to `test_check()`.
+That decision is the CRAN guard and belongs to
+[`testing/guards/`](/handbook/testing/guards/README.md);
+nothing else lives in that file.
 
-* [`AGENTS.md`](/AGENTS.md) — "Run Tests"
+Every test is a file directly under `tests/testthat/` —
+close to seventy of them, flat, named `test-<topic>.R`.
+A name is one of three things:
 
-To write this leaf:
+* the name of the `R/` file it covers
+  (`test-sql.R`, `test-relational.R`,
+  `test-backend-dbplyr__duckdb_connection.R`);
+* a DuckDB type or feature the R layer has to round-trip
+  (`test-map.R`, `test-struct.R`, `test-interval.R`, `test-timezone.R`);
+* a shared prefix, where one area is covered in several passes
+  (`test-storage-*.R`, `test-rfuns-*.R`).
 
-* absorb: `AGENTS.md` §§ "Run Tests", "Test Development",
-  "Manual Validation"; the fast loop is `build/fast-paths/`'s —
-  link it
-* drain: #2425
+There are no subdirectories:
+the file name is the unit of selection, and the only one.
+
+Beside the tests, the same directory holds
+`helper-*.R` and `setup.R` (below),
+`data/` — three Parquet fixtures,
+read either through `test_path("data/userdata1.parquet")`
+or, since testthat runs with `tests/testthat/` as the working directory,
+by the bare relative path inside SQL
+(`parquet_scan('data/userdata1.parquet')`) —
+and `_snaps/`, the recorded snapshot output,
+one `.md` per test file that snapshots, owned by
+[`testing/snapshots/`](/handbook/testing/snapshots/README.md).
+
+## Helpers and fixtures
+
+testthat sources every `helper-*.R` before the first test,
+then `setup.R` once for the run.
+
+* `helper-DBItest.R` creates the driver `drv`
+  on a temporary `.duckdb` file,
+  with a finalizer that unlinks the file,
+  and — when DBItest is installed —
+  registers the context `test-DBItest.R` runs from:
+  `dbitest_version` `"1.8.3"`, `?` placeholders,
+  no temporary tables, explicit `CAST` for timestamps, dates, times and blobs.
+  The `make_context()` call has to stay in the helper;
+  moved into the test file, `DBItest::test_some()` stops working.
+* `helper-arrow.R` loads arrow first, when `NOT_CRAN` is `true`.
+  Loading it after the relational tests have run
+  hits a garbage-collection problem
+  in how arrow releases its resources.
+* `helper-skip.R` holds the three skip predicates the tests share:
+  `skip_on_dev_version()` for anything that needs a released version —
+  a development snapshot is not `x.y.z`
+  and has no signed extensions on `extensions.duckdb.org` —
+  `skip_on_flavor()` for anything that depends on another package
+  hard-coding the mainline `duckdb` name — arrow's DuckDB integration
+  is the case that forces it —
+  and `skip_on_cran_except_r_universe()`.
+* `helper-snapshot.R` holds `transform_package_name()`,
+  which rewrites the running package's name to the mainline one
+  at capture time so one recorded snapshot serves every flavor.
+* `helper-storage.R` holds `session_home_path()`,
+  the expected storage path for the running package name.
+
+Fixtures are not in the helpers.
+`local_con()` — a connection that disconnects itself
+when the calling test exits — is package code,
+`R/test-fixtures.R`, unexported, and has a test of its own.
+The suite runs with the package's namespace loaded,
+so internal functions are callable from a test unqualified:
+`default_conn()`, `sql_exec()`, `extensions_supported()`,
+`get_duckdb_version()`, `get_package_name()`.
+Ask for the package name rather than writing it,
+for the reason [`branches/flavors/`](/handbook/branches/flavors/README.md)
+gives.
+
+`setup.R` is a single line:
+it points the `arrow_duck_con` option at `default_conn()`
+for the length of the run,
+so arrow's DuckDB integration reuses the suite's connection
+instead of opening one of its own.
+
+## Running
+
+The whole suite, about 45 seconds:
+
+```sh
+R -q -e 'testthat::test_local()'
+```
+
+`test_local()` runs `tests/testthat/` directly.
+It never goes through `tests/testthat.R`,
+so the CRAN guard in that file has no say over a local run —
+only over `R CMD check`.
+
+One file, by the name with `test-` and `.R` stripped off:
+
+```sh
+R -q -e 'testthat::test_local(filter = "^array$")'
+```
+
+`filter` is a regular expression, not a file name.
+Anchor it, or it selects every file whose name contains the string:
+unanchored, `filter = "storage"` runs all eight `test-storage-*.R` files,
+which is occasionally what you want.
+
+## The edit-test loop
+
+`test_local()` loads the package the way `pkgload::load_all()` does,
+which means it honours `DUCKDB_R_USE_SYSTEM_LIB`:
+with a prebuilt libduckdb linked,
+only the glue in `src/` is compiled — fifteen files —
+and a no-op load takes a second,
+a load after one edited glue file about four.
+Without it, the first build compiles the vendored engine:
+ten to fifteen minutes.
+That is the difference between a loop and a wait,
+so set it up once —
+[`build/fast-paths/`](/handbook/build/fast-paths/README.md)
+owns the mechanism, the version-match guard,
+and when to fall back to a source build.
+
+```sh
+export DUCKDB_R_USE_SYSTEM_LIB=1
+R -q -e 'pkgload::load_all()'
+R -q -e 'testthat::test_local(filter = "^array$")'
+```
+
+The loop's limit is the same as the fast path's:
+a run under `DUCKDB_R_USE_SYSTEM_LIB` proves the glue,
+not the engine it was built with.
+Anything a test asserts about engine configuration
+has to be confirmed against a vendored build.
+
+## Manual checks
+
+A green suite is not the same as a working package.
+After a change to the glue, drive a full scenario by hand —
+connect, create, insert, query, disconnect:
+
+```r
+library(duckdb)
+con <- dbConnect(duckdb())
+dbExecute(con, "CREATE TABLE test (id INTEGER, name VARCHAR)")
+dbExecute(con, "INSERT INTO test VALUES (1, 'Alice'), (2, 'Bob')")
+dbGetQuery(con, "SELECT * FROM test ORDER BY id")
+dbDisconnect(con, shutdown = TRUE)
+```
+
+A reproduction script at the repository root runs with `R -q -f bug.R`.
+Nothing ignores such a file —
+not `.gitignore`, not `.Rbuildignore` —
+so keep it out of the commit.
+Once it reproduces a bug you then fix,
+it has already done the work of a regression test:
+turn it into one under `tests/testthat/`.
+A fix without a test is unfinished.
+
+## Boundaries
+
+The suite is what runs; it is not where the running is decided.
+Which platforms and R versions execute it, and what the result gates,
+is [`operations/ci/`](/handbook/operations/ci/README.md)'s.
+Accepting a changed snapshot is
+[`testing/snapshots/`](/handbook/testing/snapshots/README.md)'s,
+the CRAN and flavor guards are
+[`testing/guards/`](/handbook/testing/guards/README.md)'s,
+and checking the packages that depend on this one before a release is
+[`testing/revdep/`](/handbook/testing/revdep/README.md)'s.
+
+The suite is not green on every platform it is run on.
+`test-duckdb-extensions.R` asserts that `INSTALL icu` succeeds
+wherever extensions are supported at all,
+and on Windows ARM64 it does not:
+DuckDB publishes no prebuilt extensions for arm64 MinGW,
+so the r-universe build for that platform fails there
+([#2425](https://github.com/duckdb/duckdb-r/issues/2425)).
+There is no platform skip for it today.
+The fix is in the test — a skip, or an extension that already uses
+DuckDB's C extension API — and the issue stays open until one lands.

--- a/handbook/testing/suite/README.md
+++ b/handbook/testing/suite/README.md
@@ -14,8 +14,8 @@ That decision is the CRAN guard and belongs to
 [`testing/guards/`](/handbook/testing/guards/README.md);
 nothing else lives in that file.
 
-Every test is a file directly under `tests/testthat/` —
-close to seventy of them, flat, named `test-<topic>.R`.
+Every test is a file directly under `tests/testthat/`,
+flat, named `test-<topic>.R`.
 A name is one of three things:
 
 * the name of the `R/` file it covers
@@ -31,7 +31,7 @@ the file name is the unit of selection, and the only one.
 
 Beside the tests, the same directory holds
 `helper-*.R` and `setup.R` (below),
-`data/` — three Parquet fixtures,
+`data/` — the Parquet fixtures,
 read either through `test_path("data/userdata1.parquet")`
 or, since testthat runs with `tests/testthat/` as the working directory,
 by the bare relative path inside SQL
@@ -58,7 +58,7 @@ then `setup.R` once for the run.
   Loading it after the relational tests have run
   hits a garbage-collection problem
   in how arrow releases its resources.
-* `helper-skip.R` holds the three skip predicates the tests share:
+* `helper-skip.R` holds the skip predicates the tests share:
   `skip_on_dev_version()` for anything that needs a released version —
   a development snapshot is not `x.y.z`
   and has no signed extensions on `extensions.duckdb.org` —
@@ -84,7 +84,7 @@ Ask for the package name rather than writing it,
 for the reason [`branches/flavors/`](/handbook/branches/flavors/README.md)
 gives.
 
-`setup.R` is a single line:
+`setup.R` does one thing:
 it points the `arrow_duck_con` option at `default_conn()`
 for the length of the run,
 so arrow's DuckDB integration reuses the suite's connection
@@ -92,7 +92,7 @@ instead of opening one of its own.
 
 ## Running
 
-The whole suite, about 45 seconds:
+The whole suite:
 
 ```sh
 R -q -e 'testthat::test_local()'
@@ -111,7 +111,7 @@ R -q -e 'testthat::test_local(filter = "^array$")'
 
 `filter` is a regular expression, not a file name.
 Anchor it, or it selects every file whose name contains the string:
-unanchored, `filter = "storage"` runs all eight `test-storage-*.R` files,
+unanchored, `filter = "storage"` runs every `test-storage-*.R` file,
 which is occasionally what you want.
 
 ## The edit-test loop
@@ -119,11 +119,10 @@ which is occasionally what you want.
 `test_local()` loads the package the way `pkgload::load_all()` does,
 which means it honours `DUCKDB_R_USE_SYSTEM_LIB`:
 with a prebuilt libduckdb linked,
-only the glue in `src/` is compiled — fifteen files —
-and a no-op load takes a second,
-a load after one edited glue file about four.
-Without it, the first build compiles the vendored engine:
-ten to fifteen minutes.
+only the glue in `src/` is compiled,
+so a load after one edited glue file takes seconds.
+Without it, the first build compiles the vendored engine,
+which takes minutes.
 That is the difference between a loop and a wait,
 so set it up once —
 [`build/fast-paths/`](/handbook/build/fast-paths/README.md)

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -5,6 +5,8 @@
 # Learn more about the roles of various files in:
 # * https://r-pkgs.org/testing-design.html#sec-tests-files-overview
 # * https://testthat.r-lib.org/articles/special-files.html
+#
+# Handbook: handbook/testing/suite/
 
 library(testthat)
 library(duckdb)


### PR DESCRIPTION
## What this leaf now owns

[`handbook/testing/suite/`](https://github.com/duckdb/duckdb-r/blob/claude/handbook-testing-suite-zayxqn/handbook/testing/suite/README.md)
explains the `tests/` layout as it actually is — `tests/testthat.R` as the
`R CMD check` entry point, the flat directory of `test-*.R` files and the three
naming conventions they follow, the `helper-*.R` files and what each one
sets up, `setup.R`, the `data/` Parquet fixtures, and the fact that
the test fixtures themselves (`local_con()`) are package code in
`R/test-fixtures.R` rather than helpers. It then covers running the suite,
running one file (`filter` is a regex, anchor it), the fast edit-test loop, and
the manual scenario to drive by hand after a glue change. Boundaries link out
rather than repeat: the mechanism behind `DUCKDB_R_USE_SYSTEM_LIB` is
`build/fast-paths/`'s, snapshots are `testing/snapshots/`'s, the CRAN and
flavor guards are `testing/guards/`'s, reverse dependencies are
`testing/revdep/`'s, and what CI runs is `operations/ci/`'s.

## What moved

* `AGENTS.md` — lost the bodies of §§ "Run Tests", "Manual Validation",
  "Running Tests", "Manual Testing Scripts" and "Test Development"; each heading
  is kept with a one-line pointer to the leaf. Gained the visible italic
  handbook backreference under its H1. The file is not deleted — it shrinks to
  routing.
* `tests/testthat.R` — gained a plain `# Handbook: handbook/testing/suite/`
  comment below its header block, so someone standing in `tests/` finds the leaf.

## Assumptions

* **`## Validation` in `AGENTS.md` was left alone**, although its first bullet
  restates the manual end-to-end scenario I absorbed. It is not one of the five
  sections this leaf was assigned, and five sibling leaves are editing the same
  file in parallel; whoever owns it should fold the duplicate away. Its claim
  that "one test failure is expected in clock function tests" looks stale — the
  clock translations live in `test-backend-dbplyr__duckdb_connection.R` and skip
  when `clock` is not installed — but I did not verify it by running anything.
* **The `Where to look` routing table in `AGENTS.md` still says this file owns
  "Build, test, and validate the package locally".** Left as is to avoid a
  three-way conflict with the sibling leaves; it wants one update once they land.
* **The root `README.md` was not touched.** Its `## Documentation` entry
  describes `AGENTS.md` as covering "build, test, and where to look for
  everything else", which the split makes partly stale — but `AGENTS.md` is not
  deleted, so the entry is not dangling, and the same three-way conflict applies.
* ~~**Counts are stated where they are stable and hedged where they are not**:
  "close to seventy" test files (68 today), "fifteen files" of glue in `src/`
  (verified), three Parquet fixtures (verified), eight `test-storage-*.R` files
  (verified). The "about 45 seconds" for a full run is carried over from
  `AGENTS.md` unverified — no build was run for this wave.~~ Superseded by the
  durability sweep below: every one of these is now out of the leaf.
* **#2425 is answered as a boundary, not closed.** The leaf states today's
  behavior — `test-duckdb-extensions.R` asserts `INSTALL icu` succeeds wherever
  extensions are supported, and there is no prebuilt ICU for arm64 MinGW — and
  attributes the diagnosis to the issue thread (I could not read the r-universe
  job log). The verdict is a code fix in the test, so the issue stays open.
* **`setup.R`'s effect** is described as pointing arrow's DuckDB integration at
  the suite's own connection. That reads the `arrow_duck_con` option as arrow's
  (the name and `test-arrow.R`'s comment about `arrow_duck_connection()` both
  say so); nothing in this repo consumes it.

## Durability sweep

A targeted pass for one defect class: facts a routine commit invalidates. This
leaf was the wave's worst offender, and its own assumptions bullet said so.

**Removed.**

* "close to seventy of them" test files — cut. The flat directory and the
  `test-{topic}.R` naming convention are the durable content: the convention
  tells a reader what to expect from *any* file, which a tally never did.
  (The leaf spells the placeholder with angle brackets; GitHub deletes those
  from a pull-request body even inside backticks, so this description uses
  braces.)
* "three Parquet fixtures" → "the Parquet fixtures". Adding a fixture is a
  routine commit.
* "the three skip predicates" → "the skip predicates". A new test needing a new
  predicate is routine; the list that follows still names each one.
* "`setup.R` is a single line" → "`setup.R` does one thing". The point was
  always that it does one thing, not that it occupies one line.
* "The whole suite, about 45 seconds" — cut outright. The figure came over from
  `AGENTS.md` with no run behind it, and nobody will re-measure it.
* "runs all eight `test-storage-*.R` files" → "runs every `test-storage-*.R`
  file". The argument is that an unanchored filter matches broadly; the count
  only illustrated it.
* "fifteen files" of glue, "a no-op load takes a second, a load after one edited
  glue file about four", and "ten to fifteen minutes" for the engine build —
  reduced to seconds against minutes. The order of magnitude *is* the argument
  ("the difference between a loop and a wait"), and it survives a faster
  machine, a warm ccache, and a changed glue file count. None of the figures
  did.

**Kept.**

* `dbitest_version` `"1.8.3"` — a version number identifying *which* version,
  not how many.
* "A name is one of three things" — this is the naming convention itself, and a
  fourth category would be a deliberate change to the convention rather than a
  routine commit. Load-bearing, so it stays.
* #2425 — an issue number identifies the open bug.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PD23hjFQFRWW62HFvru187)_
