### PR TITLE
docs(handbook): Let internal nodes carry their area's governing principles

### DIFF
--- a/handbook/README.md
+++ b/handbook/README.md
@@ -5,28 +5,16 @@ for every documentable aspect of this package;
 internal pages like this one navigate and state their area's principles,
 leaves explain ([the rules](meta/handbook/)).
 
-Three constraints run through every area below,
-and a reader who does not carry them will misread all of them.
-
-**No page here may assume the package is called `duckdb`.**
-One source tree is published under several names,
-applied per branch rather than chosen at build time,
-so the name is a question asked at run time wherever it appears —
-in the R code, in the tests, in what a user installs.
-
-**The engine is carried in this repository, not depended on.**
-A question about DuckDB and a question about the R package
-are therefore answered in the same tree, at different leaves,
-and drawing that boundary is part of what every area does.
-
-**Every commit is built and tested on its own.**
-History advances one upstream commit at a time and stays linear,
-which is what makes a regression attributable;
-much of the machinery described below exists to keep that affordable,
-and nothing else explains the shape it has.
-
-The areas divide by what a question is about, not by who is asking it:
-a user and a maintainer with the same question arrive at the same leaf.
+The areas divide by what a question is about,
+not by who is asking it.
+A reader who will only ever install the package
+and one who maintains the repository that produces it
+are served by the same tree,
+and the same question brings them both to the same leaf.
+That is why the list below mixes using, building and operating
+rather than separating them by audience:
+an audience split would need the same fact in two places,
+and the tree holds every fact once.
 
 * [`usage/`](usage/) — installation and flavors, connections,
   types, extensions, memory, data import, storage, integrations

--- a/handbook/README.md
+++ b/handbook/README.md
@@ -2,8 +2,31 @@
 
 The single source of truth
 for every documentable aspect of this package;
-internal pages like this one only navigate — leaves explain
-([the rules](meta/handbook/)).
+internal pages like this one navigate and state their area's principles,
+leaves explain ([the rules](meta/handbook/)).
+
+Three constraints run through every area below,
+and a reader who does not carry them will misread all of them.
+
+**No page here may assume the package is called `duckdb`.**
+One source tree is published under several names,
+applied per branch rather than chosen at build time,
+so the name is a question asked at run time wherever it appears —
+in the R code, in the tests, in what a user installs.
+
+**The engine is carried in this repository, not depended on.**
+A question about DuckDB and a question about the R package
+are therefore answered in the same tree, at different leaves,
+and drawing that boundary is part of what every area does.
+
+**Every commit is built and tested on its own.**
+History advances one upstream commit at a time and stays linear,
+which is what makes a regression attributable;
+much of the machinery described below exists to keep that affordable,
+and nothing else explains the shape it has.
+
+The areas divide by what a question is about, not by who is asking it:
+a user and a maintainer with the same question arrive at the same leaf.
 
 * [`usage/`](usage/) — installation and flavors, connections,
   types, extensions, memory, data import, storage, integrations

--- a/handbook/architecture/README.md
+++ b/handbook/architecture/README.md
@@ -2,6 +2,22 @@
 
 What the shipped code is:
 the R layer, the C++ glue, and the vendored engine.
+The area divides by who wrote the code rather than by what language it is in:
+two of the three are written here,
+and the third is upstream's, described only as far as
+this package's build of it differs from a stock one.
+
+**Little of what ships was typed where it is read.**
+A source here is as likely to be generated from an annotation,
+derived from a sibling file, or copied wholesale from upstream
+as it is to be hand-written,
+so the first thing a leaf says about a file is which of those it is.
+The consequence is a habit rather than a rule:
+a correction goes to the producer, never to the file in front of you,
+and a page in this area earns its keep by naming the producer
+rather than by describing the product.
+The hand-written surface is smaller than the directory listing suggests,
+and knowing which part of it is hand-written is most of what this area is for.
 
 * [`r-layer/`](r-layer/) — R conventions and the flavor seam
 * [`glue/`](glue/) — the R ↔ DuckDB bridge in `src/`

--- a/handbook/build/README.md
+++ b/handbook/build/README.md
@@ -1,6 +1,24 @@
 # `build/`
 
 Turning the tree into an installed package, at every speed.
+There is one build; the rest of this area is ways of doing less of it,
+and the knobs that steer both.
+
+**What ships is the plain build.**
+Every shortcut here is a development and CI convenience,
+never a second distribution model:
+the package a stranger installs always compiles the vendored sources.
+A saving that would have to be reproduced on that stranger's machine
+is not a shortcut but a change to what the package is,
+and is decided outside this area.
+
+**A shortcut fails loudly or not at all.**
+Anything that skips work also proves it was entitled to skip it,
+and stops the build where it was not.
+The failure this area is built against is not a slow build
+but a fast one that produced something other than the package —
+which is dangerous precisely because it looks like success,
+and which nothing downstream of the build is positioned to notice.
 
 * [`source-build/`](source-build/) — `configure`, Makevars, the tarball
 * [`fast-paths/`](fast-paths/) — prebuilt libduckdb in seconds

--- a/handbook/meta/handbook/README.md
+++ b/handbook/meta/handbook/README.md
@@ -4,9 +4,20 @@ The handbook is a strict topic hierarchy with full cover:
 every aspect of this package that may need documentation
 has exactly one place in this tree.
 
-* **Internal nodes navigate, only.**
-  An internal `README.md` is a scope sentence
+* **Internal nodes navigate, and may govern.**
+  An internal `README.md` is a scope sentence,
+  optionally the principles that govern its area,
   and a nested list of its subdirectories — nothing else.
+  A principle is why the area is divided as it is,
+  or a constraint every leaf under it obeys;
+  it belongs to the node because no single leaf could state it
+  without reaching past its own scope.
+  Anything one leaf could state is that leaf's,
+  and an internal node never repeats it —
+  the shape a principle takes, and the tests that keep it
+  from becoming a summary, are among [the forms](#the-forms).
+  An area whose leaves share no such constraint gets no principle;
+  a node reaching for one is navigating, which was always enough.
   The root additionally sketches each area's contents,
   naming the next level in prose —
   names, not links, so the sketch cannot rot.
@@ -100,6 +111,35 @@ and continues with the content.
 The scope sentence survives the stub because the tree's shape
 depends on every leaf declaring its boundary.
 A one-screen leaf needs no headings; a longer one uses `##`.
+
+**A principle on an internal node** is a short paragraph, or a few of them,
+between the scope sentence and the list of children.
+It survives three tests,
+and a sentence that fails any one of them belongs to a leaf instead:
+
+* **It cannot be checked by reading one leaf.**
+  A statement a single child settles is that child's.
+  A principle is confirmed only by reading the children together,
+  or by looking at how the area is divided at all.
+* **It has the lifetime of the child list.**
+  An internal node may go stale only when its children change,
+  which is when the node is being edited anyway.
+  A sentence an ordinary commit to the package could falsify
+  is a fact, and every fact has a leaf.
+* **It names no particulars.**
+  No paths, script names, environment variables, versions, counts,
+  commands, or tables — that is the vocabulary of facts.
+  A principle that needs one of them to be understood
+  is a summary of the leaf that owns it.
+
+Where a node's links may go follows from the same tests.
+An internal node links to its own children,
+and to another area's node where it draws a boundary against it;
+a link *into* a leaf is the node reaching for that leaf's evidence,
+which means the sentence was the leaf's all along.
+This is what preserves the guarantee that navigation-only bought:
+a paraphrase of the leaves below fails all three tests at once,
+so the rule that admits principles still excludes summaries.
 
 **An absorbed file goes away.**
 There are no tombstones:

--- a/handbook/meta/handbook/README.md
+++ b/handbook/meta/handbook/README.md
@@ -129,10 +129,19 @@ between the scope sentence and the list of children.
 It survives three tests,
 and a sentence that fails any one of them belongs to a leaf instead:
 
-* **It cannot be checked by reading one leaf.**
-  A statement a single child settles is that child's.
-  A principle is confirmed only by reading the children together,
-  or by looking at how the area is divided at all.
+* **A leaf yet to be written could falsify it.**
+  This is the sharp form of "no single leaf settles it",
+  and the two differ in the case that matters.
+  A statement one leaf settles *in full* is that leaf's,
+  however tree-wide it feels —
+  nothing a later leaf says could make it false,
+  which is what tells you it is finished and owned.
+  A statement each leaf settles only for itself,
+  and which holds of the area only because all of them do,
+  is the node's: a child added tomorrow could break it,
+  and that exposure is exactly what makes it a claim about the area.
+  A conjunction of finished claims is a summary;
+  a generalisation over instances is a principle.
 * **It has the lifetime of the child list.**
   An internal node may go stale only when its children change,
   which is when the node is being edited anyway.
@@ -152,6 +161,28 @@ which means the sentence was the leaf's all along.
 This is what preserves the guarantee that navigation-only bought:
 a paraphrase of the leaves below fails all three tests at once,
 so the rule that admits principles still excludes summaries.
+
+**No page writes `duckdb` as though it were the package's name.**
+The name is a run-time question:
+one source tree is published under several names,
+and which one a build carries is decided by the branch it sits on
+([`branches/flavors/`](/handbook/branches/flavors/README.md)).
+A page that qualifies our own objects with it,
+or tells a reader to call the package by it,
+is therefore wrong under every flavor but the mainline one.
+Write around the name, or say how to ask for it.
+This is checkable mechanically, and nothing else checks it:
+the scan that catches a hard-coded name in the shipped sources
+does not reach this tree, and says so as one of its limits
+([`testing/guards/`](/handbook/testing/guards/README.md)),
+so `handbook/` is the consistency skill's to cover.
+Three spellings are correct and are not violations —
+the repository, which is `duckdb-r`;
+the engine and the upstream project, which are DuckDB's own and not ours;
+and a flavor named as a flavor,
+where the mainline one is called `duckdb` alongside the others.
+What the rule is about is the *package's* name in prose
+that a rename would falsify.
 
 **An absorbed file goes away.**
 There are no tombstones:

--- a/handbook/meta/handbook/README.md
+++ b/handbook/meta/handbook/README.md
@@ -16,8 +16,20 @@ has exactly one place in this tree.
   and an internal node never repeats it —
   the shape a principle takes, and the tests that keep it
   from becoming a summary, are among [the forms](#the-forms).
+  An internal node links to its children,
+  and to another area's node where it draws a boundary against it;
+  it never links into a leaf, which is the mechanical form of the same rule.
+  There is one link into a leaf anywhere above the leaves,
+  the root's pointer to this page,
+  which orients a reader rather than supporting a claim;
+  it is named here so that the check stays a check
+  and not a matter of judgement.
   An area whose leaves share no such constraint gets no principle;
   a node reaching for one is navigating, which was always enough.
+  Look for an owner before writing one:
+  where an area has a leaf whose topic is the area's own reasons
+  or its own rules, the principles are already that leaf's,
+  and the node above it stays navigation-only.
   The root additionally sketches each area's contents,
   naming the next level in prose —
   names, not links, so the sketch cannot rot.

--- a/handbook/operations/releases/README.md
+++ b/handbook/operations/releases/README.md
@@ -1,6 +1,28 @@
 # `releases/`
 
 From a green branch to CRAN.
+The area divides into the sequence, the destination's demands,
+and the number the result carries.
+
+**A release asserts what it is; it derives nothing.**
+The commit that ships, the version it carries, the revision of the policy
+that was read — each is named explicitly at the moment it is decided,
+rather than computed from something adjacent
+that would be right until it silently was not.
+That is why so much of what follows is a value set once by a person,
+with a record of its having been set,
+and why automation here prepares and reports but never concludes.
+
+**The rules are other people's.**
+The cadence belongs to upstream, the acceptance criteria to CRAN,
+and the tools that write the version and the changelog have behaviour
+of their own.
+So these leaves describe compliance rather than design,
+and where they do record a decision it is a decision about how to comply.
+It also means a fact here can stop being true
+without anything in this repository changing,
+which is why each leaf says where it read its constraint
+rather than merely stating it.
 
 * [`process/`](process/) — the release state machine
 * [`cran/`](cran/) — submission and policy

--- a/handbook/testing/README.md
+++ b/handbook/testing/README.md
@@ -1,6 +1,22 @@
 # `testing/`
 
 Proving the package works, locally and under CRAN's rules.
+The area divides by what a check asserts —
+what the suite proves, what a recorded expectation means,
+what a guard refuses, what the packages downstream of this one need.
+Where and when any of it executes, and what the result gates,
+is [`operations/ci/`](/handbook/operations/ci/README.md)'s.
+
+**Nothing here passes by being silent.**
+A check that declines to run says so, and says how to enable it;
+a verdict that is absent is undecided rather than green;
+and a run is read for what it proved,
+never for the absence of something red.
+Every mechanism in this area is arranged so that not running
+is louder than failing,
+because a failure gets looked at and a skip does not —
+which is why so much of what follows is about how a check announces
+itself rather than about what it measures.
 
 * [`suite/`](suite/) — layout, helpers, the fast loop
 * [`snapshots/`](snapshots/) — snapshot discipline

--- a/handbook/usage/README.md
+++ b/handbook/usage/README.md
@@ -2,6 +2,22 @@
 
 Using the package from R:
 connect, query, and configure DuckDB.
+The area divides by what the reader is trying to do,
+and every leaf is about the R package's behaviour.
+The SQL dialect, the storage format and the engine's own tuning
+are DuckDB's to document;
+this area defers to that documentation instead of restating it,
+and a leaf here is worth writing where the two sides meet —
+where R's idea of a type, a lifetime or a file location
+has to be reconciled with the engine's.
+
+**The package decides as little as it can, and says so when it must.**
+A default that commits the user to something —
+a location on disk, a download, a silent conversion —
+is announced, reversible, or refused outright, never taken quietly;
+the leaves say which of the three, because they do not all choose the same one.
+Making the choice explicit is then the interface,
+and it is what turns the announcement off.
 
 * [`installation/`](installation/) — CRAN, r-universe, and the flavors
 * [`connections/`](connections/) — `dbConnect()`, instances, shutdown


### PR DESCRIPTION
Amends the rule that said an internal `README.md` may carry no prose, so that
it may state the principles governing its area — and applies it across the
tree. Five nodes gained principles; seven were examined and deliberately left
navigation-only.

## The line

> A **principle** is a constraint the area places on its leaves — why the area
> is divided as it is, or a rule every leaf under it obeys. Its truth-maker is
> the set of children, not any one of them. A **summary** is a conclusion one
> leaf reached, repeated a level up; its truth-maker is that leaf.

What the rule ships is the operational form — three tests a sentence on an
internal node must survive:

1. **A leaf yet to be written could falsify it.** A statement one leaf settles
   *in full* is that leaf's, however tree-wide it feels: nothing a later leaf
   says could make it false, which is what tells you it is finished and owned.
   A statement each leaf settles only for itself, and which holds of the area
   only because all of them do, is the node's. **A conjunction of finished
   claims is a summary; a generalisation over instances is a principle.**
2. **It has the lifetime of the child list.** An internal node may go stale
   only when its children change — which is when the node is being edited
   anyway. A sentence an ordinary commit to the package could falsify is a
   fact, and every fact has a leaf.
3. **It names no particulars.** No paths, script names, environment variables,
   versions, counts, commands, or tables. That is the vocabulary of facts.

Test 2 is why this does not reintroduce the rot the navigate-only rule was
built against: the node's text and its child list have the same lifetime, so
the node goes stale exactly when someone is already editing it.

Test 1 is in its sharp form because review found the blunt form insufficient —
see [What the review changed](#what-the-review-changed) below. It is the test
that does the real work.

Two enforcement handles, both in the rule text:

**The link rule.** An internal node links to its children, and to another
area's node where it draws a boundary. It never links *into* a leaf — that is
the node reaching for the leaf's evidence, which means the sentence was the
leaf's all along. Mechanically checkable, with exactly one allowlisted edge
(the root's pointer to the rules page), named in the rule so the check stays a
check.

**Look for an owner first.** Where an area has a leaf whose topic is the area's
own reasons or its own rules, the principles are already that leaf's and the
node stays navigation-only. This decided three areas.

## Nodes that gained principles

| Node | Principle |
|---|---|
| `handbook/` | The areas divide by what a question is about, not by who is asking it |
| `usage/` | The package decides as little as it can, and says so when it must |
| `architecture/` | Little of what ships was typed where it is read |
| `build/` | What ships is the plain build; a shortcut fails loudly or not at all |
| `testing/` | Nothing here passes by being silent |
| `operations/releases/` | A release asserts what it is, it derives nothing; and the rules are other people's |

Each also carries the rationale for how its area is divided, which is licensed
by the child list rather than by leaf content — so it is safe in areas whose
leaves are still stubs. The root now carries *only* that rationale.

Each surviving principle passes test 1 in the sharp form: a leaf added tomorrow
could falsify it. A `build/` leaf documenting a shortcut that fails quietly, a
`testing/` leaf whose check skips in silence, a `usage/` leaf with a silent
default, an `architecture/` leaf that is a large hand-written subsystem, a
`releases/` leaf with a derived version — each would break its node, which is
what makes the node's sentence a claim about the area rather than a report from
below.

**`build/`** is the cleanest case: two principles, each instantiated in all
three leaves and stated as a rule by none. **`testing/`** carries the boundary
against `operations/ci/`, the sanctioned kind of outward link.

## Nodes deliberately left navigation-only

An area with no principle getting none is the rule working, not a gap in it.

* **`operations/vendoring/`** — the candidate was "git is the only state", and
  it fails test 1: `model/` already owns "the vendor commit is the record" and
  `series-loop/` already says it keeps no state of its own. Two finished claims;
  the node would add only their conjunction. Structurally, `model/` is the
  area's rationale leaf, and a rationale leaf absorbs the node's principles by
  construction.
* **`branches/`** — same verdict, sharper reason. `invariants/` is a leaf whose
  entire topic is the area's governing rules, numbered, with what would catch
  each violation. Anything the node said would summarise it.
* **`operations/`** — five heterogeneous children; nothing binds them beyond
  the scope sentence it already has. A node high in a heterogeneous area is
  often only a junction.
* **`operations/ci/`** — only `per-commit/` is written; `workflows/` and
  `matrix/` are stubs. A principle asserted against one written leaf of three
  is a guess.
* **`contributors/`** — three leaves in temporal order. Ordering is navigation.
* **`meta/`** — the candidate is `meta/plans/`'s own subject and is stated there.

## What the review changed

The root originally carried three principles. Review caught the first, and
re-testing the other two against the same standard dropped both.

**"No page here may assume the package is called `duckdb`"** was two things
under one heading. The bolded sentence is a rule about *pages* — a
documentation-writing rule. The paragraph under it was a fact about the
codebase: one source tree, several names, applied per branch. They have gone to
different places.

The writing rule is now in `meta/handbook/`, where page rules live, phrased as
what it is: no page writes `duckdb` as though it were the package's name,
because a rename falsifies it everywhere but the mainline flavor. It is worth
having written down because it is **mechanically checkable and nothing else
checks it** — the scan that catches a hard-coded name in the shipped sources
does not reach `handbook/`, and names that as one of its own limits. Three
spellings are called out as correct so the check does not produce them as false
positives: the repository (`duckdb-r`), the engine and upstream project (not
ours), and a flavor named as a flavor.

The fact left the root entirely. `branches/flavors/` owns it, and the
navigation list already names flavors under both `usage/` and `branches/`.

**"The engine is carried in this repository, not depended on"** — dropped.
`architecture/engine/` settles it in full; nothing a later leaf could say would
make it false. Finished and owned, so a summary.

**"Every commit is built and tested on its own"** — dropped. `branches/invariants/`
is a leaf whose topic is the area's own rules and states this as one of them,
which is precisely the "look for an owner first" clause I had already derived
for `operations/vendoring/` and `branches/`. The clause kills this one too.

The root keeps its division rationale, which no leaf can settle and which a
ninth area could falsify. It is a real constraint on the tree's shape — an
audience split would need the same fact in two places, and the tree holds every
fact once — and it passes cleanly.

The sharp form of test 1 is what this review bought. The blunt form ("cannot be
checked by reading one leaf") let the flavor fact through, because the rule
stapled to it *was* genuinely tree-wide. The falsifiability form catches it: a
new leaf could not make "one source tree is published under several names"
false, so it was already owned. The same form independently confirmed both
other drops, and confirmed all six survivors.

## `meta/handbook/`: keep one page

Unchanged; the maintainer has not asked to revisit it. The rejected alternative
was `meta/handbook/{tree,leaf,forms,enforcement}/`, one sub-leaf per `##`.
Chapters are not topics; the material is cross-referential and read as a unit;
and it fails the proposal's own test, since as an internal node it could carry
only principles governing its children, whose content *is* the rules. **A node
whose principles equal its children's content should not be split.** Future
trigger: split when a section becomes separately maintained, not when the page
gets long — likeliest candidate "Writing a leaf", whose home would be
`.claude/skills/`.

## What could still go stale

Test 1 and the link rule are mechanical; test 2 and test 3 are judgement.

The standing risk is a node that is right when written and becomes a summary
later without anyone touching it — an area acquires a leaf that settles the
node's principle in full, and the node is now redundant with a leaf it predates.
Nothing detects that. Adding a leaf edits the child list, which is when the rule
puts the node up for review, and "look for an owner first" tells the writer
where to check.

The review moved one risk and left one. **Moved:** the root is no longer
carrying facts with owners, which was the live instance of that failure and had
already shipped. **Left, and now the largest:** `usage/`'s principle rests on
three written leaves out of eight. Its division rationale is safe — that follows
from the child list — but "announced, reversible, or refused" is as much a
prediction about `extensions/`, `memory/` and `types/` as a reading of
`storage/` and `integrations/`. By test 1 that exposure is what makes it a
principle rather than a summary, so this is the rule working as intended; but it
means the node is what changes if a stub lands that contradicts it, and it is
the one to check first when they do.

Verified: no dangling links, no upward links, root-absolute for everything
leaving its directory, semantic line breaks throughout. Every interior node
links only to its children, plus `testing/` → `operations/ci/` and the one
allowlisted root edge. No node written here writes the package's name. No leaf
`README.md` was touched.
