### PR TITLE
fix(series-advance): Set `-build-base`, rather than advance it

### DIFF
--- a/.claude/skills/series-loop.md
+++ b/.claude/skills/series-loop.md
@@ -21,7 +21,7 @@ this loop repairs in place and was proven on the `main` rewind
 | `<S>-build` | the routine, unconditionally | Every upstream first-parent commit vendored one-to-one, glue compiling at every commit. **No CI runs here** (`each.yaml` never matches `*-build`). The buffer. |
 | `<S>-dev` | the routine, force-push | `<S>-build` commits, consumed up to 100 at a time, with test/R/patch adaptations folded in as CI demands. What CI builds, commit by commit. |
 | `<S>-green` | the routine, fast-forward only | The newest commit such that every commit in `<S>-green..it` has a `success` run. What r-universe should build from. |
-| `<S>-build-base` | the routine | The `<S>-build` commit equivalent to `<S>-green` (same vendored upstream SHA). Marks how much of the buffer has been consumed and verified. |
+| `<S>-build-base` | the routine, force-push | The `<S>-build` commit equivalent to `<S>-green` (same vendored upstream SHA). Marks how much of the buffer has been consumed and verified. A marker with no consumer, recomputed every stage 3. |
 
 Equivalence between `-build` and `-dev` commits is by the
 `duckdb/duckdb@<sha>` reference in the commit subject —
@@ -89,9 +89,9 @@ plus a CUTOVER line for a forward series that has caught up —
 a suggestion for a human, stage 6),
 `scripts/series-advance.sh <S>`
 (stages 3 and 5 — fast-forwards `-green`,
-moves `-build-base` by vendored-SHA match,
+sets `-build-base` to the vendored-SHA match,
 extends `-dev` by ≤ 100;
-refuses on any failure or non-fast-forward),
+refuses on any failure, and on a `-green` that would not fast-forward),
 `scripts/series-port.sh <S>`
 (stage 4 — brings `<S>-dev` level with `main`:
 cherry-picks plus a tooling sync),
@@ -388,12 +388,13 @@ everything at or before `<S>-green` is trusted —
 verified by this loop,
 or accepted as the series' seed on day one —
 and is never re-examined.
-Move `<S>-build-base` to the `<S>-build` commit
-with the same vendored upstream SHA
-(day one: the seed tip, before any vendor commit is consumed).
-Fast-forward only —
-if `-green` cannot fast-forward, something rewrote verified history;
+`-green` is fast-forward only —
+if it cannot fast-forward, something rewrote verified history;
 stop and say so.
+Set `<S>-build-base` to the `<S>-build` commit
+with the same vendored upstream SHA
+(day one: the seed tip, before any vendor commit is consumed),
+force-pushing where the match is not a fast-forward.
 
 **`-build-base` lands on vendor commits only, so it lags.**
 The match is by vendored SHA,
@@ -405,9 +406,31 @@ and the *buffered* badge (`-build-base..-build`) overstates by that much:
 9 rather than 6 on `main`, 2026-08-04.
 It is display-only and self-correcting —
 the next verified vendor commit moves the ref past the whole run —
-and the ref moves forward only either way,
 so nudging it onto the newest `-build` commit green demonstrably contains
 is a legitimate manual move, not a repair.
+
+**`-build-base` is the one ref of the four that is not fast-forward only.**
+It is a marker, not a promise:
+nothing consumes it, the match is recomputed from scratch every stage 3,
+and where the ref sits today tells the next firing nothing
+it does not re-derive.
+So the stage **sets** it rather than advancing it,
+force-pushing when the match is not a fast-forward,
+and the cost of being wrong is one display column
+until the next stage 3 recomputes it.
+The other three carry their guarantees unchanged:
+`-green` fast-forwards only,
+`-build` and `-dev` are rewritten only by this loop,
+by the rules above.
+
+A ref found off the buffer's line is therefore not a puzzle to solve.
+It happened once, on `v1.4-andium`, 2026-08-06:
+an auto-update commit landed on `-build` and on `-build-base`
+31 seconds apart and left the two siblings,
+which the stage then refused as a rewind of verified history.
+Set the ref and move on;
+diagnosing what wrote it is worth doing only if it recurs.
+
 Do not teach the match to guess:
 a patch-id scan finds only the commits
 whose content reached `-dev` unsplit,
@@ -968,7 +991,10 @@ is what carries the automatic path into a forward series.
 
 ## Invariants
 
-- `<S>-green` and `<S>-build-base` move forward only.
+- `<S>-green` moves forward only.
+  `<S>-build-base` does not: it is a marker with no consumer,
+  recomputed from the vendored-SHA match every stage 3,
+  and set — force-pushed where it has to be — rather than advanced.
 - Cutover is manual.
   The loop reports that a forward series has caught up
   and prints the command; it never runs it,

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -108,7 +108,7 @@ Root of the documentation tree: [`handbook/`](/handbook/README.md).
 | File | Purpose |
 |---|---|
 | [`r-universe-check.sh`](r-universe-check.sh) | Read-only: what did r-universe make of the refs this repository publishes? |
-| [`series-advance.sh`](series-advance.sh) | The ref motion of the series loop, stages 3 and 5, for one series: fast-forward `<S>-green` over the all-green prefix, move `<S>-build-base` to the equivalen... |
+| [`series-advance.sh`](series-advance.sh) | The ref motion of the series loop, stages 3 and 5, for one series: fast-forward `<S>-green` over the all-green prefix, set `<S>-build-base` to the equivalent... |
 | [`series-check.sh`](series-check.sh) | Read-only diagnosis for the series loop: what should a firing do? |
 | [`series-cutover.sh`](series-cutover.sh) | Atomically replace a series with its forward counterpart. |
 | [`series-forward-build.sh`](series-forward-build.sh) | Populate `<S>-fwd-build`: replay every vendor commit of the old `<S>-build` onto HEAD, which must be the freshly flavored seed on current `main` (.claude/ski... |

--- a/scripts/series-advance.sh
+++ b/scripts/series-advance.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # The ref motion of the series loop, stages 3 and 5, for one series:
-# fast-forward `<S>-green` over the all-green prefix, move `<S>-build-base` to
+# fast-forward `<S>-green` over the all-green prefix, set `<S>-build-base` to
 # the equivalent `-build` commit, and extend `<S>-dev` from the buffer.
 #
 # Everything here is mechanical and gated; the judgement calls (repairs,
@@ -154,10 +154,17 @@ if [ "$new_green" != "$(git rev-parse "$green")" ]; then
   if [ -n "$up" ]; then
     eq=$(git log --format='%H %s' "$build" | grep -m 1 "duckdb@$up" | cut -d' ' -f1 || true)
     if [ -n "$eq" ]; then
-      git merge-base --is-ancestor "$base" "$eq" ||
-        { echo "Error: build-base would not move forward"; exit 1; }
-      git push "$remote" "$eq:refs/heads/$S-build-base"
-      echo "build-base -> $(git rev-parse --short "$eq")"
+      # Set, never advance. -build-base is the one ref of the four that is not
+      # fast-forward only: nothing consumes it, and the match is recomputed
+      # here from scratch every time, so where the ref sat before says nothing
+      # this stage needs (.claude/skills/series-loop.md, stage 3). Force,
+      # because a write from outside this loop -- a CI job committing onto the
+      # branch it ran on -- can leave the ref past the match or beside the
+      # buffer, and refusing that stopped stage 5 with it.
+      if [ "$(git rev-parse "$base")" != "$eq" ]; then
+        git push --force "$remote" "$eq:refs/heads/$S-build-base"
+        echo "build-base -> $(git rev-parse --short "$eq")"
+      fi
     fi
   fi
 else


### PR DESCRIPTION
## What happened

The 2026-08-06 series-loop firing found `v1.4-andium-build-base`
off the buffer's line,
and `scripts/series-advance.sh` refused the whole invocation:

```
Error: build-base would not move forward
```

`exit 1` there takes stage 5 with it,
so the buffer stopped extending
over a marker nothing downstream reads.

The cause was a one-off — two `chore: Auto-update from GitHub Actions`
commits pushed 31 seconds apart onto `v1.4-andium-build`
and `v1.4-andium-build-base`, from the same parent,
leaving the two refs siblings rather than one containing the other.
That is treated here as a fluke, not as a class to design around.

## The change

`-build-base` is the one ref of the four with no consumer.
The match is recomputed from the vendored-SHA scan every stage 3,
so where the ref sat before says nothing the stage needs,
and holding it to fast-forward only buys nothing
while costing an invocation whenever something moves it.

So the stage **sets** it, forcing where the match is not a fast-forward.

The other three keep their guarantees, unchanged:
`-green` fast-forwards only —
a `-green` that will not fast-forward is still the stop-and-report case —
and `-build` and `-dev` are rewritten only by this loop,
by the rules already in the skill.

`.claude/skills/series-loop.md` gets the same account:
the branch table, the stage-3 text, the script summary,
and the invariant, which now names only `-green`.

## What was checked

* `series-advance.sh` runs to completion for all three series against the
  live repository with the change in place.
* The remote accepts a non-fast-forward push to `-build-base`:
  that is exactly how the ref was unstuck by hand during the firing
  (`05876e5f9` → `6e7dd75ce`, `--force-with-lease`).
* No-op when the ref is already at the match, so a steady-state firing
  pushes nothing.
* `scripts/README.md` regenerated; the one changed row is this script's
  own header line.

## Worked around by hand first

Per `series-loop.md` §7, the series was unstuck by hand in the same firing,
so nothing depended on this merging.