### PR TITLE
docs: fix the clone layout, and the README links CRAN cannot follow

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ The badges track each `.dev` series:
 *ahead* counts commits ahead of the branch the series releases from,
 *in flight* counts commits in CI but not yet trusted,
 *buffered* counts commits vendored but not yet verified.
-See [`BRANCHES.md`](BRANCHES.md) for the full model.
+See the handbook's
+[`branches/`](https://github.com/duckdb/duckdb-r/blob/main/handbook/branches/README.md)
+for the full model.
 
 ## User Guide
 
@@ -86,13 +88,15 @@ See the [R API in the DuckDB documentation](https://duckdb.org/docs/api/r).
 ## Documentation
 
 Everything this repository documents is reachable from the
-[handbook](handbook/README.md), a strict topic hierarchy;
-[`AGENTS.md`](AGENTS.md) is the door for maintainers and coding
-agents, and [`plan/README.md`](plan/README.md) names the designs,
-plans, and historical documents.
-[`BRANCHES.md`](BRANCHES.md) and
-[`scripts/VENDORING.md`](scripts/VENDORING.md) hold detail the
-handbook is still absorbing.
+[handbook](https://github.com/duckdb/duckdb-r/blob/main/handbook/README.md),
+a strict topic hierarchy;
+[`AGENTS.md`](https://github.com/duckdb/duckdb-r/blob/main/AGENTS.md)
+is the door for maintainers and coding agents, and
+[`plan/README.md`](https://github.com/duckdb/duckdb-r/blob/main/plan/README.md)
+names the designs, plans, and historical documents.
+[`BRANCHES.md`](https://github.com/duckdb/duckdb-r/blob/main/BRANCHES.md) and
+[`scripts/VENDORING.md`](https://github.com/duckdb/duckdb-r/blob/main/scripts/VENDORING.md)
+hold detail the handbook is still absorbing.
 
 ## Building
 
@@ -112,23 +116,12 @@ Then, install:
 Set the `MAKEFLAGS` environment variable to `-j8` or similar for parallel builds.
 Configure `ccache` for faster repeated builds.
 A build that links a prebuilt engine and finishes in seconds,
-and the remaining knobs, are described in the handbook under
-[`build/`](handbook/build/README.md).
-
-If you wish to test new DuckDB functionality with duckdb-r, make sure your clone of `duckdb-r` is one level deeper than your clone of `duckdb` (e.g. `R/duckdb-r` and `duckdb`).
-Then run the following commands:
-
-``` sh
-~ (cd duckdb && git checkout {{desired_branch}})
-~ (cd R/duckdb-r && scripts/vendor.sh)
-~ (cd R/duckdb-r && R CMD INSTALL .)
-```
-
-It helps if both the duckdb directory and duckdb-r directory are clean.
+and other details, are described in the handbook under
+[`build/`](https://github.com/duckdb/duckdb-r/blob/main/handbook/build/README.md).
 
 ## Vendoring
 
-This package includes a vendored copy of the DuckDB C++ library. The vendoring process is automated — a scheduled routine synchronizes each release series with the upstream DuckDB repository, commit by commit. For detailed information about how vendoring works and manual vendoring procedures, see [`scripts/VENDORING.md`](scripts/VENDORING.md).
+This package includes a vendored copy of the DuckDB C++ library. The vendoring process is automated — a scheduled routine synchronizes each release series with the upstream DuckDB repository, commit by commit. How it works, and how to vendor by hand, is in the handbook under [`operations/vendoring/`](https://github.com/duckdb/duckdb-r/blob/main/handbook/operations/vendoring/README.md).
 
 ## Contributors
 

--- a/handbook/operations/vendoring/pipeline/README.md
+++ b/handbook/operations/vendoring/pipeline/README.md
@@ -21,6 +21,17 @@ A candidate is worth a commit when it is an exact tag or changes
 more than one file under `src/duckdb/`
 (one file, the version stamp, always changes).
 
+**Where the upstream repository is looked for.**
+Both scripts `cd` to the package root before anything else,
+and both default the upstream repository to `../../../duckdb`
+resolved from there —
+three levels above the package root,
+so a package clone at `~/git/R/duckdb/duckdb-r`
+finds an upstream clone at `~/git/duckdb`.
+That default is the only thing that depends on how the two clones are
+arranged: either script takes the path as a positional argument
+instead, and a caller that passes one is free of the layout entirely.
+
 **`rconfigure.py`** does the regeneration:
 `src/duckdb/`, `src/include/sources.mk`, the Makevars files
 (`src/Makevars` and `src/Makevars.win`) from `Makevars.in`,

--- a/scripts/VENDORING.md
+++ b/scripts/VENDORING.md
@@ -46,11 +46,12 @@ so check the clone out at the exact commit you want before running it;
 upstream first-parent commit at a time.
 What the two share is
 [`pipeline/`](/handbook/operations/vendoring/pipeline/README.md)'s.
-Three things an operator needs that it does not state:
+Three things an operator needs beyond what it states:
 
 * **Where the upstream clone goes.**
-  The positional argument is the source repository
-  (default `../../../duckdb`).
+  The positional argument is the source repository, and where each
+  script looks when it is omitted is
+  [`pipeline/`](/handbook/operations/vendoring/pipeline/README.md)'s.
   Unless it is already called `duckdb`, it is cloned into `./duckdb` in
   the package root — which is `.gitignore`d — and that clone is `rm -rf`ed
   when the script exits.
@@ -68,19 +69,20 @@ Three things an operator needs that it does not state:
 ### Local setup
 
 ```bash
-# Ensure your clone structure:
-# ~/
-#   duckdb/          # Upstream DuckDB repository
+# A clone structure the default reaches, three levels up:
+# ~/git/
+#   duckdb/              # Upstream DuckDB repository
 #   R/
-#     duckdb-r/      # This repository
+#     duckdb/
+#       duckdb-r/        # This repository
 
 # Update DuckDB to desired branch/commit
-cd ~/duckdb
+cd ~/git/duckdb
 git checkout desired_branch_or_commit
 
-# Run vendoring
-cd ~/R/duckdb-r
-scripts/vendor.sh ../../../duckdb
+# Run vendoring; any other layout passes the path instead
+cd ~/git/R/duckdb/duckdb-r
+scripts/vendor.sh
 
 # Build and test
 R CMD INSTALL .
@@ -112,7 +114,7 @@ so that the walk terminates by itself:
 ```bash
 export MAKEFLAGS=-j$(nproc) NOT_CRAN=true DUCKDB_R_RUN_TESTS=true
 
-while scripts/vendor-one.sh ../../../duckdb --commits 1; do
+while scripts/vendor-one.sh --commits 1; do
   rm -f src/*.o                                # see below — mandatory
   R CMD INSTALL . --no-byte-compile || break   # repair, then `git commit --amend`
   R -q -e 'testthat::test_local()'       || break


### PR DESCRIPTION
Two things, both in the same corner of the docs: the vendor scripts'
clone layout, which `README.md` and `scripts/VENDORING.md` documented
in a form that could never have worked, and the README's internal
links, every one of which is broken for a CRAN reader.

## The arithmetic

Both scripts start from the package root:

* `scripts/vendor.sh:12` — `cd "$(dirname "$0")"/..`
* `scripts/vendor-one.sh:17` — `cd "${VENDOR_REPO:-$(dirname "$0")/..}"`

and both default the upstream repository to the same relative path:

* `scripts/vendor.sh:22` — `upstream_basedir=../../../${project}`
* `scripts/vendor-one.sh:63` — `upstream_basedir=../../../${project}`

So from a package root `P`, the default resolves to `P/../../../duckdb`:
`duckdb` inside `P`'s great-grandparent. A package root of
`~/git/R/duckdb/duckdb-r` therefore finds `~/git/duckdb` — three levels
up, and the layout the maintainer actually uses.

`README.md` asked instead for a `duckdb-r` clone *one* level deeper than
the `duckdb` clone, both under one base directory `B`, as `B/R/duckdb-r`
and `B/duckdb`. From `B/R/duckdb-r` the default resolves to
`B/../duckdb`, a sibling of `B` — not the documented `B/duckdb`, and not
anything the instruction told the reader to create.

Both scripts also accept the upstream path as a positional argument
(`scripts/vendor.sh:21-25`, `scripts/vendor-one.sh:55-58`), which is the
escape hatch for any other arrangement and what the series loop already
passes. That is now stated wherever the default is, so the default reads
as a convenience rather than a requirement.

## The layout

* `handbook/operations/vendoring/pipeline/README.md` — said nothing
  about where the upstream repository is looked for. It owns what the
  two scripts share, so the rule lands here, in terms of the mechanism
  (both `cd` to the package root, both default three levels above it)
  with the positional argument named as the way out.
* `scripts/VENDORING.md` — its "Local setup" tree comment showed
  `~/duckdb` beside `~/R/duckdb-r` and its example ran
  `cd ~/R/duckdb-r && scripts/vendor.sh ../../../duckdb`, which from
  that root resolves outside `~`. The tree now shows a layout the
  default actually reaches, and the "Where the upstream clone goes"
  bullet links the leaf for the default instead of restating it. The
  commit-by-commit loop drops its redundant `../../../duckdb` argument,
  so only one place spells the default out.
* `README.md` — the vendoring-test block that carried the wrong layout
  is deleted rather than corrected; the pipeline leaf owns the rule
  now. The rest of `## Building` — `pak::pak()`, `R CMD INSTALL .`, the
  `MAKEFLAGS` and ccache sentences, the handbook pointer — stays, with
  "and the remaining knobs," reading "and other details,".

## The links

`.Rbuildignore` removes `handbook/`, `AGENTS.md`, `plan/`,
`BRANCHES.md` and `scripts/` from the tarball, and CRAN renders this
file from that tarball — so **every** internal link in `README.md` was
already broken there, not only the handbook ones. All seven are now
`https://github.com/duckdb/duckdb-r/blob/main/…` URLs:

| Link | Was | Now |
|---|---|---|
| handbook root | `handbook/README.md` | `…/blob/main/handbook/README.md` |
| `AGENTS.md` | `AGENTS.md` | `…/blob/main/AGENTS.md` |
| `plan/README.md` | `plan/README.md` | `…/blob/main/plan/README.md` |
| `BRANCHES.md` (Documentation) | `BRANCHES.md` | `…/blob/main/BRANCHES.md` |
| `scripts/VENDORING.md` (Documentation) | `scripts/VENDORING.md` | `…/blob/main/scripts/VENDORING.md` |
| build pointer | `handbook/build/README.md` | `…/blob/main/handbook/build/README.md` |
| branch model (was `BRANCHES.md`) | `BRANCHES.md` | `…/blob/main/handbook/branches/README.md` |
| vendoring (was `scripts/VENDORING.md`) | `scripts/VENDORING.md` | `…/blob/main/handbook/operations/vendoring/README.md` |

No relative link is left, because nothing the README links to ships in
the tarball; anything added later that *does* ship should stay
relative. If the intent was handbook links only, the non-handbook rows
above are the ones to drop.

Two pointers also changed target, not just form. "See `BRANCHES.md` for
the full model" now sends the reader to the handbook's `branches/`, and
`## Vendoring` to `operations/vendoring/` — the `## Documentation`
section already names both documents as detail the handbook is still
absorbing, so they were entry points into acknowledged debt. That
section's own mention of them is unchanged: naming debt is a different
claim from pointing at it.

## Checks

* `patch -p1 --dry-run < scripts/flavor.patch` succeeds, with output
  byte-identical both to the same run with these changes stashed and to
  the run on `main`. Its `README.md` hunks land at lines 12-40, above
  everything edited here, and neither gained fuzz or an offset.
* Every `blob/main/` path above verified to exist on `main` with
  `git cat-file -e origin/main:PATH` — the link checker treats an
  absolute URL as external and would not have caught a typo.
* Handbook link walk: no dangling links, none starting with `..`.
* `Rscript .claude/skills/docs-consistency/docs-readme.R --check` —
  `scripts/README.md is current`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PD23hjFQFRWW62HFvru187)_
