### PR TITLE
fix(series-advance): Restamp the vendor counter across a replay

### DIFF
--- a/.claude/skills/series-loop.md
+++ b/.claude/skills/series-loop.md
@@ -987,14 +987,14 @@ is what carries the automatic path into a forward series.
   the merge driver's gate then keeps our side verbatim
   and the counter freezes for the whole chain
   ([`operations/releases/versioning/`](/handbook/operations/releases/versioning/README.md)).
-  `main` is in that state, and every firing pays it —
-  40 commits at `1.5.99.9003.1039` on 2026-08-02,
-  five at `…1076` on 2026-08-04.
+  `main` is in that state.
   So after any replay, **restamp before pushing `-dev`**:
   walk the new commits oldest first
   and bump once per vendor commit from the parent's value.
-  Check it, do not assume it —
-  a replay that silently froze the counter
+  [`scripts/series-advance.sh`](/scripts/series-advance.sh) does that
+  and then asserts it;
+  a replay done by hand is checked the same way,
+  because one that silently froze the counter
   looks exactly like one that did not.
 - Git alone is sufficient in principle:
   even a rerun is one pushed ref —

--- a/handbook/operations/releases/versioning/README.md
+++ b/handbook/operations/releases/versioning/README.md
@@ -39,7 +39,8 @@ but only while both strands share a `major.minor.patch` prefix.
 Where they do not, the gate keeps our side verbatim,
 so a replayed vendor commit arrives with its parent's counter
 and the series stops being orderable —
-the loop restamps by hand
+[`scripts/series-advance.sh`](/scripts/series-advance.sh) restamps it,
+and refuses to push a replay whose counter did not rise
 ([`.claude/skills/series-loop.md`](/.claude/skills/series-loop.md)).
 `main-dev` carries the preview prefix `1.5.99`
 and its buffer `main-build` carries `1.5.5`,

--- a/scripts/series-advance.sh
+++ b/scripts/series-advance.sh
@@ -56,6 +56,84 @@ vendored_sha() {
   echo "$sha"
 }
 
+# Does this commit vendor? The subject decides, never the path -- the same rule
+# the rest of this loop reads state by, and the same predicate series-port.sh
+# classifies with. Matched without a pipe, so `pipefail` cannot turn a match
+# into a miss when the reader closes first.
+vendors() { # <repo> <commit>
+  case "$(git -C "$1" log -1 --format=%s "$2")" in
+    vendor:* | *duckdb/duckdb@[0-9a-f]*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Is $1 a strictly greater version than $2? Component-wise and numeric, so a
+# rise the invariant allows is not mistaken for a freeze: a bump in any
+# component counts, and the components are compared as numbers rather than as
+# text (`10` is above `9`). A non-numeric component makes the answer unknown,
+# which is a refusal, not a pass.
+version_gt() { # <a> <b>
+  local -a x y
+  case "$1" in '' | *[!0-9.]*) return 2 ;; esac
+  case "$2" in '' | *[!0-9.]*) return 2 ;; esac
+  IFS=. read -r -a x <<<"$1"
+  IFS=. read -r -a y <<<"$2"
+  local i
+  for i in 0 1 2 3 4; do
+    (( ${x[i]:-0} > ${y[i]:-0} )) && return 0
+    (( ${x[i]:-0} < ${y[i]:-0} )) && return 1
+  done
+  return 1
+}
+
+# Raise DESCRIPTION's fifth component to one above the parent's, on a commit
+# that vendors. Every vendor commit must be strictly above its parent
+# (.claude/skills/series-loop.md): gaps are fine, repeats are not, because
+# r-universe installs by version and cannot tell a run of commits sharing one
+# apart.
+#
+# The ours-version merge driver hands the pick our side of `Version:` whenever
+# the two strands' `major.minor.patch` prefixes differ, which is what this
+# repairs; where they agree, -build's own bump comes through and there is
+# nothing to do.
+restamp() { # <worktree> <buffer commit>
+  local wt=$1 c=$2 parent cur new
+  vendors . "$c" || return 0
+  parent=$(git -C "$wt" show 'HEAD~1:DESCRIPTION' | sed -n 's/^Version: //p')
+  cur=$(git -C "$wt" show 'HEAD:DESCRIPTION' | sed -n 's/^Version: //p')
+  version_gt "$cur" "$parent" && return 0
+  # The counter is the fifth component, and only a dev branch carries one; a
+  # four-component version is a strand with no counter to raise, and inventing
+  # one here would mint a version the series never chose.
+  case "$parent" in
+    *.*.*.*.*) ;;
+    *) return 0 ;;
+  esac
+  new="${parent%.*}.$((${parent##*.} + 1))"
+  # `-i.bak`, so the one edit works under both GNU and BSD sed.
+  sed -i.bak "s/^Version: .*/Version: $new/" "$wt/DESCRIPTION"
+  rm -f "$wt/DESCRIPTION.bak"
+  git -C "$wt" add DESCRIPTION
+  git -C "$wt" commit -q --amend --no-edit
+}
+
+# Check the counter rather than assume it: a replay that silently froze it
+# looks exactly like one that did not. Returns non-zero and leaves the caller
+# to clean up, so the worktree is removed on this path like every other.
+verify_counter() { # <worktree> <ref the replay started from>
+  local wt=$1 from=$2 sha parent cur rc=0
+  while IFS= read -r sha; do
+    vendors "$wt" "$sha" || continue
+    parent=$(git -C "$wt" show "$sha~1:DESCRIPTION" | sed -n 's/^Version: //p')
+    cur=$(git -C "$wt" show "$sha:DESCRIPTION" | sed -n 's/^Version: //p')
+    version_gt "$cur" "$parent" && continue
+    echo "Error: $(git -C "$wt" rev-parse --short "$sha") vendors at $cur," \
+      "its parent is $parent — the version counter did not advance"
+    rc=1
+  done < <(git -C "$wt" rev-list --reverse "$from..HEAD")
+  return "$rc"
+}
+
 # --- stage 3: the all-green prefix -------------------------------------------
 new_green=$(git rev-parse "$green")
 while IFS= read -r sha; do
@@ -160,13 +238,25 @@ else
   # carries one onto -dev, and the same fix is committed onto -build so the next
   # regenerated tree still has it -- so the redundancy is designed, not a mistake,
   # and it must not abort the extend.
-  if ! git -C "$wt" cherry-pick --empty=drop $(git rev-list --reverse "$anchor..$build" | head -n "$n"); then
-    git -C "$wt" cherry-pick --abort || true
+  #
+  # One commit at a time, because restamp runs between the picks and reads the
+  # parent it is bumping from.
+  for c in $(git rev-list --reverse "$anchor..$build" | head -n "$n"); do
+    before=$(git -C "$wt" rev-parse HEAD)
+    if ! git -C "$wt" cherry-pick --empty=drop "$c"; then
+      git -C "$wt" cherry-pick --abort || true
+      git worktree remove --force "$wt"
+      echo "Error: replay conflicted — extend by hand"
+      exit 1
+    fi
+    [ "$(git -C "$wt" rev-parse HEAD)" = "$before" ] && continue
+    restamp "$wt" "$c"
+  done
+  next=$(git -C "$wt" rev-parse HEAD)
+  if ! verify_counter "$wt" "$dev"; then
     git worktree remove --force "$wt"
-    echo "Error: replay conflicted — extend by hand"
     exit 1
   fi
-  next=$(git -C "$wt" rev-parse HEAD)
   git worktree remove --force "$wt"
   git push "$remote" "$next:refs/heads/$S-dev"
 fi


### PR DESCRIPTION
The vendor counter is what orders a series.
r-universe installs by version,
so a run of `-dev` commits sharing one is a run it cannot tell apart —
the invariant in
[`.claude/skills/series-loop.md`](https://github.com/duckdb/duckdb-r/blob/main/.claude/skills/series-loop.md)
is that every vendor commit's `Version:` is strictly above its parent's,
and it says `series-advance.sh` delivers it.
It did not.

`series-advance.sh` extends `-dev` from the buffer two ways:
a plain ref move while `-dev` still sits on `-build`'s line,
and a cherry-pick replay onto a repaired tip otherwise.
The replay runs `DESCRIPTION` through the `ours-version` merge driver,
whose prefix gate keeps our side verbatim
when the two strands' `major.minor.patch` prefixes differ —
`main-dev` reads `1.5.99.9003.*`, `main-build` reads `1.5.5.9001.*` —
so every replayed vendor commit arrives with its parent's counter.

Tonight's firing replayed six buffer commits onto `main-dev`
(`krlmlr/duckdb-r@878443adb..72d04bf5e`)
and every one came out at `1.5.99.9003.1081`:

```
368206eac 1.5.99.9003.1081 fix(vendor-one): Refuse a clone HEAD off the buffer's…
878443adb 1.5.99.9003.1081 chore: Auto-update from GitHub Actions
fd84b45c8 1.5.99.9003.1081 vendor: … duckdb/duckdb@7d1a147c9
0c915c6a4 1.5.99.9003.1081 vendor: … duckdb/duckdb@c1a755440
b5f4b34b6 1.5.99.9003.1081 vendor: … duckdb/duckdb@a0128bc39
aec1c7585 1.5.99.9003.1081 vendor: … duckdb/duckdb@163581a56
96ebbcf3d 1.5.99.9003.1081 vendor: … duckdb/duckdb@725542429
72d04bf5e 1.5.99.9003.1081 vendor: … duckdb/duckdb@47b20f125
```

Third such run: 40 commits at `…1039`, five at `…1076`, six at `…1081`.
The firing restamped these by hand — `main-dev` now runs `…1082`…`…1087` —
and this PR is so the next one does not have to.

## The change

- Pick one buffer commit at a time and restamp between picks.
  A vendor commit whose `Version:` the driver left at its parent's value
  gets the fifth component raised by one.
  A buffer commit that vendors nothing is left alone —
  the subject decides, by the same predicate `series-port.sh` uses —
  and a series whose strands share a prefix needs nothing,
  because the driver's component-wise max lets `-build`'s own bump through.
- `verify_counter` walks what was replayed
  and refuses to push unless every vendor commit is strictly above its parent.
  Strictly-above is decided component-wise and numerically,
  so a bump in any component counts, `10` sorts above `9`,
  and a non-numeric component is *unknown* rather than acceptable.
  It returns rather than exits, so the throwaway worktree is removed
  on that path like on every other.

The fix is local to the replay.
It does not change `scripts/merge-version.sh`, deliberately — see below.

## Why not fix the merge driver instead (#2488)

#2488 asks whether the driver keeping *ours* across an unequal prefix
is ever the wrong answer,
and this freeze looks exactly like the case it is asking about.
I tried it: exempt the fifth component from the prefix gate,
on the argument that a fifth component only ever meets another fifth
component as a series' `-dev` against its own `-build`.

**That argument is false, and the change regresses `series-forward-build.sh`.**
Backed out; the evidence is on #2488 so the next attempt starts from it.
The short version:

- `main` has carried five-component versions — 55 of them,
  `1.5.4.9010.1` … `.55`, from vendor commits made on `main` itself,
  ended by `fledge: Bump version to 1.5.4.9011`.
  `vendor-one.sh` stamps the fifth component unconditionally,
  on whatever branch it runs, so this is not a closed door.
- [`scripts/series-forward-build.sh`](https://github.com/duckdb/duckdb-r/blob/main/scripts/series-forward-build.sh)
  is a second place two five-component versions meet across a prefix:
  it replays an old `-build` onto a *new series' seed*, which carries `.0`.
  It reads its counter back from the working tree's `DESCRIPTION`,
  which on its restart-after-conflict path is what the driver just wrote.
  With the exemption that becomes the old chain's counter,
  so the forward chain inherits the old numbering —
  contradicting the script's own contract and the handbook paragraph
  describing it — and `git log -n "$n"` then walks ~1000 commits past the
  seed into `main`, harvesting `main`'s vendor subjects and silently
  skipping picks for upstream SHAs `main` also vendored.

## Verification

`version_gt` over nine cases, including the two the naive
"same prefix and a greater last component" test got wrong
(`1.5.5.9000` → `1.5.5.9000.7`, and `1.5.99.9003.1039` → `1.5.99.9004.1`,
both strictly greater, both previously rejected),
numeric-vs-lexical ordering, and the non-numeric and empty inputs.

End to end, synthetic repositories driving the real
`scripts/merge-version.sh`, buffer = vendor / vendor / glue / vendor:

- **prefixes differ** (`main`'s state): driver freezes,
  restamp delivers `…11`, `…12`, `…12`, `…13`;
  the glue commit correctly does not bump; `verify_counter` returns 0.
- **prefixes agree**: `-build`'s own bump comes through untouched —
  `…100`, `…101`, `…101`, `…102`.
- **frozen replay, no restamp**: `verify_counter` returns 1 with
  `Error: cd3eb74 vendors at 1.5.99.9003.10, its parent is 1.5.99.9003.10 — the version counter did not advance`,
  the shell survives, and the worktree removes cleanly.

`bash -n` clean;
`Rscript .claude/skills/docs-consistency/docs-readme.R --check` clean;
no dangling handbook links.

`handbook/operations/releases/versioning/` and the skill's invariant now name
the script that restamps, where they said the loop did it by hand.