### PR TITLE
docs(handbook): Record the steering taken during the first leaf wave

### DIFF
--- a/handbook/meta/handbook/README.md
+++ b/handbook/meta/handbook/README.md
@@ -213,6 +213,23 @@ because nothing in the sentence breaks when the forty-fifth lands.
 A list is safe, a tally is not,
 and the same number can be either depending on what surrounds it.
 
+**A fact known to be provisional carries the link to what will change it.**
+The rules already say a leaf points at the plan
+that carries its intent;
+intent also lives as an issue, ours or upstream,
+and those count the same.
+Without the link a reader cannot tell
+"this is how it works" from "this is how it works for now",
+and the two call for different decisions.
+With it, the leaf records that we already know —
+so the next reader does not re-derive the finding,
+and the acknowledgement is not lost
+the way it is when it lives only in a code comment
+or a pull-request thread.
+A behaviour that survives only because nobody has fixed it yet
+is documented as such, with its issue,
+and stops being documented that way when the issue closes.
+
 A **default is a fact**, and belongs in the prose with its value.
 How many commits a pass consumes,
 how large a chunk the planner cuts,

--- a/handbook/meta/handbook/README.md
+++ b/handbook/meta/handbook/README.md
@@ -184,6 +184,26 @@ The cost is that such a link does not resolve in a local Markdown
 preview, which has no notion of a repository root;
 the handbook is read on GitHub, and that is the trade taken.
 
+**A leaf states what stays true as the code moves.**
+A number that a normal commit invalidates —
+how many translation units, how many test files,
+how many seconds a build takes —
+is not a fact worth stating but a hostage to the next contributor,
+and a reader who trusts it is worse off than one who looked.
+Name the mechanism instead:
+the file that lists the translation units is durable,
+the count is not.
+Where the count carries no argument, cut it;
+where a qualitative statement will do, prefer it.
+Two things survive this rule.
+A measurement stays if the text says it is a measurement
+and against what — a measurement with provenance ages honestly,
+where a bare number pretends to be current.
+And a count stays when it *is* the design:
+the two version counters, the states of the release machine.
+Changing a load-bearing number means changing the design,
+which is exactly why stating it is safe.
+
 Prose absorbed into a leaf may be rewritten —
 the handbook's voice is tighter than its sources' —
 but a rewrite that loses a fact is a regression, not an edit.

--- a/handbook/meta/handbook/README.md
+++ b/handbook/meta/handbook/README.md
@@ -23,16 +23,31 @@ has exactly one place in this tree.
   [`handbook/`](/handbook/README.md);
   a topic with no place in the tree is a defect of the tree,
   not of the topic.
-* **Pointer leaves are legitimate.**
-  Where the canonical home is elsewhere —
-  R reference pages (`?topic`) shipped in the tarball,
-  machine-loaded playbooks under `.claude/skills/`,
-  or truly external documentation
-  such as the upstream DuckDB docs —
-  the leaf states the fact's home and links to it,
-  so a traversal still finds it.
+* **Leaves are comprehensive; pointing is the exception.**
+  A leaf answers its topic in full,
+  so that a reader never has to leave the tree to get the answer.
+  This holds even where a user-facing surface covers the same ground:
+  an R reference page (`?topic`) is a secondary surface
+  derived from the leaf, not the leaf's excuse to be thin.
+  Two homes are genuinely elsewhere, and only there does a leaf point
+  instead of explain: documentation that is not ours
+  (the upstream DuckDB docs, which this tree does not duplicate),
+  and the machine-loaded playbooks under `.claude/skills/`,
+  whose procedures are executed rather than read —
+  there the leaf says what the thing is and when it applies,
+  and links for the steps.
   The tree needs no separate map of what lives outside;
   the leaves are the map.
+* **Intent lives outside the tree.**
+  A plan describes work that is not done;
+  the handbook describes how the system works today.
+  So plans stay in [`plan/`](/plan/), outside `handbook/` —
+  a decision taken, not a leftover.
+  [`meta/plans/`](/handbook/meta/plans/) explains that directory
+  and the conventions that govern it,
+  and each affected leaf links the plan that carries its intent.
+  A plan that has become fact is documented as fact,
+  in the leaf, with no trace of its having once been a proposal.
 * **The tree is the single source of truth.**
   Everything outside it is secondary —
   user-facing surfaces (the root `README.md`, reference pages),
@@ -139,6 +154,18 @@ Where no index covers a document, it carries its own:
   Never a roxygen `#'` line:
   `handbook/` is `.Rbuildignore`d,
   so a reference page linking into it would be broken for users.
+* *Generated files* — the backreference belongs in the **generator**,
+  in the template the generated file is rendered from,
+  so that it survives the next regeneration.
+  Editing the generated file to add one is writing in sand.
+
+Two kinds of file take no backreference at all.
+A file covered by a generated index is already carried by it.
+And **outbound correspondence takes none** —
+`cran-comments.md` is not documentation of a topic
+but a letter whose whole text reaches a CRAN maintainer verbatim,
+so the link to it is one-way,
+and that asymmetry is correct rather than an orphan.
 
 **A link that leaves its own directory is written from the repository
 root**, with a leading `/` — `/handbook/usage/types/`, not

--- a/handbook/meta/handbook/README.md
+++ b/handbook/meta/handbook/README.md
@@ -213,6 +213,18 @@ because nothing in the sentence breaks when the forty-fifth lands.
 A list is safe, a tally is not,
 and the same number can be either depending on what surrounds it.
 
+A **default is a fact**, and belongs in the prose with its value.
+How many commits a pass consumes,
+how large a chunk the planner cuts,
+what a knob does when nobody sets it —
+these govern behaviour,
+and a reader who has to open the script to learn them
+has been sent away for the thing they came for.
+Name the value *and* where it is set,
+so the leaf stays useful when the two drift apart —
+and when a document has long claimed the wrong default,
+say so, or the wrong number comes back.
+
 Positional reference fails the same way.
 "Neither of the first two is in force"
 and "the first two, as `$pkg` and `$env`"

--- a/handbook/meta/handbook/README.md
+++ b/handbook/meta/handbook/README.md
@@ -204,6 +204,22 @@ the two version counters, the states of the release machine.
 Changing a load-bearing number means changing the design,
 which is exactly why stating it is safe.
 
+The working test is whether the prose names its members.
+"Two identifiers travel with the vendored copy" is durable
+when the next clause names both,
+because the set cannot change without the sentence changing with it;
+"forty-four files register S4 methods this way" is a hostage,
+because nothing in the sentence breaks when the forty-fifth lands.
+A list is safe, a tally is not,
+and the same number can be either depending on what surrounds it.
+
+Positional reference fails the same way.
+"Neither of the first two is in force"
+and "the first two, as `$pkg` and `$env`"
+break silently when a list above them is reordered,
+which is not even a change to the subject matter.
+Name the thing.
+
 Prose absorbed into a leaf may be rewritten —
 the handbook's voice is tighter than its sources' —
 but a rewrite that loses a fact is a regression, not an edit.


### PR DESCRIPTION
**Standing PR for handbook steering.** Decisions taken while the first
wave of 26 leaves is being written land here, so the rules stay ahead of
the leaves instead of being reconstructed afterwards. Expect this branch
to grow; it is the one place to look for "what did we decide, and why".

## Decisions in this PR

**Leaves are comprehensive; pointing is the exception.** The previous
wording — "Pointer leaves are legitimate" — invited a leaf to defer to a
reference page, and one did: `usage/storage/` came back as a thin
pointer to `?duckdb_storage`. That contradicts the rule two bullets
down, which already calls reference pages *secondary*. Now stated
directly: a reference page is derived from its leaf, not the leaf's
excuse to be thin. Only two homes are genuinely elsewhere —
documentation that is not ours (upstream DuckDB docs) and the
machine-loaded playbooks under `.claude/skills/`, whose procedures are
executed rather than read.

**Intent lives outside the tree.** Plans stay in `plan/`, deliberately.
`meta/plans/` explains that directory and its conventions; each affected
leaf links the plan carrying its intent. And a plan that has become fact
is documented as fact in the leaf, with no trace of its having once been
a proposal.

**Two additions to the backreference forms:**

* *Generated files* — the backreference belongs in the **generator**, in
  the template the file is rendered from, so it survives the next
  regeneration. Editing the generated file is writing in sand. This came
  out of #2466, which put the line in `src/Makevars.in` and in the
  `R/version.R` template inside `scripts/rconfigure.py`.
* *Outbound correspondence takes none.* `cran-comments.md` is not
  documentation of a topic but a letter whose whole text reaches a CRAN
  maintainer verbatim. The link to it is one-way, and that asymmetry is
  correct rather than an orphan. Came out of #2474, which added one and
  then reverted it.

## Already landed separately

* #2458 — no tombstones (an absorbed file goes away; the in-place
  generated `README.md` routes on), and every upward link written from
  the repository root.

## Open, not decided here

* **How `AGENTS.md` carries its backreference.** Agents split on this:
  most added the italic H1 line, #2473 argued the file's own
  `## Where to look` routing table *is* its backreference mechanism and
  updated rows instead. Six leaves touch that file in this wave, so
  whichever lands first sets the precedent. Worth settling explicitly
  rather than by merge order.
* **Extending the generated index beyond `scripts/`.** #2459 generalises
  `docs-readme.R` to cover `plan/` as well; the remaining directories
  that hold documentation are still open.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PD23hjFQFRWW62HFvru187)_