### PR TITLE
fix(tests): Expect the extension install to fail where DuckDB does not cover the platform

### DIFF
--- a/R/extensions.R
+++ b/R/extensions.R
@@ -63,6 +63,45 @@ extensions_supported <- function() {
   !is_linux() || identical(compiled_cxx_stdlib(), "libstdc++")
 }
 
+# The platform string the engine derives for itself
+# (Platform() in src/duckdb/src/include/duckdb/common/platform.hpp),
+# which is also the directory the extension repository is addressed by:
+# http://extensions.duckdb.org/<duckdb-version>/<platform>/<name>.duckdb_extension.gz
+# Wrapped for mockability,
+# and read from the engine rather than reconstructed from `.Platform`:
+# the suffixes are compile-time
+# (`_mingw` under Rtools and under R's clang-aarch64 toolchain,
+# `_musl`, `_android`) and R cannot see them.
+duckdb_platform <- function(conn = default_conn()) {
+  sql_query("PRAGMA platform", conn = conn)[[1L]]
+}
+
+# TRUE when DuckDB publishes prebuilt extensions for this platform.
+# Not a property of the build -- see extensions_supported() for that --
+# but of what the extension repository carries,
+# which is DuckDB's to decide and does change.
+# Explained in handbook/usage/extensions/README.md, which links the
+# current list; the exceptions below are what it does not carry today.
+#
+# As of 2026-08 that is `windows_arm64_mingw`,
+# which is what R's Windows/arm64 toolchain asks for:
+# DuckDB does publish for that architecture, as `windows_arm64`,
+# but that is the MSVC build,
+# and the `_mingw` artifact x86_64 gets has no arm64 counterpart
+# (https://github.com/duckdb/duckdb-r/issues/2425).
+#
+# Deliberately not wired into extensions_supported():
+# a driver that refuses INSTALL is the wrong answer to a missing
+# artifact. A locally built extension still loads,
+# and the day DuckDB publishes this platform
+# the 404 goes away by itself, with nothing here to unwind.
+# The callers are the tests:
+# where the platform is covered they expect INSTALL to succeed,
+# where it is not they expect the download error.
+extensions_published <- function(platform = duckdb_platform()) {
+  !identical(platform, "windows_arm64_mingw")
+}
+
 # Decide, for a single duckdb() call, whether this driver may load DuckDB
 # extensions. Returns list(allow, source, announce). First match wins:
 #

--- a/tests/testthat/test-duckdb-extensions.R
+++ b/tests/testthat/test-duckdb-extensions.R
@@ -5,5 +5,35 @@ test_that("Install DuckDB extension", {
   # duckdb/duckdb-r#1107); INSTALL is refused there by design.
   skip_if_not(extensions_supported(), "DuckDB extensions disabled on this build (duckdb/duckdb-r#1107)")
 
-  expect_no_error(sql_exec("INSTALL icu"))
+  if (extensions_published()) {
+    expect_no_error(sql_exec("INSTALL icu"))
+  } else {
+    # A canary, not a skip (duckdb/duckdb-r#2425):
+    # the extension repository has no directory for this platform,
+    # so the download must come back an HTTP error.
+    # The day DuckDB starts publishing for this platform,
+    # this expectation is what fails,
+    # and the platform moves to the branch above
+    # by deleting its exception in extensions_published().
+    expect_error(sql_exec("INSTALL icu"), "Failed to download extension")
+  }
+})
+
+test_that("duckdb_platform() reports the repository's path segment", {
+  # `<os>_<arch>` with an optional toolchain suffix, exactly as the extension
+  # repository is addressed; asserted by shape, since the value differs per
+  # platform and the point is that it is the engine's own string.
+  expect_match(duckdb_platform(), "^[a-z0-9]+_[a-z0-9]+(_[a-z0-9]+)?$")
+})
+
+test_that("extensions_published() knows which platforms are covered", {
+  # The gap as of 2026-08: DuckDB builds arm64 Windows extensions, but only as
+  # `windows_arm64` (MSVC); the `_mingw` flavor R's toolchain needs exists for
+  # x86_64 alone. Expected to change -- when it does, the canary above and this
+  # assertion are what say so.
+  expect_false(extensions_published("windows_arm64_mingw"))
+
+  expect_true(extensions_published("windows_amd64_mingw"))
+  expect_true(extensions_published("linux_amd64"))
+  expect_true(extensions_published("osx_arm64"))
 })


### PR DESCRIPTION
r-universe's new `windows-*-arm64` targets ERROR on one test in 1207
(`duckdb` 1.5.5.9006, run 30786453138):

```
Failed to download extension "icu" at URL
"http://extensions.duckdb.org/v1.5.5/windows_arm64_mingw/icu.duckdb_extension.gz"
(HTTP 404)
```

DuckDB publishes no extensions for `windows_arm64_mingw`,
the platform R's Windows/arm64 toolchain asks for.
The architecture is covered — but only as `windows_arm64`, the MSVC
build; the mingw flavor that x86_64 gets is not in the upstream
distribution matrix at all, with no timeline
(duckdb/duckdb#21727, confirmed in #2425).

## The change

The plan laid out in #2425:

* `duckdb_platform()` reads the engine's own platform string
  (`PRAGMA platform`), which is also the repository's path segment.
* `extensions_published(platform)` says whether the repository has a
  directory for that platform;
  the one exception today is `windows_arm64_mingw`.
* The INSTALL test branches on it:
  covered platforms keep exactly the test they had
  (`INSTALL icu` must succeed),
  and an uncovered platform becomes a canary —
  `INSTALL icu` must *fail* with the download error,
  so the day DuckDB starts publishing,
  the canary is what fails, on the platform itself,
  and the exception list is what shrinks.

Deliberately not wired into `extensions_supported()`:
a driver that refuses INSTALL is the wrong answer to a missing
artifact, and a locally built extension still loads.

## What the experiments settled

* Moving the test to a C-API extension
  (`odbc_scanner`, suggested in #2425 —
  a core extension, `odbc` its alias)
  is not possible via INSTALL:
  the community repository publishes no arm64 Windows artifacts
  under either platform name
  (krlmlr/duckdb-r#116, run 30931665169 — HTTP 404 on both builds),
  and the core repository serves the scanner only under the MSVC
  platform names, which `INSTALL` on this build never asks for.
  The canary stays on `icu`.
* Hand-fetching the MSVC `windows_arm64` artifact splits by
  extension class
  (krlmlr/duckdb-r#116, runs 30967881866, 30987274175, 31024032489):
  the C++-ABI `icu` dies in the load on both builds —
  subprocess exit 5, no R error —
  while the C-API `odbc_scanner` loads, registers 11 functions,
  and even installs from the downloaded `.gz` with `LOAD odbc`
  working by name, hatches open.
  That sideload story lands in the handbook (#2530);
  it does not touch this test, which exercises `INSTALL` by name
  from the repository,
  and that stays a 404 on `windows_arm64_mingw` either way.

## Verification

* linux_amd64 (covered platform): `INSTALL icu` still runs and passes,
  and the new unit tests pin the platform string's shape and the
  exception by name —
  `test-duckdb-extensions.R` 6 passes, 0 failures, 0 skips,
  and the extension-plumbing suite (`test-extensions-libcxx.R`,
  62 passes) untouched, on a source build of this branch.
* windows-11-arm (uncovered platform): the exact 404 and the load
  behavior are on record in krlmlr/duckdb-r#114 and
  krlmlr/duckdb-r#116
  (runs 30927023956, 30930493513, 30931665169, 30967881866,
  30987274175, 31024032489).

Closes #2425.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BqHZcWbzHbmJNgFtJA1rc1