### PR TITLE
test(extensions): Skip the install test where DuckDB publishes no binaries, and pin the gap

### DIFF
--- a/handbook/testing/suite/README.md
+++ b/handbook/testing/suite/README.md
@@ -50,6 +50,17 @@ are callable unqualified.
 Always ask for the package name rather than writing it
 ([`branches/flavors/`](/handbook/branches/flavors/README.md)).
 
+**Extensions over the network.**
+`test-duckdb-extensions.R` installs a real extension,
+so it first asks what DuckDB publishes for the platform it is running on.
+`PRAGMA platform` is the name to look that up under,
+and `helper-extensions.R` carries the platforms with no binaries at all
+([`usage/extensions/`](/handbook/usage/extensions/README.md)).
+On those the install test skips —
+and a canary asserts the HTTP 404 in its place,
+so the skip fails the day the gap closes
+rather than quietly outliving it.
+
 *To deepen: drain
 [#2425](https://github.com/duckdb/duckdb-r/issues/2425)
-(windows/aarch64 extension skip).*
+(an extension the Windows/arm64 build can actually install).*

--- a/tests/testthat/helper-extensions.R
+++ b/tests/testthat/helper-extensions.R
@@ -1,0 +1,38 @@
+# Which platforms DuckDB publishes extension binaries for, and which it does
+# not.
+#
+# Two tests install a real extension over the network, so they have to know
+# whether that can work at all on the platform running them.
+# `handbook/usage/extensions/` owns the fact; this helper is how the suite asks
+# for it.
+
+# The platform name this build fetches extensions under -- the directory
+# component of every extensions.duckdb.org URL it requests. Asked of the engine
+# rather than derived from `R.version`, because the engine is what builds the
+# URL and the naming is DuckDB's to change.
+duckdb_extension_platform <- function(conn = default_conn()) {
+  dbGetQuery(conn, "PRAGMA platform")[[1L]]
+}
+
+# Platforms the engine can be built for but that DuckDB publishes no extension
+# binaries for. `windows_arm64_mingw` -- what R's Windows/arm64 toolchain
+# produces -- is the whole list as of 2026-08: DuckDB builds
+# `windows_amd64_mingw` and the MSVC `windows_arm64`, but arm64 MinGW is not a
+# distribution target at all, and there is no timeline for adding one
+# (duckdb/duckdb-r#2425). Every `INSTALL` there is an HTTP 404.
+platforms_without_extensions <- c("windows_arm64_mingw")
+
+# Skip a test that installs an extension where there is nothing to install.
+# The gap is not this package's to close, so it is skipped rather than failed --
+# and pinned by the canary in `test-duckdb-extensions.R`, so the skip cannot
+# outlive it.
+skip_if_no_extension_binaries <- function() {
+  platform <- duckdb_extension_platform()
+  if (platform %in% platforms_without_extensions) {
+    skip(paste0(
+      "DuckDB publishes no extensions for ",
+      platform,
+      " (duckdb/duckdb-r#2425)."
+    ))
+  }
+}

--- a/tests/testthat/test-duckdb-extensions.R
+++ b/tests/testthat/test-duckdb-extensions.R
@@ -4,6 +4,26 @@ test_that("Install DuckDB extension", {
   # Disabled on a libc++ Linux build (loading a prebuilt extension crashes R --
   # duckdb/duckdb-r#1107); INSTALL is refused there by design.
   skip_if_not(extensions_supported(), "DuckDB extensions disabled on this build (duckdb/duckdb-r#1107)")
+  # Nothing to install where DuckDB publishes no binaries for this platform;
+  # the test below is what covers those.
+  skip_if_no_extension_binaries()
 
   expect_no_error(sql_exec("INSTALL icu"))
+})
+
+# The canary for what `skip_if_no_extension_binaries()` skips. Asserting the 404
+# rather than passing over it means that the day DuckDB starts publishing for
+# the platform, this fails and the skip above can go (duckdb/duckdb-r#2425).
+test_that("Installing an extension fails where DuckDB publishes none", {
+  skip_on_dev_version()
+  skip_on_cran_except_r_universe()
+  platform <- duckdb_extension_platform()
+  skip_if_not(
+    platform %in% platforms_without_extensions,
+    paste0("DuckDB publishes extensions for ", platform, ".")
+  )
+
+  err <- expect_error(sql_exec("INSTALL icu"))
+  expect_match(conditionMessage(err), "HTTP 404", fixed = TRUE)
+  expect_match(conditionMessage(err), platform, fixed = TRUE)
 })


### PR DESCRIPTION
Closes the test half of #2425, and turns the mainline flavor green on r-universe.

## What main was missing

`scripts/r-universe-check.sh` reads it straight off:

```
=== duckdb 1.5.5.9009 -- 1681f5911 <https://github.com/duckdb/duckdb-r>
  ERROR    windows-devel-arm64       2399s
  ERROR    windows-release-arm64     2306s
=== duckdb.1.4.dev 1.4.5.9000.1   -- all 15 targets OK
=== duckdb.1.5.dev 1.5.5.9007.13  -- all 15 targets OK
=== duckdb.1.4    1.4.5           -- all 13 targets OK
```

One test, on the two Windows/arm64 targets r-universe added in late July:

```
── Failure ('test-duckdb-extensions.R:8:3'): Install DuckDB extension ──
Expected `sql_exec("INSTALL icu")` not to throw any errors.
  Invalid Error: HTTP Error: Failed to download extension "icu" at URL
  "http://extensions.duckdb.org/v1.5.5/windows_arm64_mingw/icu.duckdb_extension.gz" (HTTP 404)
```

Nothing was vendored into `-dev`, and nothing was silenced there.
`tests/testthat/test-duckdb-extensions.R` and `helper-skip.R` are byte-identical
on `main`, `v1.5-variegata-dev`, `v1.4-andium-dev`, and `main-dev`.
The `-dev` flavors are green because `skip_on_dev_version()` fires on them:
it skips unless the engine version matches `^[0-9]+[.][0-9]+[.][0-9]$`,
and they vendor `v1.5.6-dev46`, `v1.4.6-dev2`, `v1.6.0-dev12245`.
`main` vendors the released `v1.5.5`, so the test runs.
`duckdb.1.4` runs it too, and passes only because its r-universe registration
still has 13 targets and none of them is arm64.

So `main` is the one ref that pairs a *released* engine with a Windows/arm64
check target — the only place the gap is reachable.
The gap itself is not ours to close: DuckDB builds `windows_amd64_mingw` and the
MSVC `windows_arm64`, but arm64 MinGW is not a distribution target at all,
and there is no timeline for adding one (#2425).

## The change

Follows the plan in https://github.com/duckdb/duckdb-r/issues/2425#issuecomment-5182098958,
minus the C-API-extension bullet, which stays on the issue.

* `tests/testthat/helper-extensions.R` (new) asks the engine for its platform
  with `PRAGMA platform` — the engine builds the URL, so the engine is what to
  ask — and carries the list of platforms with no binaries at all.
* `skip_if_no_extension_binaries()` skips the install test there.
* A canary asserts the HTTP 404 in its place, so the skip fails the day DuckDB
  starts publishing rather than quietly outliving the gap.
* `handbook/testing/suite/` records how the suite handles this;
  `handbook/usage/extensions/` already owned the underlying fact and is unchanged.

## Verification

Against a real v1.5.5 engine — the version `main` vendors — both branches were run:

| Platform | Install test | Canary |
|---|---|---|
| `linux_amd64` (real) | pass | skip — "DuckDB publishes extensions for linux_amd64." |
| gap platform (simulated: `linux_amd64` added to the list, engine pointed at a 404 repository) | skip — "DuckDB publishes no extensions for linux_amd64 (duckdb/duckdb-r#2425)." | pass, 3/3 expectations |

`flavor_package_name_offenders()` returns `character(0)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WzU3SbsECnQXUASfUuM3LW

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzU3SbsECnQXUASfUuM3LW)_