### PR TITLE
docs(handbook): Write the build/configuration leaf

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # DuckDB R Package - Operational Instructions
 
+*Handbook: [`build/configuration/`](/handbook/build/configuration/README.md).*
+
 R package that contains a vendored copy of the DuckDB C++ library and glue code for R, including a DBI and a relational interface.
 
 ## Where to look
@@ -25,7 +27,7 @@ start there rather than searching.
 
 - `sudo apt-get install -y r-base r-base-dev build-essential` -- installs R and development tools
 - `mkdir -p ~/R/library && echo '.libPaths("~/R/library")' > ~/.Rprofile` -- sets up local R library
-- `export MAKEFLAGS="-j$(nproc)"` -- enables parallel compilation
+- Build knobs -- `MAKEFLAGS` and parallelism, ccache, `UserNM`, the object-file archive, and everything else the build reads from the environment: [`handbook/build/configuration/`](/handbook/build/configuration/README.md)
 - `UserNM=true R CMD INSTALL . --no-byte-compile` -- builds and installs the package. NEVER CANCEL: takes 10-15 minutes on first build. Set timeout to 30+ minutes.
 
 `UserNM=true` is an install-time shortcut only -- **never export it for `R CMD check`**.

--- a/README.md
+++ b/README.md
@@ -114,8 +114,9 @@ Then, install:
 ~duckdb-r: R CMD INSTALL .
 ```
 
-Set the `MAKEFLAGS` environment variable to `-j8` or similar for parallel builds.
-Configure `ccache` for faster repeated builds.
+The build knobs — parallelism, `ccache`, the object-file archive, and the
+rest — are documented in
+[`handbook/build/configuration/`](/handbook/build/configuration/README.md).
 
 If you wish to test new DuckDB functionality with duckdb-r, make sure your clone of `duckdb-r` is one level deeper than your clone of `duckdb` (e.g. `R/duckdb-r` and `duckdb`).
 Then run the following commands:

--- a/handbook/build/configuration/README.md
+++ b/handbook/build/configuration/README.md
@@ -1,19 +1,123 @@
 # Configuration
 
-*Stub — this leaf will own its topic;
-today it routes to where the knowledge lives.
-The writing protocol is in [`meta/handbook/`](/handbook/meta/handbook/);
-the last section holds this leaf's parameters.*
+The knobs that change how the package builds:
+the environment variables `configure` and `src/Makevars` read,
+the settings that live in `~/.R/Makevars` rather than in the environment,
+and the variables the vendoring script reads when it *generates*
+`src/Makevars`.
+What the build then does with them is
+[`build/source-build/`](/handbook/build/source-build/README.md)'s topic;
+the runtime settings that share the `DUCKDB_R_` prefix are not build knobs
+and are listed under [Not build knobs](#not-build-knobs) below.
 
-Scope: the build knobs: `MAKEFLAGS`, ccache, `UserNM`,
-and the extension flags.
+## Build knobs
 
-Today:
+Read while the package is being built,
+so exporting one before `R CMD INSTALL .`
+(or before `pkgload::load_all()`, which builds the same way)
+is all it takes.
 
-* [`AGENTS.md`](/AGENTS.md)
+| Knob | What it does | Default | When to set |
+|---|---|---|---|
+| `MAKEFLAGS` | Passed to `make`; only `-j` matters here. When it is empty, `configure` fills it in from [`scripts/setup-makeflags.R`](/scripts/setup-makeflags.R) and prints what it chose; when it is set, `configure` prints it and leaves it alone. | `-j` with the smaller of `parallel::detectCores()` and 2, so `-j2` on any multicore box; the cap is lifted when `NOT_CRAN` is truthy | To pin parallelism yourself: `export MAKEFLAGS="-j$(nproc)"` |
+| `NOT_CRAN` | Lifts the two-core cap that `scripts/setup-makeflags.R` puts on its guess, per CRAN's policy for checks. Matched case-insensitively against `true`, `1`, `yes`; anything else counts as false. | unset, so the cap applies | A local build that should use every core without your naming a `-j` |
+| ccache | Not an environment variable — the compilers are wrapped in `~/.R/Makevars`. Turns a repeat build of the vendored tree from minutes into seconds. | off | Any machine that compiles the vendored tree more than once |
+| `UserNM` | Names the `nm` program R uses to build `symbols.rds`, which [`src/Makevars.in`](/src/Makevars.in) puts on the `all:` target. `UserNM=true` skips the sweep. | unset, so R takes `nm` from `PATH` | An install-time shortcut only, never for `R CMD check`; it saves about 10–20 s on this tree |
+| `DUCKDB_R_PREBUILT_ARCHIVE` | Path to a `.tar` of the vendored object files. If the file exists and extracts, `configure` uses [`src/include/from-tar.mk`](/src/include/from-tar.mk) and nothing is recompiled; otherwise it uses `to-tar.mk` (`to-tar-win.mk` on Windows), which writes the archive once the objects are built. | unset, so objects are built normally and no archive is written | CI. Locally ccache does the same job better, as `configure`'s own comment says |
+| `DUCKDB_R_USE_SYSTEM_LIB` | Links a prebuilt libduckdb instead of compiling the vendored sources — see [`build/fast-paths/`](/handbook/build/fast-paths/README.md). | unset | — |
+| `DUCKDB_R_LIB_DIR` | Directory holding `libduckdb.so` / `.dylib`. Read only while the system-lib opt-in is active. | `pkg-config --variable=libdir duckdb`, then `/usr/local/lib`, `/opt/homebrew/lib`, `/usr/lib/x86_64-linux-gnu`, `/usr/lib/aarch64-linux-gnu`, `/usr/lib` | libduckdb sits in a prefix none of those cover |
+| `PKG_BUILD_EXTRA_FLAGS` | pkgbuild's knob, so it applies to `pkgload::load_all()` and `devtools`, not to `R CMD INSTALL`. When on, pkgbuild merges `-UNDEBUG -Wall -pedantic -g -O0` over your `~/.R/Makevars`. | `true` (`false` and `missing` are the other accepted values) | `false`, to keep the optimisation settings you configured. CI sets it in [`install/action.yml`](/.github/workflows/install/action.yml) |
+| `DUCKDB_R_POISON_ENGINE` | Not read by the build itself: [`before-install/action.yml`](/.github/workflows/custom/before-install/action.yml) reacts to it by appending `CPPFLAGS += -DDUCKDB_R_POISON_ENGINE` to `~/.R/Makevars`, which turns `DUCKDB_R_POISON_GUARD()` in [`src/include/rapi.hpp`](/src/include/rapi.hpp) into an unconditional `cpp11::stop()`. | unset | Only through the matrix entry that carries it ([`operations/ci/matrix/`](/handbook/operations/ci/matrix/README.md)); what it proves is [`testing/guards/`](/handbook/testing/guards/README.md)'s |
 
-To write this leaf:
+**ccache.**
+Infer each compiler default with `R CMD config` and prepend `ccache`,
+rather than writing `CXX = ccache g++` by hand:
+the inferred value carries the flags R selects for that version,
+and the versioned `CXX11`…`CXX23` switches deliberately come out bare
+because R applies the standard separately through `CXXnnSTD`.
+[`install/action.yml`](/.github/workflows/install/action.yml) does exactly
+that, and also sets `CCACHE_SLOPPINESS=locale,time_macros`;
+[`each.yaml`](/.github/workflows/each.yaml) additionally moves `CCACHE_DIR`
+outside the workspace and raises `max_size`, because the shard it runs
+wipes the workspace between commits.
 
-* absorb: the knob prose from `AGENTS.md` into one row per knob —
-  `MAKEFLAGS`, ccache, `DUCKDB_R_EXTENSIONS`,
-  `DUCKDB_R_PREBUILT_ARCHIVE`: what it does, default, when to set
+**`UserNM`.**
+`UserNM=true` is a development shortcut and nothing more.
+The same R function serves the install-time `symbols.rds` target *and*
+the symbol scan `R CMD check` runs on the built shared object,
+so exporting it silently weakens a check —
+see [`build/source-build/`](/handbook/build/source-build/README.md)
+for what goes wrong.
+
+**`DUCKDB_R_PREBUILT_ARCHIVE`.**
+Only the presence of a readable file switches the build to reuse;
+setting the variable to a path that does not exist yet is how you ask for
+the archive to be *written*.
+CI keys the cached archive on the R version, the runner OS, the compiler
+version, and a hash of `src/duckdb/`, in
+[`after-install/action.yml`](/.github/workflows/custom/after-install/action.yml).
+On Windows the reuse branch additionally requires R >= 4.2,
+because earlier versions build multiarch.
+
+## Vendoring-time knobs
+
+[`scripts/rconfigure.py`](/scripts/rconfigure.py) generates `src/Makevars`
+and `src/include/sources.mk` from `src/Makevars.in` during a vendoring run,
+and the results are committed.
+Setting one of these at install time therefore does nothing —
+they only take effect through a vendoring run
+([`operations/vendoring/pipeline/`](/handbook/operations/vendoring/pipeline/README.md)).
+
+| Knob | What it does | Default | When to set |
+|---|---|---|---|
+| `DUCKDB_R_EXTENSIONS` | Comma-separated extension names appended to the built-in list. Each one contributes `-DDUCKDB_EXTENSION_<NAME>_LINKED`, its include flags, and its sources. Merely defining the variable triggers the append, so an empty value appends an empty name. | `parquet`, `core_functions` — the two statically linked in every build ([`usage/extensions/`](/handbook/usage/extensions/README.md)) | Re-vendoring with a further in-tree extension linked in |
+| `DUCKDB_DEBUG_MOVE` | Adds `-DDUCKDB_DEBUG_MOVE` to the generated `PKG_CPPFLAGS`. Triggered by the variable being defined, whatever its value. | unset | Chasing a use-after-move in the engine |
+| `DUCKDB_R_LINENR` | Passed on to upstream's `package_build.build_package()` as its `linenr` argument. Any non-empty value is true, including `0` and `false`. | unset, i.e. false | Rarely — what it produces is decided by `package_build.py`, which lives in the DuckDB checkout and not here, so it is not verifiable from this repository |
+| `DUCKDB_PATH` | Where the DuckDB checkout is. | `../duckdb` | Set for you by the vendoring scripts |
+| `DUCKDB_BUILD_UNITY` | Intended to set the unity-build chunk size — but see below: it does nothing. | 20, always | Never |
+
+`DUCKDB_BUILD_UNITY` is inert.
+`rconfigure.py` checks that the variable is defined and then converts a bare
+Python name rather than the environment entry,
+which raises `NameError` into a bare `except`,
+so the default of 20 always survives.
+It is listed as it behaves, not as it reads;
+making it work is a code change, not a documentation one.
+
+`DUCKDB_R_BINDIR`, `DUCKDB_R_CFLAGS` and `DUCKDB_R_LIBS` are a fourth
+vendoring-time knob, taking effect only when all three are set together:
+`rconfigure.py` then writes a `src/Makevars` with no sources and link flags
+derived from an existing DuckDB installation, and exits before it touches
+`src/duckdb/`.
+Nothing in this repository sets them, and no CI job exercises the path;
+the maintained way to link against a prebuilt engine is
+[`build/fast-paths/`](/handbook/build/fast-paths/README.md).
+
+## Not build knobs
+
+Several variables share the `DUCKDB_R_` prefix without touching the build,
+and are documented where they act:
+
+* `DUCKDB_R_HOME` and `DUCKDB_R_TEMP_DIRECTORY` —
+  [`usage/storage/`](/handbook/usage/storage/README.md)
+* `DUCKDB_R_ALLOW_EXTENSIONS` —
+  [`usage/extensions/`](/handbook/usage/extensions/README.md)
+* `DUCKDB_R_RUN_TESTS` —
+  [`testing/suite/`](/handbook/testing/suite/README.md).
+  `NOT_CRAN` has a second life there and in `R/s3_register.R`;
+  only its effect on `-j` is a build knob
+* `DUCKDB_R_LIB_VERSION` and `DUCKDB_R_LIB_URL`, which steer
+  `scripts/install-libduckdb.sh` rather than the build —
+  [`build/fast-paths/`](/handbook/build/fast-paths/README.md)
+
+Three more are outputs rather than inputs, and setting them by hand achieves
+nothing: `DUCKDB_RSTRTMGR`, which `configure` writes into
+`src/Makevars.rstrtmgr`, and `DUCKDB_R_PREBUILT_ARCHIVE_GHA_CACHE_KEY` and
+`DUCKDB_R_UNRELEASED`, which the CI actions compute for themselves.
+
+There is no knob for the C++ standard, the optimisation level, or the
+warning set: `src/Makevars.in` pins `CXX_STD = CXX17` and leaves the rest to
+R's own `Makeconf`, which is what a user Makevars overrides.
+Nor is there one for suppressing compiler warnings — that is a policy, not a
+setting, and it belongs to
+[`architecture/glue/`](/handbook/architecture/glue/README.md).

--- a/handbook/build/configuration/README.md
+++ b/handbook/build/configuration/README.md
@@ -74,15 +74,24 @@ they only take effect through a vendoring run
 | `DUCKDB_DEBUG_MOVE` | Adds `-DDUCKDB_DEBUG_MOVE` to the generated `PKG_CPPFLAGS`. Triggered by the variable being defined, whatever its value. | unset | Chasing a use-after-move in the engine |
 | `DUCKDB_R_LINENR` | Passed on to upstream's `package_build.build_package()` as its `linenr` argument. Any non-empty value is true, including `0` and `false`. | unset, i.e. false | Rarely — what it produces is decided by `package_build.py`, which lives in the DuckDB checkout and not here, so it is not verifiable from this repository |
 | `DUCKDB_PATH` | Where the DuckDB checkout is. | `../duckdb` | Set for you by the vendoring scripts |
-| `DUCKDB_BUILD_UNITY` | Intended to set the unity-build chunk size — but see below: it does nothing. | 20, always | Never |
+| `DUCKDB_BUILD_UNITY` | The unity-build chunk size handed to upstream's `package_build.build_package()` as its `unity_count` argument. Read and validated here; upstream disregards it — see below. | 20 | Nothing in the generated tree responds to it, so in practice never |
 
-`DUCKDB_BUILD_UNITY` is inert.
-`rconfigure.py` checks that the variable is defined and then converts a bare
-Python name rather than the environment entry,
-which raises `NameError` into a bare `except`,
-so the default of 20 always survives.
-It is listed as it behaves, not as it reads;
-making it work is a code change, not a documentation one.
+`DUCKDB_BUILD_UNITY` is read correctly and then disregarded downstream.
+`rconfigure.py` takes the value from the environment,
+keeps the default of 20 when it is unset or empty,
+and exits with a message when it is anything but a positive integer,
+so a malformed value stops the vendoring run rather than passing unnoticed.
+The value then travels to `package_build.build_package()` as `unity_count`,
+and that is as far as it gets:
+upstream's `generate_unity_builds()` accepts the split count and never uses it,
+and unity grouping is decided per directory by `add_library_unity`
+in upstream's CMakeLists.
+Every upstream version this package has followed behaves that way,
+from v0.8.1 through the vendored v1.5.5 and `main`.
+Setting the knob therefore changes the vendoring run's inputs
+and not the tree it commits.
+`package_build.py` lives in the DuckDB checkout and not here,
+so honouring the chunk size is an upstream change.
 
 `DUCKDB_R_BINDIR`, `DUCKDB_R_CFLAGS` and `DUCKDB_R_LIBS` are a further
 vendoring-time knob, taking effect only when all three are set together:

--- a/handbook/build/configuration/README.md
+++ b/handbook/build/configuration/README.md
@@ -74,33 +74,6 @@ they only take effect through a vendoring run
 | `DUCKDB_DEBUG_MOVE` | Adds `-DDUCKDB_DEBUG_MOVE` to the generated `PKG_CPPFLAGS`. Triggered by the variable being defined, whatever its value. | unset | Chasing a use-after-move in the engine |
 | `DUCKDB_R_LINENR` | Passed on to upstream's `package_build.build_package()` as its `linenr` argument. Any non-empty value is true, including `0` and `false`. | unset, i.e. false | Rarely — what it produces is decided by `package_build.py`, which lives in the DuckDB checkout and not here, so it is not verifiable from this repository |
 | `DUCKDB_PATH` | Where the DuckDB checkout is. | `../duckdb` | Set for you by the vendoring scripts |
-| `DUCKDB_BUILD_UNITY` | The unity-build chunk size handed to upstream's `package_build.build_package()` as its `unity_count` argument. Read and validated here; upstream disregards it — see below. | 20 | Nothing in the generated tree responds to it, so in practice never |
-
-`DUCKDB_BUILD_UNITY` is read correctly and then disregarded downstream.
-`rconfigure.py` takes the value from the environment,
-keeps the default of 20 when it is unset or empty,
-and exits with a message when it is anything but a positive integer,
-so a malformed value stops the vendoring run rather than passing unnoticed.
-The value then travels to `package_build.build_package()` as `unity_count`,
-and that is as far as it gets:
-upstream's `generate_unity_builds()` accepts the split count and never uses it,
-and unity grouping is decided per directory by `add_library_unity`
-in upstream's CMakeLists.
-Every upstream version this package has followed behaves that way,
-from v0.8.1 through the vendored v1.5.5 and `main`.
-Setting the knob therefore changes the vendoring run's inputs
-and not the tree it commits.
-`package_build.py` lives in the DuckDB checkout and not here,
-so honouring the chunk size is an upstream change.
-
-`DUCKDB_R_BINDIR`, `DUCKDB_R_CFLAGS` and `DUCKDB_R_LIBS` are a further
-vendoring-time knob, taking effect only when all three are set together:
-`rconfigure.py` then writes a `src/Makevars` with no sources and link flags
-derived from an existing DuckDB installation, and exits before it touches
-`src/duckdb/`.
-Nothing in this repository sets them, and no CI job exercises the path;
-the maintained way to link against a prebuilt engine is
-[`build/fast-paths/`](/handbook/build/fast-paths/README.md).
 
 ## Not build knobs
 

--- a/handbook/build/configuration/README.md
+++ b/handbook/build/configuration/README.md
@@ -22,7 +22,7 @@ is all it takes.
 | `MAKEFLAGS` | Passed to `make`; only `-j` matters here. When it is empty, `configure` fills it in from [`scripts/setup-makeflags.R`](/scripts/setup-makeflags.R) and prints what it chose; when it is set, `configure` prints it and leaves it alone. | `-j` with the smaller of `parallel::detectCores()` and 2, so `-j2` on any multicore box; the cap is lifted when `NOT_CRAN` is truthy | To pin parallelism yourself: `export MAKEFLAGS="-j$(nproc)"` |
 | `NOT_CRAN` | Lifts the two-core cap that `scripts/setup-makeflags.R` puts on its guess, per CRAN's policy for checks. Matched case-insensitively against `true`, `1`, `yes`; anything else counts as false. | unset, so the cap applies | A local build that should use every core without your naming a `-j` |
 | ccache | Not an environment variable — the compilers are wrapped in `~/.R/Makevars`. Turns a repeat build of the vendored tree from minutes into seconds. | off | Any machine that compiles the vendored tree more than once |
-| `UserNM` | Names the `nm` program R uses to build `symbols.rds`, which [`src/Makevars.in`](/src/Makevars.in) puts on the `all:` target. `UserNM=true` skips the sweep. | unset, so R takes `nm` from `PATH` | An install-time shortcut only, never for `R CMD check`; it saves about 10–20 s on this tree |
+| `UserNM` | Names the `nm` program R uses to build `symbols.rds`, which [`src/Makevars.in`](/src/Makevars.in) puts on the `all:` target. `UserNM=true` skips the sweep. | unset, so R takes `nm` from `PATH` | An install-time shortcut only, never for `R CMD check`; it trims a step from the end of the install |
 | `DUCKDB_R_PREBUILT_ARCHIVE` | Path to a `.tar` of the vendored object files. If the file exists and extracts, `configure` uses [`src/include/from-tar.mk`](/src/include/from-tar.mk) and nothing is recompiled; otherwise it uses `to-tar.mk` (`to-tar-win.mk` on Windows), which writes the archive once the objects are built. | unset, so objects are built normally and no archive is written | CI. Locally ccache does the same job better, as `configure`'s own comment says |
 | `DUCKDB_R_USE_SYSTEM_LIB` | Links a prebuilt libduckdb instead of compiling the vendored sources — see [`build/fast-paths/`](/handbook/build/fast-paths/README.md). | unset | — |
 | `DUCKDB_R_LIB_DIR` | Directory holding `libduckdb.so` / `.dylib`. Read only while the system-lib opt-in is active. | `pkg-config --variable=libdir duckdb`, then `/usr/local/lib`, `/opt/homebrew/lib`, `/usr/lib/x86_64-linux-gnu`, `/usr/lib/aarch64-linux-gnu`, `/usr/lib` | libduckdb sits in a prefix none of those cover |
@@ -70,7 +70,7 @@ they only take effect through a vendoring run
 
 | Knob | What it does | Default | When to set |
 |---|---|---|---|
-| `DUCKDB_R_EXTENSIONS` | Comma-separated extension names appended to the built-in list. Each one contributes `-DDUCKDB_EXTENSION_<NAME>_LINKED`, its include flags, and its sources. Merely defining the variable triggers the append, so an empty value appends an empty name. | `parquet`, `core_functions` — the two statically linked in every build ([`usage/extensions/`](/handbook/usage/extensions/README.md)) | Re-vendoring with a further in-tree extension linked in |
+| `DUCKDB_R_EXTENSIONS` | Comma-separated extension names appended to the built-in list. Each one contributes `-DDUCKDB_EXTENSION_<NAME>_LINKED`, its include flags, and its sources. Merely defining the variable triggers the append, so an empty value appends an empty name. | `parquet`, `core_functions` — statically linked in every build ([`usage/extensions/`](/handbook/usage/extensions/README.md)) | Re-vendoring with a further in-tree extension linked in |
 | `DUCKDB_DEBUG_MOVE` | Adds `-DDUCKDB_DEBUG_MOVE` to the generated `PKG_CPPFLAGS`. Triggered by the variable being defined, whatever its value. | unset | Chasing a use-after-move in the engine |
 | `DUCKDB_R_LINENR` | Passed on to upstream's `package_build.build_package()` as its `linenr` argument. Any non-empty value is true, including `0` and `false`. | unset, i.e. false | Rarely — what it produces is decided by `package_build.py`, which lives in the DuckDB checkout and not here, so it is not verifiable from this repository |
 | `DUCKDB_PATH` | Where the DuckDB checkout is. | `../duckdb` | Set for you by the vendoring scripts |
@@ -84,7 +84,7 @@ so the default of 20 always survives.
 It is listed as it behaves, not as it reads;
 making it work is a code change, not a documentation one.
 
-`DUCKDB_R_BINDIR`, `DUCKDB_R_CFLAGS` and `DUCKDB_R_LIBS` are a fourth
+`DUCKDB_R_BINDIR`, `DUCKDB_R_CFLAGS` and `DUCKDB_R_LIBS` are a further
 vendoring-time knob, taking effect only when all three are set together:
 `rconfigure.py` then writes a `src/Makevars` with no sources and link flags
 derived from an existing DuckDB installation, and exits before it touches
@@ -110,7 +110,7 @@ and are documented where they act:
   `scripts/install-libduckdb.sh` rather than the build —
   [`build/fast-paths/`](/handbook/build/fast-paths/README.md)
 
-Three more are outputs rather than inputs, and setting them by hand achieves
+Others are outputs rather than inputs, and setting them by hand achieves
 nothing: `DUCKDB_RSTRTMGR`, which `configure` writes into
 `src/Makevars.rstrtmgr`, and `DUCKDB_R_PREBUILT_ARCHIVE_GHA_CACHE_KEY` and
 `DUCKDB_R_UNRELEASED`, which the CI actions compute for themselves.


### PR DESCRIPTION
## What this leaf now owns

Every knob that changes how the package builds, as a reference table: one row per knob with what it does, its default, and when to set it. Build-time knobs (`MAKEFLAGS`, `NOT_CRAN`, ccache, `UserNM`, `DUCKDB_R_PREBUILT_ARCHIVE`, `DUCKDB_R_LIB_DIR`, `PKG_BUILD_EXTRA_FLAGS`, `DUCKDB_R_POISON_ENGINE`) are separated from vendoring-time knobs read by `scripts/rconfigure.py` (`DUCKDB_R_EXTENSIONS`, `DUCKDB_DEBUG_MOVE`, `DUCKDB_R_LINENR`, `DUCKDB_PATH`), because setting the latter at install time does nothing. A closing section names the `DUCKDB_R_*` variables that are *not* build knobs and links each to the leaf that owns it. Boundaries stated: `DUCKDB_R_USE_SYSTEM_LIB` is named and linked to `build/fast-paths/` but not explained here; `UserNM`'s `R CMD check` hazard is cross-referenced to `build/source-build/`; what the CI matrix sets is left to `operations/ci/matrix/`; the no-warning-suppression policy to `architecture/glue/`.

Every default was read out of the code that supplies it — `configure`, `configure.win`, `src/Makevars.in`, the `.mk` includes, `scripts/setup-makeflags.R`, `scripts/rconfigure.py`, `tools:::read_symbols_from_object_file()`, `pkgbuild:::should_add_compiler_flags()`, and the `.github/workflows/` actions.

## `DUCKDB_BUILD_UNITY` and the `DUCKDB_R_BINDIR` triple are gone

An earlier revision of this leaf documented two further vendoring-time knobs, and this PR depended on #2477 for one of them. #2477 now **deletes** both from `scripts/rconfigure.py` instead:

* `DUCKDB_BUILD_UNITY` reached upstream's `build_package()` as `unity_count`, and `generate_unity_builds()` has accepted that argument without reading it since well before v1.0.0 — unity grouping is decided per directory by `add_library_unity`. A knob that is read, validated and then disregarded is worse than no knob.
* `DUCKDB_R_BINDIR`/`DUCKDB_R_CFLAGS`/`DUCKDB_R_LIBS` wrote a `src/Makevars` for a system-library build that has not worked since `src/Makevars.in` lost its `{{ SOURCES }}` placeholder.

Both rows and the paragraph explaining them are therefore removed here. A knob table lists what exists; the removals are recorded in #2477, not in this leaf. Nothing in this PR now depends on the ordering with #2477 — the two are consistent whichever merges first, except that this leaf briefly stops naming variables that `main` still reads.

## What moved

* `AGENTS.md` — lost the `export MAKEFLAGS="-j$(nproc)"` bullet; gained a one-line pointer to the leaf in its place and the visible italic backreference under its H1. Nothing else was touched, since five sibling leaves are absorbing the rest in parallel.
* `README.md` — lost the two knob sentences under "Building" (`MAKEFLAGS` for parallel builds, configure `ccache`); gained a pointer to the leaf in their place.
* `scripts/README.md` — unchanged: `.claude/skills/docs-consistency/docs-readme.R` already maps `setup-makeflags.R` to `handbook/build/configuration`, so the generated index already carries the backreference.

## Assumptions

* The stub named four knobs; I read "that list is a starting point" as licence to sweep `configure`, `configure.win`, `src/Makevars.in`, the `.mk` includes, `scripts/rconfigure.py`, `scripts/setup-makeflags.R` and `.github/workflows/` for every variable the build reads, and to document all of them. The two tables name what came out.
* `PKG_BUILD_EXTRA_FLAGS` is pkgbuild's variable, not this package's, but CI sets it and it changes the compiler flags a `load_all()` build uses — so I judged it a build knob. Confirm that it belongs here rather than in `contributors/setup/`.
* `DUCKDB_R_LIB_DIR` is only read while `DUCKDB_R_USE_SYSTEM_LIB` is active. I kept it here (it is a variable `configure` reads) and linked the mode itself to `build/fast-paths/`; a reviewer may prefer it live entirely in that leaf.
* `DUCKDB_R_POISON_ENGINE` is set by a matrix entry and consumed by a CI action, not by `configure`. I gave it a row because its effect is a compile-time macro, and pointed both at `operations/ci/matrix/` for who sets it and `testing/guards/` for what it proves.
* `UserNM=true`'s saving was asserted by `AGENTS.md` and the comment in `.github/workflows/install/action.yml`, not measured here; the leaf no longer quotes it — see the durability sweep below.
* `DUCKDB_R_LINENR`'s effect is decided by upstream's `package_build.py`, which is not in this repository. The row says so instead of guessing.
* Trimming the root `README.md` was not in the stub's work order, but those two sentences are knob prose and "move, don't copy" applies. Flagging it in case the root `README.md` is meant to stay self-contained for CRAN readers, where `/handbook/…` does not resolve.

## Durability sweep

A follow-up pass over this leaf for facts a routine change invalidates.

**Out.** The "~10–20 s" for `UserNM=true`, which was a figure quoted from
`AGENTS.md` and a CI comment rather than measured; the row now says the knob
trims a step from the end of the install, which is what a reader needs to
decide. Three counts of knobs: "the two statically linked in every build"
(both are named on the same line), "a fourth vendoring-time knob" (it counted
the table above it, which has since grown), and "Three more are outputs rather
than inputs" (the list follows immediately). This PR body's own count of the
knobs went the same way; the tables name each one, which is the durable form.

**Stayed.** Every knob name, default and file path in the tables — the tables
are the mechanism a reader consults, and they age with the tree rather than
against it. The two-core `MAKEFLAGS` cap, which is CRAN policy and the reason
`NOT_CRAN` exists. `R >= 4.2` for the Windows archive-reuse branch and
`CXX_STD = CXX17`, which identify a version rather than counting one. ccache
"from minutes into seconds" is qualitative and survives drift.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PD23hjFQFRWW62HFvru187)_