### PR TITLE
fix(flavor): name the flavor in the README blurb, and find GNU sed

### DIFF
--- a/BRANCHES.md
+++ b/BRANCHES.md
@@ -341,8 +341,10 @@ accepted in exchange for a bisectable, merge-free active history.
   continuously: `main` (current stable) and `main-dev` (next major) vendor
   different upstream C++, so forcing ancestry would mean rebasing 400+ commits on
   every `main` patch release for no benefit. Instead it is **established once**,
-  immediately before the flip, by the linearization runbook (rewind to the
-  upstream bifurcation point, then replay).
+  immediately before the flip, by rewinding to the upstream bifurcation point and
+  replaying. Nothing automates that step — there is no runbook and no script —
+  and the flip it prepares is
+  [`operations/releases/process/`](/handbook/operations/releases/process/README.md)'s.
 - **A3 — Dev SHAs are disposable.** Because linearity is maintained by rebasing,
   `-dev` SHAs are not durable; only tags (releases) and the fast-forward-only
   `dev-base` marker are stable references. This is acceptable — `-dev` exists

--- a/handbook/contributors/workflow/README.md
+++ b/handbook/contributors/workflow/README.md
@@ -24,6 +24,13 @@ Little of this is codified; what is settled:
 * Never edit generated or vendored files
   ([`architecture/`](/handbook/architecture/README.md),
   [`operations/vendoring/`](/handbook/operations/vendoring/README.md)).
+* A script only ever run on a CI runner may assume GNU tools;
+  one a contributor may run on their own machine will meet macOS,
+  where `sed` is BSD.
+  Where such a script wants GNU behaviour it locates GNU sed —
+  `gsed` first, then `sed` — and refuses to run when neither is GNU,
+  rather than writing every expression to what the two agree on
+  ([`scripts/flavor.sh`](/scripts/flavor.sh)).
 
 The review side — what gets checked, who drives CI — is
 [`operations/review/`](/handbook/operations/review/README.md).

--- a/plan/done/PLAN-storage-locations.md
+++ b/plan/done/PLAN-storage-locations.md
@@ -4,10 +4,13 @@
 [`usage/storage/`](/handbook/usage/storage/README.md)'s; this file is kept for
 the reasoning behind it, not as a description of the system.
 
-Two things the checklist below marks `[x]` never shipped, and are not part of
+Four things the checklist below marks `[x]` never shipped, and are not part of
 what landed: the `duckdb_extension_storage()` / `duckdb_secret_storage()`
-setters, and the `?duckdb_storage_config` page. Neither exists in `R/` or
-`NAMESPACE`. `duckdb_storage_status()` is the one exported function.
+setters, the `?duckdb_storage_config` page, the Phase 2 `.duckdb-r-keep` marker
+scheme, and the writability probe that would have placed the extension cache in
+the installed library. None of them appears in `R/` or `NAMESPACE`, and the
+resolution that shipped has neither a marker nor a `"library"` root.
+`duckdb_storage_status()` is the one exported function.
 
 Implementation roadmap for the storage-location policy documented in
 `?duckdb_storage`. The design is settled in the docs; this file tracked the

--- a/scripts/VENDORING.md
+++ b/scripts/VENDORING.md
@@ -258,9 +258,10 @@ this list is the sources-and-glue side it drives):
    the rename touches the shared-object name and every `.Call()` entry point,
    so applying it later invalidates every build below it.
 
-   `flavor.sh` has three prerequisites it does not check:
-   GNU sed under the name `gsed` (present on macOS via Homebrew, absent on a plain Linux box),
-   and the `cpp11` and `decor` R packages, needed for the `cpp11::cpp_register()` step.
+   `flavor.sh` has two prerequisites it does not check:
+   the `cpp11` and `decor` R packages, needed for the `cpp11::cpp_register()` step.
+   (GNU sed it does check, and refuses to run without —
+   on macOS that means `gsed`, from Homebrew.)
    It commits the first of its two commits *before* reaching that step,
    so a missing prerequisite leaves the branch with a half-applied flavor;
    finish by hand with `cpp11::cpp_register()` and a second commit,

--- a/scripts/flavor.patch
+++ b/scripts/flavor.patch
@@ -21,13 +21,13 @@ index 2ee2528d0..7982715b8 100644
  "_PACKAGE"
  NULL
 diff --git a/README.md b/README.md
-index 9087bd425..11c8677ac 100644
+index a2a4f7b..ecc61b8 100644
 --- a/README.md
 +++ b/README.md
-@@ -12,29 +12,7 @@
+@@ -12,29 +12,9 @@
  It is designed to support analytical query workloads and is optimized for fast query execution.
  This repository contains the R bindings for DuckDB.
-
+ 
 -## Installation from CRAN
 -This is the recommended method for recent R versions on Windows or macOS which have binaries available on CRAN.
 -
@@ -51,18 +51,20 @@ index 9087bd425..11c8677ac 100644
 -```
 -
 -To check the availability of binaries for your platform, navigate to the [duckdb search page](https://p3m.dev/client/#/repos/cran/packages/overview?search=duckdb).
-+This package contains the LTS version 1.3 of DuckDB, and is only available from GitHub and r-universe.
-
++This package is the `duckdb.1.3` flavor of those bindings,
++and is only available from r-universe and GitHub.
++The `Flavors` section below says which upstream series it tracks.
+ 
  ## Installation from r-universe
-
-@@ -43,7 +21,7 @@
+ 
+@@ -43,7 +23,7 @@ Binaries are available for recent versions of R and for some platforms.
  Review <https://docs.r-universe.dev/install/binaries.html> for configuring installation of binary packages on Linux.
-
+ 
  ``` r
 -install.packages("duckdb", repos = c("https://duckdb.r-universe.dev", "https://cloud.r-project.org"))
 +install.packages("duckdb.1.3", repos = c("https://duckdb.r-universe.dev", "https://cloud.r-project.org"))
  ```
-
+ 
  Installing the package from source may take up to an hour.
 diff --git a/inst/include/duckdb_types.hpp b/inst/include/duckdb_1_3_types.hpp
 similarity index 100%

--- a/scripts/flavor.sh
+++ b/scripts/flavor.sh
@@ -6,7 +6,7 @@ set -euxo pipefail
 
 cd "$(dirname "$0")/.."
 
-package_name="$1"
+package_name="${1-}"
 if [ -z "$package_name" ]; then
   echo "Usage: $0 <package-name>"
   echo "  $0 1.5"
@@ -15,12 +15,30 @@ if [ -z "$package_name" ]; then
   exit 1
 fi
 
-# Replace all dots with \1 for the sed expression
-replacer=${package_name//./\\1}
+# GNU sed, wherever it is called: on Linux that is `sed`, on macOS it is `gsed`
+# and the system `sed` is BSD. Prefer `gsed`, then verify -- silently accepting
+# BSD sed would write a subtly wrong patch that the commit below then records.
+if command -v gsed >/dev/null 2>&1; then
+  gnu_sed=gsed
+else
+  gnu_sed=sed
+fi
+sed_version="$("$gnu_sed" --version 2>/dev/null || true)"
+case "$sed_version" in
+*"GNU sed"*) ;;
+*)
+  echo "$0: '$gnu_sed' is not GNU sed." >&2
+  echo "  Install GNU sed as 'gsed' -- on macOS, 'brew install gnu-sed'." >&2
+  exit 1
+  ;;
+esac
 
-# The patch file has 1.3
-gsed -i.bak -r 's/([._])1\13/\1'$replacer'/g' scripts/flavor.patch
-rm scripts/flavor.patch.bak
+# The patch file spells the flavor suffix 1.3, dot-separated in package names
+# and underscore-separated in file names.
+"$gnu_sed" -i \
+  -e "s/duckdb\.1\.3/duckdb.$package_name/g" \
+  -e "s/duckdb_1_3/duckdb_${package_name//./_}/g" \
+  scripts/flavor.patch
 git add scripts/flavor.patch
 git commit -m "chore: Update flavor patch to $package_name"
 


### PR DESCRIPTION
Four of the five defects listed in #2507's "Defects the wave found that `main` still has".
The fifth — the clone layout — landed in #2506.

## The blurb never carried the flavor

`scripts/flavor.patch` inserted "This package contains the LTS version 1.3 of DuckDB",
and `scripts/flavor.sh` rewrote the suffix with `s/([._])1\13/\1$replacer/g`,
which needs a `.` or `_` immediately before the `1`.
In that sentence it is a space, so the blurb was never touched:
every flavored README announced 1.3, and called itself LTS even on a `.dev` flavor.

The blurb now names the package — the one string every flavor differs in —
and leaves the series and the kind to the `Flavors` table, which is a few lines below it
in the flavored README and already carries both.
That reads correctly for a version, a version-plus-`dev`, and a bare `dev` alike.

**Before** (identical for every flavor, and this is what `duckdb.1.4` publishes today):

```
This package contains the LTS version 1.3 of DuckDB, and is only available from GitHub and r-universe.
```

**After** — the actual `README.md` written by `scripts/flavor.sh $FLAVOR` in a throwaway clone,
for each of the three shapes the script's own usage lists:

`1.5`

```
This package is the `duckdb.1.5` flavor of those bindings,
and is only available from r-universe and GitHub.
The `Flavors` section below says which upstream series it tracks.
```

`1.5.dev`

```
This package is the `duckdb.1.5.dev` flavor of those bindings,
and is only available from r-universe and GitHub.
The `Flavors` section below says which upstream series it tracks.
```

`dev`

```
This package is the `duckdb.dev` flavor of those bindings,
and is only available from r-universe and GitHub.
The `Flavors` section below says which upstream series it tracks.
```

All three runs went the whole way through `cpp11::cpp_register()` and both commits.
Spot-checking `1.5.dev`: `Package: duckdb.1.5.dev`,
`DUCKDB_PACKAGE_NAME "duckdb.1.5.dev"`, `useDynLib(duckdb.1.5.dev, ...)`,
`inst/include/duckdb_1_5_dev_types.hpp`, `man/duckdb.1.5.dev-package.Rd`,
and `_duckdb_1.5.dev_rapi_connect` in `src/cpp11.cpp`.
`flavor_package_name_offenders()` returns nothing.

### The substitution no longer needs a back-reference

Anchoring on the separator forced `replacer` to be the package name with `.` replaced by `\1`,
so for `1.5` the replacement string became `\11\15`.
That works only because GNU sed reads `\11` as group 1 followed by a literal `1`;
POSIX defines `\1` through `\9` and nothing wider.
Naming the package in the blurb lets both substitutions anchor on `duckdb` instead,
so there is no group and no back-reference left:

```sh
"$gnu_sed" -i \
  -e "s/duckdb\.1\.3/duckdb.$package_name/g" \
  -e "s/duckdb_1_3/duckdb_${package_name//./_}/g" \
  scripts/flavor.patch
```

Dot-separated for package names, underscore-separated for file names — the two shapes the patch uses.

## `gsed` is not on most Linux boxes

`flavor.sh` called `gsed` unconditionally.
It now prefers `gsed`, falls back to `sed`, and then **verifies the choice is GNU** before using it.
The verify is the point: on a macOS box without `gsed` installed,
a bare fallback silently selects BSD sed,
which understands neither `-r` nor GNU `-i` — and the script `git commit`s the rewritten
`flavor.patch` two lines later, so a wrong rewrite gets recorded rather than noticed.
Failing loudly names `gsed` and says how to get it.

Locating GNU sed is the strategy, not writing to the intersection of GNU and BSD:
the intersection constrains every future expression, the lookup costs three lines once.

Also: `package_name="${1-}"`, so the usage message is reachable under `set -u`
instead of dying on `$1: unbound variable`.

## Where the rule landed

`handbook/contributors/workflow/` — the leaf that owns the conventions a change follows.
No leaf owned script conventions as such;
the generated `scripts/README.md` maps each script to the leaf that owns its *topic*,
so a cross-cutting rule about how scripts are written has no owner in the tree.
That is a homeless topic and a defect of the tree, noted rather than fixed here:
the rule went to the closest leaf instead of inventing a node for it.

On the authoring ladder's rung 5 — could a check state it instead?
Partly, and the part that could now does: `flavor.sh` checks its own sed at run time and refuses.
The other half cannot be checked, because nothing in a script's text says who runs it,
and the rule turns on exactly that: a repo-shape guard grepping `scripts/*.sh` for GNU-only
constructs would fire on CI-only code it has no business failing.
So the run-time guard is in the code, and the prose carries the distinction and names the technique.

## Stale claims

* `BRANCHES.md` cited "the linearization runbook" for establishing flip ancestry.
  Searching the repository for `runbook` returns that one line and nothing else,
  and nothing else performs the step —
  `operations/releases/process/` describes the same rewind-and-replay without a procedure behind it.
  The sentence now says plainly that nothing automates it, and points at the release process.
* `scripts/VENDORING.md` listed GNU sed among the prerequisites `flavor.sh` does not check.
  It checks it now, so the list is down to `cpp11` and `decor`.
* `plan/done/PLAN-storage-locations.md` marked two more never-shipped items `[x]`
  than its header corrects: the Phase 2 `.duckdb-r-keep` marker scheme
  and the library writability probe.
  Verified against the tree — `R/` has no marker function and no `file.access` probe,
  `NAMESPACE` exports `duckdb_storage_status()` alone,
  and what shipped resolves one home (an existing `~/.duckdb`, else a per-session temp dir)
  with no `"library"` root at all.
  The header's existing correction is extended in its own voice.

## Patch fuzz

The `Hunk #1 succeeded at 28 with fuzz 2 (offset 1 line)` line belongs to
`src/include/rapi.hpp`, not to `README.md` —
`patch` prints a hunk's message after the `checking file` line of the file it applies to,
and `README.md`'s hunk starts at 12, not 28.
Splitting `flavor.patch` per file and dry-running each confirms it.
`README.md` was already clean, and the regenerated hunks keep it that way.

| File | Before | After |
|---|---|---|
| `DESCRIPTION` | fuzz 0, offset 0 | unchanged |
| `R/duckdb-package.R` | fuzz 0, offset 0 | unchanged |
| `README.md` | fuzz 0, offset 0 | fuzz 0, offset 0 |
| `inst/include/duckdb_types.hpp` | pure rename | unchanged |
| `src/include/rapi.hpp` | fuzz 2, offset 1 | unchanged |
| `tests/testthat.R` | fuzz 2, offset 0 | unchanged |
| `NAMESPACE` | fuzz 0, offset 7 | unchanged |
| `man/duckdb-package.Rd` | fuzz 1, offset 0 | unchanged |

The four that still drift are left alone, per scope, but the cause is known and none of it is
adjacent to what changed here:

* `rapi.hpp` — the trailing context is the old `// Helper functions to communicate errors ...`
  comment; the file now has the CRAN-guard block there.
* `tests/testthat.R` — `test_check(simulate_duckdb()$pkg)` is now indented inside `if (run) {`.
* `man/duckdb-package.Rd` — the trailing context predates the `\figure{logo.png}` line.
* `NAMESPACE` — no fuzz, just exports added above the hunk.

Regenerating those is a separate change: three of them would also want the blob hashes
in the `index` lines refreshed, and each is a different file's history.

## Markdown

The blurb is three semantic lines rather than one 100-column sentence,
and "those bindings" picks up the preceding paragraph instead of repeating "the R bindings for DuckDB".
Checked in the flavored output, not just in the patch:
the only intra-document cross-reference left in a flavored `README.md`
is the blurb's own pointer to `Flavors`, which the patch does not remove.
The one reference the removed sections contained — "(see the next section)",
pointing from the CRAN section at the Posit one — sat inside the removed range and went with it.

## Verified

* `bash -n scripts/flavor.sh`
* the `patch -p1 --dry-run` of `scripts/flavor.patch` applies, per-file numbers in the table above
* `scripts/flavor.sh` run end to end for `1.5`, `1.5.dev`, `dev` in throwaway clones
* `flavor_package_name_offenders(".")` returns `character(0)`
* the handbook link walk: no dangling, none starting with `../`
* `Rscript .claude/skills/docs-consistency/docs-readme.R --check`: `scripts/README.md is current`

---
_Generated by [Claude Code](https://claude.ai/code/session_01PD23hjFQFRWW62HFvru187)_