### PR TITLE
docs(handbook): Write the vendoring pipeline leaf

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,7 @@ The duckdb-r package vendors (includes a copy of) the DuckDB C++ core library. K
 - **Branch Strategy**: one dev branch per upstream branch (`main-dev` ← `main`, `v1.5-variegata-dev` ← `v1.5-variegata`, `v1.4-andium-dev` ← `v1.4-andium`); see [BRANCHES.md](BRANCHES.md)
 - **One commit at a time**: each vendor commit corresponds to exactly one upstream commit, and must build and pass tests on its own — fold any required glue fix into that commit rather than adding a follow-up
 - **Never modify `src/duckdb/` directly** - changes will be overwritten by vendoring
-- **Patching**: Add files to the `patch/` directory to apply R-specific modifications to vendored code. Send patches upstream as pull requests every once in a while. A patch that no longer applies is deleted by the next vendor run.
+- **Patching**: Add files to the `patch/` directory to apply R-specific modifications to vendored code. Send patches upstream as pull requests every once in a while. A patch whose change has landed upstream is deleted by the next vendor run; one that has genuinely broken stops `vendor-one.sh` instead.
 - **Manual vendoring**: Use `scripts/vendor.sh /path/to/duckdb/repo` for testing
 - **Full documentation**: See [VENDORING.md](scripts/VENDORING.md) for complete details
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,7 @@ The duckdb-r package vendors (includes a copy of) the DuckDB C++ core library. K
 - **Branch Strategy**: one dev branch per upstream branch (`main-dev` ← `main`, `v1.5-variegata-dev` ← `v1.5-variegata`, `v1.4-andium-dev` ← `v1.4-andium`); see [BRANCHES.md](BRANCHES.md)
 - **One commit at a time**: each vendor commit corresponds to exactly one upstream commit, and must build and pass tests on its own — fold any required glue fix into that commit rather than adding a follow-up
 - **Never modify `src/duckdb/` directly** - changes will be overwritten by vendoring
-- **Patching**: Add files to the `patch/` directory to apply R-specific modifications to vendored code. Send patches upstream as pull requests every once in a while. A patch whose change has landed upstream is deleted by the next vendor run; one that has genuinely broken stops `vendor-one.sh` instead.
+- **Patching**: Add files to the `patch/` directory to apply R-specific modifications to vendored code. Send patches upstream as pull requests every once in a while. A patch whose change has landed upstream is deleted by the next vendor run; one that has genuinely broken stops the run instead.
 - **Manual vendoring**: Use `scripts/vendor.sh /path/to/duckdb/repo` for testing
 - **Full documentation**: See [VENDORING.md](scripts/VENDORING.md) for complete details
 

--- a/BRANCHES.md
+++ b/BRANCHES.md
@@ -1,5 +1,7 @@
 # Branching Strategy
 
+*Handbook: [`operations/vendoring/pipeline/`](/handbook/operations/vendoring/pipeline/README.md).*
+
 Version numbers are given at the time of writing (March 2026) and may be outdated by the time you read this.
 The branching strategy is expected to remain stable.
 
@@ -623,31 +625,7 @@ duckdb/duckdb-r@main  →  krlmlr/duckdb-r@main-dev  →  krlmlr/duckdb-r@v1.5-v
 
 ## Patch Stack
 
-The upstream C++ code in `src/duckdb/` may be updated to suit the needs of the R package, but not all updates are relevant or appropriate.
-R-specific fixes are maintained as an ordered series of git-format patches under `patch/`.
-Every vendor run re-applies the full stack on top of the freshly vendored sources.
-
-```txt
-  duckdb/duckdb (upstream)
-        │
-        │  vendor.sh / vendor-one.sh
-        ▼
-  src/duckdb/   ← raw vendored C++ sources
-        │
-        │  apply patch/0001-...patch
-        │  apply patch/0002-...patch
-        │  apply patch/0003-...patch
-        │  ...
-        ▼
-  src/duckdb/   ← R-ready C++ sources (committed to branch)
-```
-
-Patches are numbered to define their application order.
-Gaps in the numbering are normal — they indicate patches that were previously removed because the fix was accepted upstream.
-
-When a patch is no longer needed (because the fix was merged upstream), delete the file. Do not renumber the remaining patches. When adding a new patch, assign it the next available number and send the same change as a pull request to `duckdb/duckdb` so it can be retired eventually.
-
-If a vendor run fails because a patch no longer applies cleanly, update the patch against the new upstream code, commit it, and re-run vendoring.
+How a patch is added, dropped, or lost by a vendor run: [`operations/vendoring/pipeline/`](/handbook/operations/vendoring/pipeline/README.md).
 
 ## Version Numbering
 
@@ -665,26 +643,7 @@ A released version is the bare three-component prefix (`1.5.4`). The `-dev` bran
 
 ### The DESCRIPTION merge driver
 
-Because the two counters advance on the same line, a plain forward-port, rebase, or release merge
-conflicts on `DESCRIPTION:Version` at essentially every commit. The merge driver in
-`scripts/merge-version.sh` resolves that line by taking the **component-wise maximum** of the two
-sides, **gated on an equal `major.minor.patch` prefix**:
-
-- Within a release line, the max keeps the 4th component from the strand that owns it (the R-client
-  strand) and the 5th from the strand that owns it (the vendor strand). E.g.
-  `1.5.3.9008` merged with `1.5.3.9006.42` → `1.5.3.9008.42`. The result is direction-agnostic.
-- Across release lines (different prefix, e.g. forward-porting a fix from `1.5.x` onto the `1.4.x`
-  LTS), the driver keeps **ours** unchanged and never inherits a foreign prefix.
-
-The rest of `DESCRIPTION` still gets a normal 3-way merge, so a genuine concurrent edit
-(e.g. two branches touching `Imports:`) still raises a real conflict. The authoritative release
-version is set by `fledge::bump_version()` at the tip after the operation completes — the driver's
-only job is to stop the version line from halting a rebase.
-
-**Setup.** The `merge=ours-version` attribute is committed in `.gitattributes`, but the driver's
-name→command mapping must live in `.git/config`. Run `scripts/setup-git.sh` once per clone — and as
-the first step of any CI job that rebases, cherry-picks, or merges — to register the driver, enable
-`rerere`, and pin `rebase.backend=merge` (the patch/`am` backend bypasses merge drivers).
+How the driver resolves the version line, and how it is wired up: [`operations/vendoring/pipeline/`](/handbook/operations/vendoring/pipeline/README.md).
 
 ## Tooling
 

--- a/BRANCHES.md
+++ b/BRANCHES.md
@@ -580,11 +580,13 @@ loop** (`.claude/skills/series-loop.md`) — which discovers every series from
 its refs and serves them all in one firing.
 Each series `<S>` has four branches:
 `<S>-build` (every upstream commit vendored, glue compiling, no CI),
-`<S>-dev` (consumed from `-build` up to 25 commits at a time; CI builds every
+`<S>-dev` (consumed from `-build` one bounded chunk per firing; CI builds every
 commit), `<S>-green` (fast-forwarded to the newest all-green commit; what
 r-universe should build from), and `<S>-build-base` (the `-build` commit
 equivalent to `-green`). CI builds the `.dev` package per commit via
 `each.yaml`.
+How large that chunk is, and what the bound buys, is
+[`branches/model/`](/handbook/branches/model/README.md)'s.
 If vendoring breaks the build, it can be fixed after the fact in the same commit.
 The `-dev` branches are not protected, so force-pushes are allowed to fix mistakes.
 

--- a/BRANCHES.md
+++ b/BRANCHES.md
@@ -625,7 +625,7 @@ duckdb/duckdb-r@main  →  krlmlr/duckdb-r@main-dev  →  krlmlr/duckdb-r@v1.5-v
 
 ## Patch Stack
 
-How a patch is added, dropped, or lost by a vendor run: [`operations/vendoring/pipeline/`](/handbook/operations/vendoring/pipeline/README.md).
+How a patch is added, dropped, or broken by a vendor run: [`operations/vendoring/pipeline/`](/handbook/operations/vendoring/pipeline/README.md).
 
 ## Version Numbering
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ and coding agents.
 * [`BRANCHES.md`](BRANCHES.md) — branch model, package flavors,
   series invariants
 * [`RELEASE.md`](RELEASE.md) — the release process
-* [`scripts/VENDORING.md`](scripts/VENDORING.md) — vendoring mechanics
+* [`handbook/operations/vendoring/`](handbook/operations/vendoring/README.md) —
+  vendoring: the model, the pipeline, the routine that runs it
 * [`plan/README.md`](plan/README.md) — designs, plans, and historical
   documents, each named there by path
 
@@ -130,7 +131,9 @@ It helps if both the duckdb directory and duckdb-r directory are clean.
 
 ## Vendoring
 
-This package includes a vendored copy of the DuckDB C++ library. The vendoring process is automated — a scheduled routine synchronizes each release series with the upstream DuckDB repository, commit by commit. For detailed information about how vendoring works and manual vendoring procedures, see [`scripts/VENDORING.md`](scripts/VENDORING.md).
+This package includes a vendored copy of the DuckDB C++ library.
+The vendoring process is automated — a scheduled routine synchronizes each release series with the upstream DuckDB repository, commit by commit.
+How it works, and how to vendor by hand, is in [`handbook/operations/vendoring/`](handbook/operations/vendoring/README.md).
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -118,13 +118,14 @@ Then, install:
 Set the `MAKEFLAGS` environment variable to `-j8` or similar for parallel builds.
 Configure `ccache` for faster repeated builds.
 
-If you wish to test new DuckDB functionality with duckdb-r, make sure your clone of `duckdb-r` is one level deeper than your clone of `duckdb` (e.g. `R/duckdb-r` and `duckdb`).
+If you wish to test new DuckDB functionality with duckdb-r, make sure your clone of `duckdb-r` is **two** levels deeper than your clone of `duckdb` (e.g. `~/git/duckdb` and `~/git/R/duckdb/duckdb-r`).
+That is the layout `scripts/vendor.sh` assumes when it is given no argument; any other layout works by passing the path to the `duckdb` clone.
 Then run the following commands:
 
 ``` sh
-~ (cd duckdb && git checkout {{desired_branch}})
-~ (cd R/duckdb-r && scripts/vendor.sh)
-~ (cd R/duckdb-r && R CMD INSTALL .)
+~/git (cd duckdb && git checkout {{desired_branch}})
+~/git (cd R/duckdb/duckdb-r && scripts/vendor.sh)
+~/git (cd R/duckdb/duckdb-r && R CMD INSTALL .)
 ```
 
 It helps if both the duckdb directory and duckdb-r directory are clean.

--- a/handbook/operations/vendoring/pipeline/README.md
+++ b/handbook/operations/vendoring/pipeline/README.md
@@ -111,7 +111,8 @@ so upstream's packaging decides which sources are emitted;
 It writes five committed things:
 
 * `src/duckdb/` — the engine sources for the package,
-  amalgamated into unity chunks of 20 translation units,
+  amalgamated into per-directory unity chunks
+  wherever upstream's own `CMakeLists.txt` says `add_library_unity`,
   with `parquet` and `core_functions` linked in
   (`DUCKDB_R_EXTENSIONS` adds more — a build knob,
   see [`build/configuration/`](/handbook/build/configuration/README.md));
@@ -155,13 +156,26 @@ Two smaller facts about the script:
 it drops the bundled jemalloc tree from the source list,
 because the R package never defines `DUCKDB_ENABLE_JEMALLOC`
 and upstream's packaging started emitting sources that neither compile nor link without it;
-and `DUCKDB_BUILD_UNITY` does **not** work —
-the branch that reads it dereferences an undefined name
-and the bare `except` swallows the error, so the chunk size stays 20.
+and `DUCKDB_BUILD_UNITY` is read from the environment,
+parsed as an integer and rejected — with a message, and a non-zero exit —
+when it is not a positive one;
+unset or empty keeps the long-standing default of 20.
+It reaches upstream's `build_package()` as its `unity_count` argument,
+and there it currently does nothing:
+upstream has accepted that argument without using it since well before v1.0.0,
+because the grouping is decided per directory by `add_library_unity`.
+So setting the knob is now honoured all the way to the call and no further —
+which is what it should do, and worth knowing before reaching for it.
 When `DUCKDB_R_BINDIR`, `DUCKDB_R_CFLAGS` and `DUCKDB_R_LIBS` are all set,
 the script writes `src/Makevars` for a system-library build and exits
-without touching the vendored tree at all;
-that path belongs to [`build/fast-paths/`](/handbook/build/fast-paths/README.md).
+without touching the vendored tree at all.
+That branch is reachable but stale:
+it still fills a `{{ SOURCES }}` placeholder that `src/Makevars.in` no longer has,
+so the generated `Makevars` keeps its `include include/sources.mk`
+and would compile the whole vendored tree anyway.
+The working route to a prebuilt library is `DUCKDB_R_USE_SYSTEM_LIB`,
+which `configure` handles instead;
+both belong to [`build/fast-paths/`](/handbook/build/fast-paths/README.md).
 
 ## The patch stack
 
@@ -173,7 +187,7 @@ in file-name order, with `patch -p1 --forward` after a dry run.
 Numbers define the order; gaps in the numbering are normal
 and mark patches that were retired.
 
-The lifecycle has three moves:
+The lifecycle has four moves:
 
 * **Adding one.**
   Edit `src/duckdb/`, capture the diff as `patch/00NN-my-fix.patch` with the next free number,
@@ -189,12 +203,26 @@ The lifecycle has three moves:
   so the patch can eventually be retired.
 * **Dropping one.**
   When the fix lands upstream, delete the file. Never renumber the rest.
-* **Losing one.**
-  A patch that no longer applies is deleted *by the vendor run*,
-  and the deletion becomes part of that vendor commit —
-  on the assumption that the fix reached upstream.
-  Verify the assumption:
-  if the patch is still needed, restore it and rebase it against the new sources.
+  `vendor-one.sh` also drops it for you, and correctly:
+  a patch that no longer applies forward but *reverses* cleanly
+  is already present in the regenerated tree,
+  which is exactly what "the fix landed upstream" looks like.
+  The deletion becomes part of that vendor commit.
+* **Breaking one.**
+  A patch that neither applies forward nor reverses cleanly is a different case:
+  its change is not in the tree and cannot be re-applied,
+  because the code around it moved.
+  `vendor-one.sh` stops, exits 4, and names the patch,
+  leaving the regenerated sources uncommitted in the working tree
+  and the upstream clone in place.
+  Rebase the patch against those sources — keep it outside the tree,
+  `git checkout -- .`, put it back, and rerun —
+  and delete it only after confirming its change is genuinely upstream.
+  Two cautions.
+  A run that used to limp past a broken patch now halts, which is the point,
+  but it does mean a series loop can stop where it previously did not.
+  And [`scripts/vendor.sh`](/scripts/vendor.sh) still deletes on any failure,
+  without the reverse check: prefer `vendor-one.sh` where a fix is at stake.
 
 Never edit `src/duckdb/` directly in a way you want to keep.
 The next run regenerates the directory from scratch, and the edit is gone.

--- a/handbook/operations/vendoring/pipeline/README.md
+++ b/handbook/operations/vendoring/pipeline/README.md
@@ -203,7 +203,7 @@ The lifecycle has four moves:
   so the patch can eventually be retired.
 * **Dropping one.**
   When the fix lands upstream, delete the file. Never renumber the rest.
-  `vendor-one.sh` also drops it for you, and correctly:
+  Both scripts also drop it for you, and correctly:
   a patch that no longer applies forward but *reverses* cleanly
   is already present in the regenerated tree,
   which is exactly what "the fix landed upstream" looks like.
@@ -212,17 +212,17 @@ The lifecycle has four moves:
   A patch that neither applies forward nor reverses cleanly is a different case:
   its change is not in the tree and cannot be re-applied,
   because the code around it moved.
-  `vendor-one.sh` stops, exits 4, and names the patch,
+  Both scripts stop, exit 4, and name the patch,
   leaving the regenerated sources uncommitted in the working tree
   and the upstream clone in place.
   Rebase the patch against those sources — keep it outside the tree,
   `git checkout -- .`, put it back, and rerun —
   and delete it only after confirming its change is genuinely upstream.
-  Two cautions.
-  A run that used to limp past a broken patch now halts, which is the point,
+  Rerunning `vendor.sh` also means clearing `./duckdb` first, or passing it,
+  because that script always clones.
+  One caution:
+  a run that used to limp past a broken patch now halts, which is the point,
   but it does mean a series loop can stop where it previously did not.
-  And [`scripts/vendor.sh`](/scripts/vendor.sh) still deletes on any failure,
-  without the reverse check: prefer `vendor-one.sh` where a fix is at stake.
 
 Never edit `src/duckdb/` directly in a way you want to keep.
 The next run regenerates the directory from scratch, and the edit is gone.

--- a/handbook/operations/vendoring/pipeline/README.md
+++ b/handbook/operations/vendoring/pipeline/README.md
@@ -90,12 +90,15 @@ Shared behaviour, in the order it happens:
    in `/tmp/vendor-one-glue-failures.txt`:
    fix the glue and amend, do not add a follow-up commit.
 
-`vendor-one.sh --commits N` repeats steps 3–9 up to `N` times —
-the series loop passes 100 —
+`vendor-one.sh --commits N` repeats steps 3–9 up to `N` times,
 stopping early on a tag or when no candidate remains.
+How large a chunk the routine asks for, and what the bound buys, is
+[`branches/model/`](/handbook/branches/model/README.md)'s.
 Its `VENDOR_REPO` variable names the checkout to vendor *into*,
 which must be the root of a worktree;
-that is what lets the loop run `main`'s copy of the script against a series' buffer.
+that is what lets `main`'s copy of the script run against another tree,
+as [`series-loop/`](/handbook/operations/vendoring/series-loop/README.md)'s
+first stage does.
 Only the script itself comes from `main` that way:
 everything it invokes by relative path —
 `scripts/rconfigure.py`, `patch/*.patch`, `./configure` —
@@ -123,59 +126,32 @@ It writes five committed things:
   filled into `src/Makevars.in`.
 
 All five carry a "do not edit by hand" header, and all five are regenerated wholesale.
-Two consequences are worth knowing before reading a diff:
+Two properties of that regeneration are defects rather than curiosities,
+and both are open:
 
-**The tree is not byte-reproducible across clones.**
-`DUCKDB_SOURCE_ID` is an *abbreviated* commit id,
-and git auto-sizes that abbreviation from the number of objects in the clone it runs in.
-The same upstream commit vendors as `7300522cf0` from one clone and `7300522cf07` from another,
-and a single branch can contain both lengths at different points of its history.
-Nothing downstream breaks —
-`configure` compares only the first ten characters
-when it checks a prebuilt library against the vendored headers —
-but a diff between two vendorings of one upstream commit
-shows this line even when everything else is identical.
-Pin `core.abbrev` in the upstream clone if an exact match matters.
+* **The tree is not byte-reproducible across clones.**
+  `DUCKDB_SOURCE_ID` is an *abbreviated* commit id,
+  and git sizes the abbreviation from the clone it runs in,
+  so a diff between two vendorings of one upstream commit
+  shows that line even when everything else is identical
+  ([#2489](https://github.com/duckdb/duckdb-r/issues/2489)).
+* **Regeneration rewrites all ~3550 files unconditionally**,
+  including the ones whose content did not change,
+  which invalidates git's stat cache
+  and is the bulk of what a vendor commit costs
+  ([#2490](https://github.com/duckdb/duckdb-r/issues/2490)).
 
-**Regeneration costs about twice what it needs to.**
-All ~3550 vendored files are rewritten unconditionally,
-including the ones whose content did not change,
-which invalidates git's stat cache;
-both the "more than one changed file" test and the `git add` then re-hash the whole tree.
-Measured: `git status` over the vendored tree costs 1.06 s right after every file is touched
-and 0.017 s when the index is still valid,
-at two full passes per candidate — including candidates that are skipped —
-which is the bulk of the ~4.9 s a vendor commit takes on four cores.
-Writing only the files that actually differ would roughly halve it,
-in CI as well as locally.
-That is one of the items in
-[`plan/PLAN-vendoring-simplification.md`](/plan/PLAN-vendoring-simplification.md),
-which carries the intent for this pipeline.
-
-Two smaller facts about the script:
+One more fact about the script:
 it drops the bundled jemalloc tree from the source list,
 because the R package never defines `DUCKDB_ENABLE_JEMALLOC`
-and upstream's packaging started emitting sources that neither compile nor link without it;
-and `DUCKDB_BUILD_UNITY` is read from the environment,
-parsed as an integer and rejected — with a message, and a non-zero exit —
-when it is not a positive one;
-unset or empty keeps the long-standing default of 20.
-It reaches upstream's `build_package()` as its `unity_count` argument,
-and there it currently does nothing:
-upstream has accepted that argument without using it since well before v1.0.0,
-because the grouping is decided per directory by `add_library_unity`.
-So setting the knob is now honoured all the way to the call and no further —
-which is what it should do, and worth knowing before reaching for it.
-When `DUCKDB_R_BINDIR`, `DUCKDB_R_CFLAGS` and `DUCKDB_R_LIBS` are all set,
-the script writes `src/Makevars` for a system-library build and exits
-without touching the vendored tree at all.
-That branch is reachable but stale:
-it still fills a `{{ SOURCES }}` placeholder that `src/Makevars.in` no longer has,
-so the generated `Makevars` keeps its `include include/sources.mk`
-and would compile the whole vendored tree anyway.
-The working route to a prebuilt library is `DUCKDB_R_USE_SYSTEM_LIB`,
-which `configure` handles instead;
-both belong to [`build/fast-paths/`](/handbook/build/fast-paths/README.md).
+and upstream's packaging emits jemalloc sources
+that neither compile nor link without it.
+That is a fact expected to change:
+[`duckdb/duckdb#22811`](https://github.com/duckdb/duckdb/issues/22811)
+is where to check whether the exclusion is still needed.
+Linking against a prebuilt engine instead of the vendored tree
+is `DUCKDB_R_USE_SYSTEM_LIB`, which `configure` handles rather than this script,
+and belongs to [`build/fast-paths/`](/handbook/build/fast-paths/README.md).
 
 ## The patch stack
 
@@ -220,9 +196,14 @@ The lifecycle has four moves:
   and delete it only after confirming its change is genuinely upstream.
   Rerunning `vendor.sh` also means clearing `./duckdb` first, or passing it,
   because that script always clones.
-  One caution:
-  a run that used to limp past a broken patch now halts, which is the point,
-  but it does mean a series loop can stop where it previously did not.
+
+The patch stack is where the pipeline's overarching rule is easiest to see:
+**a run either succeeds or dies trying, and talks about it.**
+Nothing is dropped, skipped, or worked around to keep a run alive.
+Every stop names what stopped it, where it left the tree and the upstream clone,
+and what to do next —
+exit 4 for a broken patch, exit 3 for broken glue,
+exit 1 for a base scan that came up empty.
 
 Never edit `src/duckdb/` directly in a way you want to keep.
 The next run regenerates the directory from scratch, and the edit is gone.
@@ -249,7 +230,8 @@ and `#N` in the collected subjects rewritten to a full
 
 The subject line is machine-readable state, not decoration.
 It is the only record of where a branch stands in upstream history:
-the base scan in step 3 parses it, and so do the series scripts and the repair playbooks.
+the base scan that opens every run parses it,
+and so do the series scripts and the repair playbooks.
 Do not reword it,
 and do not squash vendor commits together without keeping the newest SHA in the subject.
 
@@ -257,7 +239,7 @@ and do not squash vendor commits together without keeping the newest SHA in the 
 
 The package version carries two counters that advance on different strands —
 the fourth component on the R-client strand,
-the fifth on the vendor strands, once per vendor commit (step 7 above).
+the fifth on the vendor strands, once per vendor commit, in the version-bump step above.
 What the counters mean and who sets them is
 [`releases/versioning/`](/handbook/operations/releases/versioning/README.md)'s;
 what keeps them from halting every rebase is here.
@@ -275,7 +257,9 @@ If either side has no `Version:` line at all, the driver falls back to a plain t
 **The prefix gate.**
 The driver combines counters only when the `major.minor.patch` prefix of both sides is equal;
 otherwise it keeps *ours* verbatim and never inherits a foreign prefix.
-That is a safety rail for cross-release forward-ports, such as 1.5.x onto the 1.4.x LTS.
+That is a safety rail for cross-release forward-ports, such as 1.5.x onto the 1.4.x LTS;
+whether the larger version would be the better answer is
+[#2488](https://github.com/duckdb/duckdb-r/issues/2488).
 It also means the driver does **not** renumber a dev branch when the base moves to a new patch release:
 rebasing a series from `1.5.4.9005.N` onto a `1.5.5.9000` base
 leaves every commit at the base version rather than producing `1.5.5.9000.1`, `…2`, `…3`,
@@ -295,25 +279,32 @@ and as the first step of any CI job that rebases, cherry-picks, or merges in thi
 
 ## Vendoring by hand
 
-The scripts expect the upstream clone one level *above* the package clone —
-`~/duckdb` next to `~/R/duckdb-r` is the layout the defaults assume.
+Both scripts `cd` to the package root before anything else,
+and the default source repository is `../../../duckdb` from there:
+**three** levels up.
+So the layout the defaults assume puts the package clone
+two directories *deeper* than the upstream clone —
+with the upstream clone at `~/git/duckdb`,
+`~/git/R/duckdb/duckdb-r` is a package clone that needs no argument.
+Any other layout works by passing the upstream path as the positional argument.
+
 For a single upstream state, check the clone out at the commit you want and run `vendor.sh`,
 which vendors whatever `HEAD` is:
 
 ```bash
-cd ~/duckdb && git checkout <branch-or-commit>
-cd ~/R/duckdb-r && scripts/vendor.sh ../../../duckdb
+cd ~/git/duckdb && git checkout <branch-or-commit>
+cd ~/git/R/duckdb/duckdb-r && scripts/vendor.sh
 R CMD INSTALL .
 ```
 
-To replay a stretch of upstream history the way CI does,
+To replay a stretch of upstream history the way the routine does,
 check the clone out at the **last** commit you want vendored, so the walk terminates by itself,
 and drive `vendor-one.sh` one commit at a time:
 
 ```bash
 export MAKEFLAGS=-j$(nproc) NOT_CRAN=true DUCKDB_R_RUN_TESTS=true
 
-while scripts/vendor-one.sh ../../../duckdb --commits 1; do
+while scripts/vendor-one.sh --commits 1; do
   rm -f src/*.o                                # see below — mandatory
   R CMD INSTALL . --no-byte-compile || break   # repair, then `git commit --amend`
   R -q -e 'testthat::test_local()'       || break
@@ -352,22 +343,9 @@ so plan bulk replays off the pessimistic figure.
 When a commit breaks, fix the glue and `git commit --amend`,
 so the fix lands *in* the vendor commit that needs it and the history stays bisectable;
 then continue the loop.
-Never run `R CMD build` in a working tree you still need:
-the `cleanup` script runs `git clean -fdx src` and packs `src/duckdb/` into `src/duckdb.tar.xz`.
 
 ## Limits
 
-* **A walk that vendors nothing can leave the tree dirty.**
-  When no candidate qualifies, `vendor-one.sh` restores `src/duckdb/` and stops,
-  but `rconfigure.py` has already rewritten `R/version.R` and the generated `Makevars`
-  for the last candidate it tried.
-  On a dev branch the version string changes with almost every upstream commit,
-  so this is the common case, and the *next* run then refuses on the dirty tree.
-  `git checkout -- .` before rerunning. `vendor.sh` restores `R/version.R` as well.
-* **There is no vendoring workflow.**
-  Nothing under `.github/workflows/` runs these scripts;
-  vendoring is driven by the routine, and CI's role is to build the commits it produces
-  ([`ci/per-commit/`](/handbook/operations/ci/per-commit/README.md)).
 * **The pipeline vendors DuckDB, and one other thing.**
   [`scripts/vendor-rfuns.sh`](/scripts/vendor-rfuns.sh)
   copies the `rfuns` extension sources from a `duckdb-rfuns` checkout into `src/`,
@@ -379,4 +357,8 @@ the `cleanup` script runs `git clean -fdx src` and packs `src/duckdb/` into `src
   which is not `git merge-base`,
   and the R side has to be rewound to what that engine supports.
   That procedure belongs to
-  [`series-loop/`](/handbook/operations/vendoring/series-loop/README.md).
+  [`series-loop/`](/handbook/operations/vendoring/series-loop/README.md),
+  which also owns what schedules these scripts and how far each firing runs them.
+
+Intent — what should change about this pipeline, and what has landed — is in
+[`plan/PLAN-vendoring-simplification.md`](/plan/PLAN-vendoring-simplification.md).

--- a/handbook/operations/vendoring/pipeline/README.md
+++ b/handbook/operations/vendoring/pipeline/README.md
@@ -1,25 +1,354 @@
 # The pipeline
 
-*Stub — this leaf will own its topic;
-today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](/handbook/meta/handbook/);
-the last section holds this leaf's parameters.*
+The machinery that turns one upstream DuckDB commit into one vendor commit:
+the two vendoring scripts,
+what `rconfigure.py` regenerates,
+the lifecycle of the patch stack,
+and the `DESCRIPTION` merge driver
+that keeps the version counters mergeable across vendor commits.
+Why the engine is vendored at all,
+and the one-commit-per-upstream-commit invariant,
+are [`model/`](/handbook/operations/vendoring/model/README.md)'s;
+the routine that runs these scripts on a schedule
+is [`series-loop/`](/handbook/operations/vendoring/series-loop/README.md)'s;
+a run that comes back red
+is [`troubleshooting/`](/handbook/operations/vendoring/troubleshooting/README.md)'s.
 
-Scope: `vendor-one.sh`, `rconfigure.py`, the patch stack,
-and the `DESCRIPTION` merge driver that keeps version counters
-mergeable across vendor commits.
+## The two scripts
 
-Today:
+[`scripts/vendor.sh`](/scripts/vendor.sh) and
+[`scripts/vendor-one.sh`](/scripts/vendor-one.sh)
+both regenerate `src/duckdb/` from scratch, re-apply the patch stack, and commit.
+They differ in how they choose *which* upstream commit to vendor,
+and in what they do afterwards.
 
-* [`scripts/VENDORING.md`](/scripts/VENDORING.md)
-* [`scripts/merge-version.sh`](/scripts/merge-version.sh)
-* a generated `scripts/` directory index is proposed in
-  [#2447](https://github.com/duckdb/duckdb-r/pull/2447)
+| | `vendor.sh` | `vendor-one.sh` |
+|---|---|---|
+| Chooses | the upstream clone's `HEAD`, whatever it is | the next unvendored upstream commit, oldest first |
+| Bumps the package version | no | yes, the fifth component |
+| Checks the glue afterwards | no | yes, unless `--no-check-glue` |
+| Typical use | one-off and manual, and to seed a new series | the series loop, and any commit-by-commit walk |
 
-To write this leaf:
+Shared behaviour, in the order it happens:
 
-* absorb: the mechanics and script inventory from
-  `scripts/VENDORING.md`; own `rconfigure.py` (regenerates
-  `src/duckdb/`, `src/include/sources.mk`, `R/version.R`),
-  the patch-stack lifecycle, `merge-version.sh`,
-  and `setup-git.sh` which registers the driver
+1. **Locate the upstream clone.**
+   The positional argument is the source repository, default `../../../duckdb`.
+   Unless it is already called `duckdb`,
+   it is cloned into `./duckdb` in the package root, which is `.gitignore`d.
+   `vendor-one.sh` reuses an existing `./duckdb` and `git fetch`es it;
+   `vendor.sh` always clones, so a leftover `./duckdb` makes it fail.
+   Both remove the clone when a run finishes —
+   except when `vendor-one.sh`'s glue gate fails,
+   where it is deliberately kept for the repair.
+2. **Refuse to run on a dirty tree.**
+   `git status --porcelain` must be empty.
+   A dirty *upstream* clone is only a warning.
+3. **Find the base.**
+   The newest `duckdb/duckdb@<sha>` in the subject
+   of the last 20 commits that touched `src/duckdb/`.
+   The pathspec narrows the walk and the subject decides:
+   patch-stack fixes edit the vendored tree in place and carry no upstream SHA,
+   so the scan looks past them.
+   `BASE_SCAN_DEPTH` raises the bound.
+   Coming up empty is not an answer —
+   both scripts refuse and name the bound they hit,
+   because an empty base leaves a range with a missing left side
+   that git resolves to the clone's `HEAD`, which nobody chose.
+4. **Enumerate candidates** (`vendor-one.sh` only):
+   `git log --first-parent --reverse <base>..<HEAD of clone>`.
+   An upstream PR merge is therefore one candidate,
+   and a commit reachable only through a second parent is never vendored on its own.
+5. **Regenerate and patch.**
+   Check the candidate out, `rm -rf src/duckdb`,
+   run `rconfigure.py` against the clone,
+   then apply the patch stack.
+6. **Decide whether the candidate is worth a commit.**
+   If `git describe --tags` resolves to an exact tag, it always is:
+   the subject gains a `(tag vX.Y.Z)` marker, and `vendor-one.sh` stops after committing.
+   Otherwise the regenerated tree must differ in **more than one** file under `src/duckdb/`.
+   One file always differs —
+   `src/duckdb/src/function/table/version/pragma_version.cpp`
+   carries the `DUCKDB_SOURCE_ID` of every commit —
+   so "more than one" is the test for a real change.
+   Upstream commits that touch only tests, CI, docs, or other clients
+   produce no vendor commit; the walk moves on to the next candidate.
+7. **Bump the version** (`vendor-one.sh` only):
+   the fifth component of `Version:` is incremented,
+   missing components padded with zeroes
+   (`1.5.4.9005` → `1.5.4.9005.1`, `1.2.3` → `1.2.3.0.1`),
+   so every vendor commit is installable as a distinct version on r-universe.
+8. **Commit** `git add .` with the message below.
+9. **Gate the glue** (`vendor-one.sh` only):
+   syntax-check every `src/*.cpp` against the freshly vendored headers,
+   four at a time, with `g++ -fsyntax-only`
+   and the flags a dry `R CMD SHLIB -n` prints
+   (so they always match the local setup; `./configure` runs first if needed).
+   It costs about 20 seconds, needs no link and no R session,
+   and catches every upstream API change the glue has to follow.
+   On failure the script exits 3
+   with the breaking commit at `HEAD` and the failing files
+   in `/tmp/vendor-one-glue-failures.txt`:
+   fix the glue and amend, do not add a follow-up commit.
+
+`vendor-one.sh --commits N` repeats steps 3–9 up to `N` times —
+the series loop passes 100 —
+stopping early on a tag or when no candidate remains.
+Its `VENDOR_REPO` variable names the checkout to vendor *into*,
+which must be the root of a worktree;
+that is what lets the loop run `main`'s copy of the script against a series' buffer.
+Only the script itself comes from `main` that way:
+everything it invokes by relative path —
+`scripts/rconfigure.py`, `patch/*.patch`, `./configure` —
+stays the target tree's,
+because those are coupled to the tree they generate and patch.
+
+## What `rconfigure.py` regenerates
+
+[`scripts/rconfigure.py`](/scripts/rconfigure.py) is where the vendored tree comes from.
+It imports `package_build` from the *upstream clone's* own `scripts/`,
+so upstream's packaging decides which sources are emitted;
+`DUCKDB_PATH` points it at the clone.
+It writes five committed things:
+
+* `src/duckdb/` — the engine sources for the package,
+  amalgamated into unity chunks of 20 translation units,
+  with `parquet` and `core_functions` linked in
+  (`DUCKDB_R_EXTENSIONS` adds more — a build knob,
+  see [`build/configuration/`](/handbook/build/configuration/README.md));
+* `src/include/sources.mk` — the object list the build compiles;
+* `R/version.R` — the vendored DuckDB version string,
+  parsed out of `pragma_version.cpp` with its `v` prefix stripped;
+* `src/Makevars` and `src/Makevars.win` — the include and link flags,
+  filled into `src/Makevars.in`.
+
+All five carry a "do not edit by hand" header, and all five are regenerated wholesale.
+Two consequences are worth knowing before reading a diff:
+
+**The tree is not byte-reproducible across clones.**
+`DUCKDB_SOURCE_ID` is an *abbreviated* commit id,
+and git auto-sizes that abbreviation from the number of objects in the clone it runs in.
+The same upstream commit vendors as `7300522cf0` from one clone and `7300522cf07` from another,
+and a single branch can contain both lengths at different points of its history.
+Nothing downstream breaks —
+`configure` compares only the first ten characters
+when it checks a prebuilt library against the vendored headers —
+but a diff between two vendorings of one upstream commit
+shows this line even when everything else is identical.
+Pin `core.abbrev` in the upstream clone if an exact match matters.
+
+**Regeneration costs about twice what it needs to.**
+All ~3550 vendored files are rewritten unconditionally,
+including the ones whose content did not change,
+which invalidates git's stat cache;
+both the "more than one changed file" test and the `git add` then re-hash the whole tree.
+Measured: `git status` over the vendored tree costs 1.06 s right after every file is touched
+and 0.017 s when the index is still valid,
+at two full passes per candidate — including candidates that are skipped —
+which is the bulk of the ~4.9 s a vendor commit takes on four cores.
+Writing only the files that actually differ would roughly halve it,
+in CI as well as locally.
+That is one of the items in
+[`plan/PLAN-vendoring-simplification.md`](/plan/PLAN-vendoring-simplification.md),
+which carries the intent for this pipeline.
+
+Two smaller facts about the script:
+it drops the bundled jemalloc tree from the source list,
+because the R package never defines `DUCKDB_ENABLE_JEMALLOC`
+and upstream's packaging started emitting sources that neither compile nor link without it;
+and `DUCKDB_BUILD_UNITY` does **not** work —
+the branch that reads it dereferences an undefined name
+and the bare `except` swallows the error, so the chunk size stays 20.
+When `DUCKDB_R_BINDIR`, `DUCKDB_R_CFLAGS` and `DUCKDB_R_LIBS` are all set,
+the script writes `src/Makevars` for a system-library build and exits
+without touching the vendored tree at all;
+that path belongs to [`build/fast-paths/`](/handbook/build/fast-paths/README.md).
+
+## The patch stack
+
+Not every upstream source is right for the R package as it stands.
+The R-specific fixes are kept as an ordered series of patches in
+[`patch/`](/patch/),
+and every vendor run re-applies the whole stack on top of the freshly regenerated tree,
+in file-name order, with `patch -p1 --forward` after a dry run.
+Numbers define the order; gaps in the numbering are normal
+and mark patches that were retired.
+
+The lifecycle has three moves:
+
+* **Adding one.**
+  Edit `src/duckdb/`, capture the diff as `patch/00NN-my-fix.patch` with the next free number,
+  then check it applies against a clean tree:
+
+  ```bash
+  git diff > patch/00NN-my-fix.patch
+  git checkout -- src/duckdb/
+  patch -p1 < patch/00NN-my-fix.patch
+  ```
+
+  Send the same change to `duckdb/duckdb` as a pull request,
+  so the patch can eventually be retired.
+* **Dropping one.**
+  When the fix lands upstream, delete the file. Never renumber the rest.
+* **Losing one.**
+  A patch that no longer applies is deleted *by the vendor run*,
+  and the deletion becomes part of that vendor commit —
+  on the assumption that the fix reached upstream.
+  Verify the assumption:
+  if the patch is still needed, restore it and rebase it against the new sources.
+
+Never edit `src/duckdb/` directly in a way you want to keep.
+The next run regenerates the directory from scratch, and the edit is gone.
+Which patches a given series carries is a series property, not a pipeline one —
+each series' stack is `main`'s minus what already landed in *that* series' upstream branch,
+stated as an invariant in
+[`branches/invariants/`](/handbook/branches/invariants/README.md).
+
+## The vendor commit
+
+Both scripts write the same message:
+
+```text
+vendor: Update vendored sources to duckdb/duckdb@<commit_hash>
+
+Date: <author date of the upstream commit>
+
+<subjects of the upstream first-parent commits since the previous base>
+```
+
+with `(tag v1.x.x)` inserted after `sources` when the commit is an exact tag,
+and `#N` in the collected subjects rewritten to a full
+`https://redirect.github.com/duckdb/duckdb/pull/N` link.
+
+The subject line is machine-readable state, not decoration.
+It is the only record of where a branch stands in upstream history:
+the base scan in step 3 parses it, and so do the series scripts and the repair playbooks.
+Do not reword it,
+and do not squash vendor commits together without keeping the newest SHA in the subject.
+
+## The `DESCRIPTION` merge driver
+
+The package version carries two counters that advance on different strands —
+the fourth component on the R-client strand,
+the fifth on the vendor strands, once per vendor commit (step 7 above).
+What the counters mean and who sets them is
+[`releases/versioning/`](/handbook/operations/releases/versioning/README.md)'s;
+what keeps them from halting every rebase is here.
+
+Because each strand owns one counter and freezes the other,
+a merge or forward-port between them conflicts on the `Version:` line of *every* commit.
+[`scripts/merge-version.sh`](/scripts/merge-version.sh) is a git merge driver
+that resolves that one line by taking the component-wise maximum of the two sides.
+The ownership split makes the maximum do the right thing without either side knowing about the other:
+it keeps the fourth component from the R-client strand and the fifth from the vendor strand.
+Every other line of `DESCRIPTION` still goes through a normal three-way merge,
+so a genuine concurrent edit — two branches touching `Imports:`, say — still surfaces as a conflict.
+If either side has no `Version:` line at all, the driver falls back to a plain three-way merge.
+
+**The prefix gate.**
+The driver combines counters only when the `major.minor.patch` prefix of both sides is equal;
+otherwise it keeps *ours* verbatim and never inherits a foreign prefix.
+That is a safety rail for cross-release forward-ports, such as 1.5.x onto the 1.4.x LTS.
+It also means the driver does **not** renumber a dev branch when the base moves to a new patch release:
+rebasing a series from `1.5.4.9005.N` onto a `1.5.5.9000` base
+leaves every commit at the base version rather than producing `1.5.5.9000.1`, `…2`, `…3`,
+and the vendor counter has to be re-applied explicitly, one commit at a time, as part of the rebase.
+The gate is doing its job here, but this is the one case
+where it silently does less than a reader might assume.
+
+**Wiring it up** takes two things.
+The `DESCRIPTION merge=ours-version` attribute lives in `.gitattributes` and is committed;
+the *name → command* mapping cannot live in a versioned file, so it is not.
+[`scripts/setup-git.sh`](/scripts/setup-git.sh) installs the mapping into `.git/config`,
+enables `rerere` so a genuine resolution survives repeated rebases,
+and pins `rebase.backend=merge` —
+the patch/`am` backend bypasses merge drivers entirely, so a rebase would ignore the driver.
+Run it once per clone,
+and as the first step of any CI job that rebases, cherry-picks, or merges in this repository.
+
+## Vendoring by hand
+
+The scripts expect the upstream clone one level *above* the package clone —
+`~/duckdb` next to `~/R/duckdb-r` is the layout the defaults assume.
+For a single upstream state, check the clone out at the commit you want and run `vendor.sh`,
+which vendors whatever `HEAD` is:
+
+```bash
+cd ~/duckdb && git checkout <branch-or-commit>
+cd ~/R/duckdb-r && scripts/vendor.sh ../../../duckdb
+R CMD INSTALL .
+```
+
+To replay a stretch of upstream history the way CI does,
+check the clone out at the **last** commit you want vendored, so the walk terminates by itself,
+and drive `vendor-one.sh` one commit at a time:
+
+```bash
+export MAKEFLAGS=-j$(nproc) NOT_CRAN=true DUCKDB_R_RUN_TESTS=true
+
+while scripts/vendor-one.sh ../../../duckdb --commits 1; do
+  rm -f src/*.o                                # see below — mandatory
+  R CMD INSTALL . --no-byte-compile || break   # repair, then `git commit --amend`
+  R -q -e 'testthat::test_local()'       || break
+done
+```
+
+`rm -f src/*.o` is not an optimisation; without it the loop means nothing.
+The `src/*.dd` dependency files deliberately record only local `include/` headers —
+`src/include/deps.mk` filters out everything under `duckdb/` —
+so `make` does not know that the glue objects depend on the vendored engine headers.
+The glue is then never recompiled after vendoring:
+API breakages go unnoticed,
+and the package is linked from objects built against a different engine.
+A fresh CI checkout does not have this problem, which is why it only bites locally.
+
+Three things make the loop affordable.
+**ccache**: adjacent vendor commits change a median of two `.cpp` files and no headers,
+so a warm cache turns a cold build of ~15 minutes into a couple of minutes.
+**Failing fast**: `OBJECTS = $(GLUE) $(SOURCES)` puts the 15 glue files first,
+so a glue compile error surfaces within a minute
+instead of after the engine has been rebuilt.
+**Skipping the engine when it did not change**:
+with the objects in place, a commit touching two `.cpp` files costs those two plus the relink.
+
+Measured on a four-core container replaying 81 vendor commits of upstream `main`:
+about 4 s to vendor and 30 s to run the testsuite per commit,
+against ~50 minutes for the initial cold build of a new engine tree.
+Build time is strongly **bimodal**, and the split is what to plan around —
+a median of 56 s with 57 % of commits under two minutes, but a maximum of 754 s,
+because a commit touching a widely-included header
+invalidates a large share of the ~345 unity objects at once.
+The mix depends on which branch is replayed:
+a release branch is cheaper than a mainline window in active pre-release development,
+so plan bulk replays off the pessimistic figure.
+
+When a commit breaks, fix the glue and `git commit --amend`,
+so the fix lands *in* the vendor commit that needs it and the history stays bisectable;
+then continue the loop.
+Never run `R CMD build` in a working tree you still need:
+the `cleanup` script runs `git clean -fdx src` and packs `src/duckdb/` into `src/duckdb.tar.xz`.
+
+## Limits
+
+* **A walk that vendors nothing can leave the tree dirty.**
+  When no candidate qualifies, `vendor-one.sh` restores `src/duckdb/` and stops,
+  but `rconfigure.py` has already rewritten `R/version.R` and the generated `Makevars`
+  for the last candidate it tried.
+  On a dev branch the version string changes with almost every upstream commit,
+  so this is the common case, and the *next* run then refuses on the dirty tree.
+  `git checkout -- .` before rerunning. `vendor.sh` restores `R/version.R` as well.
+* **There is no vendoring workflow.**
+  Nothing under `.github/workflows/` runs these scripts;
+  vendoring is driven by the routine, and CI's role is to build the commits it produces
+  ([`ci/per-commit/`](/handbook/operations/ci/per-commit/README.md)).
+* **The pipeline vendors DuckDB, and one other thing.**
+  [`scripts/vendor-rfuns.sh`](/scripts/vendor-rfuns.sh)
+  copies the `rfuns` extension sources from a `duckdb-rfuns` checkout into `src/`,
+  one commit per import.
+  It shares the base-scan idea but nothing else:
+  no patch stack, no version bump, no glue gate, and no routine drives it.
+* **Seeding a new series is not a plain vendor run.**
+  A new dev line has to start at the fork point of the two upstream branches,
+  which is not `git merge-base`,
+  and the R side has to be rewound to what that engine supports.
+  That procedure belongs to
+  [`series-loop/`](/handbook/operations/vendoring/series-loop/README.md).

--- a/scripts/VENDORING.md
+++ b/scripts/VENDORING.md
@@ -275,11 +275,10 @@ R CMD INSTALL .
 **Solution**: Commit or stash all changes before vendoring.
 
 **Issue**: A patch disappeared from `patch/`
-**Solution**: That is by design, and `vendor-one.sh` only does it
+**Solution**: That is by design, and both vendor scripts only do it
 when the patch reverses cleanly against the regenerated tree —
 its change is already there, so it landed upstream.
 A patch that neither applies nor reverses stops the run instead (exit 4).
-`vendor.sh` still deletes on any failure, without that check.
 See [the patch stack](/handbook/operations/vendoring/pipeline/README.md).
 
 **Issue**: Build failures after vendoring

--- a/scripts/VENDORING.md
+++ b/scripts/VENDORING.md
@@ -274,11 +274,12 @@ R CMD INSTALL .
 **Issue**: `Error: working directory not clean`
 **Solution**: Commit or stash all changes before vendoring.
 
-**Issue**: A patch silently disappeared from `patch/`
-**Solution**: That is by design —
-a patch that no longer applies is deleted by the vendor run,
-on the assumption that the fix landed upstream.
-Verify that assumption; if the patch is still needed, restore and rebase it against the new sources.
+**Issue**: A patch disappeared from `patch/`
+**Solution**: That is by design, and `vendor-one.sh` only does it
+when the patch reverses cleanly against the regenerated tree —
+its change is already there, so it landed upstream.
+A patch that neither applies nor reverses stops the run instead (exit 4).
+`vendor.sh` still deletes on any failure, without that check.
 See [the patch stack](/handbook/operations/vendoring/pipeline/README.md).
 
 **Issue**: Build failures after vendoring

--- a/scripts/VENDORING.md
+++ b/scripts/VENDORING.md
@@ -68,129 +68,11 @@ without re-basing its vendored history — see
 
 ## The Vendoring Scripts
 
-Both scripts regenerate `src/duckdb/` from scratch
-(`rm -rf src/duckdb`, then `DUCKDB_PATH=<clone> python3 scripts/rconfigure.py`),
-re-apply the patch stack, and commit.
-They differ only in how they choose *which* upstream commit to vendor.
-
-| Script                  | Chooses                                             | Bumps version | Typical use                                                        |
-|-------------------------|-----------------------------------------------------|---------------|--------------------------------------------------------------------|
-| `scripts/vendor.sh`     | the upstream clone's `HEAD`, whatever it is          | no            | one-off / manual, and to **seed** a new dev line at the fork point  |
-| `scripts/vendor-one.sh` | the next unvendored upstream commit(s), oldest first | yes           | the series loop, and any commit-by-commit walk                      |
-
-Shared behaviour, in the order it happens:
-
-1. **Locate the upstream clone.**
-   The positional argument is the source repository (default `../../../duckdb`).
-   Unless it is already called `duckdb`, it is cloned into `./duckdb` in the package root
-   (which is `.gitignore`d), and that clone is `rm -rf`ed when the script exits.
-   In CI the clone is created by `actions/checkout` into `./duckdb` instead.
-2. **Refuse to run on a dirty tree.**
-   `git status --porcelain` must be empty.
-3. **Find the base.**
-   The last `duckdb/duckdb@<sha>` mentioned in the subject of a recent commit that touched `src/duckdb/`.
-   The pathspec narrows the walk, the subject decides:
-   patch-stack fixes edit the vendored tree in place and carry no upstream SHA,
-   so the scan looks past them — 20 commits deep, the same bound `vendored_sha()` uses
-   in [`series-advance.sh`](series-advance.sh), and `BASE_SCAN_DEPTH` raises it.
-   Coming up empty is not an answer: both scripts refuse and say which bound they hit,
-   because an empty base turns the enumeration below into a range nobody chose.
-   This is the *only* record of where the branch stands in upstream history:
-   it is parsed out of the commit message, so vendor commit subjects must keep their exact format.
-4. **Enumerate candidates** (`vendor-one.sh` only):
-   `git log --first-parent --reverse <base>..<HEAD of clone>`.
-   Upstream PR merges therefore count as one commit each,
-   and commits reachable only through a second parent are never vendored on their own.
-5. **Regenerate and patch.**
-   For each candidate, check it out, regenerate `src/duckdb/`,
-   then apply every `patch/*.patch` in order.
-   **A patch that no longer applies is deleted**, and the deletion becomes part of the vendor commit —
-   see [Patch Stack](/BRANCHES.md#patch-stack).
-6. **Decide whether the commit is worth vendoring.**
-   * If `git describe --tags <commit>` resolves to an exact tag (a release), it is **always** vendored,
-     the subject gets a `(tag vX.Y.Z)` marker, and `vendor-one.sh` stops afterwards.
-   * Otherwise the regenerated tree must differ in **more than one** file under `src/duckdb/`.
-     One file always differs —
-     `src/function/table/version/pragma_version.cpp` carries the `DUCKDB_SOURCE_ID` of every commit —
-     so "more than one" is the test for a real change.
-     Upstream commits that only touch tests, CI, docs, or other clients produce no vendor commit;
-     the walk skips forward to the next candidate that does.
-7. **Bump the package version** (`vendor-one.sh` only):
-   the fifth component of `Version:` in `DESCRIPTION` is incremented
-   (`1.5.4.9005` → `1.5.4.9005.1` → `…9005.2`),
-   so every vendor commit is installable as a distinct version on r-universe.
-8. **Commit** with the message described in [Understanding Vendor Commits](#understanding-vendor-commits).
-
-`vendor-one.sh --commits N` repeats steps 3–8 up to `N` times (the routine uses 100),
-stopping early on a tag or when no candidates remain.
-
-### Two properties of the regenerated tree
-
-**It is not byte-reproducible across clones.**
-`src/function/table/version/pragma_version.cpp` records `DUCKDB_SOURCE_ID`
-as an *abbreviated* commit id,
-and git auto-sizes that abbreviation from the number of objects in the clone it runs in.
-The same upstream commit therefore vendors as `7300522cf0` from one clone
-and `7300522cf07` from another,
-and `main-dev` contains both lengths at different points in its own history.
-Nothing downstream breaks —
-`configure` and `scripts/install-libduckdb.sh` both substring-match the id —
-but a diff between two vendorings of the same upstream commit
-will show this one line even when everything else is identical.
-Pin `core.abbrev` in the upstream clone if an exact match matters.
-
-**Step 5 costs about twice what it needs to.**
-`rconfigure.py` rewrites all ~3550 vendored files unconditionally,
-including the ~3548 whose content did not change.
-That invalidates git's stat cache,
-so both the "> 1 changed file" test in step 6 and the `git add` in step 8
-re-hash the entire tree.
-Measured: `git status` over the vendored tree costs **1.06 s** right after every file is touched
-and **0.017 s** when the index is still valid.
-At two full passes per *candidate* — including candidates that are skipped
-because they changed nothing vendorable — this is the bulk of the per-commit cost
-(measured end to end: ~4.9 s per vendor commit on 4 cores).
-Writing only files whose content actually differs would roughly halve it,
-in CI as well as locally.
+The scripts, and what a run does step by step: [`operations/vendoring/pipeline/`](/handbook/operations/vendoring/pipeline/README.md).
 
 ## Version Counters and the Merge Driver
 
-The package version carries two counters that advance on different strands:
-
-* the **4th** component is the R-client counter,
-  bumped on the source-of-truth strand (`main`): `1.5.5.9000` → `1.5.5.9001` → …
-* the **5th** component is the vendor counter,
-  bumped once per vendor commit on the `*-dev` strands: `1.5.5.9000.1` → `…9000.2` → …
-
-Each strand owns exactly one counter and freezes the other,
-so a merge or forward-port between them conflicts on the `Version:` line of *every* commit.
-`scripts/merge-version.sh` is a git merge driver that resolves that line deterministically,
-by taking the component-wise maximum of the two sides.
-Because of the ownership split, the max keeps the 4th component from the R-client strand
-and the 5th from the vendor strand, without either side having to know about the other.
-Every other line of `DESCRIPTION` still goes through a normal three-way merge,
-so a genuine concurrent edit (two branches touching `Imports:`, say) still surfaces as a conflict.
-
-The driver is wired up by two things:
-the `DESCRIPTION merge=ours-version` attribute in `.gitattributes`, which is committed,
-and the *name → command* mapping, which cannot live in a versioned file.
-`scripts/setup-git.sh` installs the latter into `.git/config`,
-and also enables `rerere` and pins `rebase.backend=merge`
-(the patch/`am` backend bypasses merge drivers entirely, so a rebase would ignore the driver).
-Run it once per clone,
-and as the first step of any CI job that rebases, cherry-picks, or merges in this repo.
-
-**The prefix gate.**
-The driver only combines counters when the `major.minor.patch` prefix of both sides is equal;
-otherwise it keeps *ours* verbatim and never inherits a foreign prefix.
-That is a safety rail for cross-release forward-ports (1.5.x → 1.4.x LTS),
-but it also means the driver does **not** renumber a dev branch
-when the base moves to a new patch release.
-Rebasing a `*-dev` branch from `1.5.4.9005.N` onto a `1.5.5.9000` base
-leaves every commit at the base version rather than producing `1.5.5.9000.1`, `…2`, `…3`, …;
-the vendor counter has to be re-applied explicitly, one commit at a time,
-as part of the rebase. This is expected — the gate is doing its job — but it is the
-one case where the driver silently does less than a reader might assume.
+The merge driver, its wiring, and its prefix gate: [`operations/vendoring/pipeline/`](/handbook/operations/vendoring/pipeline/README.md).
 
 ## Automated Vendoring
 
@@ -258,102 +140,7 @@ instead of rewriting it.
 
 ## Manual Vendoring
 
-### Local development setup
-
-```bash
-# Ensure your clone structure:
-# ~/
-#   duckdb/          # Upstream DuckDB repository
-#   R/
-#     duckdb-r/      # This repository
-
-# Update DuckDB to desired branch/commit
-cd ~/duckdb
-git checkout desired_branch_or_commit
-
-# Run vendoring
-cd ~/R/duckdb-r
-scripts/vendor.sh ../../../duckdb
-
-# Build and test
-R CMD INSTALL .
-```
-
-`vendor.sh` vendors the upstream clone's current `HEAD`,
-so check the clone out at the exact commit you want before running it.
-
-### Commit-by-commit vendoring, verified locally
-
-This is the local equivalent of what CI does,
-and the loop to use when replaying a long stretch of upstream history
-(see [Starting a new dev line](#starting-a-new-dev-line-the-fork-point-rule)).
-Check the upstream clone out at the **last** commit you want vendored,
-so that the walk terminates by itself:
-
-```bash
-export MAKEFLAGS=-j$(nproc) NOT_CRAN=true DUCKDB_R_RUN_TESTS=true
-
-while scripts/vendor-one.sh ../../../duckdb --commits 1; do
-  rm -f src/*.o                                # see below — mandatory
-  R CMD INSTALL . --no-byte-compile || break   # repair, then `git commit --amend`
-  R -q -e 'testthat::test_local()'       || break
-done
-```
-
-`rm -f src/*.o` is not an optimisation, it is required for the loop to mean anything.
-The `src/*.dd` dependency files deliberately record only local `include/` headers
-(`src/include/deps.mk` filters out everything under `duckdb/`),
-so `make` does not know that the glue objects depend on the vendored engine headers.
-Without the `rm`, the glue is never recompiled after vendoring:
-API breakages go unnoticed and the package is linked from objects
-built against a different engine.
-A fresh CI checkout does not have this problem, which is why it only bites locally.
-
-Three things make this affordable:
-
-* **ccache.**
-  Adjacent vendor commits change a median of two `.cpp` files and no headers,
-  so a warm ccache turns a ~15 minute cold build into a couple of minutes;
-  wide-header commits are the exception, not the rule
-  (measured in [history/vendoring-loop.md](/plan/history/vendoring-loop.md) Appendix A).
-  Point R at it via `~/.R/Makevars` (`CXX = ccache g++`, …)
-  and give it a cache large enough to hold several trees (`ccache --max-size=20G`).
-  Note that ccache reads `$CCACHE_DIR/ccache.conf` (i.e. `~/.ccache/ccache.conf`)
-  in preference to `~/.config/ccache/ccache.conf` once the legacy directory exists —
-  a `--set-config` that lands in the wrong file silently keeps the 5 GB default.
-* **Failing fast.**
-  Most breakages are glue-code compile errors,
-  and `OBJECTS = $(GLUE) $(SOURCES)` puts the ~15 glue files first,
-  so they fail within a minute rather than after the engine has been rebuilt.
-  To check the glue alone, without building anything, compile it with `-fsyntax-only`
-  using the flags `R CMD INSTALL` prints.
-* **Skipping the engine when it did not change.**
-  With the objects already in place, a vendor commit that touches two `.cpp` files
-  costs only those two plus the glue relink.
-
-Measured on a 4-core container (R 4.5.3, ccache 4.9.1, `-O2` without `-g`, no LTO),
-replaying 81 vendor commits of upstream `main` one at a time:
-about 4 s to vendor and 30 s to run the testsuite, against ~50 minutes
-for the initial cold build of a new engine tree.
-Build time is strongly **bimodal**, and the split is what to plan around:
-
-| | median | min | max | share under 2 min | total |
-|---|---|---|---|---|---|
-| 81 commits, fork point → 102 upstream first-parent commits later | 56 s | 15 s | 754 s | 46/80 (57 %) | ~5 h |
-
-The cheap mode is a commit that changes only `.cpp` files;
-the expensive mode is a commit touching a widely-included header,
-which invalidates a large share of the ~345 unity objects at once.
-Note that the mix depends on *which* branch is being replayed:
-Appendix A of [history/vendoring-loop.md](/plan/history/vendoring-loop.md) measured a release branch,
-where 66 % of commits touch no header at all,
-whereas a mainline window in active pre-release development
-runs closer to a 57/43 split — plan bulk replays off the pessimistic figure.
-
-When a commit breaks, fix the glue and `git commit --amend`
-so the fix lands *in* the vendor commit (invariant 3), then continue the loop.
-Never run `R CMD build` in a working tree you still need:
-the `cleanup` script runs `git clean -fdx src` and packs `src/duckdb/` into `src/duckdb.tar.xz`.
+Vendoring by hand, and the local commit-by-commit loop: [`operations/vendoring/pipeline/`](/handbook/operations/vendoring/pipeline/README.md).
 
 ## Starting a New Dev Line: the Fork-Point Rule
 
@@ -436,7 +223,7 @@ this list is the sources-and-glue side it drives):
    that have nothing to do with the engine.
 4. Check the upstream clone out at the branch tip
    and walk forward with the
-   [commit-by-commit loop](#commit-by-commit-vendoring-verified-locally).
+   [commit-by-commit loop](/handbook/operations/vendoring/pipeline/README.md).
 
 Step 3 is only needed for the line that *rewinds*,
 i.e. the mainline whose fork point predates the current release.
@@ -445,28 +232,7 @@ at a point the package already builds against, so it needs no rewind.
 
 ## Understanding Vendor Commits
 
-Vendor commits follow a specific format:
-
-```text
-vendor: Update vendored sources to duckdb/duckdb@<commit_hash>
-
-Date: <author date of the upstream commit>
-
-<subjects of the upstream first-parent commits since the previously vendored commit>
-```
-
-For tagged releases:
-
-```text
-vendor: Update vendored sources (tag v1.x.x) to duckdb/duckdb@<commit_hash>
-```
-
-The subject line is machine-readable state:
-`vendor-one.sh`, `series-advance.sh`, `series-port.sh` and the repair skills
-all recover "where is this branch in upstream history"
-by parsing `duckdb/duckdb@<sha>` out of it.
-Do not reword it, and do not squash vendor commits together
-without keeping the newest SHA in the subject.
+The vendor commit message, and why its subject is machine-readable state: [`operations/vendoring/pipeline/`](/handbook/operations/vendoring/pipeline/README.md).
 
 ## Troubleshooting
 
@@ -513,7 +279,7 @@ R CMD INSTALL .
 a patch that no longer applies is deleted by the vendor run,
 on the assumption that the fix landed upstream.
 Verify that assumption; if the patch is still needed, restore and rebase it against the new sources.
-See [Patch Stack](/BRANCHES.md#patch-stack).
+See [the patch stack](/handbook/operations/vendoring/pipeline/README.md).
 
 **Issue**: Build failures after vendoring
 **Solution**: Usually a DuckDB C++ API change;
@@ -587,58 +353,11 @@ git log -1 --grep="^vendor:" --format=%s   # upstream commit it came from
 
 ## Files and Directories
 
-### Key vendoring files
-
-- `scripts/vendor.sh` - Manual vendoring of one specific upstream state
-- `scripts/vendor-one.sh` - Commit-by-commit vendoring (used by the series loop)
-- `scripts/each-plan.sh` - Selects commits with no verdict on the `rcc` branch and shards them by predicted build cost
-- `scripts/each-cost.py` - Counts the unity objects a commit invalidates, from the include graph
-- `scripts/each-shard.sh` - Builds one shard of commits in a single job
-- `scripts/rcc-one.sh` - The per-commit `rcc` gate
-- `scripts/each-harvest.sh` - Folds the shards' results onto the orphan `rcc` branch
-- `scripts/rcc-part-push.sh` - Publishes one commit's result to the `rcc` branch from the leg that decided it
-- `scripts/rcc-decided.sh` - Lists the commits the `rcc` branch has a verdict for; what work selection reads (see [`EACH.md`](EACH.md))
-- `scripts/rcc-merge.sh` - Brings `runs2.ndjson` level with the records in `runs2.d/`
-- `scripts/rcc-consolidate.sh` - Manual: makes the layouts agree, GCs logs older than a month, squashes the `rcc` branch
-- `scripts/rconfigure.py` - Regenerates `src/duckdb/`, `src/include/sources.mk`, `R/version.R`
-- `scripts/setup-git.sh` - Registers the `DESCRIPTION` merge driver, `rerere`, and `rebase.backend=merge`
-- `scripts/merge-version.sh` - The merge driver itself (see [Version counters and the merge driver](#version-counters-and-the-merge-driver))
-- `.github/workflows/each.yaml` - Per-commit CI as a sharded matrix (see [`EACH.md`](EACH.md))
-- `patch/*.patch` - R-specific patches applied to vendored code
-  (see [Patch Stack](/BRANCHES.md#patch-stack))
-
-### Vendored content
-
-- `src/duckdb/` - Complete DuckDB C++ source code (DO NOT modify directly)
-- `R/version.R` - The vendored **DuckDB** version, generated by `rconfigure.py`
-- `src/include/sources.mk` - Object list for the package build, generated by `rconfigure.py`
-
-### Generated content
-
-- `./duckdb/` - Temporary clone of the DuckDB repository, removed when the script exits
+What each file in `scripts/` is for: the generated index, [`README.md`](README.md). What the pipeline generates and consumes: [`operations/vendoring/pipeline/`](/handbook/operations/vendoring/pipeline/README.md).
 
 ## Development Guidelines
 
-### When working with vendored code
-
-1. **Never modify `src/duckdb/` directly** - changes will be overwritten by the next vendor run
-2. **Use patches**: create `.patch` files in `patch/` for necessary changes,
-   and send the same change upstream so the patch can be retired
-3. **Update `rconfigure.py`**: for R-specific build configuration changes
-4. **Keep the fix in the commit that needs it**:
-   an R-side fix for a vendored API change belongs in the vendor commit that introduced the break,
-   so the history stays bisectable
-
-### Creating patches
-
-```bash
-# 1. Make changes to src/duckdb/
-# 2. Generate patch
-git diff > patch/00NN-my-fix.patch
-# 3. Test that patch applies cleanly
-git checkout -- src/duckdb/
-patch -p1 < patch/00NN-my-fix.patch
-```
+Working with vendored code, and the patch-stack lifecycle: [`operations/vendoring/pipeline/`](/handbook/operations/vendoring/pipeline/README.md).
 
 ## Release Considerations
 

--- a/scripts/vendor-one.sh
+++ b/scripts/vendor-one.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Vendors DuckDB sources commit-by-commit from the upstream repository.
 # Used by the series loop (.claude/skills/series-loop.md)
-# See scripts/VENDORING.md for complete documentation
+# See handbook/operations/vendoring/pipeline/ for what this does and why.
 # https://unix.stackexchange.com/a/654932/19205
 # Using bash for -o pipefail
 

--- a/scripts/vendor.sh
+++ b/scripts/vendor.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Vendors DuckDB sources from the upstream repository (manual vendoring).
 # For manual testing and development use
-# See scripts/VENDORING.md for complete documentation
+# See handbook/operations/vendoring/pipeline/ for what this does and why.
 # https://unix.stackexchange.com/a/654932/19205
 # Using bash for -o pipefail
 


### PR DESCRIPTION
## Documentation only — the code moved to #2491

This branch was rebuilt to carry the five `docs`/`docs(handbook)` commits and
nothing else. Every change to `scripts/vendor.sh`, `scripts/vendor-one.sh`,
`scripts/rconfigure.py` and the generated `scripts/README.md` is now in
**#2491**, together with the comment strip.

**The split is by artifact, not by intent**, and that is deliberate: the
comment deletions are a documentation change in spirit, but they are
interleaved with the functional hunks in the same three files, and splitting
a file across two PRs would guarantee conflicts between our own branches.
`scripts/VENDORING.md` stays here, being prose that happens to live under
`scripts/`.

**#2491 merges first.** The leaf below describes the *fixed* behaviour —
exit 4, the retirement message, the clean tree after a no-op run — as the
pipeline's rule rather than as a caution. Merged the other way round, it
documents behaviour the scripts do not yet have.

The two branches together reproduce this PR's pre-split tree byte-for-byte;
checked with `git merge-tree --write-tree` against the original tip.

## What this leaf now owns

`handbook/operations/vendoring/pipeline/` explains the machinery that turns
one upstream DuckDB commit into one vendor commit: `vendor.sh` and
`vendor-one.sh` (how each picks its commit, the shared nine-step run,
`--commits`, `VENDOR_REPO`, and the glue gate that exits 3 with the breaking
commit at `HEAD`), what `rconfigure.py` regenerates, the patch-stack
lifecycle — adding, dropping, and breaking a patch in a vendor run — the
vendor commit message and why its subject is machine-readable state, the
`DESCRIPTION` merge driver with its prefix gate and the `setup-git.sh`
wiring, and vendoring by hand including the mandatory `rm -f src/*.o`. It
closes with its limits: `vendor-rfuns.sh` is a separate path, and seeding a
new series is not a plain vendor run. The schedule and playbooks are linked
to `series-loop/`, how far each firing runs the scripts to `branches/model/`,
red runs to `troubleshooting/`, the counters themselves to
`releases/versioning/`, the build knobs to `build/configuration/`, and the
tarball caution to `build/source-build/`.

The rule the leaf now states once and plainly, because #2491's exit-4 change
is what makes it true: **a vendor run either succeeds or dies trying, and
talks about it.** Nothing is dropped, skipped, or worked around to keep a run
alive; every stop names what stopped it, where it left the tree and the
upstream clone, and what to do next.

## What moved

* **`scripts/VENDORING.md`** — lost §§ "The Vendoring Scripts", "Version
  Counters and the Merge Driver", "Manual Vendoring", "Understanding Vendor
  Commits", "Files and Directories" and "Development Guidelines"; each
  heading remains with a one-line pointer at the leaf, so anchors elsewhere
  keep resolving. Two surviving cross-references (the commit-by-commit loop,
  the patch stack) now point at the leaf.
* **`BRANCHES.md`** — lost § "Patch Stack" and the "The DESCRIPTION merge
  driver" subsection of § "Version Numbering", both replaced by pointers;
  gained the visible italic handbook backreference under its H1. Its
  § Synchronization › Vendoring also said `-dev` is consumed "**up to 25
  commits at a time**" — a default that has never been the default:
  `scripts/series-advance.sh` has `chunk=${2:-100}`. Two sibling leaves
  tripped over the contradiction and correctly left it, because that section
  is this leaf's territory. The sentence now states the shape and links
  `branches/model/`, which owns the number. (`RELEASE.md` carries the same
  false 25 at line 111; #2471 deletes that section wholesale, so it is left
  alone here to avoid a conflict. `scripts/EACH.md`'s 25 is an example batch
  size, not a claim about the default — that document already says the cap is
  100.)
* **`README.md`** — the `## Vendoring` section and the `## Documentation`
  entry now point at `handbook/operations/vendoring/` instead of
  `scripts/VENDORING.md`. Its `## Building` section's clone-layout
  instruction was **wrong** and is corrected — see below.
* **`AGENTS.md`** — the sentence describing the two vendor scripts as
  behaving differently around a failing patch is gone, because after #2491
  they do not.
* **`build/source-build/` (#2481)** — the "never run `R CMD build` in a
  working tree you still need" caution moved there, restated in that leaf's
  voice beside the `cleanup` script it is about. Removed here.
* **`build/configuration/` (#2479)** — the `DUCKDB_BUILD_UNITY` row and the
  `DUCKDB_R_BINDIR`/`CFLAGS`/`LIBS` paragraph are removed there, because
  #2491 deletes both knobs. That PR no longer depends on this one, but it
  does depend on #2491 landing.

## The clone layout was wrong everywhere

The leaf, the root `README.md`, and `AGENTS.md`-era prose all said the
`duckdb-r` clone sits "one level deeper" than the `duckdb` clone, e.g.
`duckdb` and `R/duckdb-r`. Read from the code, that is off by one:

* `vendor.sh` runs `cd "$(dirname "$0")"/..` and `vendor-one.sh` runs
  `cd "${VENDOR_REPO:-$(dirname "$0")/..}"`, so both resolve relative paths
  **from the package root**.
* The default source repository in both is
  `upstream_basedir=../../../${project}` — **three** levels up from the
  package root.

So the package clone has to sit two directories *deeper* than the upstream
clone. With the upstream clone at `~/git/duckdb`, `~/git/R/duckdb/duckdb-r`
is a package clone the defaults find with no argument — which is the
maintainer's actual layout. The old root `README.md` block
(`cd R/duckdb-r && scripts/vendor.sh`) could not have worked as written. Both
the leaf and the root `README.md` now state it correctly and use `~/git/...`
paths; any other layout still works by passing the upstream path as the
positional argument.

## Issues linked as boundaries

* **#2489 — the vendored tree is not byte-reproducible across clones.**
  `DUCKDB_SOURCE_ID` is an abbreviated commit id and git sizes the
  abbreviation from the clone it runs in, so one upstream commit vendors as
  `7300522cf0` from one clone and `7300522cf07` from another.
* **#2490 — `rconfigure.py` rewrites all ~3550 files unconditionally**,
  invalidating git's stat cache twice per candidate, including for candidates
  that are skipped.

Both are linked from the leaf in a line each, instead of being narrated as
properties of a diff; both are changes to vendored output rather than to the
scripts' control flow, which is why neither is in #2491. The earlier claim
that the second was "one of the items in
`plan/PLAN-vendoring-simplification.md`" was not true — the plan does not
carry it.

Two further intents are linked rather than restated: **#2488** (should the
merge driver keep the larger version instead of *ours*?) from the prefix-gate
paragraph, and **`duckdb/duckdb#22811`** from the jemalloc sentence, so a
reader sees that fact is provisional and where to check it.

## What was cut as belonging elsewhere

* "the series loop passes 100" → the consumption bound is `branches/model/`'s;
  the leaf links it, and so does the corrected sentence in `BRANCHES.md`.
* "There is no vendoring workflow" → `series-loop/` already states it; the
  duplicate limit is gone, and the surviving `series-loop/` link says that
  leaf also owns what schedules these scripts.
* `VENDOR_REPO`'s two-paragraph rationale → one sentence plus a link to
  `series-loop/`'s first stage.
* The `R CMD build` caution → `build/source-build/` (#2481).

**Judged shared and kept**: the hand-replay section — `rm -f src/*.o`,
ccache, `OBJECTS = $(GLUE) $(SOURCES)` failing fast, and the bimodal
build-time figures. These are what a person driving `vendor-one.sh` by hand
needs; `series-loop/` is about the routine's stages and carries no cost
model.

## Verification

`Rscript .claude/skills/docs-consistency/docs-readme.R --check` and the
handbook link check (no dangling target, none starting with `../`) are clean
on this branch, as are `bash -n` on both vendor scripts and
`python3 -m py_compile scripts/rconfigure.py` — unchanged here, and verified
separately on #2491.

The one thing this leaf asserts that cannot be checked from this branch alone
is that the scripts behave as described; that is #2491's diff, and the merge
order above is what keeps the two honest.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PD23hjFQFRWW62HFvru187)_