### PR TITLE
docs(versioning): Record the declined max-across-prefixes merge rule

### DIFF
--- a/handbook/operations/releases/versioning/README.md
+++ b/handbook/operations/releases/versioning/README.md
@@ -53,6 +53,13 @@ and refuses to push a replay whose counter did not rise
 and its buffer `main-build` carries `1.5.5`,
 which is that state.
 Aligning a series' two strands is the fix.
+Exempting the fifth component from the gate — taking the maximum counter
+across differing prefixes too — is declined
+([#2488](https://github.com/duckdb/duckdb-r/issues/2488)):
+`main` has itself carried five-component versions,
+so the gate is what keeps a foreign counter off a `-dev`,
+and a forward rebuild reads its counter back from the merged
+`DESCRIPTION`, where a maximum would restore the old chain's numbering.
 
 The prefix gate has a consequence worth knowing:
 because the driver keeps *ours* verbatim when the prefixes differ,


### PR DESCRIPTION
Closes #2488.

`operations/releases/versioning/` explains why the `DESCRIPTION` merge driver
gates its component-wise maximum on an equal `major.minor.patch` prefix,
but not why the obvious relaxation — exempt the fifth component,
so the vendor counter takes the maximum across prefixes too — is not taken.
A declined request with its reason is a fact the tree owns
([`meta/authoring/`](https://github.com/duckdb/duckdb-r/blob/main/handbook/meta/authoring/README.md)),
so it lands on the leaf that owns the driver, in three sentences:

- `main` has itself carried five-component versions,
  so the gate is what keeps a foreign counter off a `-dev`;
- a forward rebuild reads its counter back from the merged `DESCRIPTION`,
  where a maximum would restore the old chain's numbering.

The evidence behind both is in #2488;
the counter freezing across a replay is fixed in the replay instead (#2525),
which the same paragraph already documents.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R12sWCM3DtpuFLUWiM884i)_