### PR TITLE
fix(ci): Let `adbcdrivermanager` fail to build on Windows arm64

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -68,6 +68,11 @@ Config/build/compilation-database: false
 Config/build/never-clean: true
 Config/comment/compilation-database: Generate manually with
     pkgload:::generate_db() for faster pkgload::load_all()
+Config/gha/extra-packages: adbcdrivermanager=?ignore-build-errors
+Config/comment/gha/extra-packages: adbcdrivermanager does not compile
+    against Rtools45, and the aarch64 Windows runner has no binary to
+    install instead. Explained in
+    handbook/operations/ci/matrix/README.md.
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/handbook/operations/ci/matrix/README.md
+++ b/handbook/operations/ci/matrix/README.md
@@ -37,6 +37,41 @@ Entries carry extra environment through the generic `env` field —
 the mechanism by which one matrix row can flip any knob
 ([`build/configuration/`](/handbook/build/configuration/README.md)).
 
+## A dependency that will not build
+
+An entry is only as useful as the dependency set it can install,
+and the failure lands before the check begins:
+one dependency that will not compile
+takes the whole entry with it.
+`windows-11-arm` is where this bites —
+Posit Package Manager publishes no aarch64 Windows binaries,
+so that runner builds every dependency from source.
+
+The lever is `Config/gha/extra-packages` in `DESCRIPTION`,
+which [`install/`](/.github/workflows/install/action.yml)
+passes to pak as extra package references.
+A reference carries pak parameters,
+so `<package>=?ignore-build-errors` demotes a failed source build
+of that one package to a warning
+and drops it from the installation plan.
+This package says that about `adbcdrivermanager`,
+which does not compile against Rtools45;
+the field's `Config/comment/…` twin records why.
+
+The condition is the build, not the platform,
+which is what makes this the right lever:
+nothing is declared about *where* the package is expected to fail,
+so every runner that has a binary still checks against it,
+and the one that does not picks it back up
+the day it builds again — with no commit here.
+
+Dropping a `Suggests` package is safe because the check is written for it:
+tests guard with `skip_if_not_installed()`,
+examples with `requireNamespace()`,
+and `rcc` downgrades `RCMDCHECK_ERROR_ON` to `warning`
+when a declared dependency is missing,
+so the entry reports a NOTE where it would otherwise error.
+
 *To deepen: state how the base action derives its version window,
 and what `Config/gha/filter` would remove from it —
 this package sets no such field today.*


### PR DESCRIPTION
`rcc: windows-11-arm (4.6)` is the only red job on `main`,
and it has been red on every push and every nightly run
([`31063639754`](https://github.com/duckdb/duckdb-r/actions/runs/31063639754),
[`30995280634`](https://github.com/duckdb/duckdb-r/actions/runs/30995280634)).
Posit Package Manager publishes no aarch64 Windows binaries,
so that runner builds every dependency from source,
and `adbcdrivermanager` does not compile against Rtools45 —
`strsafe.h` macro-poisons `strcpy()` and friends
while the libc++ headers re-export them,
so the build stops at
`no member named 'strcpy_instead_use_StringCbCopyA_or_StringCchCopyA'`.
pak then aborts the whole installation,
before the check of this package has begun.

## The change

One `DESCRIPTION` field, plus the handbook leaf that carries the reasoning.

`Config/gha/extra-packages` is the field `install/` already passes to pak
as extra package references —
the one igraph uses to keep its Bioconductor-only `graph` dependency
off the R versions where it cannot be resolved.
The parameter here is `?ignore-build-errors`:
a failed source build of that one package becomes a warning,
and the package drops out of the installation plan
instead of taking the job with it.

**The condition is the build, not the platform.**
Nothing is declared about where the package is expected to fail,
so every runner that has a binary still checks against it,
and Windows arm64 picks it back up the day it builds again —
with no commit here.

Dropping a `Suggests` package is safe on that entry:
the tests guard with `skip_if_not_installed()`,
the examples with `requireNamespace()`,
and `rcc` downgrades `RCMDCHECK_ERROR_ON` to `warning`
when a declared dependency is missing,
so the entry reports a NOTE where it would otherwise error.

## What was checked

* `?ignore-build-errors` is in `known_query_params` in **released**
  pkgdepends 0.9.1, and pak 0.11.1 embeds pkgdepends 0.9.1.9000,
  so `pak-version: stable` has it today.
  It is undocumented in `?pkg_refs`;
  unknown parameters only warn, never error,
  so an older pak degrades to the current behaviour rather than a new one.
* Resolving this `DESCRIPTION` locally with
  `c("deps::.", "any::rcmdcheck", "adbcdrivermanager=?ignore-build-errors")`
  puts the flag on exactly 1 of 70 packages,
  and `is_true_param(params, "ignore-build-errors")` is `TRUE` —
  the same predicate `stop_task_build()` consults.
* `grep Config/gha/extra-packages DESCRIPTION | cut -d " " -f 2-`,
  which is what the action runs,
  yields `adbcdrivermanager=?ignore-build-errors` and nothing else:
  the `Config/comment/…` twin does not match it.

The build is still attempted on that runner and still fails,
so the compile time is spent before the warning;
it is spent only where the build actually breaks.

## Not verified here

A same-repo pull request skips the `versions-matrix` step,
so `rcc-full` — and with it `windows-11-arm` — does not run on this PR.
The first real signal is the push to `main`,
or a dispatch with `versions-matrix: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6bfRw2A3tGavX9aYSpc9e


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q6bfRw2A3tGavX9aYSpc9e)_