### PR TITLE
fix(ci): Drop the invalid `workflows` permission that stops `sync` parsing

### DIFF
--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -15,9 +15,12 @@ jobs:
 
     name: "Fast-forward main from duckdb/duckdb-r"
 
+    # `workflows` is not a `permissions` scope, and naming it makes the whole
+    # file unparseable, so the workflow never runs at all.
+    # Pushing a change under `.github/workflows/` is refused for `GITHUB_TOKEN`
+    # whatever this block says; that needs a PAT or an app (#2494).
     permissions:
       contents: write
-      workflows: write
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## What happened

The 2026-08-05 series-loop firing found the fork's `main` eight commits
(≈ 10 h) behind `duckdb/duckdb-r@main`,
so stage 4 reported *tooling: identical to main* against a stale `main`
and would have ported nothing —
including [#2531](https://github.com/duckdb/duckdb-r/pull/2531)'s fix,
once it merges.

`sync.yaml` is supposed to fast-forward the fork's `main` hourly
([`branches/model/`](https://github.com/duckdb/duckdb-r/blob/main/handbook/branches/model/README.md)).
It has not run at all since `d7003666d` (2026-06-29).

## Why it is a tooling bug

`workflows` is not a `permissions` scope.
GitHub rejects the whole file, so the workflow is unrunnable —
not merely unprivileged.

The dispatch API states it verbatim:

```
POST /repos/krlmlr/duckdb-r/actions/workflows/sync.yaml/dispatches
422 failed to parse workflow: (Line: 20, Col: 7): Unexpected value 'workflows'
```

Line 20 is `workflows: write`.

Two more symptoms agree:

- every run of the workflow in the last 400 is a startup failure with
  **zero jobs** — no `schedule` run appears at all,
  only push-event runs that die instantly
  ([one such run](https://github.com/krlmlr/duckdb-r/actions/runs/31002920451));
- `/actions/workflows` registers it as `.github/workflows/sync.yaml`
  rather than as its `name: sync`,
  because the name was never read.

`series-loop.md`'s test for a stage-7 PR is whether the same firing done
again would hit it. Every firing does, until this merges.

## The change

Remove the invalid key, and record in a comment what it was reaching for.

The intent behind it stands and is unreachable this way:
`GITHUB_TOKEN` may not push a change under `.github/workflows/`
whatever the block says,
so a range carrying a workflow edit still needs a PAT or an app
([#2494](https://github.com/duckdb/duckdb-r/issues/2494)).
That failure is at least loud and per-range;
the parse error was silent and total,
which is why the drift went unnoticed for five weeks
while the ref was kept current by hand.

Verified by the 422 above naming that exact line and column,
and by the file parsing to `permissions: {contents: write}` after the edit.

## Worked around by hand first

Per `series-loop.md` §7, the fork's `main` was fast-forwarded by hand in the
same firing (`e022d90f9..1681f5911`, fast-forward only, exactly what the
workflow does), so nothing depends on this merging.
Stage 4 then ported four `ci:` commits and one `fix(flavor):` into all
three series.

---
_Generated by [Claude Code](https://claude.ai/code/session_016btQXaFkZhRjd2UhqBaaJJ)_