### PR TITLE
docs(handbook): add `usage/relational/`, and give duckplyr its own section

### DIFF
--- a/R/relational.R
+++ b/R/relational.R
@@ -1,3 +1,8 @@
+# The relational API: lazy relation trees and the ALTREP data frames they
+# produce.  Internal -- every function here is @noRd, and duckplyr is the one
+# supported consumer.
+# Explained in handbook/usage/relational/README.md.
+
 # expressions
 
 #' Create a column reference expression

--- a/handbook/README.md
+++ b/handbook/README.md
@@ -15,7 +15,8 @@ an audience split would need the same fact in two places,
 and the tree holds every fact once.
 
 * [`usage/`](usage/) — installation and flavors, connections,
-  types, extensions, memory, data import, storage, integrations
+  types, extensions, memory, data import, storage, integrations,
+  the relational API
 * [`architecture/`](architecture/) — the R layer, the C++ glue,
   the embedded engine
 * [`build/`](build/) — source build, fast paths, build knobs

--- a/handbook/architecture/glue/README.md
+++ b/handbook/architecture/glue/README.md
@@ -56,6 +56,8 @@ Formatting runs through the Makefile `format-*` targets,
 driving [`scripts/format.py`](/scripts/format.py).
 
 **ALTREP relations.**
+The R-facing half of this, and who consumes it, is
+[`usage/relational/`](/handbook/usage/relational/README.md).
 `rapi_rel_to_altrep()` wraps an unexecuted relation as a data frame;
 nothing runs until R touches the values,
 materialization is budgeted by `n_rows` and `n_cells`,

--- a/handbook/meta/glossary/README.md
+++ b/handbook/meta/glossary/README.md
@@ -18,7 +18,7 @@ one line, so the register stays greppable and diffs per term.
 * **deepen line** — the italic last line naming what a not-yet-comprehensive leaf still owes ([`meta/handbook/`](/handbook/meta/handbook/README.md)).
 * **depths** (reference, core, comprehensive) — a leaf's three legitimate published states ([`meta/handbook/`](/handbook/meta/handbook/README.md)).
 * **driver / database instance** — `duckdb()` returns a driver owning one database instance; connections share it, and file-backed instances are cached by path ([`usage/connections/`](/handbook/usage/connections/README.md)).
-* **duckplyr** — the dplyr-native downstream package, the closest reverse dependency and a gate for behavior changes ([`testing/revdep/`](/handbook/testing/revdep/README.md)).
+* **duckplyr** — the dplyr-native downstream package: it drives the relational API rather than generating SQL, and is the closest reverse dependency ([`usage/integrations/`](/handbook/usage/integrations/README.md)).
 * **engine** — the DuckDB database engine embedded in `src/duckdb/` ([`architecture/engine/`](/handbook/architecture/engine/README.md)).
 * **fast path** — linking a prebuilt engine library instead of compiling the vendored sources ([`build/fast-paths/`](/handbook/build/fast-paths/README.md)).
 * **flavor** — a mechanical rename publishing the one source tree under another package name ([`branches/flavors/`](/handbook/branches/flavors/README.md)).

--- a/handbook/meta/glossary/README.md
+++ b/handbook/meta/glossary/README.md
@@ -36,7 +36,7 @@ one line, so the register stays greppable and diffs per term.
 * **patch stack** — the patches under `patch/` re-applied to each freshly vendored tree ([`operations/vendoring/pipeline/`](/handbook/operations/vendoring/pipeline/README.md)).
 * **pointer leaf** — a leaf that states and links its topic's canonical home elsewhere ([`meta/handbook/`](/handbook/meta/handbook/README.md)).
 * **register** — expose an R data frame as a scannable table without copying ([`usage/data-import/`](/handbook/usage/data-import/README.md)); Arrow objects register the same way ([`usage/integrations/`](/handbook/usage/integrations/README.md)).
-* **relation** — an unexecuted query tree built by the relational API, run only when its values are touched ([`architecture/glue/`](/handbook/architecture/glue/README.md)).
+* **relation** — an unexecuted query tree built by the relational API, run only when its values are touched ([`usage/relational/`](/handbook/usage/relational/README.md)).
 * **secret store** — where `CREATE PERSISTENT SECRET` writes, under the storage home ([`usage/storage/`](/handbook/usage/storage/README.md)).
 * **series** — one upstream DuckDB branch with the package branches that carry it ([`branches/model/`](/handbook/branches/model/README.md)).
 * **series loop** — the scheduled agent routine that vendors every series ([`operations/vendoring/series-loop/`](/handbook/operations/vendoring/series-loop/README.md)).

--- a/handbook/usage/README.md
+++ b/handbook/usage/README.md
@@ -23,4 +23,5 @@ and is what turns the announcement off.
 * [`memory/`](memory/) — limits, spill, streaming
 * [`data-import/`](data-import/) — CSV and Parquet ingestion
 * [`storage/`](storage/) — where extensions and secrets live
-* [`integrations/`](integrations/) — dbplyr and Arrow
+* [`integrations/`](integrations/) — dbplyr, duckplyr, and Arrow
+* [`relational/`](relational/) — the internal lazy-relation API

--- a/handbook/usage/integrations/README.md
+++ b/handbook/usage/integrations/README.md
@@ -1,7 +1,8 @@
 # Integrations
 
 The routes into DuckDB beside plain SQL:
-dplyr pipelines translated by dbplyr, Arrow interchange, and ADBC.
+dplyr pipelines by two different mechanisms, Arrow interchange,
+and ADBC.
 What a value becomes across the boundary is
 [`types/`](/handbook/usage/types/README.md).
 
@@ -45,6 +46,28 @@ the boundaries users keep hitting:
   unblocked; what it still needs is a `dbplyr (>= 2.6.0)` floor, which
   `DESCRIPTION`'s `Suggests` does not carry
   ([#1982](https://github.com/duckdb/duckdb-r/issues/1982)).
+
+## duckplyr
+
+The other dplyr route, and it is not a dbplyr backend:
+duckplyr drives the **relational API** directly
+([`relational/`](/handbook/usage/relational/README.md)),
+so a pipeline becomes a relation tree rather than a SQL string,
+and the result arrives as an ALTREP data frame that computes on access.
+Nothing is translated to SQL and back, which is the point —
+and which is also why the two routes fail differently:
+where dbplyr's boundaries are translation gaps
+(the ones listed above), duckplyr's are the verbs the relational API
+does not yet express, and it falls back to dplyr for those.
+
+The dependency runs the other way from the rest of this page:
+duckplyr consumes this package rather than being consumed by it.
+It is the closest reverse dependency, so a behaviour change here is
+checked against it before release
+([`testing/revdep/`](/handbook/testing/revdep/README.md)),
+and its version pins parts of the relational API in place.
+`compute_parquet()` is its route to a Parquet file
+([`data-import/`](/handbook/usage/data-import/README.md)).
 
 ## Arrow
 

--- a/handbook/usage/relational/README.md
+++ b/handbook/usage/relational/README.md
@@ -1,0 +1,57 @@
+# The relational API
+
+Building a query as a *relation* — a lazy node graph — instead of a SQL
+string, and handing the result to R as an ALTREP data frame.
+It is **internal**: nothing here is exported or documented for users,
+and the one supported consumer is duckplyr
+([`integrations/`](/handbook/usage/integrations/README.md)).
+The DBI and dbplyr routes are what a user reaches for
+([`connections/`](/handbook/usage/connections/README.md)).
+
+**Can I use it?** Not supportedly.
+Every function in [`R/relational.R`](/R/relational.R) is marked `@noRd`,
+so none reaches `NAMESPACE` and none gets a reference page;
+calling one means `duckdb:::`, and a `:::` caller has no promise that the
+next release keeps the signature.
+The answer is deliberate rather than an oversight —
+see the coupling below for what it costs to change.
+
+**What a relation is.**
+`rel_from_df()` turns a data frame into a relation without copying it;
+`rel_from_table()`, `rel_from_table_function()` and `rel_from_sql()`
+start from the database side.
+From there the verbs compose —
+project, filter, aggregate, order, limit, the joins, the set operations —
+each returning a new relation and executing nothing.
+Expressions are built separately (`expr_reference()`, `expr_constant()`,
+`expr_function()`, `expr_comparison()`, `expr_window()`),
+so a caller assembles a tree rather than splicing text,
+and the engine never parses a string the caller built.
+
+**How a result comes back.**
+`rel_to_altrep()` wraps an unexecuted relation as a data frame:
+nothing runs until R touches the values, materialization is budgeted by
+`n_rows` and `n_cells`, and an execution error is stored and re-raised at
+every later access.
+`rel_from_altrep_df()` is the way back.
+The C++ side of that, and its known weak point around raising an R error
+from inside an ALTREP method, is
+[`architecture/glue/`](/handbook/architecture/glue/README.md)'s.
+`rel_to_parquet()`, `rel_to_csv()`, `rel_to_table()` and `rel_to_view()`
+execute to a destination instead.
+
+**The coupling is the reason this page exists.**
+The API grew to serve duckplyr — `NEWS.md` records rounds of "internal
+changes to support the duckplyr package" — and being internal does not
+make it free to change:
+`rel_to_altrep()` still carries
+`# FIXME: Move dots after `rel` for duckplyr >= 1.1.0`,
+a signature held in place by a downstream version.
+So a change here is negotiated with duckplyr rather than merely reviewed,
+and duckplyr is the reverse dependency a behaviour change is checked
+against first
+([`testing/revdep/`](/handbook/testing/revdep/README.md)).
+
+*To deepen: state which verbs duckplyr actually calls, so a change can be
+scoped against real use rather than the whole surface;
+drain the `rel_to_altrep()` signature FIXME when duckplyr's floor allows.*


### PR DESCRIPTION
Two leaves' worth of work that came out of asking where duckplyr sits in the tree. The answer turned out to be that it sits in four places, three of which already existed — and that the fourth topic did not exist at all.

Rebased onto `main` now that #2493 has merged; the temporary fold commit is gone, so this is two commits against `main`.

## `usage/relational/` — a topic the tree did not have

`architecture/glue/` owns the ALTREP mechanism from the C++ side and `usage/integrations/` owns dbplyr and Arrow, but nothing owned the R-facing relational surface: what a relation is, how a result comes back, and — the question a reader actually arrives with — whether they may call any of it.

The answer is **no**, and the leaf says so plainly rather than leaving it to be inferred from the absence of a reference page. Verified rather than assumed:

- every function in [`R/relational.R`](/R/relational.R) is marked `@noRd`, so none gets a `man/` page;
- none of them reaches `NAMESPACE` — only the four S3 methods on `duckdb_relation` are registered, so the *class* is visible while the constructors are not;
- a caller therefore needs `duckdb:::`, with no promise across releases.

Internal is not the same as free to change, though, and that is the reason the leaf exists at all: `rel_to_altrep()` still carries `# FIXME: Move dots after 'rel' for duckplyr >= 1.1.0` — an argument order held in place by a downstream's version — and `NEWS.md` records rounds of "internal changes to support the duckplyr package". So the page records the coupling as a live constraint on how this API may evolve.

`R/relational.R` gains its backreference; the glossary's *relation* entry and `architecture/glue/`'s ALTREP section now point at the new leaf instead of at each other.

## duckplyr in `usage/integrations/`

That leaf's scope sentence promised "the routes into DuckDB beside plain SQL" and then named two. duckplyr is a third, and a different kind — it drives the relational API directly rather than generating SQL, so a pipeline becomes a relation tree and the result arrives as an ALTREP frame that computes on access.

Worth stating because it predicts how the two dplyr routes fail differently: dbplyr's boundaries are translation gaps (the list already on that page), duckplyr's are the verbs the relational API does not yet express. It is also the only entry on the page whose dependency runs the other way — duckplyr consumes this package — which the section says outright rather than leaving the reader to infer from a package name.

The glossary's *duckplyr* entry now points at `usage/integrations/` as its owner; `testing/revdep/` keeps the release-gate half, which is its own topic.

## What is deliberately not here

The relational API's verb-by-verb inventory. The deepen line asks for the subset duckplyr actually calls, which is what would let a change be scoped against real use rather than the whole 40-function surface — that needs reading duckplyr, not this repository.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUnQmoT6zu4qjCcCMbx7x4

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUnQmoT6zu4qjCcCMbx7x4)_