### PR TITLE
fix(vendor): Drop the dead knobs, classify patch failures, restore the tree on a no-op run

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -83,7 +83,7 @@ Root of the documentation tree: [`handbook/`](/handbook/).
 | File | Purpose |
 |---|---|
 | [`merge-version.sh`](merge-version.sh) | Git merge driver for DESCRIPTION. |
-| [`rconfigure.py`](rconfigure.py) | Regenerate the vendored build configuration from a DuckDB checkout: src/duckdb/, src/include/sources.mk, and R/version.R. |
+| [`rconfigure.py`](rconfigure.py) | Regenerate the vendored build configuration from a DuckDB checkout: src/duckdb/, src/include/sources.mk, R/version.R and the Makevars files. |
 | [`setup-git.sh`](setup-git.sh) | Register repository-local git configuration that cannot live in versioned files. |
 | [`vendor-one.sh`](vendor-one.sh) | Vendors DuckDB sources commit-by-commit from the upstream repository. |
 | [`vendor-rfuns.sh`](vendor-rfuns.sh) | Vendor the rfuns extension: copy sources from a duckdb-rfuns checkout into src/ and commit with the upstream log, one commit per import. |

--- a/scripts/rconfigure.py
+++ b/scripts/rconfigure.py
@@ -3,8 +3,6 @@
 # Called by vendor.sh and vendor-one.sh with DUCKDB_PATH set.
 import os
 import sys
-import shutil
-import subprocess
 import platform
 
 extensions = ['parquet','core_functions']
@@ -12,13 +10,6 @@ extensions = ['parquet','core_functions']
 # check if there are any additional extensions being requested
 if 'DUCKDB_R_EXTENSIONS' in os.environ:
     extensions = extensions + os.environ['DUCKDB_R_EXTENSIONS'].split(",")
-
-unity_build = 20
-if 'DUCKDB_BUILD_UNITY' in os.environ:
-    try:
-        unity_build = int(DUCKDB_BUILD_UNITY)
-    except:
-        pass
 
 debug_move_flag = ''
 if 'DUCKDB_DEBUG_MOVE' in os.environ:
@@ -97,39 +88,6 @@ link_flags = ''
 for libname in libraries:
     link_flags += ' -l' + libname
 
-# check if we are doing a build from an existing DuckDB installation
-if 'DUCKDB_R_BINDIR' in os.environ and 'DUCKDB_R_CFLAGS' in os.environ and 'DUCKDB_R_LIBS' in os.environ:
-    existing_duckdb_dir = os.environ['DUCKDB_R_BINDIR']
-    compile_flags = os.environ['DUCKDB_R_CFLAGS'].replace('\\', '').replace('  ', ' ')
-    rlibs = [x for x in os.environ['DUCKDB_R_LIBS'].split(' ') if len(x) > 0]
-
-    # use existing installation: set up Makevars
-    with open_utf8(os.path.join('src', 'Makevars.in'), 'r') as f:
-        text = f.read()
-
-    compile_flags += package_build.include_flags(extensions)
-    compile_flags += extension_list
-
-    # find libraries
-    result_libs = package_build.get_libraries(existing_duckdb_dir, rlibs, extensions)
-
-    for rlib in result_libs:
-        libdir = rlib[0]
-        libname = rlib[1]
-        if libdir != None:
-            link_flags += ' -L' + libdir
-        if libname != None:
-            link_flags += ' -l' + libname
-
-    text = text.replace('{{ SOURCES }}', '')
-    text = text.replace('{{ INCLUDES }}', compile_flags.strip())
-    text = text.replace('{{ LINK_FLAGS }}', link_flags.strip())
-
-    # now write it to the output Makevars
-    with open_utf8(os.path.join('src', 'Makevars'), 'w+') as f:
-        f.write(text)
-    exit(0)
-
 if not os.path.isfile(os.path.join(duckdb_path, 'scripts', 'amalgamation.py')):
     print("Could not find amalgamation script!")
     exit(1)
@@ -138,7 +96,7 @@ target_dir = os.path.join(os.getcwd(), 'src', 'duckdb')
 
 linenr = bool(os.getenv("DUCKDB_R_LINENR", ""))
 
-(source_list, include_list, original_sources) = package_build.build_package(target_dir, extensions, linenr, unity_build)
+(source_list, include_list, original_sources) = package_build.build_package(target_dir, extensions, linenr)
 
 # Drop the bundled jemalloc sources. The R package does not enable jemalloc
 # (DUCKDB_ENABLE_JEMALLOC is never defined), so duckdb's allocator uses the

--- a/scripts/rconfigure.py
+++ b/scripts/rconfigure.py
@@ -1,13 +1,14 @@
-# Regenerate the vendored build configuration from a DuckDB checkout:
-# src/duckdb/, src/include/sources.mk, and R/version.R.
-# Called by vendor.sh and vendor-one.sh with DUCKDB_PATH set.
+"""Regenerate the vendored build configuration from a DuckDB checkout:
+src/duckdb/, src/include/sources.mk, R/version.R and the Makevars files.
+
+Called by vendor.sh and vendor-one.sh with DUCKDB_PATH set.
+"""
 import os
 import sys
 import platform
 
 extensions = ['parquet','core_functions']
 
-# check if there are any additional extensions being requested
 if 'DUCKDB_R_EXTENSIONS' in os.environ:
     extensions = extensions + os.environ['DUCKDB_R_EXTENSIONS'].split(",")
 
@@ -15,15 +16,12 @@ debug_move_flag = ''
 if 'DUCKDB_DEBUG_MOVE' in os.environ:
     debug_move_flag = ' -DDUCKDB_DEBUG_MOVE'
 
-# This requires the mother duckdb repo to be checked out in a parallel directory
-# (or in a directory specified by the DUCKDB_PATH environment variable).
-# Submodules can't be used because they break R CMD build
+# Submodules can't be used for the DuckDB checkout because they break R CMD build.
 if 'DUCKDB_PATH' in os.environ:
     duckdb_path = os.environ['DUCKDB_PATH']
 else:
     duckdb_path = os.path.join('../duckdb')
 
-# Extract version information early when DuckDB sources are available
 def extract_version_info():
     """Extract version info from duckdb sources if available."""
     pragma_version_path = os.path.join('src', 'duckdb', 'src', 'function', 'table', 'version', 'pragma_version.cpp')
@@ -43,7 +41,6 @@ def extract_version_info():
 
     return version
 
-# Generate R file with version information early in the process
 def generate_version_r_file(version):
     """Generate R file with hard-coded version information."""
     if version:
@@ -119,28 +116,23 @@ for root, dirs, files in os.walk(target_dir):
                     with open (filename, "a") as fw:
                         fw.write("\n")
 
-# object list, relative paths
 script_path = os.path.dirname(os.path.abspath(__file__)).replace('\\', '/')
 
-# remove last component of the path
 root_path = os.path.dirname(script_path)
 
 duckdb_sources = [package_build.get_relative_path(os.path.join(root_path, 'src'), x) for x in source_list]
 object_list = ' '.join([x.rsplit('.', 1)[0] + '.o' for x in sorted(duckdb_sources)])
 
 
-# include list
 include_list = ' '.join(['-I' + 'duckdb/' + x for x in include_list])
 include_list += ' -I' + os.path.join('..', 'inst', 'include')
 include_list += ' -Iduckdb'
 include_list += extension_list
 include_list += debug_move_flag
 
-# add -Werror if enabled
 if 'TREAT_WARNINGS_AS_ERRORS' in os.environ:
     include_list += ' -Werror'
 
-# read Makevars.in and replace the {{ SOURCES }} and {{ INCLUDES }} macros
 with open_utf8(os.path.join('src', 'Makevars.in'), 'r') as f:
     text = f.read()
 
@@ -151,12 +143,10 @@ if len(libraries) == 0:
 else:
     text = text.replace('{{ LINK_FLAGS }}', link_flags.strip())
 
-# now write it to the output Makevars
 with open_utf8(os.path.join('src', 'Makevars'), 'w+') as f:
     f.write(text)
 
 # same dance for Windows
-# read Makevars.in and replace the {{ SOURCES }} and {{ INCLUDES }} macros
 with open_utf8(os.path.join('src', 'Makevars.in'), 'r') as f:
     text = f.read()
 
@@ -165,16 +155,13 @@ include_list += " -DDUCKDB_PLATFORM_RTOOLS=1"
 text = text.replace('{{ INCLUDES }}', include_list)
 text = text.replace('{{ LINK_FLAGS }}', "-lws2_32 $(DUCKDB_RSTRTMGR_LIB)")
 
-# now write it to the output Makevars
 with open_utf8(os.path.join('src', 'Makevars.win'), 'w+') as f:
     f.write(text)
 
-# write sources.mk
 text = "SOURCES=" + object_list + '\n'
 
 with open_utf8(os.path.join('src', 'include', 'sources.mk'), 'w') as f:
     f.write(text)
 
-# Try to extract version and generate R file
 extracted_version = extract_version_info()
 generate_version_r_file(extracted_version)

--- a/scripts/vendor-one.sh
+++ b/scripts/vendor-one.sh
@@ -192,12 +192,34 @@ while [ $commits_vendored -lt $num_commits ]; do
       exit 1
     }
 
+    # The patch stack, classified in three: a patch that applies forward is
+    # applied; one that reverses cleanly is already in the regenerated tree,
+    # so its change landed upstream and it is retired; one that does neither
+    # has genuinely broken -- the code it patches moved -- and deleting it
+    # would silently lose an R-side fix, so the run stops instead.
+    # scripts/vendor.sh has the same three-way split and the same exit 4.
+    #
+    # `--reverse` needs `--forward` beside it: on its own it prompts
+    # ("Unreversed patch detected!  Ignore -R? [n]") and hangs a run whose
+    # stdin is a terminal.
     for f in patch/*.patch; do
       if patch -i "$f" -p1 --forward --dry-run; then
         patch -i "$f" -p1 --forward --no-backup-if-mismatch
-      else
-        echo "Removing patch $f"
+      elif patch -i "$f" -p1 --reverse --forward --dry-run; then
+        echo "Removing patch $f (its change is already in the regenerated tree)"
         rm "$f"
+      else
+        echo ""
+        echo "=== PATCH BROKEN: $f (upstream ${commit}) ==="
+        echo "It neither applies forward nor reverses cleanly, so its change is"
+        echo "not in the regenerated tree and cannot be re-applied: the code it"
+        echo "patches moved."
+        echo "The regenerated sources for ${commit} are in the working tree,"
+        echo "uncommitted, and the upstream clone is kept."
+        echo "Rebase $f against them, keeping the rebased patch outside the tree,"
+        echo "then 'git checkout -- .', put it back, and rerun this script."
+        echo "Delete it only after confirming its change is genuinely upstream."
+        exit 4
       fi
     done
 

--- a/scripts/vendor-one.sh
+++ b/scripts/vendor-one.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # Vendors DuckDB sources commit-by-commit from the upstream repository.
 # Used by the series loop (.claude/skills/series-loop.md).
-# See handbook/operations/vendoring/pipeline/ for what this does and why.
 #
 # https://unix.stackexchange.com/a/654932/19205
 # Using bash for -o pipefail
@@ -218,8 +217,11 @@ while [ $commits_vendored -lt $num_commits ]; do
     # rconfigure.py rewrites R/version.R, src/Makevars, src/Makevars.win and
     # src/include/sources.mk for every candidate it tries, not just ${vendor_dir},
     # and any leftover of those would make the next run refuse on a dirty tree.
-    # Restoring everything is safe because the run refused to start on one.
+    # Restoring everything is safe because the run refused to start on one:
+    # anything untracked here was created by this run. The clone is ignored,
+    # so `git clean` leaves it for `rm -rf` below to remove deliberately.
     git checkout -- .
+    git clean -fd
     rm -rf "$upstream_dir"
     exit 0
   fi

--- a/scripts/vendor-one.sh
+++ b/scripts/vendor-one.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Vendors DuckDB sources commit-by-commit from the upstream repository.
 # Used by the series loop (.claude/skills/series-loop.md).
+# See scripts/VENDORING.md for complete documentation
 #
 # https://unix.stackexchange.com/a/654932/19205
 # Using bash for -o pipefail

--- a/scripts/vendor-one.sh
+++ b/scripts/vendor-one.sh
@@ -240,7 +240,12 @@ while [ $commits_vendored -lt $num_commits ]; do
 
   if [ "$message" = "" ]; then
     echo "No changes found. Done."
-    git checkout -- ${vendor_base_dir}
+    # Nothing was vendored, so leave the tree exactly as the run found it.
+    # rconfigure.py rewrites R/version.R, src/Makevars, src/Makevars.win and
+    # src/include/sources.mk for every candidate it tries, not just ${vendor_dir},
+    # and any leftover of those would make the next run refuse on a dirty tree.
+    # Restoring everything is safe because the run refused to start on one.
+    git checkout -- .
     rm -rf "$upstream_dir"
     exit 0
   fi

--- a/scripts/vendor-one.sh
+++ b/scripts/vendor-one.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # Vendors DuckDB sources commit-by-commit from the upstream repository.
-# Used by the series loop (.claude/skills/series-loop.md)
-# See scripts/VENDORING.md for complete documentation
+# Used by the series loop (.claude/skills/series-loop.md).
+# See handbook/operations/vendoring/pipeline/ for what this does and why.
+#
 # https://unix.stackexchange.com/a/654932/19205
 # Using bash for -o pipefail
 
@@ -9,17 +10,10 @@ set -e
 set -x
 set -o pipefail
 
-# The checkout to vendor into. Defaults to this script's own, which is what it
-# has always meant. The series loop sets it, so the routine can run `main`'s copy
-# of this script against a `<S>-build` worktree: stage 1 is the one stage the
-# port stage cannot reach, because ports land on `-dev` and the buffer's own
-# tooling only refreshes at a forward (.claude/skills/series-loop.md stage 1,
-# and plan/PLAN-vendoring-simplification.md §4).
-#
-# Only *this* script comes from `main` that way. Everything it invokes by
-# relative path -- `scripts/rconfigure.py`, `patch/*.patch`, `./configure` --
-# stays the target tree's, because those are coupled to the vendored tree they
-# generate and patch rather than to the loop that drives them.
+# The checkout to vendor into, so the series loop can run `main`'s copy of this
+# script against another worktree. Only *this* script comes from `main` that
+# way: everything it invokes by relative path -- `scripts/rconfigure.py`,
+# `patch/*.patch`, `./configure` -- stays the target tree's.
 cd "${VENDOR_REPO:-$(dirname "$0")/..}"
 toplevel=$(git rev-parse --show-toplevel 2>/dev/null) || {
   echo "Error: $PWD is not a git worktree" >&2
@@ -41,9 +35,7 @@ upstream_basedir=""
 num_commits=1
 check_glue=true
 
-# How far to look past commits that touch the vendored tree without vendoring.
-# Matches the bound in vendored_sha() (scripts/series-advance.sh); override for a
-# branch that genuinely stacks more of them.
+# Matches the bound in vendored_sha() (scripts/series-advance.sh).
 base_scan_depth="${BASE_SCAN_DEPTH:-20}"
 
 while [ $# -gt 0 ]; do
@@ -73,11 +65,9 @@ fi
 
 upstream_dir=${project}
 
-# Clone the repo only once if it doesn't exist
 if [ ! -d "$upstream_dir" ]; then
   git clone "$upstream_basedir" "$upstream_dir"
 elif [ "$upstream_basedir" != "$upstream_dir" ]; then
-  # Update existing clone
   git -C "$upstream_dir" fetch origin
 fi
 
@@ -92,10 +82,6 @@ fi
 
 start=$(git -C "$upstream_dir" rev-parse --verify HEAD)
 
-# The glue gate: after each vendored commit, syntax-check the R glue against
-# the freshly vendored headers.  This catches every upstream API change the
-# glue has to follow, costs ~20 s, and needs no link and no R session.  The
-# compile flags come from a dry run, so they always match the local setup.
 glue_compile_flags() {
   # src/Makevars includes Makevars.rstrtmgr, which only ./configure writes and
   # .gitignore keeps out of the tree; without it `make -n` stops before it ever
@@ -123,16 +109,11 @@ glue_compiles() {
 }
 
 # The upstream SHA the branch has vendored, and the base of the next walk.
-# The pathspec narrows the walk, the subject decides: the patch stack is applied
-# to the vendored tree in place, so commits land under ${vendor_dir} carrying no
-# upstream SHA, and this looks past them -- bounded, so git ends the walk itself
-# rather than being killed by a closing pipe.
-#
-# Answering empty is not an option here, which is why this refuses instead. An
-# empty base makes the range below read `..${start}`, whose missing left side
-# git resolves to the upstream clone's HEAD -- a range nobody chose, and one
-# that silently vendors the wrong span. The same rule, and the same bound, as
-# vendored_sha() in scripts/series-advance.sh; scripts/vendor.sh has its own copy.
+# Answering empty is not an option: an empty base makes the range below read
+# `..${start}`, whose missing left side git resolves to the upstream clone's
+# HEAD -- a range nobody chose, and one that silently vendors the wrong span.
+# The same rule, and the same bound, as vendored_sha() in
+# scripts/series-advance.sh; scripts/vendor.sh has its own copy.
 vendored_sha() {
   local subjects sha n
   subjects=$(git log -n "${base_scan_depth}" --format="%s" -- ${vendor_dir} | tee /dev/stderr)
@@ -150,7 +131,6 @@ vendored_sha() {
   echo "$sha"
 }
 
-# Loop for the specified number of commits
 commits_vendored=0
 
 while [ $commits_vendored -lt $num_commits ]; do
@@ -192,16 +172,10 @@ while [ $commits_vendored -lt $num_commits ]; do
       exit 1
     }
 
-    # The patch stack, classified in three: a patch that applies forward is
-    # applied; one that reverses cleanly is already in the regenerated tree,
-    # so its change landed upstream and it is retired; one that does neither
-    # has genuinely broken -- the code it patches moved -- and deleting it
-    # would silently lose an R-side fix, so the run stops instead.
-    # scripts/vendor.sh has the same three-way split and the same exit 4.
-    #
     # `--reverse` needs `--forward` beside it: on its own it prompts
     # ("Unreversed patch detected!  Ignore -R? [n]") and hangs a run whose
     # stdin is a terminal.
+    # scripts/vendor.sh has the same three-way split and the same exit 4.
     for f in patch/*.patch; do
       if patch -i "$f" -p1 --forward --dry-run; then
         patch -i "$f" -p1 --forward --no-backup-if-mismatch
@@ -230,8 +204,8 @@ while [ $commits_vendored -lt $num_commits ]; do
       break
     fi
 
-    # Expecting one change under ${vendor_base_dir} (and other changes) even if nothing else changed.
-    # Need at least three changed files to consider it a real update.
+    # pragma_version.cpp always differs, so "more than one" is the test for a
+    # real change.
     if [ "$(git status --porcelain -- ${vendor_base_dir} | wc -l)" -gt 1 ]; then
       message="vendor: Update vendored sources to ${repo_org}/${repo_name}@$commit"
       break
@@ -261,12 +235,6 @@ while [ $commits_vendored -lt $num_commits ]; do
   echo "Our tag: $our_tag"
   echo "Upstream tag: $upstream_tag"
 
-  # Increase fifth version component by one
-  # Set to one if missing
-  # Set intermediate components to zero if missing
-  # 1.2.3 -> 1.2.3.0.1
-  # 1.2.3.9000 -> 1.2.3.9000.1
-  # 1.2.3.9000.4 -> 1.2.3.9000.5
   version=$(sed -r -n '/^Version: (.*)$/ s//\1/p' DESCRIPTION)
   version_array=(${version//./ })
   for i in {0..4}; do
@@ -311,7 +279,6 @@ while [ $commits_vendored -lt $num_commits ]; do
     exit 3
   fi
 
-  # If we just vendored a tag, stop here
   if [ -n "${is_tag}" ]; then
     echo "Vendored a tag. Stopping."
     rm -rf "$upstream_dir"

--- a/scripts/vendor.sh
+++ b/scripts/vendor.sh
@@ -74,12 +74,36 @@ for commit in $original; do
   echo "R: configure"
   DUCKDB_PATH="$upstream_dir" python3 scripts/rconfigure.py
 
+  # The patch stack, classified in three: a patch that applies forward is
+  # applied; one that reverses cleanly is already in the regenerated tree,
+  # so its change landed upstream and it is retired; one that does neither
+  # has genuinely broken -- the code it patches moved -- and deleting it
+  # would silently lose an R-side fix, so the run stops instead.
+  # scripts/vendor-one.sh has the same three-way split and the same exit 4.
+  #
+  # `--reverse` needs `--forward` beside it: on its own it prompts
+  # ("Unreversed patch detected!  Ignore -R? [n]") and hangs a run whose
+  # stdin is a terminal.
   for f in patch/*.patch; do
     if patch -i "$f" -p1 --forward --dry-run; then
       patch -i "$f" -p1 --forward --no-backup-if-mismatch
-    else
-      echo "Removing patch $f"
+    elif patch -i "$f" -p1 --reverse --forward --dry-run; then
+      echo "Removing patch $f (its change is already in the regenerated tree)"
       rm "$f"
+    else
+      echo ""
+      echo "=== PATCH BROKEN: $f (upstream ${commit}) ==="
+      echo "It neither applies forward nor reverses cleanly, so its change is"
+      echo "not in the regenerated tree and cannot be re-applied: the code it"
+      echo "patches moved."
+      echo "The regenerated sources for ${commit} are in the working tree,"
+      echo "uncommitted, and the upstream clone is kept."
+      echo "Rebase $f against them, keeping the rebased patch outside the tree,"
+      echo "then 'git checkout -- .' and put it back."
+      echo "Before rerunning, remove ./duckdb or pass it as the argument:"
+      echo "this script always clones, so a leftover clone makes it fail."
+      echo "Delete $f only after confirming its change is genuinely upstream."
+      exit 4
     fi
   done
 

--- a/scripts/vendor.sh
+++ b/scripts/vendor.sh
@@ -124,7 +124,12 @@ done
 
 if [ "$message" = "" ]; then
   echo "No changes."
-  git checkout -- ${vendor_base_dir} R/version.R
+  # Nothing was vendored, so leave the tree exactly as the run found it.
+  # rconfigure.py rewrites R/version.R, src/Makevars, src/Makevars.win and
+  # src/include/sources.mk as well as ${vendor_dir}, and any leftover of those
+  # would make the next run refuse on a dirty tree. Restoring everything is safe
+  # because the run refused to start on one.
+  git checkout -- .
   rm -rf "$upstream_dir"
   exit 0
 fi

--- a/scripts/vendor.sh
+++ b/scripts/vendor.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Vendors DuckDB sources from the upstream repository (manual vendoring).
+# See scripts/VENDORING.md for complete documentation
 #
 # https://unix.stackexchange.com/a/654932/19205
 # Using bash for -o pipefail

--- a/scripts/vendor.sh
+++ b/scripts/vendor.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Vendors DuckDB sources from the upstream repository (manual vendoring).
-# For manual testing and development use
-# See scripts/VENDORING.md for complete documentation
+# See handbook/operations/vendoring/pipeline/ for what this does and why.
+#
 # https://unix.stackexchange.com/a/654932/19205
 # Using bash for -o pipefail
 
@@ -39,13 +39,8 @@ if [ -n "$(git -C "$upstream_dir" status --porcelain)" ]; then
   echo "Warning: working directory $upstream_dir not clean"
 fi
 
-# The upstream SHA the branch has vendored. The pathspec narrows the walk, the
-# subject decides: the patch stack is applied to the vendored tree in place, so
-# commits land under ${vendor_dir} carrying no upstream SHA, and this looks past
-# them -- bounded, so git ends the walk itself.
-#
-# Answering empty is not an option here, which is why this refuses instead: an
-# empty base makes the message body below read `${base}..${commit}` with a
+# The upstream SHA the branch has vendored. Answering empty is not an option:
+# an empty base makes the message body below read `${base}..${commit}` with a
 # missing left side, which git resolves to the clone's HEAD and which writes a
 # changelog nobody chose. The same rule, and the same bound, as vendored_sha()
 # in scripts/series-advance.sh; scripts/vendor-one.sh has its own copy.
@@ -74,16 +69,10 @@ for commit in $original; do
   echo "R: configure"
   DUCKDB_PATH="$upstream_dir" python3 scripts/rconfigure.py
 
-  # The patch stack, classified in three: a patch that applies forward is
-  # applied; one that reverses cleanly is already in the regenerated tree,
-  # so its change landed upstream and it is retired; one that does neither
-  # has genuinely broken -- the code it patches moved -- and deleting it
-  # would silently lose an R-side fix, so the run stops instead.
-  # scripts/vendor-one.sh has the same three-way split and the same exit 4.
-  #
   # `--reverse` needs `--forward` beside it: on its own it prompts
   # ("Unreversed patch detected!  Ignore -R? [n]") and hangs a run whose
   # stdin is a terminal.
+  # scripts/vendor-one.sh has the same three-way split and the same exit 4.
   for f in patch/*.patch; do
     if patch -i "$f" -p1 --forward --dry-run; then
       patch -i "$f" -p1 --forward --no-backup-if-mismatch
@@ -114,8 +103,8 @@ for commit in $original; do
     break
   fi
 
-  # Expecting one change under ${vendor_base_dir} (and other changes) even if nothing else changed.
-  # Need at least three changed files to consider it a real update.
+  # pragma_version.cpp always differs, so "more than one" is the test for a
+  # real change.
   if [ "$(git status --porcelain -- ${vendor_base_dir} | wc -l)" -gt 1 ]; then
     message="vendor: Update vendored sources to ${repo_org}/${repo_name}@$commit"
     break

--- a/scripts/vendor.sh
+++ b/scripts/vendor.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # Vendors DuckDB sources from the upstream repository (manual vendoring).
-# See handbook/operations/vendoring/pipeline/ for what this does and why.
 #
 # https://unix.stackexchange.com/a/654932/19205
 # Using bash for -o pipefail
@@ -116,9 +115,13 @@ if [ "$message" = "" ]; then
   # Nothing was vendored, so leave the tree exactly as the run found it.
   # rconfigure.py rewrites R/version.R, src/Makevars, src/Makevars.win and
   # src/include/sources.mk as well as ${vendor_dir}, and any leftover of those
-  # would make the next run refuse on a dirty tree. Restoring everything is safe
-  # because the run refused to start on one.
+  # would make the next run refuse on a dirty tree. Regenerating can also add
+  # files upstream has that we do not, which `checkout` will not take back.
+  # Restoring everything is safe because the run refused to start on a dirty
+  # tree: anything untracked here was created by this run. The clone is
+  # ignored, so `git clean` leaves it for the `rm -rf` below.
   git checkout -- .
+  git clean -fd
   rm -rf "$upstream_dir"
   exit 0
 fi


### PR DESCRIPTION
## Why this is a separate PR

Split out of #2477, which is now documentation only.
The behaviour changes belong in their own scoped PR.

**The split is by artifact, not by intent, and that is deliberate.**
Everything under `scripts/` that is not Markdown lands here —
including the comment strip, which is a documentation change in spirit.
Those deletions are interleaved with the functional hunks
in the same three files;
splitting `scripts/vendor.sh`, `scripts/vendor-one.sh` and
`scripts/rconfigure.py` across two PRs
would guarantee conflicts between our own branches.
`scripts/VENDORING.md` stays with #2477, being prose that happens to live
under `scripts/`.

**Merge order: this PR first, then #2477.**
#2477's handbook leaf describes the *fixed* behaviour —
exit 4, the retirement message, the clean tree after a no-op run —
as the pipeline's rule rather than as a caution.
Merged the other way round, the leaf documents behaviour the scripts do not
yet have.

The two branches together reproduce #2477's pre-split tree byte-for-byte;
checked with `git merge-tree --write-tree` against the original tip.

## A note on the history

An earlier revision of #2477 made `DUCKDB_BUILD_UNITY` *readable* and
validated. The maintainer's call mid-review was that a knob read, validated
and then disregarded is worse than no knob. This branch is authored as the
decision that was actually reached — the knob is removed, full stop — rather
than replaying the change of mind as two commits.

## 1. `DUCKDB_BUILD_UNITY`, `DUCKDB_R_BINDIR`, `DUCKDB_R_CFLAGS`, `DUCKDB_R_LIBS` are deleted

`DUCKDB_BUILD_UNITY` reached upstream's `build_package()` as its
`unity_count` argument, and upstream's
`generate_unity_builds(source_list, nsplits, linenumbers)` has accepted that
argument **without reading `nsplits`** since well before v1.0.0 — checked at
`v0.8.1`, `v0.9.2`, `v1.0.0`, `v1.1.3`, `v1.2.2`, `v1.3.0`, `v1.4.0`, the
vendored `v1.5.5`, and `main`. Unity grouping is decided per directory by
`add_library_unity` in upstream's `CMakeLists.txt`. So the environment read,
the fallback, the variable and the argument at the call site are all gone.
`build_package()` declares `unity_count=32`, so the call simply stops passing
it — and because upstream ignores the value, **the vendored output is
unchanged**.

`DUCKDB_R_BINDIR`/`DUCKDB_R_CFLAGS`/`DUCKDB_R_LIBS` are remnants of an old
system-library build. The branch fills a `{{ SOURCES }}` placeholder that
`src/Makevars.in` no longer has, so the `Makevars` it writes keeps its
`include include/sources.mk` and would compile the whole vendored tree
anyway. An earlier revision kept them as reachable-but-stale and documented
them; that is overridden. The branch is gone,
`package_build.include_flags()` and `get_libraries()` are no longer called,
and the now-unused `shutil`/`subprocess` imports go with them. The maintained
route to a prebuilt library is `DUCKDB_R_USE_SYSTEM_LIB`, which `configure`
handles.

## 2. The vendor scripts silently dropped patches

Both scripts deleted any patch that failed `patch --forward --dry-run`. That
failure has two causes and the loop could not tell them apart: either the
change is *already in* the regenerated tree — the fix landed upstream, and
deleting the patch is correct — or the code around it moved and the patch has
genuinely broken, in which case deleting it silently loses an R-side fix and
the loss rides into the vendor commit.

A second dry run classifies the two: a patch that reverses cleanly is retired
with a message saying why; one that neither applies forward nor reverses
cleanly stops the run with **exit 4**, naming the patch, leaving the
regenerated sources uncommitted and the upstream clone in place.

`--reverse` carries `--forward` beside it deliberately, in both scripts. On
its own, `patch --reverse --dry-run` asks
`Unreversed patch detected!  Ignore -R? [n]` whenever the patch is not
already applied — exactly the broken case this change exists to detect — and
would hang any run whose stdin is a terminal.

`vendor.sh` and `vendor-one.sh` get the same three-way split and the same
exit 4: leaving one path silently dropping a fix while the other halts is
worse than either choice made consistently. Only the recovery message
differs — `vendor.sh` always clones, so a leftover `./duckdb` makes a rerun
fail, and its message says to clear it or pass it as the argument. Each
script's comment names the other, so the pair stays in step.

### What could break

A series-loop run that previously limped past a broken patch, dropping it and
carrying on, **halts at that commit and needs a human to rebase the patch.**
That is the point of the change. Exit 4 sits beside the glue gate's exit 3;
nothing branches on either script's exit code other than the manual `while`
loop documented in #2477's leaf, which stops on any non-zero.

## 3. A run that vendors nothing no longer leaves the tree dirty

`rconfigure.py` rewrites `R/version.R`, `src/Makevars`, `src/Makevars.win`
and `src/include/sources.mk` for **every candidate it tries**, not only
`src/duckdb/`. When no candidate qualified, `vendor-one.sh` restored only
`src/duckdb/` and `vendor.sh` only `src/duckdb/` and `R/version.R`, so the
*next* run refused on a dirty tree. On a dev branch the version string moves
with almost every upstream commit, so that was the common case.

Both scripts now `git checkout -- .` on that path. That is safe precisely
because the run refuses to start on a dirty tree: the only changes present
are the ones it made itself, including a patch it retired for a candidate
that was then not vendored.

## 4. Comments stripped from the vendoring scripts

Now that `handbook/operations/vendoring/pipeline/` (#2477) carries the
explanation, `scripts/vendor.sh`, `scripts/vendor-one.sh` and
`scripts/rconfigure.py` no longer restate it: the base scan's rationale, the
patch classification, the glue gate's purpose, the version-bump examples,
`VENDOR_REPO`'s series-loop motivation, and a dozen one-liners that named the
next statement.

**Kept**: each script's one-line header (the generated `scripts/` index is
built from it), everything that says *why* — the `--forward`/`--reverse`
prompt, the `eval` around R's quoted include path, `Makevars.rstrtmgr` being
the reason `make -n` needs `./configure`, the jemalloc exclusion — and the
cross-file invariants a code reader needs at that spot: that both scripts
share a base-scan bound with `series-advance.sh`, and share the patch
classification and exit 4 with each other.

Two stripped comments were **wrong**, not merely redundant: "Need at least
three changed files to consider it a real update" described a `-gt 1` test,
and `rconfigure.py`'s Makevars comments named a `{{ SOURCES }}` placeholder
the template no longer has. Both script headers now point at the leaf rather
than at `scripts/VENDORING.md`.

`scripts/README.md` is regenerated: `rconfigure.py`'s header comment became a
module docstring (the extractor prefers one, and the old comment listed three
of the five outputs).

## Defects found but not fixed here

Both are properties of the vendored *output*, so they are changes to that
output rather than to these scripts' control flow, and #2477's leaf links
them as boundaries:

* **#2489 — the vendored tree is not byte-reproducible across clones.**
  `DUCKDB_SOURCE_ID` is an abbreviated commit id and git sizes the
  abbreviation from the clone it runs in, so one upstream commit vendors as
  `7300522cf0` from one clone and `7300522cf07` from another. The fix is to
  pin `core.abbrev` in the clone the scripts create, which needs a decision
  on the length and rewrites that line on the next vendor commit.
* **#2490 — `rconfigure.py` rewrites all ~3550 files unconditionally**,
  invalidating git's stat cache twice per candidate (the "more than one
  changed file" test and the `git add`), including for candidates that are
  skipped. Writing only files that differ would roughly halve the per-commit
  cost.

## What I could not verify

No build and no vendor run — neither is feasible in this container, and there
is no upstream `duckdb` clone here. What was run:
`python3 -m py_compile scripts/rconfigure.py`, `bash -n` on both shell
scripts, `Rscript .claude/skills/docs-consistency/docs-readme.R --check`, and
the handbook link check, all clean. Upstream `scripts/package_build.py` was
read at the nine refs listed above, including `unity_count`'s default.

Still unverified by execution: that `build_package()` without `unity_count`
produces a byte-identical `src/duckdb/` (it should — upstream ignores the
argument, but that is read from source rather than observed); that
`git checkout -- .` leaves a real vendor tree exactly at `HEAD` after a walk
that qualified nothing; and that a real retired patch in `patch/` reverses
cleanly against a real regenerated tree — the patch classification was
verified on a scratch fixture, not against this repository's stack.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PD23hjFQFRWW62HFvru187)_