### PR TITLE
docs(handbook): Complete the leaves the triage closes will link

### DIFF
--- a/handbook/operations/releases/versioning/README.md
+++ b/handbook/operations/releases/versioning/README.md
@@ -38,7 +38,10 @@ Taking the maximum is what keeps that true through a replay:
 each replayed vendor commit carries its own higher counter,
 and the driver keeps it.
 
-The prefix gate has a consequence worth knowing:
+The prefix gate has a consequence worth knowing
+(it is the answer to
+[#2488](https://github.com/duckdb/duckdb-r/issues/2488) —
+no, nothing should inherit across prefixes):
 because the driver keeps *ours* verbatim when the prefixes differ,
 it does **not** renumber a `-dev` branch when the base moves to a new
 patch release.

--- a/handbook/usage/integrations/README.md
+++ b/handbook/usage/integrations/README.md
@@ -77,6 +77,14 @@ Out: `dbGetQueryArrow()` returns a `nanoarrow_array_stream`,
 and `dbSendQueryArrow()` / `dbFetchArrowChunk()` stream a result
 batch by batch — true streaming since 1.5.4
 ([#162](https://github.com/duckdb/duckdb-r/issues/162)).
+The stream is the interchange:
+any Arrow-C-stream consumer takes a result onward
+without an R data frame in between —
+`polars::as_polars_df()`, `arrow::as_arrow_table()`,
+`nanoarrow::convert_array_stream()` —
+so a dedicated writer per frame library
+(Polars was the one asked for) is this route, not new C++
+([#642](https://github.com/duckdb/duckdb-r/issues/642)).
 `arrow::to_duckdb()` and `to_arrow()`
 bridge dplyr pipelines both ways.
 The DBI Arrow API plan is

--- a/handbook/usage/memory/README.md
+++ b/handbook/usage/memory/README.md
@@ -26,11 +26,15 @@ and how to keep results from materializing in R.
   beside the file (`src/duckdb/src/main/config.cpp`);
   the options that override either are
   [`storage/`](/handbook/usage/storage/README.md)'s.
+  Spill covers query state, not a transaction's own uncommitted
+  writes — those blocks stay pinned, so a very large single append
+  can still fail at `COMMIT` under a tight limit
+  (engine-side; reported once on 1.3.2 and not reproduced since,
+  [#1604](https://github.com/duckdb/duckdb-r/issues/1604)).
 * Larger-than-memory data is best left in DuckDB —
-  query it lazily via dbplyr and `collect()` only the reduction.
+  query it lazily via dbplyr and `collect()` only the reduction;
+  [#72](https://github.com/duckdb/duckdb-r/issues/72) is the long
+  history behind that advice.
 
 *To deepen: verify and state the engine's default `memory_limit`
-as shipped, on a vendored build;
-drain what survives of
-[#72](https://github.com/duckdb/duckdb-r/issues/72),
-[#1604](https://github.com/duckdb/duckdb-r/issues/1604).*
+as shipped, on a vendored build.*


### PR DESCRIPTION
The inbox-zero triage routes every close-without-code to the handbook leaf that owns its answer
(per [`operations/triage/`](https://github.com/duckdb/duckdb-r/blob/main/handbook/operations/triage/README.md)).
Before posting those closes, this verifies each target leaf actually carries the answer at closing depth — and lands the three entries that were missing.

## Verification result

Already complete, citing their issues by number (their closes just link the section, no doc change needed):

- `usage/types/` — #12 (UTF-8 + `iconv()`), #1670 (WKB write recipe, #117 as the epic), #155, #200/#590
- `usage/connections/` — #83/#171 (config binds at instance creation), #179 (multi-statement prepare rule), #2498 noted
- `usage/data-import/` — #1733 (`tbl_function()` glob + `filename`), #1511/#118
- `usage/extensions/` — #2306 (autoload ≠ autoinstall), the #2234 Windows gap that also answers #2503, #2425
- `usage/memory/` — #1065 (`memory_limit` bounds the engine, not R)

## The three gaps, closed here

- **`usage/integrations/`** — the types leaf promises "what consumes an Arrow result is integrations'", but the consumer line was missing. Now stated: the `nanoarrow_array_stream` is the interchange, and any Arrow-C-stream consumer takes a result onward without an R data frame in between (`polars::as_polars_df()`, `arrow::as_arrow_table()`, `nanoarrow::convert_array_stream()`). That is the #642 answer: the requested per-library writers are this route, not new C++.
- **`operations/releases/versioning/`** — the prefix-gate paragraph already *was* the #2488 answer but didn't say so. It now cites the question and states the answer: no, nothing should inherit across prefixes; keeping ours verbatim is the gate doing its job.
- **`usage/memory/`** — drains what survives of #1604 and #72, exactly as the leaf's deepen line requested: spill covers query state but not a transaction's own pinned uncommitted writes (so a huge single append can still fail at `COMMIT` under a tight limit — engine-side, reported once on 1.3.2), and the lazy-query advice now carries #72's history. The deepen line is trimmed accordingly.

Deliberately **no `Closes` keywords**: per the triage doctrine a close credits the reporter and names the reopen condition, so the closes are posted as comments linking these sections once this merges (#642, #2488, and the stale trio #72/#1065/#1604 among them).

Checks: `docs-consistency` link integrity and the generated `scripts/README.md` index both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RH9bWPafmAxsjucWCDBA4G

---
_Generated by [Claude Code](https://claude.ai/code/session_01RH9bWPafmAxsjucWCDBA4G)_