### PR TITLE
docs(handbook): weigh documenting a limitation against removing it

### DIFF
--- a/handbook/meta/authoring/README.md
+++ b/handbook/meta/authoring/README.md
@@ -53,10 +53,32 @@ the rest move the fact somewhere better than a paragraph.
    so a fact is edited in one place
    and found from the place it is about.
 
+**A behaviour that looks wrong rather than chosen is settled before the
+ladder, not on it.**
+A fact can be true and still be one nobody should have to read,
+and no rung can tell which:
+nothing mechanical distinguishes a deliberate limitation from an unfixed
+one, because both are only what the code does.
+So it is a discussion, not a test —
+is the behaviour *desirable*, or is it a mere *limitation*?
+Desirable, and it is an ordinary fact, taking the ladder like any other.
+A limitation, and the two costs are weighed against each other.
+A fix of one to three lines, with consequences obvious enough to approve
+at a glance, is cheaper than the paragraph and every later edit of it:
+make it, and write nothing.
+Anything larger is work carrying its own risk, review and timeline,
+so the limitation is real for as long as that takes —
+and the tree requires the leaf to state its limits,
+with the issue that will remove it, so the fact reads as provisional.
+Silence is the one answer never available:
+a limitation nobody wrote down is one the next reader rediscovers,
+and pays for twice.
+
 ## Where the handbook stops
 
-Rungs 3 to 5 all ask the same question — is something else a better
-home for this? — and the answer generalises.
+The rungs asking after another owner, an artifact, and a check
+all ask the same question — is something else a better home for this? —
+and the answer generalises.
 **The tree owns what the code cannot say about itself**, which is three
 things:
 


### PR DESCRIPTION
The ladder in [`meta/authoring/`](https://github.com/duckdb/duckdb-r/blob/main/handbook/meta/authoring/README.md)
asks whether a sentence is a fact, whether it is true, whether something else
owns it, whether an artifact states it, and whether a check could state it
instead. Nothing on it asks whether the behaviour being described ought to
exist.

So prose that explains a defect passes every rung and gets written, and reads
to the next person as if the behaviour were deliberate. The worked example is
`scripts/format.py`: it sends CMake files through `cmake-format`, which ships
separately from `clang-format`, and without it `make format-check` dies with a
`FileNotFoundError` on the first file it reaches and never returns a verdict on
anything. That is a fact, it is true, no leaf owns it, no artifact states it,
and no check can state it — the check is the thing that is broken. Written
down, it becomes a documented prerequisite: a contributor installs
`cmake-format` and moves on.

## Why this is not a rung

An earlier revision of this PR added "Should it be true?" as a numbered rung
after "Is it true?". That over-claims, and the review was right to reject it.

A rung gates whether a sentence is written. That gate is only correct when the
alternative is genuinely cheaper than the sentence — a one- to three-line change
with obvious consequences, trivial to review. Anything larger is a piece of work
with its own risk, review and timeline, and the behaviour it would remove is,
until then and possibly for a long time, **a limitation**. Documenting a
limitation is not entrenchment; it is the leaf doing its job. `meta/handbook/`
already requires a leaf to state "its limits, its declined requests with their
reasons". A rung phrased as "should it be true?" tells an author to stop writing
in exactly the cases where writing is right.

It is also not the kind of question a rung can hold. A rung is a test. This is a
judgment: nothing mechanical distinguishes a deliberate limitation from an
unfixed one, because both are only what the code does. Whoever is reading the
code has to decide.

## What this adds instead

A short prose part at the end of "Before writing a sentence", after the ladder
and explicitly not on it, following the shape from review:

> **A behaviour that looks wrong rather than chosen is settled before the
> ladder, not on it.** A fact can be true and still be one nobody should have to
> read, and no rung can tell which: nothing mechanical distinguishes a
> deliberate limitation from an unfixed one, because both are only what the code
> does. So it is a discussion, not a test — is the behaviour *desirable*, or is
> it a mere *limitation*? Desirable, and it is an ordinary fact, taking the
> ladder like any other. A limitation, and the two costs are weighed against
> each other. A fix of one to three lines, with consequences obvious enough to
> approve at a glance, is cheaper than the paragraph and every later edit of it:
> make it, and write nothing. Anything larger is work carrying its own risk,
> review and timeline, so the limitation is real for as long as that takes — and
> the tree requires the leaf to state its limits, with the issue that will
> remove it, so the fact reads as provisional. Silence is the one answer never
> available: a limitation nobody wrote down is one the next reader rediscovers,
> and pays for twice.

Two questions, in order: desirable or a limitation, and then document or remove
— whichever is cheaper. The closing sentence is there because the failure mode
of a rule like this is that it gets read as permission to omit inconvenient
truths.

Because it is no longer a gate that can discard a fact, the ladder is untouched:
six rungs, original numbering, and the preamble sentence about which rungs end
in nothing being written is restored exactly as it was.

## `cmake-format`, under the new shape

The behaviour is not desirable. Is the fix small? The two tracked CMake files
turn out to be real — they exist to emit `compile_commands.json` for clangd, and
they stay — but both carry a "generated, do not edit by hand" header, so
formatting them was never right. The fix is deleting one list element, one dict
entry, and a four-line `os.system` call from `format.py`, with nothing else
affected. That is cheaper than the paragraph, so it is #2511 and no leaf gains
a sentence.

Not every finding lands there. The vendoring glue gate reports `GLUE BROKEN`
with an empty file list when the real failure is that it could not derive
compile flags (#2513). Fixing it means restructuring an error path in a script
that pushes commits and exits with documented codes — not a glance-approvable
change. So that one is a limitation, `operations/vendoring/troubleshooting/`
states how to read the message, and links the issue. The rule earns its keep by
splitting those two cases apart.

## The one unrelated fix kept

"Where the handbook stops" opened by citing "Rungs 3 to 5". The page's own rule
says never to refer by position, so those rungs are now named by what they ask.

## Verification

- Handbook link walk: no dangling links, none starting with `../`.
- `Rscript .claude/skills/docs-consistency/docs-readme.R --check`: current.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PD23hjFQFRWW62HFvru187)_