### PR TITLE
docs(handbook): Record the Windows extension-coverage boundaries the issues keep re-finding

### DIFF
--- a/experiments/2026-08-05-windows-extension-coverage/README.md
+++ b/experiments/2026-08-05-windows-extension-coverage/README.md
@@ -1,4 +1,4 @@
-# Windows extension coverage, and the arm64 escape that isn't
+# Windows extension coverage, and which class crosses the toolchain
 
 *What it measures:* which prebuilt-extension artifacts DuckDB's
 repositories serve the platforms R's Windows toolchains ask for,
@@ -21,8 +21,9 @@ Method and logs:
 [krlmlr/duckdb-r#114](https://github.com/krlmlr/duckdb-r/pull/114)
 (`INSTALL icu`; runs 30927023956 and 30930493513) and
 [krlmlr/duckdb-r#116](https://github.com/krlmlr/duckdb-r/pull/116)
-(`INSTALL odbc_scanner FROM community`, run 30931665169,
-and the manual fetch-and-load, run 30967881866).
+(`INSTALL odbc_scanner FROM community`, run 30931665169;
+the manual fetch-and-load of `icu`, run 30967881866;
+the same for `odbc_scanner`, run 30987274175).
 
 *What it supports:* the Windows and platform-coverage bullets in
 [`usage/extensions/`](/handbook/usage/extensions/README.md).
@@ -73,7 +74,7 @@ the one whose version check is "equal or higher"
 and which resolves no host symbols —
 cannot rescue the platform for lack of artifacts.
 
-## Whether the MSVC artifact loads by hand
+## Whether the MSVC artifact loads by hand: the C++-ABI class
 
 The obstacle course, in order:
 
@@ -116,13 +117,46 @@ This is the failure that took the whole job as an access violation
 (#114, run 30930493513); the subprocess turns it into a printed
 status.
 
+## Whether the MSVC artifact loads by hand: the C-API class
+
+`odbc_scanner` is built against the C API
+(`ExtensionABIType::C_STRUCT`,
+`src/duckdb/src/include/duckdb/main/extension.hpp`):
+the host passes the API in as a function-pointer struct,
+the extension imports nothing from the host's export table,
+and its version check is "equal or higher" rather than exact.
+The core repository begins serving it at v1.5.5,
+MSVC platforms only
+(probed 2026-08-05: `windows_arm64` 200, `windows_amd64` 200,
+both `*_mingw` names 404, and 404 across the board at v1.4.3).
+
+Run 30987274175 repeats the fetch-and-load with
+`windows_arm64/odbc_scanner.duckdb_extension.gz`
+(242,866 bytes, 579,606 unpacked), same hatches, same subprocess:
+
+On both builds the load succeeds and the extension registers —
+`LOAD` returns, `duckdb_extensions()` reports `loaded = TRUE`
+(extension_version 274a330734),
+and `duckdb_functions()` counts 11 `odbc` functions,
+so registration ran through the C API into the catalog.
+Subprocess exit status 0, both legs.
+Both hatches are needed on the as-built leg even though the file is
+signed: the metadata error throws from the signed branch,
+so only `allow_unsigned_extensions` opens the path to the mismatch
+setting.
+An actual ODBC round-trip is beyond the runner (no DSN);
+what is proven is load, catalog entry, and function registration.
+
 **What it shows.**
 Coverage gaps are toolchain-flavor gaps, not architecture gaps,
-on x86_64 and arm64 alike;
-the community repository does not fill them;
-and the MSVC artifacts cannot be carried across the toolchain
-boundary by hand —
-the hatches move every refusal out of the way,
-and the binary then kills the process.
-[#2425](https://github.com/duckdb/duckdb-r/issues/2425) is a gap to
-wait out, with nothing to hand users in the meantime.
+on x86_64 and arm64 alike,
+and the community repository does not fill them.
+Across the toolchain boundary the extension class decides:
+a C++-ABI artifact binds host symbols and kills the process,
+a C-API artifact takes the API as a struct and loads.
+So [#2425](https://github.com/duckdb/duckdb-r/issues/2425) has a
+narrow, documentable escape —
+hand-load an MSVC C-API extension by path, hatches open —
+that widens exactly as fast as upstream moves extensions to the
+C API, while `INSTALL` stays a 404 until the repository grows the
+platform directory.

--- a/experiments/2026-08-05-windows-extension-coverage/README.md
+++ b/experiments/2026-08-05-windows-extension-coverage/README.md
@@ -68,11 +68,12 @@ exactly as on arm64.
 (run 30931665169): HTTP 404 under `windows_arm64_mingw`
 *and* under `windows_arm64`.
 The community repository publishes no arm64 Windows build of
-`odbc_scanner` under either name,
-so the C-API extension class —
-the one whose version check is "equal or higher"
-and which resolves no host symbols —
-cannot rescue the platform for lack of artifacts.
+`odbc_scanner` under either name.
+(A correction landed later:
+`odbc_scanner` is a *core* extension,
+and this run asked a repository it does not live in —
+the core repository's artifacts, next section, are the ones that
+exist.)
 
 ## Whether the MSVC artifact loads by hand: the C++-ABI class
 
@@ -119,7 +120,14 @@ status.
 
 ## Whether the MSVC artifact loads by hand: the C-API class
 
-`odbc_scanner` is built against the C API
+`odbc_scanner` is a core extension —
+`odbc` is its alias
+(`src/duckdb/src/main/extension/extension_alias.cpp`),
+[documented on duckdb.org](https://duckdb.org/docs/current/core_extensions/odbc/overview),
+not autoloadable (`AUTOLOADABLE_EXTENSIONS`,
+`src/duckdb/src/include/duckdb/main/extension_entries.hpp`),
+so `LOAD` stays explicit —
+and it is built against the C API
 (`ExtensionABIType::C_STRUCT`,
 `src/duckdb/src/include/duckdb/main/extension.hpp`):
 the host passes the API in as a function-pointer struct,

--- a/experiments/2026-08-05-windows-extension-coverage/README.md
+++ b/experiments/2026-08-05-windows-extension-coverage/README.md
@@ -23,7 +23,8 @@ Method and logs:
 [krlmlr/duckdb-r#116](https://github.com/krlmlr/duckdb-r/pull/116)
 (`INSTALL odbc_scanner FROM community`, run 30931665169;
 the manual fetch-and-load of `icu`, run 30967881866;
-the same for `odbc_scanner`, run 30987274175).
+the same for `odbc_scanner`, run 30987274175;
+download + `INSTALL` + `LOAD`, run 31024032489).
 
 *What it supports:* the Windows and platform-coverage bullets in
 [`usage/extensions/`](/handbook/usage/extensions/README.md).
@@ -155,6 +156,34 @@ setting.
 An actual ODBC round-trip is beyond the runner (no DSN);
 what is proven is load, catalog entry, and function registration.
 
+## Whether download + INSTALL + LOAD is enough
+
+Run 31024032489 runs the easiest recipe —
+download the `windows_arm64` flavor,
+`INSTALL` the downloaded file, `LOAD odbc` by name —
+twice per build, in fresh subprocesses with fresh stores:
+
+* On the build whose platform string matches the file
+  (`windows_arm64`), the plain recipe works with no configuration:
+  the file is signed and its metadata matches,
+  `INSTALL '<file.gz>'` returns 0 (`install_mode CUSTOM_PATH`),
+  `LOAD odbc` resolves the alias, and 11 functions register.
+* On the real build (`windows_arm64_mingw`), no configuration is a
+  clean refusal at `INSTALL` — the platform check, no crash —
+  and with both hatches in the driver config everything works:
+  `INSTALL '<file.gz>'` 0, `LOAD odbc` 0, `loaded = TRUE`,
+  11 functions, subprocess exit 0.
+
+Direct install handles the `.gz` as downloaded — no gunzip step.
+The store keeps the file,
+but the platform tags still differ at every later `LOAD`,
+so on the real build the two settings are a per-session companion
+of using the extension, not a one-time step;
+the mismatch hatch is what gates `INSTALL`
+(consulted directly,
+`src/duckdb/src/main/extension/extension_install.cpp`),
+and `LOAD` walks the signed branch and needs both.
+
 **What it shows.**
 Coverage gaps are toolchain-flavor gaps, not architecture gaps,
 on x86_64 and arm64 alike,
@@ -164,7 +193,8 @@ a C++-ABI artifact binds host symbols and kills the process,
 a C-API artifact takes the API as a struct and loads.
 So [#2425](https://github.com/duckdb/duckdb-r/issues/2425) has a
 narrow, documentable escape —
-hand-load an MSVC C-API extension by path, hatches open —
+download an MSVC C-API extension, `INSTALL` the file, `LOAD` by
+name, hatches open —
 that widens exactly as fast as upstream moves extensions to the
-C API, while `INSTALL` stays a 404 until the repository grows the
-platform directory.
+C API, while `INSTALL` by name stays a 404 until the repository
+grows the platform directory.

--- a/experiments/2026-08-05-windows-extension-coverage/README.md
+++ b/experiments/2026-08-05-windows-extension-coverage/README.md
@@ -1,0 +1,128 @@
+# Windows extension coverage, and the arm64 escape that isn't
+
+*What it measures:* which prebuilt-extension artifacts DuckDB's
+repositories serve the platforms R's Windows toolchains ask for,
+and whether the `windows_arm64` (MSVC) artifact that *does* exist
+can be hand-loaded into R's mingw build —
+that is, whether
+[#2425](https://github.com/duckdb/duckdb-r/issues/2425)
+has a user-side escape.
+
+*When and on what:* repository probes 2026-08-05,
+HTTP HEAD against `extensions.duckdb.org` ([`probe.sh`](probe.sh));
+install and load runs 2026-08-04 and 2026-08-05
+on `windows-11-arm` GitHub runners —
+R release, DuckDB 1.5.5, package built from source —
+each question asked of two builds:
+as built (`windows_arm64_mingw`)
+and pinned to the MSVC platform name
+(`-DDUCKDB_CUSTOM_PLATFORM=windows_arm64`).
+Method and logs:
+[krlmlr/duckdb-r#114](https://github.com/krlmlr/duckdb-r/pull/114)
+(`INSTALL icu`; runs 30927023956 and 30930493513) and
+[krlmlr/duckdb-r#116](https://github.com/krlmlr/duckdb-r/pull/116)
+(`INSTALL odbc_scanner FROM community`, run 30931665169,
+and the manual fetch-and-load, run 30967881866).
+
+*What it supports:* the Windows and platform-coverage bullets in
+[`usage/extensions/`](/handbook/usage/extensions/README.md).
+
+## What the core repository serves
+
+`extensions.duckdb.org/<version>/<platform>/<name>.duckdb_extension.gz`,
+HTTP status for `icu`:
+
+| | `windows_amd64_mingw` | `windows_arm64_mingw` | `windows_arm64` |
+|---|---|---|---|
+| v1.4.1 | 200 | 404 | 404 |
+| v1.4.3 | 200 | 404 | 200 |
+| v1.5.5 | 200 | 404 | 200 |
+
+The arm64 story: DuckDB covers the architecture (since 1.4.3),
+but only as the MSVC build —
+`windows_arm64_mingw` is not in the upstream distribution matrix at all,
+was considered and shelved with no timeline
+([duckdb/duckdb#21727](https://github.com/duckdb/duckdb/pull/21727),
+confirmed in
+[#2425](https://github.com/duckdb/duckdb-r/issues/2425#issuecomment-5181680038)).
+
+And within `windows_amd64_mingw`, coverage is per extension
+(v1.5.5, same probe):
+
+```
+postgres_scanner   404
+spatial            200
+excel              200
+icu                200
+httpfs             200
+```
+
+`postgres_scanner` exists as `windows_amd64` (MSVC, 200) —
+the toolchain flavor, not the architecture, is what is missing,
+exactly as on arm64.
+
+## What the community repository serves
+
+`INSTALL odbc_scanner FROM community`, from R, on both builds
+(run 30931665169): HTTP 404 under `windows_arm64_mingw`
+*and* under `windows_arm64`.
+The community repository publishes no arm64 Windows build of
+`odbc_scanner` under either name,
+so the C-API extension class —
+the one whose version check is "equal or higher"
+and which resolves no host symbols —
+cannot rescue the platform for lack of artifacts.
+
+## Whether the MSVC artifact loads by hand
+
+The obstacle course, in order:
+
+1. `INSTALL icu` on the pinned build fetches the `windows_arm64` file,
+   and its `LOAD` dies with an access violation —
+   the job ends with no R error to read
+   (#114, run 30930493513).
+2. On the as-built flavor the same file is refused by metadata first:
+   *"The file was built for the platform 'windows_arm64', but we can
+   only load extensions built for platform 'windows_arm64_mingw'."*
+3. `SET allow_extensions_metadata_mismatch = true` does not lift the
+   refusal: in `ExtensionHelper::LoadExtensionInternal`
+   (`src/duckdb/src/main/extension/extension_load.cpp`)
+   that setting is consulted only when `allow_unsigned_extensions`
+   is also on, and the engine refuses to *enable* that one once the
+   database is running
+   (`AllowUnsignedExtensionsSetting::OnSet`,
+   `src/duckdb/src/main/settings/custom_settings.cpp`) —
+   `SET` can never reach the branch.
+4. Both hatches do open together as driver config,
+   which is applied at startup:
+   `duckdb(config = list(allow_unsigned_extensions = "true",
+   allow_extensions_metadata_mismatch = "true"))`.
+   The load then reaches the binary itself.
+
+The final leg (run 30967881866) fetches the `windows_arm64` file by
+hand (10,575,466 bytes, 32,176,662 unpacked), gunzips it,
+and `LOAD`s it by path in a subprocess,
+hatches open, on both builds — subprocess, because step 1 predicts the
+answer is an exit code, not an error message:
+
+On both builds the subprocess prints its platform, reaches `LOAD`,
+and dies there — exit status 5, no R error for `try()` to catch,
+nothing after the `LOAD` line runs.
+On the pinned build the file's metadata *matches* the host's platform
+string, so no hatch even stood between `LOAD` and the binary:
+same death.
+This is the failure that took the whole job as an access violation
+(0xC0000005) when the same file arrived via `INSTALL`
+(#114, run 30930493513); the subprocess turns it into a printed
+status.
+
+**What it shows.**
+Coverage gaps are toolchain-flavor gaps, not architecture gaps,
+on x86_64 and arm64 alike;
+the community repository does not fill them;
+and the MSVC artifacts cannot be carried across the toolchain
+boundary by hand —
+the hatches move every refusal out of the way,
+and the binary then kills the process.
+[#2425](https://github.com/duckdb/duckdb-r/issues/2425) is a gap to
+wait out, with nothing to hand users in the meantime.

--- a/experiments/2026-08-05-windows-extension-coverage/probe.sh
+++ b/experiments/2026-08-05-windows-extension-coverage/probe.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# HTTP status of prebuilt-extension artifacts on the core repository,
+# by DuckDB version, platform, and extension.
+# Reads the repository, writes nothing.
+set -eu
+
+repo=https://extensions.duckdb.org
+
+status() {
+  curl -s -o /dev/null -w '%{http_code}' -I "$1"
+}
+
+echo "== icu, by version and platform"
+for v in v1.4.1 v1.4.3 v1.5.5; do
+  for p in windows_amd64_mingw windows_arm64_mingw windows_arm64; do
+    printf '%s %-21s %s\n' "$v" "$p" \
+      "$(status "$repo/$v/$p/icu.duckdb_extension.gz")"
+  done
+done
+
+echo "== v1.5.5 windows_amd64_mingw, by extension"
+for e in postgres_scanner spatial excel icu httpfs; do
+  printf '%-18s %s\n' "$e" \
+    "$(status "$repo/v1.5.5/windows_amd64_mingw/$e.duckdb_extension.gz")"
+done
+
+echo "== v1.5.5 windows_amd64 (MSVC), for contrast"
+for e in postgres_scanner spatial; do
+  printf '%-18s %s\n' "$e" \
+    "$(status "$repo/v1.5.5/windows_amd64/$e.duckdb_extension.gz")"
+done

--- a/experiments/README.md
+++ b/experiments/README.md
@@ -36,6 +36,10 @@ the directory keeps the method so that is possible.
 * [`2026-08-02-lts-drift/`](2026-08-02-lts-drift/) —
   how far the v1.4 LTS flavor has drifted from its baseline; supports
   [`branches/invariants/`](/handbook/branches/invariants/README.md).
+* [`2026-08-05-windows-extension-coverage/`](2026-08-05-windows-extension-coverage/) —
+  which prebuilt extensions DuckDB's repositories serve R's Windows
+  builds, and whether the MSVC arm64 artifact can be hand-loaded;
+  supports [`usage/extensions/`](/handbook/usage/extensions/README.md).
 
 Adding one: create the directory, name it for the date and the topic,
 open its `README.md` with what and when and on what,

--- a/handbook/usage/extensions/README.md
+++ b/handbook/usage/extensions/README.md
@@ -10,6 +10,11 @@ and how to get more.
   [`src/Makevars`](/src/Makevars);
   changing it is a vendoring-time decision
   ([`build/configuration/`](/handbook/build/configuration/README.md)).
+  Everything else downloads at `INSTALL` time;
+  there is no companion R package carrying extensions,
+  and none is coming —
+  upstream declined a second distribution channel
+  ([#1582](https://github.com/duckdb/duckdb-r/issues/1582)).
 * **Autoload is on, autoinstall is off.**
   The build flips `autoload_known_extensions`
   (`-DDUCKDB_EXTENSION_AUTOLOAD_DEFAULT`)
@@ -30,10 +35,27 @@ and how to get more.
   `?duckdb`, section "DuckDB extensions on Linux",
   owns that decision tree
   ([#1107](https://github.com/duckdb/duckdb-r/issues/1107)).
+* **Community extensions come from a second repository:**
+  `INSTALL <name> FROM community` fetches from
+  `community-extensions.duckdb.org`,
+  whose build matrix and platform coverage are its own —
+  what one repository carries says nothing about the other.
 * **Windows** fetches extensions for the `windows_amd64_mingw` platform,
-  which DuckDB has distributed since 1.4.1;
-  gaps for out-of-tree extensions are tracked as the toolchain epic
-  ([#2234](https://github.com/duckdb/duckdb-r/issues/2234)).
+  which DuckDB has distributed since 1.4.1 —
+  as a per-extension subset:
+  a core extension can opt out of the mingw flavor upstream,
+  and the `NOT MINGW` guards in duckdb/duckdb's
+  [`.github/config/extensions`](https://github.com/duckdb/duckdb/tree/main/.github/config/extensions)
+  are the list.
+  As of 2026-08, `INSTALL postgres` is a 404
+  where `INSTALL spatial` works
+  ([#1581](https://github.com/duckdb/duckdb-r/issues/1581));
+  the troubleshooting link in the download error
+  looks up the failing extension, version, and platform.
+  The standing gaps are the toolchain epic
+  ([#2234](https://github.com/duckdb/duckdb-r/issues/2234),
+  upstream
+  [duckdb/duckdb#24431](https://github.com/duckdb/duckdb/issues/24431)).
 * **Some platforms are not covered**, and which ones is DuckDB's to say
   and does change:
   [Extension Distribution](https://duckdb.org/docs/stable/extensions/extension_distribution)
@@ -45,6 +67,26 @@ and how to get more.
   DuckDB publishes `windows_arm64`, built with MSVC,
   but no `windows_arm64_mingw`, which is what R's toolchain produces
   ([#2425](https://github.com/duckdb/duckdb-r/issues/2425)).
+  Neither repository fills that gap —
+  the community one serves no arm64 Windows name at all —
+  and the MSVC artifact is not a back door:
+  hand-loaded with every hatch open, it kills the R process at `LOAD`,
+  platform metadata matching or not
+  ([experiment](/experiments/2026-08-05-windows-extension-coverage/README.md)).
+* **Loading an extension file by path** —
+  `LOAD '/path/to/name.duckdb_extension'` —
+  is how a locally built extension comes in,
+  and an unsigned file needs the driver created with
+  `duckdb(config = list(allow_unsigned_extensions = "true"))`,
+  plus `allow_extensions_metadata_mismatch = "true"`
+  when the file's platform tag differs from the build's.
+  Driver config is the only door:
+  the engine refuses to enable `allow_unsigned_extensions` once it is
+  running, so `SET` is always too late,
+  and the mismatch setting alone changes nothing —
+  it is consulted only on the unsigned path
+  (`LoadExtensionInternal`,
+  [`src/duckdb/src/main/extension/extension_load.cpp`](/src/duckdb/src/main/extension/extension_load.cpp)).
 
 Verify any claim about the shipped set on a **vendored build** —
 the fast path answers for a different artifact

--- a/handbook/usage/extensions/README.md
+++ b/handbook/usage/extensions/README.md
@@ -67,24 +67,32 @@ and how to get more.
   DuckDB publishes `windows_arm64`, built with MSVC,
   but no `windows_arm64_mingw`, which is what R's toolchain produces
   ([#2425](https://github.com/duckdb/duckdb-r/issues/2425)).
-  Neither repository fills that gap —
-  the community one serves no arm64 Windows name at all —
-  and the MSVC artifact is not a back door:
-  hand-loaded with every hatch open, it kills the R process at `LOAD`,
-  platform metadata matching or not
+  `INSTALL` stays closed there —
+  the community repository serves no arm64 Windows name at all —
+  but hand-loading the MSVC `windows_arm64` artifact by path
+  splits by extension class:
+  a C++-ABI extension (`icu`) kills the R process at `LOAD`,
+  platform metadata matching or not,
+  while a C-API extension (`odbc_scanner`) loads and registers its
+  functions, hatches open,
+  on the strength of importing nothing from the host
   ([experiment](/experiments/2026-08-05-windows-extension-coverage/README.md)).
+  The escape widens exactly as fast as upstream moves extensions
+  to the C API.
 * **Loading an extension file by path** —
   `LOAD '/path/to/name.duckdb_extension'` —
   is how a locally built extension comes in,
-  and an unsigned file needs the driver created with
-  `duckdb(config = list(allow_unsigned_extensions = "true"))`,
-  plus `allow_extensions_metadata_mismatch = "true"`
-  when the file's platform tag differs from the build's.
+  and takes two driver settings when the file is unsigned
+  or carries a foreign platform tag:
+  `duckdb(config = list(allow_unsigned_extensions = "true",
+  allow_extensions_metadata_mismatch = "true"))`.
   Driver config is the only door:
   the engine refuses to enable `allow_unsigned_extensions` once it is
-  running, so `SET` is always too late,
-  and the mismatch setting alone changes nothing —
-  it is consulted only on the unsigned path
+  running, so `SET` is always too late.
+  And the mismatch setting alone changes nothing,
+  even for a signed file —
+  the metadata error throws from the signed branch,
+  so it is consulted only when unsigned loading is already allowed
   (`LoadExtensionInternal`,
   [`src/duckdb/src/main/extension/extension_load.cpp`](/src/duckdb/src/main/extension/extension_load.cpp)).
 

--- a/handbook/usage/extensions/README.md
+++ b/handbook/usage/extensions/README.md
@@ -86,6 +86,10 @@ and how to get more.
   or carries a foreign platform tag:
   `duckdb(config = list(allow_unsigned_extensions = "true",
   allow_extensions_metadata_mismatch = "true"))`.
+  `INSTALL '/path/to/file.duckdb_extension.gz'` accepts the same
+  file as downloaded — compression included —
+  and keeps it in the store, so later sessions `LOAD` it by name;
+  a foreign platform tag keeps needing the settings at every load.
   Driver config is the only door:
   the engine refuses to enable `allow_unsigned_extensions` once it is
   running, so `SET` is always too late.


### PR DESCRIPTION
A review of every issue matching "extension" in this repository
(69 as of 2026-08-05) finds four shapes users keep rediscovering
that no handbook leaf owned.
This PR is handbook-only; the companion test change is #2529.

## What the leaf gains

* **The mingw directory is a per-extension subset even on x86_64.**
  `INSTALL postgres` 404s today where `INSTALL spatial` works —
  the recurring report behind #1581, #2503, #1821, #100 —
  and the `NOT MINGW` guards in duckdb/duckdb's
  `.github/config/extensions` are where a core extension opts out
  (per the #2425 discussion, tracked as #2234 and
  duckdb/duckdb#24431).
  Verified against the repository today: see the experiment record.
* **Community extensions come from a second repository**
  (`INSTALL <name> FROM community`), with coverage of its own.
* **Loading a file by path takes driver config, not `SET`.**
  `allow_unsigned_extensions` cannot be enabled on a running
  database, and `allow_extensions_metadata_mismatch` is consulted
  only on the unsigned path — so both are needed even for a signed
  file with a foreign platform tag —
  verified in the vendored source
  (`extension_load.cpp`, `custom_settings.cpp`),
  from R on linux_amd64,
  and exercised on Windows arm64 in krlmlr/duckdb-r#116.
* **There is no companion-package channel, and none is coming** —
  upstream declined a second distribution channel (#1582).

## The experiment record

The Windows evidence is measured work
(HTTP probes of both repositories; install and hand-load runs on
`windows-11-arm` in krlmlr/duckdb-r#114 and krlmlr/duckdb-r#116),
so it lands as `experiments/2026-08-05-windows-extension-coverage/`
with the probe script, and the leaf links it —
per the authoring ladder, rung five.

Headline numbers, re-probed today:
`windows_arm64_mingw` 404 on every version;
`windows_arm64` (MSVC) 200 since v1.4.3;
`postgres_scanner` 404 on `windows_amd64_mingw` at v1.5.5
while spatial/excel/icu/httpfs are 200;
the community repository serves no arm64 Windows name.
The hand-load of the MSVC artifact **splits by extension class**
(runs 30967881866 and 30987274175):
the C++-ABI `icu` dies at `LOAD` on both builds
(exit status 5, no R error),
while the C-API `odbc_scanner` — a core extension, served since
v1.5.5 — loads and registers 11 functions on both builds, exit 0.
And the easiest recipe works end to end (run 31024032489):
download the `windows_arm64` flavor,
`INSTALL` the `.gz` as downloaded (`install_mode CUSTOM_PATH`),
`LOAD odbc` by name —
with no configuration on a platform-matching build,
with both hatches in driver config on the real mingw build.
The class decides, so #2425 gets a narrow, documentable escape
that widens as upstream moves extensions to the C API.

## Reviewed and deliberately not written

* The `ui` extension works from R (`CALL start_ui()`, #1083 midway) —
  the early "no mingw build" state resolved with 1.2.2,
  so there is no durable fact to record.
* Individual extensions' usage (httpfs/S3 setup, spatial interop:
  #224, #2315, #117, #1670) — engine behavior,
  owned by duckdb.org's documentation, not this tree.
* Per-extension coverage tables (#100's snapshot) —
  the repository is the list; the leaf names the mechanism and one
  dated example instead.
* `INSTALL` under a vendored dev snapshot —
  real (#628-era reports; `skip_on_dev_version()` exists for it)
  but not verified on a build here, so not written.

`docs-consistency` run: links resolve, no upward links,
`scripts/README.md` current, the experiment record carries its
backreference (*What it supports:* `usage/extensions/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BqHZcWbzHbmJNgFtJA1rc1