### PR TITLE
docs(plan): record what the closed handbook wave verified, and file what it should not have written down

### DIFF
--- a/plan/README.md
+++ b/plan/README.md
@@ -55,7 +55,7 @@ topic today.
 
 | To read about | Read |
 |---|---|
-| Findings verified against the code by the closed handbook wave, and the defects it turned up | [`history/2026-08-handbook-wave-salvage.md`](history/2026-08-handbook-wave-salvage.md) |
+| Findings verified against the code by the closed handbook wave, and the issues its defects became | [`history/2026-08-handbook-wave-salvage.md`](history/2026-08-handbook-wave-salvage.md) |
 
 ## Adding a document here
 

--- a/plan/README.md
+++ b/plan/README.md
@@ -46,6 +46,17 @@ a plan may still come true, a superseded design never will.
 |---|---|
 | The agentic-loop design that preceded the series loop (its measurements now live in [`experiments/`](/experiments/README.md)) | [`superseded/vendoring-loop.md`](superseded/vendoring-loop.md) |
 
+## `history/` — what a piece of work left behind
+
+Not a plan and not a design: a record of something that happened,
+kept because closing it would otherwise lose a fact.
+Each says in its first lines what it is and which document owns its
+topic today.
+
+| To read about | Read |
+|---|---|
+| Findings verified against the code by the closed handbook wave, and the defects it turned up | [`history/2026-08-handbook-wave-salvage.md`](history/2026-08-handbook-wave-salvage.md) |
+
 ## Adding a document here
 
 A plan goes in `plan/` as `PLAN-<topic>.md`, and opens with a line saying
@@ -55,5 +66,7 @@ the one thing the tree's structure exists to prevent.
 Where a plan leaves depends on what happened to it:
 one that came true moves to `done/`, one overtaken by events to
 `superseded/`, and its row moves with it.
+A record of work that is over rather than a proposal for work goes in
+`history/`, named for when it happened, and never moves again.
 A measurement is not a plan at all — it belongs in
 [`experiments/`](/experiments/README.md), one directory per run.

--- a/plan/history/2026-08-handbook-wave-salvage.md
+++ b/plan/history/2026-08-handbook-wave-salvage.md
@@ -24,34 +24,22 @@ The bar applied was
 so most of the wave's prose is not here at all;
 what it excluded is listed at the end.
 
-## Findings
+**This record changed its mind once, and says so.**
+Its first version sorted the survivors into findings worth writing and a
+short tail of defects.
+The ladder then gained the rung that asks whether a fact *should* be
+true, and every survivor was walked down it again, against the code.
+A fact that reports a defect is not deepening material at any depth:
+the paragraph is what makes the defect look deliberate, so the output is
+an issue or a fix, and only what survives the fix is written.
+That reweighing moved three entries out of the findings and into the
+issue tracker, and moved two more out of the record entirely, because a
+leaf or a merged fix now states them better.
+Each defect below is a link rather than a paragraph for the same reason:
+an issue can be closed, and this directory is for things that never move
+again.
 
-* **`make format-check` aborts instead of reporting when `cmake-format`
-  is absent.**
-  [`scripts/format.py`](/scripts/format.py) sends `src/CMakeLists.txt`
-  through `cmake-format`, which ships separately from `clang-format`;
-  without it the run dies with a `FileNotFoundError` before it reaches a
-  verdict on any file, rather than reporting a difference.
-  Run, not inferred.
-  *Proof:* `scripts/format.py`, the `format-*` targets in
-  [`Makefile`](/Makefile).
-  *Leaf:* [`architecture/glue/`](/handbook/architecture/glue/README.md).
-  *From:* [#2484](https://github.com/duckdb/duckdb-r/pull/2484).
-
-* **The vendor scripts' default clone layout is two levels, not one.**
-  Both scripts `cd` to the package root first and then default
-  `upstream_basedir` to `../../../duckdb`,
-  so the package clone has to sit *two* directories deeper than the
-  upstream clone — upstream at `~/git/duckdb` pairs with a package clone
-  at `~/git/R/duckdb/duckdb-r`, and the layout `README.md` describes
-  resolves to a path that does not exist.
-  Any other layout works by passing the upstream path as the positional
-  argument.
-  *Proof:* [`scripts/vendor.sh`](/scripts/vendor.sh),
-  [`scripts/vendor-one.sh`](/scripts/vendor-one.sh);
-  the wrong statement is in [`README.md`](/README.md).
-  *Leaf:* [`operations/vendoring/pipeline/`](/handbook/operations/vendoring/pipeline/README.md).
-  *From:* [#2477](https://github.com/duckdb/duckdb-r/pull/2477).
+## Deepening material
 
 * **A local commit-by-commit replay must delete `src/*.o` between
   commits, or it means nothing.**
@@ -65,36 +53,17 @@ what it excluded is listed at the end.
   engine.
   A fresh CI checkout never hits this, which is why it bites only
   locally.
-  *Proof:* `src/include/deps.mk`.
+  The filtering is deliberate and the file says why —
+  the dependency lists would otherwise carry the whole vendored tree —
+  and the pipeline catches the API break by other means,
+  compiling the glue against the fresh headers after each commit.
+  So the caveat is an operator's, not a bug's.
+  *Proof:* `src/include/deps.mk`, and the glue gate in
+  [`scripts/vendor-one.sh`](/scripts/vendor-one.sh).
   *Leaf:* [`operations/vendoring/pipeline/`](/handbook/operations/vendoring/pipeline/README.md),
   or [`build/source-build/`](/handbook/build/source-build/README.md),
   which already owns the `.dd` files.
   *From:* [#2477](https://github.com/duckdb/duckdb-r/pull/2477).
-
-* **`BASE_SCAN_DEPTH` does not reach the series scripts.**
-  The variable is honoured by the two vendor scripts only.
-  [`scripts/series-advance.sh`](/scripts/series-advance.sh) and
-  [`scripts/series-check.sh`](/scripts/series-check.sh)
-  hard-code the same depth and read no such variable,
-  so a branch that stacks enough non-vendoring commits under
-  `src/duckdb/` to need the bound raised needs both of them changed too.
-  *Proof:* those two scripts, against
-  [`scripts/vendor-one.sh`](/scripts/vendor-one.sh).
-  *Leaf:* [`operations/vendoring/troubleshooting/`](/handbook/operations/vendoring/troubleshooting/README.md).
-  *From:* [#2472](https://github.com/duckdb/duckdb-r/pull/2472).
-
-* **An empty `Files:` list from the glue gate is a local setup problem,
-  not a broken glue.**
-  When it prints
-  `Error: could not derive glue compile flags (R CMD SHLIB -n)`
-  alongside an empty file list, the flags could not be derived at all.
-  Deriving them needs `src/Makevars.rstrtmgr`, which only `./configure`
-  writes; the gate runs `./configure` itself when the file is missing,
-  so reaching this message means that failed.
-  *Proof:* [`scripts/vendor-one.sh`](/scripts/vendor-one.sh),
-  the glue-flag block.
-  *Leaf:* [`operations/vendoring/troubleshooting/`](/handbook/operations/vendoring/troubleshooting/README.md).
-  *From:* [#2472](https://github.com/duckdb/duckdb-r/pull/2472).
 
 * **The version merge driver's prefix gate silently declines to
   renumber across a patch release.**
@@ -107,7 +76,10 @@ what it excluded is listed at the end.
   producing a rising vendor counter, which then has to be re-applied by
   hand, one commit at a time, as part of the rebase.
   Whether the larger version would be the better answer is
-  [#2488](https://github.com/duckdb/duckdb-r/issues/2488).
+  [#2488](https://github.com/duckdb/duckdb-r/issues/2488),
+  which is the boundary the prose carries:
+  the gate is deliberate, and the open question is which answer is
+  right, not whether the script is broken.
   *Proof:* `scripts/merge-version.sh`.
   *Leaf:* [`operations/vendoring/pipeline/`](/handbook/operations/vendoring/pipeline/README.md).
   *From:* [#2477](https://github.com/duckdb/duckdb-r/pull/2477).
@@ -120,7 +92,10 @@ what it excluded is listed at the end.
   accessor).
   That is the whole of what the define does,
   which makes it the one flag whose name suggests more than it delivers.
-  *Proof:* that header.
+  The two blocks are upstream's own, not this repository's:
+  nothing under `patch/` mentions the define,
+  so it is an accommodation upstream offers and the Makevars opt into.
+  *Proof:* that header, and the absence of the define from `patch/`.
   *Leaf:* [`architecture/engine/`](/handbook/architecture/engine/README.md).
   *From:* [#2466](https://github.com/duckdb/duckdb-r/pull/2466).
 
@@ -149,34 +124,31 @@ what it excluded is listed at the end.
   at the `roxygenize` step, before anything is compiled —
   which is why the failure reads as unrelated to the edit that caused
   it.
+  The instance is gone from `main`, and the CI step is the guard that
+  keeps it gone, so what a leaf owes is the trigger and the action —
+  never write the package name into an inline chunk, and read a
+  `roxygenize` failure as an unresolvable reference — not the anatomy.
   *Proof:* `R/storage.R` and its generated `man/` page.
   *Leaf:* [`architecture/r-layer/`](/handbook/architecture/r-layer/README.md),
   which states the rule but not this failure mode.
   *From:* [#2480](https://github.com/duckdb/duckdb-r/pull/2480).
 
-* **The flavor-name guard fires in exactly one place.**
-  `tests/testthat/test-flavor-package-name.R` can only ever skip under
-  `R CMD check`: [`.Rbuildignore`](/.Rbuildignore) excludes `scripts$`,
-  so neither
-  [`scripts/flavor-package-name.R`](/scripts/flavor-package-name.R)
-  nor the [`scripts/flavor.patch`](/scripts/flavor.patch) allowlist it
-  reads is present in a built tarball.
-  The `custom/after-install` CI step running the scan against a plain
-  checkout is the guard; delete it and nothing is left,
-  while the test keeps passing by skipping.
-  *Proof:* `.Rbuildignore`, that test file, and
-  [`.github/workflows/custom/after-install/action.yml`](/.github/workflows/custom/after-install/action.yml).
-  *Leaf:* [`testing/guards/`](/handbook/testing/guards/README.md).
-  *From:* [#2467](https://github.com/duckdb/duckdb-r/pull/2467).
-
-* **CI turns the installed-size check off.**
+* **CI turns the installed-size check off, because it treats every NOTE
+  as an error.**
   [`.github/workflows/custom/before-install/action.yml`](/.github/workflows/custom/before-install/action.yml)
-  exports `_R_CHECK_PKG_SIZES_=FALSE`,
-  so the standing package-size NOTE cannot fail a matrix run —
-  and neither can a size regression.
-  The NOTE is seen at submission time and nowhere earlier.
-  *Proof:* that action file.
-  *Leaf:* [`operations/releases/cran/`](/handbook/operations/releases/cran/README.md).
+  exports `_R_CHECK_PKG_SIZES_=FALSE`.
+  The check action runs `r-lib/actions/check-r-package` with
+  `error-on: "note"` unless `RCMDCHECK_ERROR_ON` overrides it, so
+  without that export the standing package-size NOTE would fail every
+  matrix run — the suppression is what makes a strict error level
+  usable at all.
+  The cost is that a size regression cannot fail a run either, and the
+  NOTE is seen at submission time and nowhere earlier.
+  *Proof:* that action file, and
+  [`.github/workflows/check/action.yml`](/.github/workflows/check/action.yml).
+  *Leaf:* [`operations/releases/cran/`](/handbook/operations/releases/cran/README.md),
+  which already names the known package-size NOTE as the one blocker
+  it tolerates.
   *From:* [#2474](https://github.com/duckdb/duckdb-r/pull/2474).
 
 * **`-j4` is safe on a 16 GB runner, and there is no second parallelism
@@ -194,11 +166,8 @@ what it excluded is listed at the end.
   *From:* [#2485](https://github.com/duckdb/duckdb-r/pull/2485).
 
 * **The per-invariant enforcement audit.**
-  [`branches/invariants/`](/handbook/branches/invariants/README.md)
-  says most invariants are enforced by nothing and defers the
-  per-statement notes to `BRANCHES.md`, which does not carry them.
-  The wave derived them against the scripts:
-  the only continuous mechanical checks are
+  The wave derived, against the scripts, what would actually catch a
+  violation: the only continuous mechanical checks are
   [`scripts/series-advance.sh`](/scripts/series-advance.sh)'s
   `git merge-base --is-ancestor` gate before it pushes `-green` or
   `-build-base`, and the vendor counter the pipeline bumps.
@@ -206,61 +175,85 @@ what it excluded is listed at the end.
   rename is one patch, so its diff is the surface — and the linearity
   and dev-baseline invariants are checked by nothing at all.
   Worth re-deriving rather than trusting, but the shape held.
-  *Proof:* `scripts/series-advance.sh`, `scripts/series-check.sh`,
+  That the leaf has nowhere to absorb this from is a defect of its own,
+  [#2516](https://github.com/duckdb/duckdb-r/issues/2516).
+  *Proof:* `scripts/series-advance.sh`,
+  [`scripts/series-check.sh`](/scripts/series-check.sh),
   [`scripts/flavor.patch`](/scripts/flavor.patch).
   *Leaf:* [`branches/invariants/`](/handbook/branches/invariants/README.md).
   *From:* [#2478](https://github.com/duckdb/duckdb-r/pull/2478).
 
-## Defects the wave found that `main` still has
+## Defects, filed as issues
 
-Each is a thing to fix, not a thing to write down;
-they are listed here so closing the wave does not lose them.
+Each is a thing to fix, not a thing to write down.
+They are links rather than paragraphs because a defect belongs where it
+can be closed, and this directory cannot close anything.
+Where a fix does not land, the leaf that owns the topic states today's
+behaviour and links the issue, as
+[`meta/authoring/`](/handbook/meta/authoring/README.md) requires of a
+provisional fact — that is the only prose any of these earns.
+
+Filed from this reweighing:
+
+* [#2511](https://github.com/duckdb/duckdb-r/issues/2511) —
+  `make format-check` dies with a `FileNotFoundError` when
+  `cmake-format` is absent, and formats generated CMake files it should
+  not touch. The two tracked CMake files are real: they exist to emit
+  `compile_commands.json` for clangd, and stay.
+* [#2512](https://github.com/duckdb/duckdb-r/issues/2512) —
+  `BASE_SCAN_DEPTH` raises the base-scan bound in the two vendor
+  scripts and not in the two series scripts that hard-code the same
+  twenty, which `scripts/VENDORING.md` states the other way round.
+* [#2513](https://github.com/duckdb/duckdb-r/issues/2513) —
+  the glue gate reports `GLUE BROKEN` with an empty file list when the
+  real failure is that it could not derive compile flags, discarding
+  the distinct return code it already computes.
+* [#2519](https://github.com/duckdb/duckdb-r/issues/2519) —
+  `plan/done/PLAN-storage-locations.md` still marks the Phase 2
+  `.duckdb-r-keep` marker scheme and the library writability probe
+  `[x]`, though neither reached `R/` or `NAMESPACE`.
+
+The flavor rename, one file, three wrong statements in the README it
+produces — the fix is one change, and a check in
+`scripts/flavor-package-name.R` would cover all three:
+
+* [#2517](https://github.com/duckdb/duckdb-r/issues/2517) —
+  `## Installation from GitHub` still says
+  `pak::pak("duckdb/duckdb-r")`, which installs the mainline package
+  rather than the flavor whose README the reader is on.
+  Whether a flavor is installable from GitHub at all, and with which
+  ref, is
+  [`branches/flavors/`](/handbook/branches/flavors/README.md)'s
+  question.
+* [#2514](https://github.com/duckdb/duckdb-r/issues/2514) —
+  the blurb announces LTS version 1.3 on every flavor, because the
+  substitution requires a `.` or `_` before the version and that one is
+  preceded by a space.
+* [#2518](https://github.com/duckdb/duckdb-r/issues/2518) —
+  the `# duckdb` H1 sits above every hunk in `scripts/flavor.patch`, so
+  every flavor is titled as the mainline package.
+
+`#2517` and `#2518` were surfaced by
+[#2510](https://github.com/duckdb/duckdb-r/pull/2510) rather than by the
+wave, and are recorded here because they belong beside `#2514`.
+
+Elsewhere in the same scripts, and in the branch documentation:
+
+* [#2515](https://github.com/duckdb/duckdb-r/issues/2515) —
+  `scripts/flavor.sh` invokes `gsed`, so it fails wherever GNU sed is
+  `sed`.
+* [#2516](https://github.com/duckdb/duckdb-r/issues/2516) —
+  `BRANCHES.md` is cited twice for content it does not carry: a
+  linearization runbook that is not in the repository, and the
+  per-invariant enforcement notes the invariants leaf defers to it for.
+
+Already filed when the wave closed, and not repeated here:
 [#2489](https://github.com/duckdb/duckdb-r/issues/2489)
 (the vendored tree is not byte-reproducible across clones, because
 `DUCKDB_SOURCE_ID` is an abbreviated commit id sized by the clone) and
 [#2490](https://github.com/duckdb/duckdb-r/issues/2490)
 (regeneration rewrites every file unconditionally, invalidating git's
-stat cache) already have issues and are not repeated.
-
-* **`README.md` states the wrong vendoring clone layout.**
-  It says the `duckdb-r` clone must be one level deeper than the
-  `duckdb` clone, and gives `R/duckdb-r` beside `duckdb` as the example.
-  The scripts default to `../../../duckdb` from the package root, which
-  makes that example resolve outside both clones — see the finding
-  above.
-  Either the sentence or the default is wrong; the scripts are what
-  runs.
-
-* **The flavor rename misses the README blurb.**
-  [`scripts/flavor.patch`](/scripts/flavor.patch) writes
-  "This package contains the LTS version 1.3 of DuckDB" into
-  `README.md`, and
-  [`scripts/flavor.sh`](/scripts/flavor.sh) rewrites the flavor suffix
-  with a substitution that requires a `.` or `_` immediately before the
-  `1`.
-  In that sentence the `1.3` is preceded by a space, so it is never
-  rewritten, and every flavored branch's README announces version 1.3
-  whatever it actually carries — visible on the published `duckdb.1.4`.
-  The rest of the rename is unaffected.
-
-* **`scripts/flavor.sh` requires `gsed`.**
-  It invokes `gsed` directly, so on a system where GNU sed is simply
-  `sed` — most Linux — the script fails unless a `gsed` is on `PATH`.
-
-* **`BRANCHES.md` cites a runbook that does not exist.**
-  The major-flip linearization invariant defers to "the linearization
-  runbook"; no such document is in the repository.
-  A reader following the citation finds nothing.
-
-* **`plan/done/PLAN-storage-locations.md` still marks unshipped work
-  `[x]`.**
-  Its header already corrects two of them — the
-  `duckdb_extension_storage()` / `duckdb_secret_storage()` setters and
-  the `?duckdb_storage_config` page.
-  A third is not corrected: the Phase 2 `.duckdb-r-keep` marker scheme
-  and the writability probe of the installed library directory.
-  Neither appears in `R/` or `NAMESPACE`, and the extension cache is
-  never placed in the package library.
+stat cache).
 
 ## What the ladder excluded
 
@@ -278,6 +271,16 @@ diffs, which remain readable on the closed pull requests.
   [`scripts/merge-version.sh`](/scripts/merge-version.sh),
   [`scripts/rconfigure.py`](/scripts/rconfigure.py) and
   `tests/testthat/helper-skip.R` already carry inline.
+  The reweighing added one: that the flavor-name guard can only ever
+  skip under `R CMD check`, because `.Rbuildignore` excludes `scripts$`
+  and a tarball therefore has neither the scan nor the allowlist it
+  reads, is stated in almost those words by the header of
+  `tests/testthat/test-flavor-package-name.R` *and* by the comment on
+  the `custom/after-install` step that runs the scan against the
+  checkout — and
+  [`testing/guards/`](/handbook/testing/guards/README.md)
+  already states the operative half, that CI runs the scan against a
+  plain checkout and the test wraps it for the suite.
 * **Reference-page material.**
   Storage resolution order, dbplyr translation coverage, and the
   connect-time message's throttling all belong to `?duckdb_storage` and
@@ -297,3 +300,9 @@ diffs, which remain readable on the closed pull requests.
   now states the operative fact directly — the status is a display
   artifact, selection reads records, and a commit without a record is
   undecided — which is the durable form of the same thing.
+  The reweighing added the vendor scripts' clone layout, which this
+  record carried twice, once as a finding and once as a defect:
+  [#2506](https://github.com/duckdb/duckdb-r/pull/2506) fixed the
+  `README.md` sentence that contradicted the scripts, and
+  [`operations/vendoring/pipeline/`](/handbook/operations/vendoring/pipeline/README.md)
+  now owns where the upstream repository is looked for.

--- a/plan/history/2026-08-handbook-wave-salvage.md
+++ b/plan/history/2026-08-handbook-wave-salvage.md
@@ -1,0 +1,299 @@
+# Salvage from the closed handbook wave
+
+*A record, not a leaf.*
+Twenty-nine pull requests written against a stub handbook were closed
+unmerged in August 2026, superseded by the MVP tree
+([#2493](https://github.com/duckdb/duckdb-r/pull/2493),
+[#2495](https://github.com/duckdb/duckdb-r/pull/2495),
+[#2504](https://github.com/duckdb/duckdb-r/pull/2504)).
+Each topic is owned today by its leaf under
+[`handbook/`](/handbook/README.md) —
+walk down from the root to find it —
+and where a finding below and a leaf disagree, the leaf is right.
+This file exists so the verified findings those branches carried,
+and that no leaf states yet, are not lost with the branches.
+
+Every entry names the file that proves the claim,
+the leaf that would own it, and the pull request it came from.
+Nothing here is written for a reader who needs the fact today;
+it is written for whoever deepens that leaf next,
+who should re-verify before writing —
+the claims were checked in August 2026 and nothing keeps them current.
+The bar applied was
+[`meta/authoring/`](/handbook/meta/authoring/README.md)'s ladder,
+so most of the wave's prose is not here at all;
+what it excluded is listed at the end.
+
+## Findings
+
+* **`make format-check` aborts instead of reporting when `cmake-format`
+  is absent.**
+  [`scripts/format.py`](/scripts/format.py) sends `src/CMakeLists.txt`
+  through `cmake-format`, which ships separately from `clang-format`;
+  without it the run dies with a `FileNotFoundError` before it reaches a
+  verdict on any file, rather than reporting a difference.
+  Run, not inferred.
+  *Proof:* `scripts/format.py`, the `format-*` targets in
+  [`Makefile`](/Makefile).
+  *Leaf:* [`architecture/glue/`](/handbook/architecture/glue/README.md).
+  *From:* [#2484](https://github.com/duckdb/duckdb-r/pull/2484).
+
+* **The vendor scripts' default clone layout is two levels, not one.**
+  Both scripts `cd` to the package root first and then default
+  `upstream_basedir` to `../../../duckdb`,
+  so the package clone has to sit *two* directories deeper than the
+  upstream clone — upstream at `~/git/duckdb` pairs with a package clone
+  at `~/git/R/duckdb/duckdb-r`, and the layout `README.md` describes
+  resolves to a path that does not exist.
+  Any other layout works by passing the upstream path as the positional
+  argument.
+  *Proof:* [`scripts/vendor.sh`](/scripts/vendor.sh),
+  [`scripts/vendor-one.sh`](/scripts/vendor-one.sh);
+  the wrong statement is in [`README.md`](/README.md).
+  *Leaf:* [`operations/vendoring/pipeline/`](/handbook/operations/vendoring/pipeline/README.md).
+  *From:* [#2477](https://github.com/duckdb/duckdb-r/pull/2477).
+
+* **A local commit-by-commit replay must delete `src/*.o` between
+  commits, or it means nothing.**
+  The `%.dd: %.d` rule in
+  [`src/include/deps.mk`](/src/include/deps.mk)
+  filters every path under `duckdb/` out of the recorded dependencies,
+  so no glue object depends on a vendored engine header.
+  After a vendor run `make` therefore does not recompile the glue:
+  an upstream API break goes unnoticed
+  and the package is linked from objects built against a different
+  engine.
+  A fresh CI checkout never hits this, which is why it bites only
+  locally.
+  *Proof:* `src/include/deps.mk`.
+  *Leaf:* [`operations/vendoring/pipeline/`](/handbook/operations/vendoring/pipeline/README.md),
+  or [`build/source-build/`](/handbook/build/source-build/README.md),
+  which already owns the `.dd` files.
+  *From:* [#2477](https://github.com/duckdb/duckdb-r/pull/2477).
+
+* **`BASE_SCAN_DEPTH` does not reach the series scripts.**
+  The variable is honoured by the two vendor scripts only.
+  [`scripts/series-advance.sh`](/scripts/series-advance.sh) and
+  [`scripts/series-check.sh`](/scripts/series-check.sh)
+  hard-code the same depth and read no such variable,
+  so a branch that stacks enough non-vendoring commits under
+  `src/duckdb/` to need the bound raised needs both of them changed too.
+  *Proof:* those two scripts, against
+  [`scripts/vendor-one.sh`](/scripts/vendor-one.sh).
+  *Leaf:* [`operations/vendoring/troubleshooting/`](/handbook/operations/vendoring/troubleshooting/README.md).
+  *From:* [#2472](https://github.com/duckdb/duckdb-r/pull/2472).
+
+* **An empty `Files:` list from the glue gate is a local setup problem,
+  not a broken glue.**
+  When it prints
+  `Error: could not derive glue compile flags (R CMD SHLIB -n)`
+  alongside an empty file list, the flags could not be derived at all.
+  Deriving them needs `src/Makevars.rstrtmgr`, which only `./configure`
+  writes; the gate runs `./configure` itself when the file is missing,
+  so reaching this message means that failed.
+  *Proof:* [`scripts/vendor-one.sh`](/scripts/vendor-one.sh),
+  the glue-flag block.
+  *Leaf:* [`operations/vendoring/troubleshooting/`](/handbook/operations/vendoring/troubleshooting/README.md).
+  *From:* [#2472](https://github.com/duckdb/duckdb-r/pull/2472).
+
+* **The version merge driver's prefix gate silently declines to
+  renumber across a patch release.**
+  [`scripts/merge-version.sh`](/scripts/merge-version.sh)
+  combines counters only when both sides share a `major.minor.patch`
+  prefix, and otherwise keeps ours verbatim.
+  The script header states the gate; what it does not state is the
+  consequence for a rebase — a series at `1.5.4.9005.N` rebased onto a
+  `1.5.5.9000` base leaves every commit at the base version instead of
+  producing a rising vendor counter, which then has to be re-applied by
+  hand, one commit at a time, as part of the rebase.
+  Whether the larger version would be the better answer is
+  [#2488](https://github.com/duckdb/duckdb-r/issues/2488).
+  *Proof:* `scripts/merge-version.sh`.
+  *Leaf:* [`operations/vendoring/pipeline/`](/handbook/operations/vendoring/pipeline/README.md).
+  *From:* [#2477](https://github.com/duckdb/duckdb-r/pull/2477).
+
+* **`-DDUCKDB_R_BUILD` has exactly one effect on the vendored tree.**
+  It replaces the `atomic` next pointer in `SegmentNode` with a plain
+  pointer, in
+  `src/duckdb/src/include/duckdb/storage/table/segment_tree.hpp`
+  (two `#ifndef DUCKDB_R_BUILD` blocks, the member and its `Next()`
+  accessor).
+  That is the whole of what the define does,
+  which makes it the one flag whose name suggests more than it delivers.
+  *Proof:* that header.
+  *Leaf:* [`architecture/engine/`](/handbook/architecture/engine/README.md).
+  *From:* [#2466](https://github.com/duckdb/duckdb-r/pull/2466).
+
+* **The ALTREP materialization budget stops a runaway query rather than
+  truncating it.**
+  `AltrepRelationWrapper::Materialize()` converts the cell budget to a
+  row budget, pushes a `LimitRelation` of the budget *plus one* row, and
+  raises if that extra row comes back — so an over-budget relation
+  fails, and a caller never receives a silently shortened frame.
+  The same path temporarily doubles `max_expression_depth`, because
+  deeply nested relation trees otherwise hit the engine's own limit
+  ([#101](https://github.com/duckdb/duckdb-r/issues/101)).
+  *Proof:* [`src/reltoaltrep.cpp`](/src/reltoaltrep.cpp).
+  *Leaf:* [`architecture/glue/`](/handbook/architecture/glue/README.md),
+  which already flags the budget for deepening.
+  *From:* [#2484](https://github.com/duckdb/duckdb-r/pull/2484).
+
+* **One hard-coded package qualifier de-evaluates every inline chunk in
+  its roxygen block.**
+  roxygen2 evaluates inline chunks in the package's own namespace, and
+  an unresolvable reference does not raise: the chunk *and its
+  neighbours in the same block* are emitted verbatim as `\verb{r ...}`.
+  A single qualified reference in [`R/storage.R`](/R/storage.R) also
+  took out the `lifecycle::badge()` chunk beside it.
+  The regenerated `.Rd` then differs from the committed one and CI fails
+  at the `roxygenize` step, before anything is compiled —
+  which is why the failure reads as unrelated to the edit that caused
+  it.
+  *Proof:* `R/storage.R` and its generated `man/` page.
+  *Leaf:* [`architecture/r-layer/`](/handbook/architecture/r-layer/README.md),
+  which states the rule but not this failure mode.
+  *From:* [#2480](https://github.com/duckdb/duckdb-r/pull/2480).
+
+* **The flavor-name guard fires in exactly one place.**
+  `tests/testthat/test-flavor-package-name.R` can only ever skip under
+  `R CMD check`: [`.Rbuildignore`](/.Rbuildignore) excludes `scripts$`,
+  so neither
+  [`scripts/flavor-package-name.R`](/scripts/flavor-package-name.R)
+  nor the [`scripts/flavor.patch`](/scripts/flavor.patch) allowlist it
+  reads is present in a built tarball.
+  The `custom/after-install` CI step running the scan against a plain
+  checkout is the guard; delete it and nothing is left,
+  while the test keeps passing by skipping.
+  *Proof:* `.Rbuildignore`, that test file, and
+  [`.github/workflows/custom/after-install/action.yml`](/.github/workflows/custom/after-install/action.yml).
+  *Leaf:* [`testing/guards/`](/handbook/testing/guards/README.md).
+  *From:* [#2467](https://github.com/duckdb/duckdb-r/pull/2467).
+
+* **CI turns the installed-size check off.**
+  [`.github/workflows/custom/before-install/action.yml`](/.github/workflows/custom/before-install/action.yml)
+  exports `_R_CHECK_PKG_SIZES_=FALSE`,
+  so the standing package-size NOTE cannot fail a matrix run —
+  and neither can a size regression.
+  The NOTE is seen at submission time and nowhere earlier.
+  *Proof:* that action file.
+  *Leaf:* [`operations/releases/cran/`](/handbook/operations/releases/cran/README.md).
+  *From:* [#2474](https://github.com/duckdb/duckdb-r/pull/2474).
+
+* **`-j4` is safe on a 16 GB runner, and there is no second parallelism
+  knob.**
+  Peak RSS was measured at about 834 MB per vendored unity object, so
+  four compiles in flight fit with room to spare.
+  Nothing else in the build oversubscribes: the package requests no
+  `-flto`, R's `Makeconf` reports `LTO =` empty, and `DESCRIPTION`
+  carries no `Config/testthat/parallel`, so the suite runs serially.
+  A measurement taken in August 2026, on a four-core container;
+  the three negatives are checkable at any time.
+  *Proof:* [`DESCRIPTION`](/DESCRIPTION), `R CMD config`,
+  [`src/Makevars`](/src/Makevars).
+  *Leaf:* [`operations/ci/per-commit/legs/`](/handbook/operations/ci/per-commit/legs/README.md).
+  *From:* [#2485](https://github.com/duckdb/duckdb-r/pull/2485).
+
+* **The per-invariant enforcement audit.**
+  [`branches/invariants/`](/handbook/branches/invariants/README.md)
+  says most invariants are enforced by nothing and defers the
+  per-statement notes to `BRANCHES.md`, which does not carry them.
+  The wave derived them against the scripts:
+  the only continuous mechanical checks are
+  [`scripts/series-advance.sh`](/scripts/series-advance.sh)'s
+  `git merge-base --is-ancestor` gate before it pushes `-green` or
+  `-build-base`, and the vendor counter the pipeline bumps.
+  The structural and flavor invariants hold *by construction* — the
+  rename is one patch, so its diff is the surface — and the linearity
+  and dev-baseline invariants are checked by nothing at all.
+  Worth re-deriving rather than trusting, but the shape held.
+  *Proof:* `scripts/series-advance.sh`, `scripts/series-check.sh`,
+  [`scripts/flavor.patch`](/scripts/flavor.patch).
+  *Leaf:* [`branches/invariants/`](/handbook/branches/invariants/README.md).
+  *From:* [#2478](https://github.com/duckdb/duckdb-r/pull/2478).
+
+## Defects the wave found that `main` still has
+
+Each is a thing to fix, not a thing to write down;
+they are listed here so closing the wave does not lose them.
+[#2489](https://github.com/duckdb/duckdb-r/issues/2489)
+(the vendored tree is not byte-reproducible across clones, because
+`DUCKDB_SOURCE_ID` is an abbreviated commit id sized by the clone) and
+[#2490](https://github.com/duckdb/duckdb-r/issues/2490)
+(regeneration rewrites every file unconditionally, invalidating git's
+stat cache) already have issues and are not repeated.
+
+* **`README.md` states the wrong vendoring clone layout.**
+  It says the `duckdb-r` clone must be one level deeper than the
+  `duckdb` clone, and gives `R/duckdb-r` beside `duckdb` as the example.
+  The scripts default to `../../../duckdb` from the package root, which
+  makes that example resolve outside both clones — see the finding
+  above.
+  Either the sentence or the default is wrong; the scripts are what
+  runs.
+
+* **The flavor rename misses the README blurb.**
+  [`scripts/flavor.patch`](/scripts/flavor.patch) writes
+  "This package contains the LTS version 1.3 of DuckDB" into
+  `README.md`, and
+  [`scripts/flavor.sh`](/scripts/flavor.sh) rewrites the flavor suffix
+  with a substitution that requires a `.` or `_` immediately before the
+  `1`.
+  In that sentence the `1.3` is preceded by a space, so it is never
+  rewritten, and every flavored branch's README announces version 1.3
+  whatever it actually carries — visible on the published `duckdb.1.4`.
+  The rest of the rename is unaffected.
+
+* **`scripts/flavor.sh` requires `gsed`.**
+  It invokes `gsed` directly, so on a system where GNU sed is simply
+  `sed` — most Linux — the script fails unless a `gsed` is on `PATH`.
+
+* **`BRANCHES.md` cites a runbook that does not exist.**
+  The major-flip linearization invariant defers to "the linearization
+  runbook"; no such document is in the repository.
+  A reader following the citation finds nothing.
+
+* **`plan/done/PLAN-storage-locations.md` still marks unshipped work
+  `[x]`.**
+  Its header already corrects two of them — the
+  `duckdb_extension_storage()` / `duckdb_secret_storage()` setters and
+  the `?duckdb_storage_config` page.
+  A third is not corrected: the Phase 2 `.duckdb-r-keep` marker scheme
+  and the writability probe of the installed library directory.
+  Neither appears in `R/` or `NAMESPACE`, and the extension cache is
+  never placed in the package library.
+
+## What the ladder excluded
+
+Recorded so the same material is not salvaged again from the branch
+diffs, which remain readable on the closed pull requests.
+
+* **Enumerations an artifact already is** — per-translation-unit
+  responsibility tables for `src/`, the `.Rbuildignore` inclusion and
+  exclusion lists, roster tables of skip helpers, test files, workflow
+  files, patch files, and script exit codes.
+  The file is the list.
+* **Restatements of a script's own header.**
+  Several branches copied out reasoning that
+  [`scripts/setup-git.sh`](/scripts/setup-git.sh),
+  [`scripts/merge-version.sh`](/scripts/merge-version.sh),
+  [`scripts/rconfigure.py`](/scripts/rconfigure.py) and
+  `tests/testthat/helper-skip.R` already carry inline.
+* **Reference-page material.**
+  Storage resolution order, dbplyr translation coverage, and the
+  connect-time message's throttling all belong to `?duckdb_storage` and
+  the roxygen sources, which ship to readers who do not have this tree.
+* **Counts and snapshots that an ordinary commit invalidates** —
+  file counts under `src/duckdb/`, object counts, and version strings
+  quoted as status rather than as dated examples.
+* **History and rejected alternatives** — retired scripts, what a
+  document used to say, why a design was abandoned.
+  That is git's and the issues'.
+* **Facts a newer leaf states better.**
+  The wedged `pending` status is the clearest case: the wave's finding
+  was that `PENDING_TTL_HOURS` survives only in a plan document and in a
+  comment about the heuristic that was removed, so a `pending` status
+  can be disbelieved.
+  [`operations/ci/per-commit/`](/handbook/operations/ci/per-commit/README.md)
+  now states the operative fact directly — the status is a display
+  artifact, selection reads records, and a commit without a record is
+  undecided — which is the durable form of the same thing.

--- a/plan/history/2026-08-handbook-wave-salvage.md
+++ b/plan/history/2026-08-handbook-wave-salvage.md
@@ -27,17 +27,23 @@ what it excluded is listed at the end.
 **This record changed its mind once, and says so.**
 Its first version sorted the survivors into findings worth writing and a
 short tail of defects.
-The ladder then gained the rung that asks whether a fact *should* be
-true, and every survivor was walked down it again, against the code.
-A fact that reports a defect is not deepening material at any depth:
-the paragraph is what makes the defect look deliberate, so the output is
-an issue or a fix, and only what survives the fix is written.
-That reweighing moved three entries out of the findings and into the
-issue tracker, and moved two more out of the record entirely, because a
+`meta/authoring/` then gained the discussion that precedes the ladder —
+is a behaviour that looks wrong actually desirable, or a mere
+limitation, and for a limitation, is it cheaper to document or to
+remove? — and every survivor was walked through it again, against the
+code.
+Where the fix is one to three lines with obvious consequences, it is
+cheaper than the paragraph, so the entry became an issue and nothing
+else.
+Where the fix is larger, the behaviour is a limitation for as long as
+that takes: it stays deepening material, and carries the issue so the
+leaf writes it as provisional.
+That reweighing moved two entries out of the findings and into the issue
+tracker alone, and moved two more out of the record entirely, because a
 leaf or a merged fix now states them better.
-Each defect below is a link rather than a paragraph for the same reason:
-an issue can be closed, and this directory is for things that never move
-again.
+The defects listed below are links rather than paragraphs for a separate
+reason: an issue can be closed, and this directory is for things that
+never move again.
 
 ## Deepening material
 
@@ -64,6 +70,28 @@ again.
   or [`build/source-build/`](/handbook/build/source-build/README.md),
   which already owns the `.dd` files.
   *From:* [#2477](https://github.com/duckdb/duckdb-r/pull/2477).
+
+* **An empty `Files:` list from the glue gate is a local setup problem,
+  not a broken glue.**
+  When it prints
+  `Error: could not derive glue compile flags (R CMD SHLIB -n)`
+  alongside an empty file list, the flags could not be derived at all.
+  Deriving them needs `src/Makevars.rstrtmgr`, which only `./configure`
+  writes; the gate runs `./configure` itself when the file is missing,
+  so reaching this message means that failed.
+  The script has the right answer and discards it — `glue_compiles()`
+  returns a distinct 2, and the caller's `!` collapses it into the
+  `GLUE BROKEN` path — but recovering it means restructuring an error
+  path in a script that pushes commits and exits with documented codes,
+  which is not a change a reviewer approves at a glance.
+  So this stays a limitation the leaf states while
+  [#2513](https://github.com/duckdb/duckdb-r/issues/2513) is open,
+  and the trigger and the action are what a reader needs:
+  an empty list means the setup, not the glue.
+  *Proof:* [`scripts/vendor-one.sh`](/scripts/vendor-one.sh),
+  the glue-flag block.
+  *Leaf:* [`operations/vendoring/troubleshooting/`](/handbook/operations/vendoring/troubleshooting/README.md).
+  *From:* [#2472](https://github.com/duckdb/duckdb-r/pull/2472).
 
 * **The version merge driver's prefix gate silently declines to
   renumber across a patch release.**
@@ -185,13 +213,14 @@ again.
 
 ## Defects, filed as issues
 
-Each is a thing to fix, not a thing to write down.
+Each is a thing to fix rather than a thing to write down, because the
+fix is small enough to be cheaper than the paragraph:
+a filed defect whose fix is *not* glance-sized is a limitation
+meanwhile, and appears above instead, with its issue linked —
+[#2513](https://github.com/duckdb/duckdb-r/issues/2513) is the one such
+case here.
 They are links rather than paragraphs because a defect belongs where it
 can be closed, and this directory cannot close anything.
-Where a fix does not land, the leaf that owns the topic states today's
-behaviour and links the issue, as
-[`meta/authoring/`](/handbook/meta/authoring/README.md) requires of a
-provisional fact — that is the only prose any of these earns.
 
 Filed from this reweighing:
 
@@ -199,15 +228,14 @@ Filed from this reweighing:
   `make format-check` dies with a `FileNotFoundError` when
   `cmake-format` is absent, and formats generated CMake files it should
   not touch. The two tracked CMake files are real: they exist to emit
-  `compile_commands.json` for clangd, and stay.
+  `compile_commands.json` for clangd, and stay. The fix is deleting the
+  CMake handling from `scripts/format.py`.
 * [#2512](https://github.com/duckdb/duckdb-r/issues/2512) —
   `BASE_SCAN_DEPTH` raises the base-scan bound in the two vendor
   scripts and not in the two series scripts that hard-code the same
   twenty, which `scripts/VENDORING.md` states the other way round.
-* [#2513](https://github.com/duckdb/duckdb-r/issues/2513) —
-  the glue gate reports `GLUE BROKEN` with an empty file list when the
-  real failure is that it could not derive compile flags, discarding
-  the distinct return code it already computes.
+  The fix reads the variable in place of the literal, with the same
+  default, so it changes nothing until someone sets it.
 * [#2519](https://github.com/duckdb/duckdb-r/issues/2519) —
   `plan/done/PLAN-storage-locations.md` still marks the Phase 2
   `.duckdb-r-keep` marker scheme and the library writability probe


### PR DESCRIPTION
Twenty-nine pull requests written when every handbook leaf was a stub are
superseded by the MVP tree (#2493, #2495, #2504).
They conflict throughout, and merging any of them would revert the newer tree,
so they are being closed unmerged.

Several of them, though, carried claims checked against the code that no leaf
states today, plus a handful of unfixed defects.
Losing those is the only real cost of closing, and it is avoidable.

This adds `plan/history/` and one document in it, holding what survived
[`meta/authoring/`](https://github.com/duckdb/duckdb-r/blob/main/handbook/meta/authoring/README.md)'s
ladder: for each survivor, the finding, the file that proves it, the leaf that
would own it, and the pull request it came from.
It is a record for later deepening, not a leaf — where it and a leaf disagree,
the leaf is right.

**Depends on #2509**, which adds the question this document is now sorted by.

## Reweighed by "document it, or remove it?"

The first version sorted the survivors into findings worth writing and a short
tail of defects. #2509 adds the discussion that precedes the ladder — is a
behaviour that looks wrong actually *desirable*, or a mere *limitation*, and for
a limitation, is it cheaper to document it or to remove it? Every survivor has
been walked through that again, verified against the code rather than
reclassified on shape. The document says so in its own opening, so the record is
honest about having changed its mind, and about which question it changed under.

**Two findings have fixes cheaper than the paragraph**, so they are issues and
nothing else:

* #2511 — `make format-check` dies with a `FileNotFoundError` when
  `cmake-format` is absent, so a run reaches no verdict on anything. The two
  tracked CMake files are not vestigial: they exist to emit
  `compile_commands.json` for clangd, and stay. What should go is `format.py`
  formatting them at all — both carry a "do not edit by hand" generator header —
  which is one list element, one dict entry and a four-line call, deleted.
* #2512 — `BASE_SCAN_DEPTH` raises the base-scan bound in the two vendor
  scripts and not in the two series scripts that hard-code the same twenty,
  which `scripts/VENDORING.md` states the other way round. The fix substitutes
  the variable for the literal with the same default, so nothing changes until
  someone sets it.

**One does not, and is therefore a limitation.** #2513 — the vendoring glue gate
prints `GLUE BROKEN` with an empty file list when the real failure is that it
could not derive compile flags. The script already computes the right answer and
throws it away, but recovering it means restructuring an error path in a script
that pushes commits and exits with documented codes: not a change a reviewer
approves at a glance. The issue stays filed, and the finding returns to the
deepening material carrying it, so
`operations/vendoring/troubleshooting/` can state the trigger and the action —
an empty list means the setup, not the glue — as a provisional fact.

**The defects the record already listed became links**, not paragraphs: #2514,
#2515, #2516, #2519. The reason is the directory: `plan/history/` is for things
that "never move again", and a defect belongs where it can be closed. #2517 and
#2518, surfaced by #2510, join #2514 as the flavored README's three wrong
statements — the most serious being that `## Installation from GitHub` tells a
flavor reader to install the mainline package.

**Two entries left the record entirely.** The vendor scripts' clone layout was
carried twice, as a finding and as a defect; #2506 merged, fixing the `README.md`
sentence, and the pipeline leaf now owns where the upstream repository is looked
for. The flavor-name guard finding is stated by `testing/guards/` and repeated
almost verbatim by two file headers.

**The survivors were verified, not assumed** — several looked like defects and
turn out to be desirable:

* `_R_CHECK_PKG_SIZES_=FALSE` is load-bearing: the check action runs
  `r-lib/actions/check-r-package` with `error-on: "note"`, so without the export
  the standing package-size NOTE would fail every matrix run.
* The `deps.mk` filtering of engine headers is deliberate, says why inline, and
  the API break it could hide is caught by the glue gate instead.
* The two `#ifndef DUCKDB_R_BUILD` blocks are upstream's own — nothing under
  `patch/` mentions the define — so the flag is an accommodation offered, not
  a local edit.

What remains as deepening material is either a true fact about a deliberate
design or a limitation with its issue, each naming the file that proves it and
the leaf that would own it.

A closing section records what the ladder excluded, in categories, so the same
prose is not salvaged again from the branch diffs.

## Verification

- Handbook link walk: no dangling links, none starting with `../`; the two
  touched `plan/` files walk clean too.
- `Rscript .claude/skills/docs-consistency/docs-readme.R --check`: current.
- `origin/main` merged, including #2506.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PD23hjFQFRWW62HFvru187)_