### PR TITLE
fix(rcc): Stop a roxygen2 dev release turning every series red

### DIFF
--- a/scripts/rcc-one.sh
+++ b/scripts/rcc-one.sh
@@ -386,11 +386,31 @@ EOF
   return "${rc}"
 }
 
-# Mirrors .github/workflows/roxygenize/action.yml.
+# Mirrors .github/workflows/roxygenize/action.yml, less one field.
+#
+# roxygen2 stamps `Config/roxygen2/version` with the version that ran, and CI
+# installs roxygen2 from r-lib's r-universe -- a rolling dev build. Every time
+# that build moves, the stamp differs from the one every already-written commit
+# carries, gate_clean turns that one line into a failure, and every series in
+# flight goes red at once over metadata no commit could have pinned: the field
+# records which roxygen2 wrote the committed docs, and a per-commit replay runs
+# under whatever roxygen2 exists today. `main` keeps the field current through
+# its own auto-update commit, which is where that belongs; the replay only has
+# to not fail on time having passed.
+#
+# Restoring the committed value rather than exempting it in gate_clean keeps
+# the tree clean for the `check` gate too, and leaves gate_clean judging real
+# drift only.
 gate_roxygen() {
-  rscript <<'EOF'
+  local pinned rc=0
+  pinned=$(sed -n 's|^Config/roxygen2/version: ||p' DESCRIPTION)
+  rscript <<'EOF' || rc=1
 roxygen2::roxygenize()
 EOF
+  if [ -n "${pinned}" ]; then
+    sed -i "s|^Config/roxygen2/version: .*|Config/roxygen2/version: ${pinned}|" DESCRIPTION
+  fi
+  return "${rc}"
 }
 
 # Mirrors the "Write diff and fail for workflow_dispatch" step of


### PR DESCRIPTION
## What happened

The 2026-08-05 series-loop firing found **all three series red at once**,
every one of them on the same single line:

```
::group::gate: clean
Changes detected in workflow_dispatch build. Diff:
diff --git a/DESCRIPTION b/DESCRIPTION
@@ -72,4 +72,4 @@ Config/testthat/edition: 3
-Config/roxygen2/version: 8.0.0.9000
+Config/roxygen2/version: 8.1.0.9000
gate clean: failure
```

Evidence, one run per series — `clean` was the *only* failed stage in each:

| series | commit | run |
|---|---|---|
| `main` | `368206eac` | [30954236130](https://github.com/krlmlr/duckdb-r/actions/runs/30954236130) |
| `v1.5-variegata` | `b21247df4` | [30954239516](https://github.com/krlmlr/duckdb-r/actions/runs/30954239516) |
| `v1.4-andium` | `b35c4eec9` | [30954244109](https://github.com/krlmlr/duckdb-r/actions/runs/30954244109) |

## Why it is a tooling bug and not drift

`gate_roxygen` runs `roxygen2::roxygenize()`,
which stamps `Config/roxygen2/version` with the version that ran,
and CI installs roxygen2 from r-lib's r-universe — a rolling dev build
(8.1.0.9000 as of this writing).
The field records which roxygen2 wrote the *committed* docs,
while a per-commit replay runs under whatever roxygen2 exists *today*.
No commit can pin that, and every roxygen2 dev release therefore reds
every commit in flight on every series simultaneously.

The cost is not the one line.
Each red is repaired by folding the bump into the oldest failing commit,
which re-mints every commit above it:
this firing discarded six already-verified `main` runs
and one on `v1.5-variegata` to reprint metadata.
`series-loop.md`'s test for a stage-7 PR is whether the same firing done
again would hit it. This one would, on r-lib's next dev release.

## The change

`gate_roxygen` restores the committed value of the field after
`roxygenize()`. That keeps the tree clean for the `check` gate too, and
leaves `gate_clean` judging real drift only — style, snapshots, generated
`.Rd`.

`main` is unaffected in the direction that matters: its own auto-update
commit still bumps the field when roxygen2 moves
(`68e4989d2` is the most recent one), which is where keeping it current
belongs. Only the per-commit replay stops failing on time having passed.

Verified by exercising `gate_roxygen` with a stubbed `rscript`: the bump
is reverted, and a `roxygenize()` failure still returns 1.

## Worked around by hand first

Per `series-loop.md` §7, the three series were unstuck by hand in the same
firing (fold + replay + force-push), so nothing depends on this merging.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cxh5jKLH1zG6e5JM7zSRum)_