### PR TITLE
docs(branches): State the mirrors' cadence, now that `krlmlr/duckdb-r` is a fork

### DIFF
--- a/.claude/skills/series-open.md
+++ b/.claude/skills/series-open.md
@@ -104,8 +104,10 @@ Two things to check before pushing:
 * **Every ref a badge names must live in `krlmlr/duckdb-r`.**
   A base that exists only in the canonical repo
   renders as an error, not a count.
-  Push the release branch into the fork,
-  and keep the mirror fresh
+  Push the release branch into the fork once —
+  the Pull app keeps a mirror fresh but never creates one —
+  and give it a rule in [`.github/pull.yml`](/.github/pull.yml)
+  if the badge measures against it
   ([`branches/mirrors/`](/handbook/branches/mirrors/README.md)).
 * **The table must stay clear of `scripts/flavor.patch`.**
   `README.md` is a flavored file;

--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -8,12 +8,6 @@
 # truth for CI/CD infrastructure and the fork's `main` is a mirror of it;
 # in this repository the file does nothing, because Pull acts on forks.
 #
-# Not in force yet: `krlmlr/duckdb-r` is a standalone copy rather than a fork
-# object, and Pull requires the upstream to be in the same fork network, so
-# every rule below is skipped until the fork move (duckdb/duckdb-r#2494).
-# Until then the mirrors stand where they were last pushed, and one an *ahead*
-# badge reads from is refreshed by hand.
-#
 # Every rule hard-resets, which is what makes the branch a mirror rather than a
 # branch of the fork's own: a commit pushed onto one is discarded on the next
 # run, not merged. The fork's series refs carry a suffix and match no rule here,

--- a/handbook/branches/mirrors/README.md
+++ b/handbook/branches/mirrors/README.md
@@ -26,22 +26,23 @@ shipped.
 
 **The mechanism is the fork's own, not a job of ours.**
 Keeping a fork level with what it forked from is what the Pull app does,
-and [`.github/pull.yml`](/.github/pull.yml) is where it is configured:
+and it reaches this fork at all because `krlmlr/duckdb-r` is a fork object
+of the canonical repository rather than a copy of it:
+Pull requires the upstream to be in the same fork network.
+[`.github/pull.yml`](/.github/pull.yml) is where it is configured:
 that file's rules are the list of mirrors,
 and the fork's series refs match none of them.
 It is authored here, in the canonical repository,
 because CI/CD infrastructure has its source of truth on `main`,
 and read from the fork's default branch, which is a mirror of that `main`.
 
-**No mirror moves until the fork is a fork object.**
-Pull requires the upstream to be in the same fork network,
-and `krlmlr/duckdb-r` is still a standalone copy,
-so every rule is skipped and every mirror stands where it was last pushed
-([#2494](https://github.com/duckdb/duckdb-r/issues/2494)).
-Until the move, a mirror an *ahead* badge reads from is refreshed by hand.
-Afterwards Pull syncs a repository every six hours on a schedule it picks
-itself, and a sync can be asked for at any moment
-from the URL that config names.
+**A mirror moves on the app's schedule, not on ours.**
+Pull syncs a repository every six hours,
+at a fixed offset it picks itself,
+so a mirror is at most that far behind what it copies;
+a sync can be asked for at any moment from the URL that config names —
+which is what someone who needs a mirror at the canonical tip asks for,
+rather than pushing the branch.
 
 **A mirror is created by pushing it, not by configuring it.**
 Pull skips a rule whose base branch the fork does not have,
@@ -49,6 +50,3 @@ and says so only in its own logs,
 so a branch that is about to be measured against is pushed once by hand
 ([`.claude/skills/series-open.md`](/.claude/skills/series-open.md));
 the config keeps it fresh afterwards and never creates it.
-
-*To deepen: drain [#2494](https://github.com/duckdb/duckdb-r/issues/2494),
-after which this page states a mirror's cadence rather than its absence.*

--- a/handbook/branches/model/README.md
+++ b/handbook/branches/model/README.md
@@ -18,13 +18,17 @@ sibling `<S>-dev`, so opening one is creating refs
 `duckdb/duckdb-r` is canonical:
 `main`, the parked stable baselines, the LTS flavor branch;
 CRAN and the numbered r-universe packages publish from here.
-`krlmlr/duckdb-r` is a fork used for CI/CD
+`krlmlr/duckdb-r` is a fork of it — a fork object in the same fork
+network, not a copy that shares its name — used for CI/CD
 so the per-commit builds do not consume
 the `duckdb` organization's Actions quota;
 every series' working refs live there,
 beside mirrors of the canonical branches
 they are seeded from and measured against
 ([`mirrors/`](/handbook/branches/mirrors/README.md)).
+The fork carries only the refs the loop serves;
+what it does not carry stands in `krlmlr/duckdb-r-old`,
+an archive that nothing reads and nothing writes to.
 
 **The four refs** of a series `<S>`, all in the fork:
 

--- a/handbook/meta/glossary/README.md
+++ b/handbook/meta/glossary/README.md
@@ -7,6 +7,7 @@ added by the change that reaches for it —
 one line, so the register stays greppable and diffs per term.
 
 * **ALTREP** — R's alternative-representation mechanism: how an unexecuted relation masquerades as a data frame until touched ([`architecture/glue/`](/handbook/architecture/glue/README.md)).
+* **archive** — `krlmlr/duckdb-r-old`, holding the refs the fork does not carry; nothing reads it and nothing writes to it ([`branches/model/`](/handbook/branches/model/README.md)).
 * **autoload / autoinstall** — an *installed* extension loads on first use; nothing downloads without being asked ([`usage/extensions/`](/handbook/usage/extensions/README.md)).
 * **backreference** — the link a secondary document carries back to the handbook node it serves ([`meta/handbook/`](/handbook/meta/handbook/README.md)).
 * **buffer** — a series' `-build` ref: vendored ahead of CI, deliberately untested ([`branches/model/`](/handbook/branches/model/README.md)).
@@ -50,5 +51,5 @@ one line, so the register stays greppable and diffs per term.
 * **triage verdicts** — the dispositions issue intake assigns, exactly one per open item ([`operations/triage/`](/handbook/operations/triage/README.md)).
 * **vendor commit** — one commit advancing `src/duckdb/` by exactly one upstream commit ([`operations/vendoring/model/`](/handbook/operations/vendoring/model/README.md)).
 * **vendoring** — keeping a dependency's sources inside the depending repository ([`operations/vendoring/model/`](/handbook/operations/vendoring/model/README.md)).
-* **verdict store** / **`rcc2` branch** — the orphan branch holding each commit's build verdict and log, one file per commit ([`operations/ci/per-commit/store/`](/handbook/operations/ci/per-commit/store/README.md)). Its predecessor `rcc` is retired but not deleted.
+* **verdict store** / **`rcc2` branch** — the orphan branch holding each commit's build verdict and log, one file per commit ([`operations/ci/per-commit/store/`](/handbook/operations/ci/per-commit/store/README.md)). Its predecessor `rcc` is retired, and kept whole in the archive.
 * **WKB** — well-known binary, the geometry interchange across the R boundary ([`usage/types/`](/handbook/usage/types/README.md)).

--- a/handbook/operations/ci/per-commit/store/README.md
+++ b/handbook/operations/ci/per-commit/store/README.md
@@ -129,8 +129,9 @@ flat `logs2/<sha>.log` files move under the fan-out;
 a legacy `logs/<run-id>.log` is recovered as its commit's log
 when that run decided exactly one commit,
 and dropped rather than guessed at when it did not.
-`rcc` is never written to, and is left whole:
-deleting it is a separate step for whenever nothing reads it.
+`rcc` is never written to, and is left whole,
+in the archive rather than in the fork
+([`branches/model/`](/handbook/branches/model/README.md)).
 
 ### Runbook: the cutover
 

--- a/plan/PLAN-vendoring-simplification.md
+++ b/plan/PLAN-vendoring-simplification.md
@@ -7,7 +7,8 @@ and the documentation tree's own rules are
 this file is the proposal, and where the two disagree the leaf is right.
 
 Status: **in progress** (2026-07-30, branch `claude/vendoring-tooling-design-3swawc`;
-Phase 1 landed as #87, the README root as #88 — see §9;
+Phase 1 landed as #87, the README root as #88, Phase 3 as the fork
+move (#2534) — see §9;
 revised after a clean-context review of this document against `origin/main`).
 Inputs: `BRANCHES.md`, `scripts/VENDORING.md`, `scripts/EACH.md`,
 `scripts/VENDORING-LOOP.md` (historical), the four skills in `.claude/skills/`,
@@ -473,6 +474,15 @@ kept light by habit rather than process:
 
 ## 6. A fresh fork replaces the standalone repo
 
+*Status:* **landed.** `krlmlr/duckdb-r` is a fork object of
+`duckdb/duckdb-r`, carrying the series refs, the mirrors and the verdict
+store and nothing else, with the Pull app in force (#2534);
+the repository it replaced is the archive `krlmlr/duckdb-r-old`.
+What holds today is
+[`branches/model/`](/handbook/branches/model/README.md)'s and
+[`branches/mirrors/`](/handbook/branches/mirrors/README.md)'s;
+the rest of this section is the reasoning that got there.
+
 `krlmlr/duckdb-r` is a standalone copy, not a GitHub fork object
 (the docs call it "the fork" colloquially);
 the intent is to replace it with a fresh, genuine fork —
@@ -647,11 +657,11 @@ of the kernel.
 | **1 — landed (#87)** | the port stage: `scripts/series-port.sh` plus the amended `series-loop` / `series-forward` / `series-rebase` skills | first real `--apply` still runs supervised |
 | **1a (follow-up)** | resolve the subject-vs-path contradiction (§4), in order: harden `vendor-one.sh` and `vendor.sh`'s subject scans to bounded-and-loud; relax `classify()` to subject-decided; rewrite the landed rationale in `series-port.sh`'s header and `series-loop.md` stage 4; stage 1 invokes `main`'s `vendor-one.sh` against the buffer worktree | wider than first scoped — two scanners, one classifier, two rationale blocks, one skill rule; each independently shippable |
 | **2** | single verdict store (D1: selection and resume by record; backstop stops writing, its schedule dispatches idle undecided work); one sweep, then drop the aggregate outright (D2); the fan-in stays (per-commit logs, §3.2) | verdicts are already dual-written today; rollback = read statuses again |
-| **3** | replace the standalone repo with a fresh fork (§6), configured with the Pull app so the release-branch mirrors stay current without a job of our own; mirrors stay manual until then | one-time move; keep the standalone until the fork has served one full loop cycle |
+| **3 — landed (#2534)** | replace the standalone repo with a fresh fork (§6), configured with the Pull app so the release-branch mirrors stay current without a job of our own | one-time move; the replaced repository is kept as `krlmlr/duckdb-r-old` |
 | **4** | docs tree (§8): README root landed (#88); next the moves, then node rewrites (including `AGENTS.md`'s and `BRANCHES.md`'s stale rows); `docs-tree` skill | docs only |
 | **5** | kernel extraction + `rigraph` port (config file, generalized subject marker, igraph cost estimator or constant weight) | new repo consumed `@main`; rollback = vendored copy of the kernel |
 
-Phases 1a–3 are independently shippable; the deletions concentrate in
+Phases 1a and 2 are independently shippable; the deletions concentrate in
 Phase 2.
 
 ## 10. Open questions
@@ -664,11 +674,11 @@ Phase 2.
 2. **Record-store scale.** One commit per record keeps `rcc` growing
    (~1 commit/record; consolidation squashes). Is the current
    consolidation cadence enough once statuses stop being a second copy?
-3. **Fork migration depth (§6).** Carry the `rcc` records/logs and the
-   1175 snapshot branches into the fresh fork, or restart them and keep
-   the standalone repo read-only as the archive? Records at or below a
-   series' green are never re-read by the loop, so a restart may be
-   cheap.
+3. ~~**Fork migration depth (§6).**~~ *Settled by the move:* `rcc2`
+   came across whole, and everything else — the retired `rcc`, the
+   snapshot branches, the ref litter, the finished topic branches —
+   stayed in `krlmlr/duckdb-r-old`, which is read-only from here on.
+   The snapshot branches the gate needs it recreates as it goes.
 4. **Extraction home (Phase 5).** Shared repo (`krlmlr/vendor-loop`?)
    consumed `@main`, vs. copy-with-config in each consumer.
    Leaning shared repo; decide when the port starts.


### PR DESCRIPTION
`krlmlr/duckdb-r` is now a fork object in `duckdb/duckdb-r`'s fork network, so the Pull app's rules are in force: a mirror is at most one six-hour sync behind the branch it copies, and none of them is refreshed by hand any more. The docs still described the state before that, which this change replaces with what holds today.

**Handbook**

- `branches/mirrors/` — the "no mirror moves until the fork is a fork object" paragraph becomes the cadence: Pull's six-hourly sync at an offset it picks itself, plus the on-demand trigger. The fork-network requirement moves into the paragraph about the mechanism, where it explains why the app reaches this fork at all. The deepen line goes: the leaf is comprehensive.
- `branches/model/` — `krlmlr/duckdb-r` is stated as a fork object rather than a copy sharing the name, and `krlmlr/duckdb-r-old` is named as the archive for the refs the fork does not carry.
- `operations/ci/per-commit/store/` and `meta/glossary/` — the retired `rcc` store is located in that archive, since it did not come across; `rcc2` did, whole. The glossary also registers "archive" as a term.

**Derived docs**

- `.github/pull.yml` — drops the header paragraph saying every rule below is skipped.
- `.claude/skills/series-open.md` — a new mirror is pushed once and then given a rule in `.github/pull.yml`, instead of being kept fresh by hand.

**Plan**

- `PLAN-vendoring-simplification.md` — §6 and phase 3 record what landed; the open question on fork-migration depth records what the move settled (`rcc2` carried over, everything else left in the archive, snapshot branches recreated by the gate as it goes).

Closes #2494.

Verified against the live repositories: the fork carries only series refs, mirrors, `rcc2` and `gh-pages`; `main`, `v1.4-andium`, `v1.4-andium-lts` and `v1.5-variegata` are level with their canonical tips; `rcc`, the snapshot branches and the ref litter are in `krlmlr/duckdb-r-old`. The handbook link check and the generated `scripts/` index check both pass.

One thing this PR deliberately does not touch: `fledge.yaml` still carries a `krlmlr/duckdb-r` special case below its `is_forked` check, which that check now covers on its own. Removing it is a code change, not a doc change — happy to do it separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_017jGzquEvfdvBdrMfFUq4TV)_