### PR TITLE
docs(extensions): Close the remaining gaps the extension issues map to

### DIFF
--- a/handbook/usage/extensions/README.md
+++ b/handbook/usage/extensions/README.md
@@ -35,6 +35,9 @@ and how to get more.
   `?duckdb`, section "DuckDB extensions on Linux",
   owns that decision tree
   ([#1107](https://github.com/duckdb/duckdb-r/issues/1107)).
+* **What an extension's values become in R** —
+  spatial's geometry, ICU's timestamps —
+  is [`types/`](/handbook/usage/types/README.md)'s.
 * **Community extensions come from a second repository:**
   `INSTALL <name> FROM community` fetches from
   `community-extensions.duckdb.org`,
@@ -55,7 +58,9 @@ and how to get more.
   The standing gaps are the toolchain epic
   ([#2234](https://github.com/duckdb/duckdb-r/issues/2234),
   upstream
-  [duckdb/duckdb#24431](https://github.com/duckdb/duckdb/issues/24431)).
+  [duckdb/duckdb#24431](https://github.com/duckdb/duckdb/issues/24431)),
+  and the fix for a missing flavor is an upstream pull request per extension
+  ([#2425, maintainer's offer](https://github.com/duckdb/duckdb-r/issues/2425#issuecomment-5182746870)).
 * **Some platforms are not covered**, and which ones is DuckDB's to say
   and does change:
   [Extension Distribution](https://duckdb.org/docs/stable/extensions/extension_distribution)
@@ -81,7 +86,8 @@ and how to get more.
   to the C API.
 * **Loading an extension file by path** —
   `LOAD '/path/to/name.duckdb_extension'` —
-  is how a locally built extension comes in,
+  is how an extension comes in that was built locally
+  or for another toolchain — MSVC, where this package is mingw —
   and takes two driver settings when the file is unsigned
   or carries a foreign platform tag:
   `duckdb(config = list(allow_unsigned_extensions = "true",
@@ -99,6 +105,15 @@ and how to get more.
   so it is consulted only when unsigned loading is already allowed
   (`LoadExtensionInternal`,
   [`src/duckdb/src/main/extension/extension_load.cpp`](/src/duckdb/src/main/extension/extension_load.cpp)).
+* **`INSTALL` can be pointed at another repository:**
+  `SET custom_extension_repository = '<repo>'`
+  redirects the download to a mirror or a local directory
+  in the repository's layout —
+  `<repo>/<duckdb-version>/<platform>/<name>.duckdb_extension.gz` —
+  and `FORCE INSTALL <name>` re-fetches from it.
+  This is the self-hosting path upstream prefers,
+  and the escape when the network, not the platform,
+  blocks the default repository.
 
 Verify any claim about the shipped set on a **vendored build** —
 the fast path answers for a different artifact


### PR DESCRIPTION
A pass over every issue matching "extension" (69 as of 2026-08-05),
checking each against the leaf that should own it.
Most already have a home; three facts did not, and land here —
a 17-line addition to `handbook/usage/extensions/README.md`,
tightened against the authoring rules,
rebased onto `main` now that #2529 and #2530 have merged
(the interim fold commit is dropped, as promised).

## The issue map

* **Coverage and platform gaps** —
  #2425, #2234 (epic), #100, #1581, #2503, #1821, #1740, #1014,
  #1517, #444, #2026, #623, #628, #600, #23, #1094, #65 —
  owned by the extensions leaf's Windows and platform bullets,
  the experiment record
  (`experiments/2026-08-05-windows-extension-coverage/`, #2530),
  and the canary test (#2529, closed #2425; #2535/#2537 settled the
  overlap with the parallel skip).
* **Loading policy / libc++ ABI** — #1107 —
  owned by the leaf's allow-loading bullet and `?duckdb`.
* **Autoload** — #2306, #582, #1084 —
  owned by the leaf's autoload bullet.
* **The store** — #2389, #2370 — owned by `usage/storage/`.
* **Types interop** — #117, #1670, #2278, #184, #590, #55, #174,
  #1400, #1060 —
  owned by `usage/types/` (the geometry, timestamp, and units
  bullets already cite them); the extensions leaf now links that
  boundary (new bullet).
* **Distribution alternatives** — #1582 (companion package
  declined; self-hosting recommended) —
  the decline was on the leaf; the self-hosting half lands here
  (new bullet).
* **Upstream resolution** —
  the #2425 thread's outcome: a missing mingw flavor is fixed by an
  upstream pull request per extension; the leaf now says so where
  the gaps are named, linking the maintainer's offer.
* **webR** — #66 — stays the leaf's deepen note:
  the current behavior is recorded in the issue, and nothing here
  can verify a wasm claim.
* **`ui`** — #1083 — no durable fact:
  the early "no mingw build" state resolved with 1.2.2 and
  `CALL start_ui()` works.
* **rfuns** — #381 — owned by `architecture/rfuns/`.
* Build-time issues that merely mention extensions
  (#2233, #1401, #203, #193, #63, #109, #113) — not extension
  facts; owned by the build pages.

## The three additions

* **The types boundary, linked.**
  A reader who just loaded spatial or ICU next asks what the values
  become in R; that is `usage/types/`'s, stated once on this leaf.
* **The upstream path, stated.**
  A missing mingw flavor is fixed by an upstream pull request per
  extension, linked to the maintainer's offer in the #2425 thread.
  The by-path bullet's opening now also names the second origin a
  file can have: built locally, or for another toolchain — MSVC,
  where this package is mingw.
* **`SET custom_extension_repository`.**
  Points `INSTALL` at a mirror or a local directory in the
  repository's layout
  (`REPO/DUCKDB-VERSION/PLATFORM/NAME.duckdb_extension.gz`),
  `FORCE INSTALL` re-fetches.
  Verified on linux_amd64 against a local directory:
  `install_mode = REPOSITORY`, `installed_from` the directory,
  and the loaded extension works.
  The self-hosting path upstream prefers,
  and the escape for network-blocked installs.

`docs-consistency`: links resolve, no upward links,
generated indexes untouched by this delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BqHZcWbzHbmJNgFtJA1rc1