### PR TITLE
fix(series-port): Hold `main`'s version bumps back from a series

### DIFF
--- a/.claude/skills/series-loop.md
+++ b/.claude/skills/series-loop.md
@@ -592,8 +592,8 @@ scripts/series-port.sh <S> --apply <sha>…   # a chosen subset instead
 
 The script lists **every** commit `main` has that the series lacks,
 oldest first,
-classified TOOLING / MIXED / OTHER / VENDOR by what it touches,
-and applies all but VENDOR by default.
+classified TOOLING / MIXED / OTHER / VENDOR / VERSION by what it touches,
+and applies all but VENDOR and VERSION by default.
 A MIXED or OTHER commit is a *forward-port*
 in `BRANCHES.md`'s sense (invariant S4):
 `-dev` has always been vendor commits
@@ -619,6 +619,21 @@ carrying no upstream SHA;
 excluding them by path made exactly those fixes wait for a forward,
 which is the one thing the port exists to end.
 They are ordinary commits, ported like any other.
+
+VERSION commits are listed and never auto-picked either:
+`main`'s R-client counter is not this series'.
+A `-dev` version says which release line the series was seeded from
+and how far its own vendoring has run,
+and what `main` is at today is read from `main`
+([`operations/releases/versioning/`](/handbook/operations/releases/versioning/README.md)).
+Here the **content** decides, not the subject:
+the commit moves `Version:` and carries nothing but release paperwork,
+so a bump under a subject other than `fledge:` is held back too,
+and a bump riding on real content is not —
+that one is a forward-port that happens to bump,
+ported whole like any other,
+because a pick is never half a commit.
+
 Port volume threatens nothing either:
 the readers of the strand — `vendored_sha()` in stage 5,
 the base scan in `vendor-one.sh` — look *past* such commits by subject,

--- a/handbook/operations/releases/versioning/README.md
+++ b/handbook/operations/releases/versioning/README.md
@@ -16,8 +16,15 @@ that advance on different strands and never interfere:
 
 The 4th free-runs on `main`,
 where every glue and R change is born,
-and is inherited frozen on a `-dev` branch;
-the 5th exists only on `-dev` branches, making every vendor commit
+and is inherited frozen on a `-dev` branch —
+frozen at the value the series was seeded with,
+because [`scripts/series-port.sh`](/scripts/series-port.sh) classifies a
+version bump `VERSION` and does not port it
+([#2496](https://github.com/duckdb/duckdb-r/issues/2496)).
+A `-dev` version says which release line the series was seeded from
+and how far its own vendoring has run;
+what `main` is at today is read from `main`.
+The 5th exists only on `-dev` branches, making every vendor commit
 installable as a distinct version on r-universe.
 Each strand owns one counter and freezes the other,
 which is what lets the `DESCRIPTION` merge driver
@@ -44,10 +51,7 @@ the loop restamps by hand
 `main-dev` carries the preview prefix `1.5.99`
 and its buffer `main-build` carries `1.5.5`,
 which is that state.
-Aligning a series' two strands is the fix,
-and the principle it follows is
-[#2496](https://github.com/duckdb/duckdb-r/issues/2496)'s:
-a `-dev` version identifies the series, not what `main` is now.
+Aligning a series' two strands is the fix.
 
 The prefix gate has a consequence worth knowing:
 because the driver keeps *ours* verbatim when the prefixes differ,

--- a/scripts/series-port.sh
+++ b/scripts/series-port.sh
@@ -9,15 +9,28 @@
 # The script lists EVERY commit on `main` since the series' base that has no
 # patch-id equivalent on <S>-dev (`git cherry`), oldest first, classified by
 # what it touches: TOOLING (only tooling paths), MIXED (tooling and more),
-# OTHER (no tooling), VENDOR.
-# --apply cherry-picks everything except VENDOR — a MIXED or OTHER commit is
-# a forward-port like any other, judged by CI like every -dev commit — or
-# exactly the SHAs given, for when judgement says a commit cannot work
+# OTHER (no tooling), VENDOR, VERSION.
+# --apply cherry-picks everything except VENDOR and VERSION — a MIXED or OTHER
+# commit is a forward-port like any other, judged by CI like every -dev commit —
+# or exactly the SHAs given, for when judgement says a commit cannot work
 # against this series' engine yet. Picks are always whole commits: a pick
 # that matches its main commit is skipped by patch-id at the next rebase,
 # a half-pick would only replay. VENDOR commits are never auto-picked,
 # because main's engine is not this series' engine: the series' own
 # vendoring owns that strand.
+#
+# **A VERSION commit is not auto-picked either**, because `main`'s R-client
+# counter is not this series'. A series' version says which release line it was
+# seeded from and how far its own vendoring has run; what `main` is at today is
+# read from `main` (#2496). Porting fledge's bumps made the fourth component
+# free-run behind `main` instead of staying at the seed, which is the opposite
+# of the model handbook/operations/releases/versioning/ describes. The class is
+# read from the content -- the commit moves `Version:` and carries nothing but
+# release paperwork -- not from the `fledge:` subject, so a bump under another
+# name is caught and a bump riding on real content is not. Dropping one leaves
+# NEWS.md at the state the series was seeded with; that file is the release
+# strand's and already outside the sync commit's path set. Naming a VERSION
+# commit explicitly still ports it, like any other SHA.
 #
 # **The subject is what decides a VENDOR commit, never the path.** The patch
 # stack is applied to the vendored tree in place, so CRAN and
@@ -124,9 +137,40 @@ under=0
 frozen=
 [ "$under" != 0 ] && frozen=1
 
-classify() { # <sha> -> TOOLING | MIXED | OTHER | VENDOR
+# Files a version bump is allowed to carry and still be nothing but a bump:
+# DESCRIPTION itself, plus the release paperwork fledge writes beside it. Both
+# belong to the release strand, and neither is in the tooling set the sync
+# commit rewrites, so dropping the commit drops nothing the series executes.
+bump_paths_re='^(DESCRIPTION|NEWS\.md|cran-comments\.md)$'
+
+# Is this commit a version bump and nothing else? Two questions, both of which
+# have to answer yes:
+#
+#   * `Version:` moved -- read against the first parent rather than from the
+#     diff, so a merge commit answers as truthfully as an ordinary one. The
+#     content is the fact, not the subject: a bump is one whatever it is called,
+#     and `fledge:` is only today's name for it.
+#   * it carries nothing else. A commit that bumps the version *and* changes the
+#     package is a forward-port that happens to bump, and it is ported like any
+#     other, because a pick is a whole commit and never half of one. `Sync with
+#     main` (4e41675f9) is the shape this guards: a bump riding on 130 files of
+#     tooling, R code, tests and patches, which classifying by the version line
+#     alone would have dropped whole.
+version_bump() { # <sha>
+  local before after f
+  before=$(git show "$1^:DESCRIPTION" 2>/dev/null | sed -n 's/^Version: //p' || true)
+  after=$(git show "$1:DESCRIPTION" 2>/dev/null | sed -n 's/^Version: //p' || true)
+  [ -n "$after" ] && [ "$before" != "$after" ] || return 1
+  while IFS= read -r f; do
+    [[ "$f" =~ $bump_paths_re ]] || return 1
+  done < <(git diff-tree --no-commit-id --name-only -r "$1")
+  return 0
+}
+
+classify() { # <sha> -> TOOLING | MIXED | OTHER | VENDOR | VERSION
   local f t= o=
   if [[ "$(git log -1 --format=%s "$1")" =~ $vendor_subject_re ]]; then echo VENDOR; return; fi
+  if version_bump "$1"; then echo VERSION; return; fi
   while IFS= read -r f; do
     if [[ "$f" =~ $paths_re ]]; then t=1; else o=1; fi
   done < <(git diff-tree --no-commit-id --name-only -r "$1")
@@ -180,9 +224,10 @@ fi
 
 [ -n "$apply" ] || exit 0
 
-# OTHER picks routinely touch DESCRIPTION's `Version:` (fledge bumps,
-# forward-ports); the ours-version merge driver keeps that line off the
-# conflict list. Idempotent; .git/config is shared with the worktree.
+# A pick can still meet DESCRIPTION's `Version:` -- a named VERSION commit, a
+# forward-port that carries one -- and the ours-version merge driver is what
+# keeps that line off the conflict list. Idempotent; .git/config is shared with
+# the worktree.
 if [ -x "$(dirname "$0")/setup-git.sh" ]; then
   "$(dirname "$0")/setup-git.sh" >/dev/null
 fi
@@ -193,7 +238,8 @@ fi
 picks=("$@")
 if [ ${#picks[@]} -eq 0 ] && [ -z "$frozen" ]; then
   for sha in "${candidates[@]}"; do
-    [ "${klass[$sha]}" = VENDOR ] || picks+=("$sha")
+    case "${klass[$sha]}" in VENDOR | VERSION) continue ;; esac
+    picks+=("$sha")
   done
 fi
 


### PR DESCRIPTION
Closes #2496.

A `-dev` version says two things: which release line the series was seeded from,
and how far its own vendoring has run.
What `main` is at today is not one of them — that is read from `main`.

[`handbook/operations/releases/versioning/`](https://github.com/duckdb/duckdb-r/blob/main/handbook/operations/releases/versioning/README.md)
already describes the fourth component as free-running on `main`
and **inherited frozen** on a `-dev` branch.
It has not been frozen.
Stage 4 ports every commit `main` has that the series lacks, fledge's bumps among
them, and `ours-version` resolves `Version:` by component-wise maximum where the
prefixes agree — so each ported bump carried `main`'s fourth component onto the
series:

```
main                1.5.5.9007
v1.5-variegata-dev  1.5.5.9007.13   ← fourth component tracking main exactly,
                                       across 8 ported fledge bumps
v1.4-andium-dev     1.4.5.9000.1    ← frozen series, no ports, kept its seed
```

`v1.4-andium-dev` is what the model says every series should look like; it only
looks that way because a frozen series takes no ports at all.

## The change

Classify such a commit `VERSION` and leave it where it is, as `VENDOR` is already
left.

**The content decides, not the subject.**
A version bump is one whatever it is called, and `fledge:` is only today's name.
But the test is two questions, not one:

- `Version:` moved — read against the first parent, so a merge commit answers as
  truthfully as an ordinary one;
- **and** the commit carries nothing but release paperwork: `DESCRIPTION`,
  `NEWS.md`, `cran-comments.md`.

The second question is load-bearing. Classifying on the version line alone
swallowed `Sync with main` (`4e41675f9`) — a bump riding on 130 files of tooling,
R code, tests and patches — and dropped the lot. A bump riding on real content is
a forward-port that happens to bump, ported whole like any other, because a pick
is never half a commit.

Dropping a VERSION commit leaves `NEWS.md` at the state the series was seeded
with. That file belongs to the release strand and is already outside the paths
the sync commit rewrites, so nothing the series *executes* is lost. Naming one
with `--apply <sha>` still ports it, like any other explicit SHA.

Nothing already published moves: a series that has absorbed bumps keeps them and
stops taking more, so no version goes down.

## Verification

**Before and after on identical synthetic fixtures** — a `main` carrying a
tooling change, two fledge bumps and an R change, and an `s-dev` seeded at
`1.5.5.9000.7`, driving the real `series-port.sh` and the real
`scripts/merge-version.sh` against a local origin:

```
BEFORE   1.5.5.9002.7  pkg=duckdb.dev  R/a.R=y  tool=t2
AFTER    1.5.5.9000.7  pkg=duckdb.dev  R/a.R=y  tool=t2
```

The series keeps its own version; the flavor, the R change and the tooling change
port exactly as before. `NEWS.md` stays at the seed's state.

**Against real history** — `series-port.sh v1.4-andium --list`, whose walk reaches
back 1163 commits, before and after:

| class | before | after |
|---|---|---|
| TOOLING | 122 | 122 |
| MIXED | 33 | 33 |
| OTHER | 233 | 148 |
| VENDOR | 771 | 771 |
| VERSION | — | 85 |

The new class takes only from OTHER (233 − 148 = 85); TOOLING, MIXED and VENDOR
are untouched. Every one of the 85 was checked to carry nothing outside
`DESCRIPTION` / `NEWS.md` / `cran-comments.md`, and `Sync with main` is back in
MIXED where it belongs — an earlier, broader version of this rule had it in
VERSION, which is what the file-set test exists to prevent.

`git cherry` emits no merge commits (checked over the same 1163 candidates), so
the first-parent read is belt-and-braces rather than load-bearing.

`bash -n` clean;
`Rscript .claude/skills/docs-consistency/docs-readme.R --check` clean;
no dangling handbook links.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BZvcyECqw8awVyokSZMPQ4)_