### PR TITLE
docs: Record the August 2026 forward, and turn the cpp11 gap it walked into into a check

### DIFF
--- a/.claude/skills/series-forward.md
+++ b/.claude/skills/series-forward.md
@@ -26,9 +26,8 @@ the replay then populates `<S>-fwd-build`.
    plus the separate fifth-component commit on a dev branch
    (`series-open.md`) —
    then replay each vendor commit onto it.
-   `flavor.sh` needs `krlmlr/cpp11` installed and refuses the run without
-   it, having already committed the first half of the flavor —
-   install it first (`series-open.md`, step 2).
+   `flavor.sh` needs `krlmlr/cpp11` installed, and refuses the whole run
+   without it (`series-open.md`, step 2).
    A series seeded from a release branch rather than from `main`
    regenerates on **that** branch,
    whose `scripts/` may be older than `main`'s —

--- a/.claude/skills/series-forward.md
+++ b/.claude/skills/series-forward.md
@@ -26,6 +26,15 @@ the replay then populates `<S>-fwd-build`.
    plus the separate fifth-component commit on a dev branch
    (`series-open.md`) —
    then replay each vendor commit onto it.
+   `flavor.sh` has a prerequisite it does not check
+   and cannot fail loudly on:
+   the installed cpp11 has to be `krlmlr/cpp11`,
+   or a two-dot flavor is regenerated with entry points
+   no compiler accepts (`series-open.md`, step 2).
+   A series seeded from a release branch rather than from `main`
+   regenerates on **that** branch,
+   whose `scripts/` may be older than `main`'s —
+   replay the recorded seed commits instead when it is.
 
    **The forward series takes the whole of the new base.**
    The replay is a cherry-pick, not a tree reconstruction:

--- a/.claude/skills/series-forward.md
+++ b/.claude/skills/series-forward.md
@@ -96,6 +96,41 @@ the replay then populates `<S>-fwd-build`.
    `scripts/series-forward-build.sh <old-build> <old-base>`
    does exactly this, run on the fresh seed —
    `<old-base>` only delimits the range.
+
+   **It refuses to start while the buffer carries a change
+   the new base does not have.**
+   `-build` takes no ports, so a non-vendor commit above its first
+   vendor commit is the buffer's own —
+   the `patch/` entries stage 3 commits onto it —
+   and the replay has nowhere to put it.
+   The script names each one and stops before writing anything.
+   Work through them in this order:
+
+   1. **Read it.** The refusal rests on two cheap tests,
+      so a change the new base carries in a shape neither recognises
+      is listed too; confirm by reading the base for its effect.
+      If it is there, the commit is done.
+   2. **Find the commit it belongs to** —
+      the first whose tree carries the code it answers, never the commit
+      it was written at
+      ([`vendoring/troubleshooting/`](/handbook/operations/vendoring/troubleshooting/README.md)).
+      Name it by its upstream SHA:
+      the replayed commit does not exist yet.
+   3. **Rerun with `--placed <sha>` for each** — the script prints the
+      whole command — and let the replay finish.
+      The acknowledgement is remembered, so a conflict stop resumes
+      without it.
+   4. **Fold each change into its commit, then replay the tail.**
+      Detach at the commit, apply the change, `git commit --amend`,
+      and `git rebase --onto HEAD <that commit> <S>-fwd-build`.
+      Amending rather than inserting is what keeps the counter equal to
+      the number of commits the script wrote,
+      which is how it finds its place on a later resume.
+   5. **Verify by tree.**
+      `git diff --name-only <S>-build <S>-fwd-build -- src/duckdb patch/`
+      must be empty.
+      This is the check that catches everything above going wrong,
+      including a fold that landed in the wrong place.
    `DESCRIPTION` merges on every commit,
    so register the merge driver first (`scripts/setup-git.sh`);
    on a conflict the script stops with the tree in place,

--- a/.claude/skills/series-forward.md
+++ b/.claude/skills/series-forward.md
@@ -26,11 +26,9 @@ the replay then populates `<S>-fwd-build`.
    plus the separate fifth-component commit on a dev branch
    (`series-open.md`) —
    then replay each vendor commit onto it.
-   `flavor.sh` has a prerequisite it does not check
-   and cannot fail loudly on:
-   the installed cpp11 has to be `krlmlr/cpp11`,
-   or a two-dot flavor is regenerated with entry points
-   no compiler accepts (`series-open.md`, step 2).
+   `flavor.sh` needs `krlmlr/cpp11` installed and refuses the run without
+   it, having already committed the first half of the flavor —
+   install it first (`series-open.md`, step 2).
    A series seeded from a release branch rather than from `main`
    regenerates on **that** branch,
    whose `scripts/` may be older than `main`'s —

--- a/.claude/skills/series-open.md
+++ b/.claude/skills/series-open.md
@@ -44,19 +44,14 @@ This skill is the release branch's birth certificate.
    **Install `krlmlr/cpp11` before running `flavor.sh`**, from GitHub —
    `remotes::install_github("krlmlr/cpp11")`, beside `decor`.
    `flavor.sh` runs `cpp11::cpp_register()`,
-   and its symbol names come from the cpp11 that happens to be installed,
-   not from the vendored headers:
-   CRAN's replaces the *first* dot of the package name only,
-   so a `1.5.dev` flavor comes out as `_duckdb_1.5.dev_rapi_connect`,
-   which is not a valid C identifier
-   ([`architecture/glue/`](/handbook/architecture/glue/README.md)
-   owns why, and says what to check).
-   `krlmlr.r-universe.dev` does not build cpp11,
-   so asking for it there and falling back to CRAN installs CRAN's
-   and looks like it worked.
-   Compare `R/cpp11.R` against an existing series' seed either way;
-   this is also why a forward series is rebased rather than reseeded
-   (`series-rebase.md`).
+   whose symbol names come from the installed cpp11 rather than from the
+   vendored headers
+   ([`architecture/glue/`](/handbook/architecture/glue/README.md)).
+   The script refuses the result when it is wrong,
+   but only after committing the first half of the flavor,
+   so installing first is cheaper than being told.
+   That the two cpp11s differ at all is also why a forward series is
+   rebased rather than reseeded (`series-rebase.md`).
 
 3. **Create all four refs at the seed tip**
    (day-one rule, no exceptions):

--- a/.claude/skills/series-open.md
+++ b/.claude/skills/series-open.md
@@ -47,9 +47,10 @@ This skill is the release branch's birth certificate.
    whose symbol names come from the installed cpp11 rather than from the
    vendored headers
    ([`architecture/glue/`](/handbook/architecture/glue/README.md)).
-   The script refuses the result when it is wrong,
-   but only after committing the first half of the flavor,
-   so installing first is cheaper than being told.
+   The script refuses the result when it is wrong
+   and restores the tree, so a missing fork costs a rerun and nothing
+   else — but it costs the whole run, and `cpp_register()` is the last
+   step.
    That the two cpp11s differ at all is also why a forward series is
    rebased rather than reseeded (`series-rebase.md`).
 

--- a/.claude/skills/series-open.md
+++ b/.claude/skills/series-open.md
@@ -41,13 +41,20 @@ This skill is the release branch's birth certificate.
    `flavor.sh` never stamps it,
    because regular LTS flavors keep their four-component version.
 
-   **Check the generated cpp11 files before trusting a fresh seed.**
+   **Install `krlmlr/cpp11` before running `flavor.sh`**, from GitHub —
+   `remotes::install_github("krlmlr/cpp11")`, beside `decor`.
    `flavor.sh` runs `cpp11::cpp_register()`,
-   whose symbol names depend on the cpp11 that happens to be installed:
-   0.5.5 replaces only the *first* dot of the package name,
+   and its symbol names come from the cpp11 that happens to be installed,
+   not from the vendored headers:
+   CRAN's replaces the *first* dot of the package name only,
    so a `1.5.dev` flavor comes out as `_duckdb_1.5.dev_rapi_connect`,
-   which is not a valid C identifier.
-   Compare `R/cpp11.R` against an existing series' seed;
+   which is not a valid C identifier
+   ([`architecture/glue/`](/handbook/architecture/glue/README.md)
+   owns why, and says what to check).
+   `krlmlr.r-universe.dev` does not build cpp11,
+   so asking for it there and falling back to CRAN installs CRAN's
+   and looks like it worked.
+   Compare `R/cpp11.R` against an existing series' seed either way;
    this is also why a forward series is rebased rather than reseeded
    (`series-rebase.md`).
 

--- a/handbook/architecture/glue/README.md
+++ b/handbook/architecture/glue/README.md
@@ -34,23 +34,17 @@ which are generated and never edited.
 `cpp_register()` does not come from `inst/include/cpp11/` —
 it is an R function, resolved from whatever cpp11 the library holds,
 and so it is the one part of cpp11 this repository cannot pin.
-It has to be the fork as well:
-CRAN's cpp11 mangles the package name into the `.Call` prefix with
-`sub("[.]", "_", package)`, replacing the first dot only,
-so a flavor carrying two — `duckdb.1.5.dev` — is written as
-`_duckdb_1.5.dev_rapi_connect`, which is not a C identifier.
-The fork spells that `gsub` ([`R/register.R`](https://github.com/krlmlr/cpp11/blob/main/R/register.R)),
-and is otherwise indistinguishable, which is what makes the failure quiet:
-a one-dot flavor comes out correct from either.
+It has to be the fork as well,
+because the flavor names it derives the `.Call` prefix from
+carry more dots than CRAN's cpp11 replaces.
 Install it from GitHub —
 `remotes::install_github("krlmlr/cpp11")` —
-beside `decor`, which `cpp_register()` also needs.
-Not from CRAN, and not from `krlmlr.r-universe.dev`, which does not
-build cpp11 at all,
-so naming that repository first and CRAN second installs CRAN's
-and says nothing.
-What runs the generator, and what a wrong one costs there, is
-[`branches/flavors/`](/handbook/branches/flavors/README.md)'s.
+beside `decor`, which `cpp_register()` also needs;
+`krlmlr.r-universe.dev` does not build cpp11,
+so naming that repository ahead of CRAN installs CRAN's.
+[`scripts/flavor.sh`](/scripts/flavor.sh) refuses a generated binding
+whose entry points are not C identifiers, which is what a wrong cpp11
+produces.
 
 **`RStrings`.**
 R string constants and `Rf_install()` symbols used from C++

--- a/handbook/architecture/glue/README.md
+++ b/handbook/architecture/glue/README.md
@@ -24,13 +24,33 @@ and `DUCKDB_R_POISON_GUARD()` (the C++ half of the CRAN guard).
 taken from [`krlmlr/cpp11`](https://github.com/krlmlr/cpp11),
 a patch stack on top of
 [`r-lib/cpp11`](https://github.com/r-lib/cpp11):
-this package needs extensions upstream does not ship,
-support for package names carrying more than one dot
-(`duckdb.1.5.dev`) among them.
+this package needs extensions upstream does not ship.
 An entry point is a function marked `[[cpp11::register]]`;
 `cpp11::cpp_register()` writes both halves of the binding
 (`src/cpp11.cpp`, `R/cpp11.R`),
 which are generated and never edited.
+
+**The generator is the fork too, and it is not vendored.**
+`cpp_register()` does not come from `inst/include/cpp11/` —
+it is an R function, resolved from whatever cpp11 the library holds,
+and so it is the one part of cpp11 this repository cannot pin.
+It has to be the fork as well:
+CRAN's cpp11 mangles the package name into the `.Call` prefix with
+`sub("[.]", "_", package)`, replacing the first dot only,
+so a flavor carrying two — `duckdb.1.5.dev` — is written as
+`_duckdb_1.5.dev_rapi_connect`, which is not a C identifier.
+The fork spells that `gsub` ([`R/register.R`](https://github.com/krlmlr/cpp11/blob/main/R/register.R)),
+and is otherwise indistinguishable, which is what makes the failure quiet:
+a one-dot flavor comes out correct from either.
+Install it from GitHub —
+`remotes::install_github("krlmlr/cpp11")` —
+beside `decor`, which `cpp_register()` also needs.
+Not from CRAN, and not from `krlmlr.r-universe.dev`, which does not
+build cpp11 at all,
+so naming that repository first and CRAN second installs CRAN's
+and says nothing.
+What runs the generator, and what a wrong one costs there, is
+[`branches/flavors/`](/handbook/branches/flavors/README.md)'s.
 
 **`RStrings`.**
 R string constants and `Rf_install()` symbols used from C++

--- a/handbook/branches/flavors/README.md
+++ b/handbook/branches/flavors/README.md
@@ -34,15 +34,9 @@ what the patch rewrites is the surface, by construction.
 [`scripts/flavor.sh`](/scripts/flavor.sh) takes the suffix
 (`1.4`, `1.5.dev`, `dev`) and applies it,
 regenerating `src/cpp11.cpp` and `R/cpp11.R` instead of patching them,
-because cpp11 derives the `.Call` symbol prefix from the name.
-That step is the one place the *installed* cpp11 has to be the fork
-rather than CRAN's
-([`architecture/glue/`](/handbook/architecture/glue/README.md)):
-with the wrong one a two-dot suffix regenerates entry points that no
-compiler will accept, and only a two-dot suffix does,
-so the script exits 0 either way.
-Check the prefix in `src/cpp11.cpp` before committing a fresh flavor —
-underscores all the way, `_duckdb_1_5_dev_`.
+because cpp11 derives the `.Call` symbol prefix from the name —
+which is also why the cpp11 that generates them has to be the fork
+([`architecture/glue/`](/handbook/architecture/glue/README.md)).
 Everywhere else the package asks for its name at run time
 ([`architecture/r-layer/`](/handbook/architecture/r-layer/README.md));
 the scan that keeps it that way is

--- a/handbook/branches/flavors/README.md
+++ b/handbook/branches/flavors/README.md
@@ -35,6 +35,14 @@ what the patch rewrites is the surface, by construction.
 (`1.4`, `1.5.dev`, `dev`) and applies it,
 regenerating `src/cpp11.cpp` and `R/cpp11.R` instead of patching them,
 because cpp11 derives the `.Call` symbol prefix from the name.
+That step is the one place the *installed* cpp11 has to be the fork
+rather than CRAN's
+([`architecture/glue/`](/handbook/architecture/glue/README.md)):
+with the wrong one a two-dot suffix regenerates entry points that no
+compiler will accept, and only a two-dot suffix does,
+so the script exits 0 either way.
+Check the prefix in `src/cpp11.cpp` before committing a fresh flavor —
+underscores all the way, `_duckdb_1_5_dev_`.
 Everywhere else the package asks for its name at run time
 ([`architecture/r-layer/`](/handbook/architecture/r-layer/README.md));
 the scan that keeps it that way is

--- a/handbook/operations/vendoring/series-loop/README.md
+++ b/handbook/operations/vendoring/series-loop/README.md
@@ -51,15 +51,16 @@ to do, and they run in this order:
 
 **A forward carries the vendor strand, and the rest is placed by hand.**
 `<S>-fwd-build` is replayed from the buffer's `vendor:` commits alone, so
-the buffer's own `patch/` entries do not travel with it; and a series
+the buffer's own `patch/` entries do not travel with it, and a series
 seeded from a release branch regenerates its seed on that branch, with
-the tooling that branch carries rather than `main`'s, which the port
-stage restores on the next firing.
-Neither is reported — a vendor commit replayed onto a tree missing a
-patch applies cleanly — so what settles it is a comparison of the
-forward's `src/duckdb/` and `patch/` against the buffer's, never the
-script's exit status
-([#2545](https://github.com/duckdb/duckdb-r/issues/2545)).
+the tooling that branch carries rather than `main`'s.
+The replay refuses to start rather than leave a `patch/` entry behind,
+naming what it cannot place —
+it has to, because dropping one raises no conflict:
+a vendor diff taken after the entry landed is neutral in the region it
+touched, so it applies to a tree that lacks it.
+The tooling delta nothing reports, and nothing needs to:
+the port stage brings it back on the next firing.
 
 [`scripts/series-check.sh`](/scripts/series-check.sh) prints each
 series' verdict read-only and is always safe to run

--- a/handbook/operations/vendoring/series-loop/README.md
+++ b/handbook/operations/vendoring/series-loop/README.md
@@ -49,6 +49,18 @@ to do, and they run in this order:
   around a script opens a pull request against it,
   so the next firing does not have to.
 
+**A forward carries the vendor strand, and the rest is placed by hand.**
+`<S>-fwd-build` is replayed from the buffer's `vendor:` commits alone, so
+the buffer's own `patch/` entries do not travel with it; and a series
+seeded from a release branch regenerates its seed on that branch, with
+the tooling that branch carries rather than `main`'s, which the port
+stage restores on the next firing.
+Neither is reported — a vendor commit replayed onto a tree missing a
+patch applies cleanly — so what settles it is a comparison of the
+forward's `src/duckdb/` and `patch/` against the buffer's, never the
+script's exit status
+([#2545](https://github.com/duckdb/duckdb-r/issues/2545)).
+
 [`scripts/series-check.sh`](/scripts/series-check.sh) prints each
 series' verdict read-only and is always safe to run
 ([`troubleshooting/`](/handbook/operations/vendoring/troubleshooting/README.md)).

--- a/handbook/operations/vendoring/troubleshooting/README.md
+++ b/handbook/operations/vendoring/troubleshooting/README.md
@@ -1,6 +1,6 @@
 # Troubleshooting
 
-When a vendoring run is red:
+When a vendoring run is red, or a build no run covers is:
 telling the failure modes apart and reaching the right repair.
 The repair procedures are the series loop's playbooks
 ([`series-loop/`](/handbook/operations/vendoring/series-loop/README.md)).
@@ -39,6 +39,12 @@ The failure classes, and what each needs:
   When the tree upstream shipped is itself the defect, see below.
 * **Stale snapshots** — engine output drifted;
   [`testing/snapshots/`](/handbook/testing/snapshots/README.md).
+* **A diagnostic no run raised** — the per-commit gate is Linux on one
+  R version, so a warning from another platform's compiler reaches this
+  repository through the published build or through a bisect, never
+  through a verdict.
+  The fix is a `patch/` entry, and which commit carries it is
+  *Where a patch goes in the chain*.
 
 ## A commit upstream broke
 
@@ -87,6 +93,29 @@ which is what a counter that orders rather than counts allows
 ([`versioning/`](/handbook/operations/releases/versioning/README.md)).
 The loop's own statement of the rule is in its repair stage
 ([`series-loop.md`](/.claude/skills/series-loop.md)).
+
+## Where a patch goes in the chain
+
+A `patch/` entry belongs in the first commit whose tree carries the code
+it answers, which is the first commit whose tree it applies to.
+That is rarely the commit at which it was written:
+an entry answering a compiler diagnostic is written when someone reads
+the diagnostic, and the upstream change that raised it can be far below.
+Finding the right one is mechanical — the answer can only change where
+the patched file changes, so walk that file's commits and take the first
+whose tree `patch --dry-run` accepts.
+Fold the entry and its effect on the vendored tree into that commit
+together, with an `R-side fix` section, as a forward-ported fix is folded.
+
+The buffer is where the choice is load-bearing.
+No run covers it at all
+([`branches/model/`](/handbook/branches/model/README.md)),
+and the gate that covers `-dev` is a single platform,
+so a diagnostic only the others raise is found by bisecting the buffer by
+hand — and a bisect answers what is asked of it only when every commit in
+its range is clean of what is being bisected for.
+An entry added at the top of the chain instead leaves the span below it
+carrying a defect the same branch already knows how to silence.
 
 *To deepen: absorb `scripts/VENDORING.md` § Troubleshooting —
 rebuilding the upstream clone, and the spurious `src/*.dd` churn.*

--- a/plan/README.md
+++ b/plan/README.md
@@ -56,6 +56,7 @@ topic today.
 | To read about | Read |
 |---|---|
 | Findings verified against the code by the closed handbook wave, and the issues its defects became | [`history/2026-08-handbook-wave-salvage.md`](history/2026-08-handbook-wave-salvage.md) |
+| The glue adaptations the August 2026 forward of all three series replayed, where each modification was placed, and what the run found out about the routine | [`history/2026-08-series-forward-glue.md`](history/2026-08-series-forward-glue.md) |
 
 ## Adding a document here
 

--- a/plan/history/2026-08-series-forward-glue.md
+++ b/plan/history/2026-08-series-forward-glue.md
@@ -37,7 +37,8 @@ so the list can be re-derived without the local build.
   14 vendor commits replayed, no conflict, no glue change.
 * **`main-fwd`** — base `main` @ `faa1610b5`,
   1133 vendor commits replayed, no conflict,
-  plus three `patch/` commits re-inserted by hand (below).
+  plus three `patch/` entries folded into the commits that first need
+  them (below).
 
 For all three, the whole glue delta between the old buffer tip and the
 new one is exactly what `main` gained in the window —
@@ -199,8 +200,7 @@ replaying a diff does.
 No conflict arose in any of the three replays, so no resolution had to be
 routed anywhere.
 
-**Three `patch/` commits: backported into the chain, not stacked on the
-tip.**
+**Three `patch/` entries: folded into the commit that first needs each.**
 Above its seed, `main-build` carries five commits that vendor nothing,
 and [`series-forward-build.sh`](/scripts/series-forward-build.sh) replays
 only `vendor:` subjects, so all five were dropped.
@@ -210,44 +210,66 @@ Two of them were harmless — their content had since reached `main`
 `patch/0034` carry as part of
 [`e54313d7f`](https://github.com/duckdb/duckdb-r/commit/e54313d7f)) and
 the regenerated seed brings it.
-The other three had not:
+The other three had not, and each was folded into the vendor commit that
+brings in the code its patch answers:
 
-* `3823fe48e` — `patch/0035`, silencing the deprecated
-  `Catalog::GetEntry()` self-delegation.
-* `4ade36dc1` — `patch/0036`, guarding the assert-only plan verifiers.
-* `918f28b5f` — `patch/0037`, casting to `void *` in the default
-  aggregate state initializer.
+* `patch/0035`, silencing the deprecated `Catalog::GetEntry()`
+  self-delegation, into `duckdb/duckdb@6d4f53284` —
+  the commit that puts the 14 `[[deprecated]]` attributes into
+  `catalog.hpp`; its parent has none.
+* `patch/0037`, casting to `void *` in the default aggregate state
+  initializer, into `duckdb/duckdb@2daa4fc9a` —
+  the eager-aggregation change that introduces the `memset` over a
+  non-trivial state.
+* `patch/0036`, guarding the assert-only plan verifiers, into
+  `duckdb/duckdb@8956cec9b` —
+  the correlated-join change that adds them, growing `planner.cpp` from
+  268 lines to 339.
 
-They were re-inserted at the position they held in the buffer —
-two after the vendor commit for `duckdb/duckdb@d38be889c`, the third five
-vendor commits later — rather than replayed onto the tip.
-Three reasons, in the order they matter:
+Not the position each held in the buffer.
+A `patch/` entry gets written when someone notices the warning, which is
+whenever r-universe next builds a green tip, and the commit that *caused*
+it sits a few hundred below: replaying the patch where it was written
+leaves that whole stretch carrying a defect the same branch already knows
+how to fix —
+312 commits for `patch/0035`, 292 for `patch/0037`, 77 for `patch/0036`.
 
-* **Every vendor commit above them was generated with the patch
+**This is the case the buffer's per-commit promise exists for.**
+None of the three changes behaviour on Linux,
+so the per-commit gate never judges them,
+and r-universe only ever builds a green tip —
+which is precisely why their position in the chain is the only thing
+that can help.
+A warning or an error that shows up on macOS or Windows and nowhere else
+is found by bisecting the buffer by hand,
+and a bisect means something only if every commit in its range is clean
+of what is being bisected for.
+A range seeded with 312 commits' worth of a warning the branch can
+already silence answers a question nobody asked.
+The loop states the same rule for `-dev` —
+fold the fix into the commit that needs it, never stack it on top, so the
+chain stays bisectable —
+and it binds `-build` for the platforms `-dev` cannot speak for.
+
+Two mechanical properties follow from folding rather than stacking, and
+both were checked afterwards:
+
+* **Every vendor commit above the fold was generated with the patch
   applied.** `vendor-one.sh` re-applies the buffer's whole `patch/` stack
   to each tree it regenerates, so a vendor diff taken after the patch
   landed is patch-neutral in the patched region.
   Replayed onto a tree that lacks the patch it still applies —
-  cleanly, silently — and the region simply stays unpatched.
-  Placing the patch in the chain is what makes the commits above it mean
-  what they meant.
-* **The buffer's promise is per-commit, not per-tip.**
-  A buffer whose patch stack is only right at the tip is one whose
-  intermediate commits cannot be vendored from or bisected.
+  cleanly, silently — and the region simply stays unpatched,
+  which is how the first pass lost all three without a single conflict.
 * **Self-retirement keeps working.**
   A `patch/` entry is deleted by the vendor run that finds upstream has
   taken it; that only happens if the entry is in the tree when that run
   replays.
 
-Moving them *earlier* than their buffer position was considered and
-rejected: `patch/0037` names the earliest commit it applies to
-(`duckdb/duckdb@2daa4fc9a4`, vendored as `c3ad3d55f`) and the others are
-no different, but nothing observable improves.
-None of the three changes behaviour on Linux, which is the only platform
-the per-commit gate judges, and r-universe only ever builds a green tip.
-An earlier position would buy a longer stretch of warning-free
-intermediate commits nobody compiles, at the cost of three more replays
-over a 1133-commit chain.
+Both were verified per commit rather than at the tip:
+every commit from each fold point to the buffer tip carries the patched
+hunk and the `patch/` file, and the tip's `src/duckdb/` and `patch/`
+match `main-build`'s byte for byte.
 
 **`main-fwd-dev`: nothing placed, but something to mine.**
 All four refs start equal at the seed tip, as the day-one rule requires.

--- a/plan/history/2026-08-series-forward-glue.md
+++ b/plan/history/2026-08-series-forward-glue.md
@@ -325,11 +325,14 @@ Corrected in this change, mostly by a check rather than by prose:
 [`scripts/flavor.sh`](/scripts/flavor.sh) now refuses a generated binding
 whose entry points are not C identifiers, so the failure this run took
 for unavoidable cannot be reached quietly again.
-The pages keep only what the check cannot say —
+The script also prepares the whole rename before committing any of it,
+and restores the tree when it cannot finish,
+so the half-applied flavor a missing prerequisite used to leave —
+its first commit lands before `cpp_register()` runs — is not reachable
+either.
+The pages keep only what neither can say:
 [`architecture/glue/`](/handbook/architecture/glue/README.md) that the
-generator is a second, unvendored half of cpp11 and has to be the fork,
-and `VENDORING.md` and `series-open.md` that installing it first is
-cheaper than being refused after the first commit of the flavor lands.
+generator is a second, unvendored half of cpp11 and has to be the fork.
 The `v1.4-andium` seed is still replayed rather than regenerated, for an
 unrelated reason: a frozen series regenerates on its own release branch,
 and `v1.4-andium`'s `scripts/flavor.sh` predates the GNU-sed fix

--- a/plan/history/2026-08-series-forward-glue.md
+++ b/plan/history/2026-08-series-forward-glue.md
@@ -288,10 +288,15 @@ The failure is quiet: the first `main-fwd-build` came out with zero
 conflicts and a vendored tree differing from the buffer's by 20 lines
 across three files, plus three missing `patch/` entries.
 Only a tree comparison against the source buffer showed it.
-Filed as [#2545](https://github.com/duckdb/duckdb-r/issues/2545), which
-carries what a fix has to handle;
-[`series-loop/`](/handbook/operations/vendoring/series-loop/README.md)
-states the standing check until there is one.
+Fixed in this change
+([#2545](https://github.com/duckdb/duckdb-r/issues/2545)):
+the replay classifies every non-vendor commit above the buffer's first
+vendor commit, and refuses to start while one carries a change the new
+base does not have.
+Two tests decide it — the commit's diff reverse-applying to the new
+base, and patch-id equality against what that base gained — because each
+catches what the other misses on the five commits this run had to judge,
+and a false alarm costs one `--placed` where a miss costs the forward.
 
 **The seed needs `krlmlr/cpp11` installed, and the run did not have it.**
 `scripts/flavor.sh` runs `cpp11::cpp_register()`, whose symbol names come

--- a/plan/history/2026-08-series-forward-glue.md
+++ b/plan/history/2026-08-series-forward-glue.md
@@ -227,49 +227,25 @@ brings in the code its patch answers:
   268 lines to 339.
 
 Not the position each held in the buffer.
-A `patch/` entry gets written when someone notices the warning, which is
-whenever r-universe next builds a green tip, and the commit that *caused*
-it sits a few hundred below: replaying the patch where it was written
-leaves that whole stretch carrying a defect the same branch already knows
-how to fix —
-312 commits for `patch/0035`, 292 for `patch/0037`, 77 for `patch/0036`.
+The rule those three answer to is
+[`vendoring/troubleshooting/`](/handbook/operations/vendoring/troubleshooting/README.md)'s;
+what this run adds is the size of the span it governs.
+The entries were written when r-universe reported the diagnostics, and
+the upstream changes that raised them sit far below:
+312 commits below for `patch/0035`, 292 for `patch/0037`, 77 for
+`patch/0036`.
+Every one of those commits carried a warning the same branch already knew
+how to silence, on exactly the platforms no verdict covers.
 
-**This is the case the buffer's per-commit promise exists for.**
-None of the three changes behaviour on Linux,
-so the per-commit gate never judges them,
-and r-universe only ever builds a green tip —
-which is precisely why their position in the chain is the only thing
-that can help.
-A warning or an error that shows up on macOS or Windows and nowhere else
-is found by bisecting the buffer by hand,
-and a bisect means something only if every commit in its range is clean
-of what is being bisected for.
-A range seeded with 312 commits' worth of a warning the branch can
-already silence answers a question nobody asked.
-The loop states the same rule for `-dev` —
-fold the fix into the commit that needs it, never stack it on top, so the
-chain stays bisectable —
-and it binds `-build` for the platforms `-dev` cannot speak for.
-
-Two mechanical properties follow from folding rather than stacking, and
-both were checked afterwards:
-
-* **Every vendor commit above the fold was generated with the patch
-  applied.** `vendor-one.sh` re-applies the buffer's whole `patch/` stack
-  to each tree it regenerates, so a vendor diff taken after the patch
-  landed is patch-neutral in the patched region.
-  Replayed onto a tree that lacks the patch it still applies —
-  cleanly, silently — and the region simply stays unpatched,
-  which is how the first pass lost all three without a single conflict.
-* **Self-retirement keeps working.**
-  A `patch/` entry is deleted by the vendor run that finds upstream has
-  taken it; that only happens if the entry is in the tree when that run
-  replays.
-
-Both were verified per commit rather than at the tip:
+Verified per commit rather than at the tip:
 every commit from each fold point to the buffer tip carries the patched
-hunk and the `patch/` file, and the tip's `src/duckdb/` and `patch/`
-match `main-build`'s byte for byte.
+hunk and the `patch/` file, the fold commit's parent carries neither, and
+the tip's `src/duckdb/` and `patch/` match `main-build`'s byte for byte.
+The last of those is what the first pass failed silently —
+a vendor diff taken after a patch landed is patch-neutral in the patched
+region, so replaying it onto a tree that lacks the patch applies cleanly
+and leaves the region unpatched
+([#2545](https://github.com/duckdb/duckdb-r/issues/2545)).
 
 **`main-fwd-dev`: nothing placed, but something to mine.**
 All four refs start equal at the seed tip, as the day-one rule requires.
@@ -312,14 +288,10 @@ The failure is quiet: the first `main-fwd-build` came out with zero
 conflicts and a vendored tree differing from the buffer's by 20 lines
 across three files, plus three missing `patch/` entries.
 Only a tree comparison against the source buffer showed it.
-Worth fixing in the script rather than in the reader's habits:
-a commit in `<old-base>..<old-build>` that is neither a `vendor:` subject
-nor an ancestor of the new base is either replayed or reported, never
-dropped.
-`series-forward-build.sh`'s resume logic would have to change with it —
-it recovers its place from the counter by counting back `n` commits from
-`HEAD`, which stops being the number of commits it has written as soon as
-a non-vendor commit is interleaved.
+Filed as [#2545](https://github.com/duckdb/duckdb-r/issues/2545), which
+carries what a fix has to handle;
+[`series-loop/`](/handbook/operations/vendoring/series-loop/README.md)
+states the standing check until there is one.
 
 **The seed needs `krlmlr/cpp11` installed, and the run did not have it.**
 `scripts/flavor.sh` runs `cpp11::cpp_register()`, whose symbol names come

--- a/plan/history/2026-08-series-forward-glue.md
+++ b/plan/history/2026-08-series-forward-glue.md
@@ -299,23 +299,42 @@ it recovers its place from the counter by counting back `n` commits from
 `HEAD`, which stops being the number of commits it has written as soon as
 a non-vendor commit is interleaved.
 
-**Regenerating the seed with `flavor.sh` is only safe for a one-dot
-flavor.**
-`scripts/flavor.sh` runs `cpp11::cpp_register()`, and cpp11 0.5.5 — what
-`install.packages("cpp11")` gives you today — replaces only the first dot
-of the package name when it builds the symbols.
-Confirmed here: a fresh `flavor.sh 1.5.dev` on current `main` generated
-`_duckdb_1.5.dev_rapi_connect`, which is not a C identifier.
+**The seed needs `krlmlr/cpp11` installed, and the run did not have it.**
+`scripts/flavor.sh` runs `cpp11::cpp_register()`, whose symbol names come
+from the cpp11 in the library rather than from the vendored headers.
+CRAN's spells the `.Call` prefix with `sub("[.]", "_", package)`, first
+dot only, so `flavor.sh 1.5.dev` on current `main` generated
+`_duckdb_1.5.dev_rapi_connect`, which is not a C identifier;
 `flavor.sh dev` came out byte-identical to the seed the `main` series was
 built on, because `duckdb.dev` has one dot.
-So the run took the two generated files (`R/cpp11.R`, `src/cpp11.cpp`)
-from the old seed for `1.5.dev`, having first checked that `main` had not
-touched their unflavored originals in the window, and replayed the
-`v1.4-andium` seed whole.
-`series-open.md` already carries the trap;
-`series-forward.md` step 1 says "regenerate the seed" without it,
-and the safe recipe is the one `series-rebase.md` states for a rebase —
-replay the seed, then verify against a scratch flavoring.
+The first pass read that as an unavoidable trap and worked around it,
+taking `R/cpp11.R` and `src/cpp11.cpp` from the old seed for `1.5.dev`
+after checking that `main` had not touched their unflavored originals.
+It is not unavoidable.
+[`krlmlr/cpp11`](https://github.com/krlmlr/cpp11) spells that `gsub`,
+and installing it from GitHub makes `flavor.sh 1.5.dev` generate the
+correct `_duckdb_1_5_dev_` prefix directly —
+byte-identical to what the workaround produced, which is the check that
+the workaround had been right and is now unnecessary.
+Two things hid it.
+The fork was named in
+[`architecture/glue/`](/handbook/architecture/glue/README.md), but as the
+origin of the *vendored headers*, with multi-dot support listed among
+what they carry; the generator is neither vendored nor a declared
+dependency, and no page said which one to install —
+`scripts/VENDORING.md` asked for "the `cpp11` and `decor` R packages"
+flat.
+And `krlmlr.r-universe.dev` does not build cpp11, so
+`install.packages("cpp11", repos = c(krlmlr, CRAN))` falls through to
+CRAN and reports installing cpp11 0.5.5, which reads like success.
+Corrected in this change: `architecture/glue/` now separates the two
+halves of cpp11, `branches/flavors/` says what to check after a flavor
+run, and `VENDORING.md`, `series-open.md` and `series-forward.md` name
+the fork where they ask for the package.
+The `v1.4-andium` seed is still replayed rather than regenerated, for an
+unrelated reason: a frozen series regenerates on its own release branch,
+and `v1.4-andium`'s `scripts/flavor.sh` predates the GNU-sed fix
+[#2510](https://github.com/duckdb/duckdb-r/pull/2510) that `main` has.
 
 **A frozen series' forward hands its tooling back.**
 `v1.4-andium-fwd`'s seed comes from the `v1.4-andium` release line, which

--- a/plan/history/2026-08-series-forward-glue.md
+++ b/plan/history/2026-08-series-forward-glue.md
@@ -1,0 +1,352 @@
+# The August 2026 forward of all three series
+
+*A record, not a leaf.*
+On 2026-08-06 all three live series were forwarded onto the current
+mainline at once — `v1.4-andium`, then `v1.5-variegata`, then `main` —
+and this file is the list of glue-code changes that took,
+where each one was placed, and what the run found out about the routine.
+The routine itself is owned by
+[`.claude/skills/series-forward.md`](/.claude/skills/series-forward.md)
+and [`operations/vendoring/series-loop/`](/handbook/operations/vendoring/series-loop/README.md);
+what a glue adaptation may be is
+[`architecture/glue/`](/handbook/architecture/glue/README.md)'s.
+Where one of those and this record disagree, they are right —
+this describes one run, on the day it happened, and nothing keeps it
+current.
+
+The twelve `-fwd-*` refs were built locally and deliberately **not
+pushed**: the CI/CD side was not in a state to judge them,
+and a forward series that nothing is verifying is better as four local
+refs than as four refs consumers can see.
+Every SHA quoted below names a commit that already exists —
+on `main` here, or on the series refs in the fork —
+so the list can be re-derived without the local build.
+
+## What each forward took
+
+* **`v1.4-andium-fwd`** — base `v1.4-andium` @ `2b5afce5a`,
+  1 vendor commit replayed, no conflict, no glue change.
+  A frozen series seeds from its own release line rather than from
+  `main`, so the base moved only by the two commits that line gained
+  since the old seed
+  ([#2433](https://github.com/duckdb/duckdb-r/pull/2433) and the
+  `each-rcc` race fix beneath it).
+  The seed was **replayed**, not regenerated — see the second finding
+  below.
+* **`v1.5-variegata-fwd`** — base `main` @ `faa1610b5`,
+  14 vendor commits replayed, no conflict, no glue change.
+* **`main-fwd`** — base `main` @ `faa1610b5`,
+  1133 vendor commits replayed, no conflict,
+  plus three `patch/` commits re-inserted by hand (below).
+
+For all three, the whole glue delta between the old buffer tip and the
+new one is exactly what `main` gained in the window —
+`src/rfuns.cpp`'s handbook backreference, the flavored
+`src/duckdb.<flavor>-win.def`, the removal of `src/CMakeLists.txt`, and
+the R-side documentation work.
+Nothing upstream had moved under the glue since the buffers were built,
+which is why the replay was quiet.
+That is the expected shape of a forward run soon after the last one,
+not a claim about forwards in general.
+
+## The glue set `main-fwd-build` carries
+
+39 of the 1133 replayed vendor commits carry a hand-written glue
+adaptation.
+The replay is a cherry-pick of each commit's diff, so every one of them
+rides in the commit that made it, by construction —
+there was nothing to place and nothing to decide.
+The list is here because it is the only place the *shape* of the range is
+visible: upstream spent this window making the engine's C++ API
+narrower, and the same call sites were adapted repeatedly as it did.
+Read it before the next forward:
+resolving one conflict against one upstream change rederives work a later
+commit in the same range already did.
+[`scripts/series-glue.sh`](/scripts/series-glue.sh) prints it from the
+branch; what the script cannot say is which entries belong together.
+
+**Members become accessors.**
+The largest strand: upstream privatised member after member and migrated
+its own call sites in the same change, so the glue followed each time.
+
+* `duckdb#22351` (`b43ded70e`) — `(Base)Expression`:
+  `expr->alias` → `SetAlias()`, `expr->type` → `GetExpressionType()`,
+  `->return_type` → `GetReturnType()`.
+* `duckdb#22463` (`f514c965b`) — `ConstantExpression::value` →
+  `GetValue()`.
+* `duckdb#22942` (`8b29d243a`) — `FunctionExpression` and
+  `WindowExpression`: `order_bys`, `filter`, `start`, `end`,
+  `start_expr`, `end_expr`, `partitions`, `children` all become
+  `…Mutable()` accessors.
+* `duckdb#22985` (`960f2313b`) — the bound expressions:
+  `BoundConstantExpression::value` → `GetValue()`,
+  `conj.children` → `GetChildren()`.
+* `duckdb#24273` (`29de1cde1`) — `PreparedStatement`:
+  `named_param_map.size()` → `GetParameterCount()`,
+  `stmt->context` → `TryGetContext()`.
+* `duckdb#24351` (`4d43cb0cd`) — `PreparedStatement::error` →
+  `GetErrorObject()`, which keeps the type and extra info that
+  `rapi_error_with_context()` reports.
+* `duckdb#24357` (`d4729fda1`) — `BaseQueryResult`: `type`, `types`,
+  `names` → `GetResultType()`, `GetTypes()`, `GetNames()`.
+
+**Const and mutable split apart.**
+Reading a vector and writing one stopped being the same call.
+
+* `duckdb#21978` (`49c5ca9a0`) — `FlatVector::GetData<T>` returns
+  `const`; every write site takes `GetDataMutable<T>`.
+* `duckdb#22122` (`2c5e70ae4`) — the same for
+  `FlatVector::Validity` → `ValidityMutable`.
+* `duckdb#22157` (`6fd32a9fa`) — `ListVector::GetEntry` → `GetChild` /
+  `GetChildMutable`, and `ArrayVector` likewise.
+* `duckdb#21612` (`85cdd4637`) — `Vector` lost its implicit copy, so
+  `auto input = args.data[0]` became `auto &input`.
+* `duckdb#21534` (`91e259775`) — `StructVector::GetEntries()` hands back
+  references rather than `unique_ptr`s; one `*` dropped at each site.
+* `duckdb#21526` (`081843d28`) — vector helpers moved to their own
+  headers; four glue units gained includes.
+* `duckdb#22268` (`ddb56a47a`) — `Vector::Reference(Value &)` requires a
+  count.
+* `duckdb#22377` (`27ced7204`) — `DataChunk::SetCardinality` →
+  `SetChildCardinality`.
+* `duckdb#22493` (`0c812b11a`) — the `count` overloads of
+  `ToUnifiedFormat` and friends are deprecated.
+* `duckdb#21679` (`f1a8e3410`) — `ValidityMask::AllValid` →
+  `CannotHaveNull`.
+
+**`Identifier` replaces `string` for every name.**
+The single widest change in the range: names in the parser, the catalog
+and the result stopped being strings.
+
+* `duckdb#23161` (`bec92045d`) — the type arrives.
+  Seven glue units promote R names to `Identifier` explicitly and read
+  them back through `GetIdentifierName()`;
+  whole vectors go through upstream's own `StringsToIdentifiers()` and
+  `IdentifiersToStrings()`.
+  The explicitness is the point: the conversion discards the
+  case-insensitive semantics the type carries.
+* `duckdb#24269` (`4ece94def`) — COPY and scan options:
+  `ListToVectorOfValue()` returns `identifier_map_t<vector<Value>>`.
+  Option-name lookup stays case-insensitive, because `Identifier`
+  compares and hashes case-insensitively just as `case_insensitive_map_t`
+  did.
+* `duckdb#24278` (`419eca006`) — `table_function_bind_t` hands back
+  `vector<Identifier>`; `DataFrameScanBind()` is the one glue call site.
+
+**Table filters become expressions.**
+The Arrow pushdown translation in `src/register.cpp` was rewritten under
+us in five steps, and only the last spelling survives the range.
+
+* `duckdb#21229` (`58b9ba197`) — `TableFilterSet` members go private;
+  iterate the set, ask `HasFilters()`.
+* `duckdb#21497` (`646d546f2`) — `ColumnIndex()` → `GetIndex()`.
+* `duckdb#22005` (`bed8c8fde`) — `EXPRESSION_FILTER` arrives;
+  the glue gains `TransformExpression()` for bound comparisons and
+  conjunctions.
+* `duckdb#22514` (`5f41c3726`) — `BoundComparisonExpression` becomes a
+  `BoundFunctionExpression`; read sides via `Left()` / `Right()`.
+* `duckdb#22617` (`cad2a51c3`) — the remaining filter types are renamed
+  `LEGACY_*`, their classes `Legacy…Filter`, and
+  `TableFilter::ToString(column_name)` goes away —
+  replaced here by a local `FilterDescription()` over `EnumUtil`.
+
+**Function binding grew a parameter object.**
+
+* `duckdb#22034` (`8b15c103d`) — bind callbacks take
+  `BindAggregateFunctionInput &` / `BindScalarFunctionInput &` instead of
+  three loose parameters.
+* `duckdb#22428` (`099b43986`) — assigning the bound function is
+  replaced by `ReplaceImplementation()`.
+* `duckdb#22400` (`cd1e356f7`) — `ExecuteWithNulls` retires;
+  the executors take a lambda returning `optional<T>`, so `rfuns`'
+  overflow and NaN paths return `nullopt` instead of poking a
+  `ValidityMask`.
+* `duckdb#22941` and `duckdb#23059` (`c00bd841f`, `f3cdc78fd`) —
+  function children become `FunctionArgument`s, for window functions too.
+* `duckdb#21562` (`dc12f181d`) — the `WindowExpression` constructor
+  loses its window-type argument, and `LEAD`/`LAG` offsets move into the
+  children; the glue casts the offset to `BIGINT` there, which is the one
+  entry in this list that is a fix rather than a translation.
+
+**New types and renamed fields.**
+
+* `duckdb#22412` (`efadbcbb1`) — `TIMESTAMP_TZ_NS`, carried through
+  `duckdb_r_typeof()`, `duckdb_r_decorate()`, `duckdb_r_transform()` and
+  `DetectLogicalType()`.
+* `duckdb#23017` (`80916e01c`) — `SQLNULL` becomes a result type;
+  mapped to `INTSXP`.
+* `duckdb#23493` (`c7f37720c`) — `dtime_t::micros` → `.value`.
+* `duckdb#23222` and `duckdb#23470` (`4089414d1`, `db677d3ea`) —
+  `ExplainFormat` folds into `ProfilerPrintFormat`, then the renderer
+  registry keys on the lowercase name, so `rapi_rel_explain()` lowercases
+  what R passes.
+* `duckdb#23579` (`2beb9245d`) — an include the cleanup stopped
+  providing transitively.
+
+**Two entries that are not upstream's doing.**
+`a361d748f` and `1a2b23e10` are the rewind pair at the foot of the
+buffer: the range starts at the fork point of the mainline rewind, so
+`src/reltoaltrep.cpp`'s `max_expression_depth` handling is first rewound
+to the fork-point spelling and then re-adapted to the settings API by the
+merge commit that brings it back.
+They cancel out over the range and mean nothing on their own.
+
+## Where the modifications were placed
+
+**The 39 glue adaptations: nowhere new.**
+Each rides in the vendor commit that made it, because that is what
+replaying a diff does.
+No conflict arose in any of the three replays, so no resolution had to be
+routed anywhere.
+
+**Three `patch/` commits: backported into the chain, not stacked on the
+tip.**
+Above its seed, `main-build` carries five commits that vendor nothing,
+and [`series-forward-build.sh`](/scripts/series-forward-build.sh) replays
+only `vendor:` subjects, so all five were dropped.
+Two of them were harmless — their content had since reached `main`
+(`fix(rconfigure)` as
+[`8b5eb9c88`](https://github.com/duckdb/duckdb-r/commit/8b5eb9c88), the
+`patch/0034` carry as part of
+[`e54313d7f`](https://github.com/duckdb/duckdb-r/commit/e54313d7f)) and
+the regenerated seed brings it.
+The other three had not:
+
+* `3823fe48e` — `patch/0035`, silencing the deprecated
+  `Catalog::GetEntry()` self-delegation.
+* `4ade36dc1` — `patch/0036`, guarding the assert-only plan verifiers.
+* `918f28b5f` — `patch/0037`, casting to `void *` in the default
+  aggregate state initializer.
+
+They were re-inserted at the position they held in the buffer —
+two after the vendor commit for `duckdb/duckdb@d38be889c`, the third five
+vendor commits later — rather than replayed onto the tip.
+Three reasons, in the order they matter:
+
+* **Every vendor commit above them was generated with the patch
+  applied.** `vendor-one.sh` re-applies the buffer's whole `patch/` stack
+  to each tree it regenerates, so a vendor diff taken after the patch
+  landed is patch-neutral in the patched region.
+  Replayed onto a tree that lacks the patch it still applies —
+  cleanly, silently — and the region simply stays unpatched.
+  Placing the patch in the chain is what makes the commits above it mean
+  what they meant.
+* **The buffer's promise is per-commit, not per-tip.**
+  A buffer whose patch stack is only right at the tip is one whose
+  intermediate commits cannot be vendored from or bisected.
+* **Self-retirement keeps working.**
+  A `patch/` entry is deleted by the vendor run that finds upstream has
+  taken it; that only happens if the entry is in the tree when that run
+  replays.
+
+Moving them *earlier* than their buffer position was considered and
+rejected: `patch/0037` names the earliest commit it applies to
+(`duckdb/duckdb@2daa4fc9a4`, vendored as `c3ad3d55f`) and the others are
+no different, but nothing observable improves.
+None of the three changes behaviour on Linux, which is the only platform
+the per-commit gate judges, and r-universe only ever builds a green tip.
+An earlier position would buy a longer stretch of warning-free
+intermediate commits nobody compiles, at the cost of three more replays
+over a 1133-commit chain.
+
+**`main-fwd-dev`: nothing placed, but something to mine.**
+All four refs start equal at the seed tip, as the day-one rule requires.
+What the next firing must know is that `main-dev` holds glue its buffer
+never had, and the forward's `-dev` starts without it:
+
+* `duckdb/duckdb@b5e4f5bec` — `main-build` (`29de1cde1`) adapts
+  `src/statement.cpp` to `GetParameterCount()` and `TryGetContext()`;
+  `main-dev` (`3312fa9e9`) additionally introduces `RCallbackScope` in
+  `src/include/rapi.hpp` and arms it at the three sites where duckdb runs
+  R code under the client-context lock.
+  That is the crash-class fix
+  [`architecture/glue/`](/handbook/architecture/glue/README.md) states as
+  a rule, and it exists only on `-dev`.
+* `duckdb/duckdb@0f0cd4fb6` — `main-dev` (`ba9cb11cc`) only:
+  `LogicalType::TUPLE` travels with `STRUCT`, and
+  `RApiTypes::StructLikeChildTypes()` synthesises the positional member
+  names a data frame needs.
+* `duckdb/duckdb@24c543706` — `main-dev` (`e740a81ff`) only:
+  `rel_to_parquet()` rejects an empty `file_name` on the R side, because
+  upstream stopped erroring on it.
+
+The other 39 glue adaptations are identical on both branches.
+Neither `v1.5-variegata` nor `v1.4-andium` has any `-dev`-only glue: for
+those two the `-build`↔`-dev` delta is exactly the forward-ports from
+`main`, which the new seed already carries.
+
+## What the run found out
+
+**A forward silently loses a buffer's non-vendor commits, and `-build`
+has them.**
+`series-forward.md` justifies replaying `vendor:` subjects only by saying
+that a `-dev` branch's other commits belong to `main` and are already in
+the seed.
+That holds for `-dev`.
+It does not hold for `-build`, which by design takes no ports and
+therefore carries its own `patch/` commits — the ones stage 3 requires be
+committed onto the buffer as well as onto `-dev`.
+The failure is quiet: the first `main-fwd-build` came out with zero
+conflicts and a vendored tree differing from the buffer's by 20 lines
+across three files, plus three missing `patch/` entries.
+Only a tree comparison against the source buffer showed it.
+Worth fixing in the script rather than in the reader's habits:
+a commit in `<old-base>..<old-build>` that is neither a `vendor:` subject
+nor an ancestor of the new base is either replayed or reported, never
+dropped.
+`series-forward-build.sh`'s resume logic would have to change with it —
+it recovers its place from the counter by counting back `n` commits from
+`HEAD`, which stops being the number of commits it has written as soon as
+a non-vendor commit is interleaved.
+
+**Regenerating the seed with `flavor.sh` is only safe for a one-dot
+flavor.**
+`scripts/flavor.sh` runs `cpp11::cpp_register()`, and cpp11 0.5.5 — what
+`install.packages("cpp11")` gives you today — replaces only the first dot
+of the package name when it builds the symbols.
+Confirmed here: a fresh `flavor.sh 1.5.dev` on current `main` generated
+`_duckdb_1.5.dev_rapi_connect`, which is not a C identifier.
+`flavor.sh dev` came out byte-identical to the seed the `main` series was
+built on, because `duckdb.dev` has one dot.
+So the run took the two generated files (`R/cpp11.R`, `src/cpp11.cpp`)
+from the old seed for `1.5.dev`, having first checked that `main` had not
+touched their unflavored originals in the window, and replayed the
+`v1.4-andium` seed whole.
+`series-open.md` already carries the trap;
+`series-forward.md` step 1 says "regenerate the seed" without it,
+and the safe recipe is the one `series-rebase.md` states for a rebase —
+replay the seed, then verify against a scratch flavoring.
+
+**A frozen series' forward hands its tooling back.**
+`v1.4-andium-fwd`'s seed comes from the `v1.4-andium` release line, which
+is 93 files behind `main` on `.github/`, `scripts/` and `.claude/`.
+`v1.4-andium-dev` was level with `main` through stage 4's sync commits;
+`v1.4-andium-fwd-dev` starts at the seed, so it is 93 files behind again
+until the next firing's stage 4 re-ports them.
+Nothing is lost and no judgement is needed — the port is mechanical — but
+the forward is only free of that churn if the release line is brought
+level first, which is what
+[#2429](https://github.com/duckdb/duckdb-r/pull/2429),
+[#2430](https://github.com/duckdb/duckdb-r/pull/2430) and
+[#2433](https://github.com/duckdb/duckdb-r/pull/2433) did for the
+previous one.
+
+**One of the three carried patches belongs on `main`.**
+Stage 3's routing rule is that a fix is series-specific only when the
+code it touches is not on `main`.
+Tested against `main`'s tree: `patch/0036` and `patch/0037` do not apply
+— their code arrived after the engine `main` vendors — so they are
+correctly the series'.
+`patch/0035` **does** apply.
+Landing it on `main` would put it in every future seed and end its
+per-forward carry;
+until then every forward of every series has to place it by hand.
+
+**`patch/0034` is two files.**
+`main-build` carries both
+`patch/0034-Guard-explicit-producer-token-in-concurrent-queue.patch`
+(minted inside a vendor commit, `704336470`) and
+`patch/0034-Undef-ERROR-for-the-unity-build.patch` (from `main`).
+`vendor-one.sh` globs the directory, so both apply and nothing
+misbehaves; the collision is in the naming only, and it predates this
+run.

--- a/plan/history/2026-08-series-forward-glue.md
+++ b/plan/history/2026-08-series-forward-glue.md
@@ -321,10 +321,15 @@ flat.
 And `krlmlr.r-universe.dev` does not build cpp11, so
 `install.packages("cpp11", repos = c(krlmlr, CRAN))` falls through to
 CRAN and reports installing cpp11 0.5.5, which reads like success.
-Corrected in this change: `architecture/glue/` now separates the two
-halves of cpp11, `branches/flavors/` says what to check after a flavor
-run, and `VENDORING.md`, `series-open.md` and `series-forward.md` name
-the fork where they ask for the package.
+Corrected in this change, mostly by a check rather than by prose:
+[`scripts/flavor.sh`](/scripts/flavor.sh) now refuses a generated binding
+whose entry points are not C identifiers, so the failure this run took
+for unavoidable cannot be reached quietly again.
+The pages keep only what the check cannot say —
+[`architecture/glue/`](/handbook/architecture/glue/README.md) that the
+generator is a second, unvendored half of cpp11 and has to be the fork,
+and `VENDORING.md` and `series-open.md` that installing it first is
+cheaper than being refused after the first commit of the flavor lands.
 The `v1.4-andium` seed is still replayed rather than regenerated, for an
 unrelated reason: a frozen series regenerates on its own release branch,
 and `v1.4-andium`'s `scripts/flavor.sh` predates the GNU-sed fix

--- a/scripts/VENDORING.md
+++ b/scripts/VENDORING.md
@@ -258,19 +258,15 @@ this list is the sources-and-glue side it drives):
    the rename touches the shared-object name and every `.Call()` entry point,
    so applying it later invalidates every build below it.
 
-   `flavor.sh` has two prerequisites it does not check:
-   the `cpp11` and `decor` R packages, needed for the `cpp11::cpp_register()` step.
-   **The `cpp11` has to be `krlmlr/cpp11`**, from GitHub —
-   `remotes::install_github("krlmlr/cpp11")` —
-   and not CRAN's, which writes an invalid `.Call` prefix for a suffix
-   carrying two dots and none of the usual signs of having done so
+   `flavor.sh` needs the `cpp11` and `decor` R packages for its
+   `cpp11::cpp_register()` step, and the `cpp11` has to be `krlmlr/cpp11`
    ([`handbook/architecture/glue/`](/handbook/architecture/glue/README.md)).
+   Neither is checked before the run starts, and the script commits the first
+   of its two commits *before* reaching that step, so a missing or wrong one
+   leaves the branch with a half-applied flavor; install what is missing,
+   finish by hand with `cpp11::cpp_register()`, and commit.
    (GNU sed it does check, and refuses to run without —
    on macOS that means `gsed`, from Homebrew.)
-   It commits the first of its two commits *before* reaching that step,
-   so a missing prerequisite leaves the branch with a half-applied flavor;
-   finish by hand with `cpp11::cpp_register()` and a second commit,
-   and check that `src/cpp11.cpp` really carries the renamed `_duckdb_<flavor>_*` entry points.
 2. Seed it with **one** vendor commit at the fork point:
    check the upstream clone out at that commit and run `scripts/vendor.sh`.
 3. Rewind the R side as far as the fork-point engine requires,

--- a/scripts/VENDORING.md
+++ b/scripts/VENDORING.md
@@ -260,6 +260,11 @@ this list is the sources-and-glue side it drives):
 
    `flavor.sh` has two prerequisites it does not check:
    the `cpp11` and `decor` R packages, needed for the `cpp11::cpp_register()` step.
+   **The `cpp11` has to be `krlmlr/cpp11`**, from GitHub —
+   `remotes::install_github("krlmlr/cpp11")` —
+   and not CRAN's, which writes an invalid `.Call` prefix for a suffix
+   carrying two dots and none of the usual signs of having done so
+   ([`handbook/architecture/glue/`](/handbook/architecture/glue/README.md)).
    (GNU sed it does check, and refuses to run without —
    on macOS that means `gsed`, from Homebrew.)
    It commits the first of its two commits *before* reaching that step,

--- a/scripts/VENDORING.md
+++ b/scripts/VENDORING.md
@@ -258,15 +258,13 @@ this list is the sources-and-glue side it drives):
    the rename touches the shared-object name and every `.Call()` entry point,
    so applying it later invalidates every build below it.
 
-   `flavor.sh` needs the `cpp11` and `decor` R packages for its
-   `cpp11::cpp_register()` step, and the `cpp11` has to be `krlmlr/cpp11`
+   `flavor.sh` needs GNU sed, and the `cpp11` and `decor` R packages for its
+   `cpp11::cpp_register()` step — the `cpp11` being `krlmlr/cpp11`
    ([`handbook/architecture/glue/`](/handbook/architecture/glue/README.md)).
-   Neither is checked before the run starts, and the script commits the first
-   of its two commits *before* reaching that step, so a missing or wrong one
-   leaves the branch with a half-applied flavor; install what is missing,
-   finish by hand with `cpp11::cpp_register()`, and commit.
-   (GNU sed it does check, and refuses to run without —
-   on macOS that means `gsed`, from Homebrew.)
+   On macOS, GNU sed means `gsed`, from Homebrew.
+   A missing or wrong one costs a rerun and nothing else:
+   the script refuses a dirty tree, prepares the whole rename before it
+   commits anything, and restores the tree if it cannot finish.
 2. Seed it with **one** vendor commit at the fork point:
    check the upstream clone out at that commit and run `scripts/vendor.sh`.
 3. Rewind the R side as far as the fork-point engine requires,

--- a/scripts/flavor.sh
+++ b/scripts/flavor.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 # Apply a package flavor: rewrite scripts/flavor.patch to the target name
 # (say, duckdb.dev), apply it, and commit the rename; see BRANCHES.md.
+#
+# The whole rename is prepared and checked before anything is committed, and a
+# failure at any point restores the tree to where the run started. A flavor is
+# the foot of a branch -- everything built above it carries the names it
+# writes -- so a half-applied one is worse than none at all.
 
 set -euxo pipefail
 
@@ -33,34 +38,62 @@ case "$sed_version" in
   ;;
 esac
 
+# Nothing this run writes is distinguishable from a change that was already
+# there, so the restore below can only promise to undo its own work.
+if [ -n "$(git status --porcelain)" ]; then
+  echo "$0: the working tree is not clean; commit or stash first." >&2
+  exit 1
+fi
+
+start=$(git rev-parse HEAD)
+committed=
+
+# Undo everything, unless the two commits at the end were both reached.
+# Resetting to the branch's own tip moves no ref: the commits are the last
+# thing the run does, so this either drops working-tree changes or drops the
+# first commit after the second one failed. `git clean` without -x leaves
+# ignored build products alone, and the check above is what makes the
+# untracked files it does remove this run's.
+restore() {
+  if [ -n "$committed" ]; then
+    return 0
+  fi
+  echo "$0: nothing committed; restoring the tree to $start" >&2
+  git reset -q --hard "$start"
+  git clean -qfd
+}
+trap restore EXIT
+
 # The patch file spells the flavor suffix 1.3, dot-separated in package names
 # and underscore-separated in file names.
 "$gnu_sed" -i \
   -e "s/duckdb\.1\.3/duckdb.$package_name/g" \
   -e "s/duckdb_1_3/duckdb_${package_name//./_}/g" \
   scripts/flavor.patch
-git add scripts/flavor.patch
-git commit -m "chore: Update flavor patch to $package_name"
 
 # Updates to man/ and NAMESPACE are handled in the patch file for efficiency
 patch -p1 < scripts/flavor.patch
 R -q -e 'cpp11::cpp_register()'
 
+# Avoid storing .orig files
+git clean -f -- "*.orig"
+
 # cpp11 derives the .Call prefix from `Package:`, replacing dots with
 # underscores -- but only the fork replaces every one of them, so a flavor
 # carrying two comes out of CRAN's cpp11 as `_duckdb_1.5.dev_rapi_connect`.
-# Refuse it here: the next reader is the compiler, and the seed is committed
-# before then. handbook/architecture/glue/README.md says which cpp11 to install.
+# The compiler is the next thing that would see it.
+# handbook/architecture/glue/README.md says which cpp11 to install.
 if grep -qE '^extern "C" SEXP [A-Za-z_][A-Za-z0-9_]*\.' src/cpp11.cpp; then
   echo "$0: cpp11::cpp_register() wrote entry points that are not C identifiers:" >&2
   grep -E '^extern "C" SEXP [A-Za-z_][A-Za-z0-9_]*\.' src/cpp11.cpp | head -n 3 >&2
-  echo "  Install the fork -- R -q -e 'remotes::install_github(\"krlmlr/cpp11\")' --" >&2
-  echo "  then rerun cpp11::cpp_register(). The flavor patch is already committed;" >&2
-  echo "  the rename itself is applied but uncommitted." >&2
+  echo "  Install the fork -- R -q -e 'remotes::install_github(\"krlmlr/cpp11\")'" >&2
   exit 1
 fi
 
-# Avoid storing .orig files
-git clean -f -- "*.orig"
-git add .
+# Two commits, and the flavor patch is its own so the rename it drives can be
+# read against it.
+git add scripts/flavor.patch
+git commit -m "chore: Update flavor patch to $package_name"
+git add -A
 git commit -m "chore: Update version to $package_name"
+committed=1

--- a/scripts/flavor.sh
+++ b/scripts/flavor.sh
@@ -45,6 +45,21 @@ git commit -m "chore: Update flavor patch to $package_name"
 # Updates to man/ and NAMESPACE are handled in the patch file for efficiency
 patch -p1 < scripts/flavor.patch
 R -q -e 'cpp11::cpp_register()'
+
+# cpp11 derives the .Call prefix from `Package:`, replacing dots with
+# underscores -- but only the fork replaces every one of them, so a flavor
+# carrying two comes out of CRAN's cpp11 as `_duckdb_1.5.dev_rapi_connect`.
+# Refuse it here: the next reader is the compiler, and the seed is committed
+# before then. handbook/architecture/glue/README.md says which cpp11 to install.
+if grep -qE '^extern "C" SEXP [A-Za-z_][A-Za-z0-9_]*\.' src/cpp11.cpp; then
+  echo "$0: cpp11::cpp_register() wrote entry points that are not C identifiers:" >&2
+  grep -E '^extern "C" SEXP [A-Za-z_][A-Za-z0-9_]*\.' src/cpp11.cpp | head -n 3 >&2
+  echo "  Install the fork -- R -q -e 'remotes::install_github(\"krlmlr/cpp11\")' --" >&2
+  echo "  then rerun cpp11::cpp_register(). The flavor patch is already committed;" >&2
+  echo "  the rename itself is applied but uncommitted." >&2
+  exit 1
+fi
+
 # Avoid storing .orig files
 git clean -f -- "*.orig"
 git add .

--- a/scripts/series-forward-build.sh
+++ b/scripts/series-forward-build.sh
@@ -10,8 +10,16 @@
 # deleted, tooling `main` gained comes along, and glue born on a `-dev` branch
 # rides in the commit that needed it.
 #
-# Only `vendor:` subjects are replayed: a `-dev` branch's non-vendor commits
-# belong to `main` and are already in the seed.
+# Only `vendor:` subjects are replayed. On a `-dev` branch the other commits
+# belong to `main` and the regenerated seed already carries them; on a `-build`
+# branch they do not, because the buffer takes no ports -- the `patch/` entries
+# stage 3 requires be committed onto it are its own. So a non-vendor commit
+# above the first vendor commit is checked rather than assumed: if the new base
+# does not already carry its change, the run refuses to start and names it,
+# because replaying the vendor commits above it would succeed and leave its
+# effect silently missing (duckdb/duckdb-r#2545). `--placed` is how the caller
+# says a commit has been dealt with; where such a change belongs is
+# handbook/operations/vendoring/troubleshooting/README.md.
 #
 # The fifth version component is renumbered as a true counter, one per replayed
 # commit, so it counts this chain rather than carrying the old one's numbering.
@@ -24,14 +32,28 @@
 # `git add`, and rerun; the counter and the remaining picks are derived from
 # HEAD, so the replay continues where it stopped.
 #
-# Usage: series-forward-build.sh <old-build-ref> <old-base-ref>
+# Usage: series-forward-build.sh [--placed <sha>]... <old-build-ref> <old-base-ref>
 #   old-base-ref only delimits the replay range; it has to sit below the oldest
 #   vendor commit to replay, and nothing else is read from it.
+#   --placed names a non-vendor commit whose change has been dealt with, once
+#   per commit. The acknowledgement is remembered for the rest of the replay,
+#   so a resumed run does not need it again.
 
 set -euo pipefail
 
-OLD=${1:?usage: series-forward-build.sh <old-build-ref> <old-base-ref>}
-OLDBASE=${2:?usage: series-forward-build.sh <old-build-ref> <old-base-ref>}
+usage='usage: series-forward-build.sh [--placed <sha>]... <old-build-ref> <old-base-ref>'
+
+PLACED_ARGS=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --placed) PLACED_ARGS+=("${2:?$usage}"); shift 2 ;;
+    -*) echo "$usage" >&2; exit 1 ;;
+    *) break ;;
+  esac
+done
+
+OLD=${1:?$usage}
+OLDBASE=${2:?$usage}
 
 cd "$(dirname "$0")/.."
 
@@ -57,6 +79,35 @@ upstream_sha() { git log -1 --format=%s "$1" | sed -rn 's|^.*duckdb/duckdb@([0-9
 # `git cherry-pick -n` leaves no CHERRY_PICK_HEAD, so the in-flight pick is
 # recorded here instead; it is what makes a stopped replay resumable.
 STATE="$(git rev-parse --git-dir)/series-forward-pick"
+# The `--placed` ledger, so a resumed run does not ask again. Both files are
+# removed when the replay finishes.
+PLACED="$(git rev-parse --git-dir)/series-forward-placed"
+
+for p in ${PLACED_ARGS+"${PLACED_ARGS[@]}"}; do
+  git rev-parse -q --verify "$p^{commit}" >/dev/null ||
+    { echo "Error: --placed $p is not a commit"; exit 1; }
+  git rev-parse "$p^{commit}" >> "$PLACED"
+done
+placed() { [ -f "$PLACED" ] && grep -qx "$1" "$PLACED"; }
+
+# Is this commit's change already in the tree the replay is building on?
+# Two tests, because each sees what the other misses, and a false alarm costs
+# one `--placed` while a miss costs a wrong forward:
+#
+#   * reverse-applying the commit's own diff -- about content, so it holds when
+#     `main` landed the same change under another subject or bundled with more
+#     (patch/0034, carried onto the buffer alone and onto `main` inside a larger
+#     commit);
+#   * patch-id equality against what the new base gained -- about the change,
+#     so it holds when the file has moved on since and the context no longer
+#     matches (the jemalloc filter in `scripts/rconfigure.py`).
+#
+# `git cherry` marks a commit `-` when the base carries an equivalent patch.
+CHERRY=$(git cherry HEAD "$OLD" "$OLDBASE" 2>/dev/null | sed -n 's/^- //p' || true)
+in_base() {
+  git show --format= "$1" | git apply --reverse --check - 2>/dev/null && return 0
+  grep -qx "$1" <<<"$CHERRY"
+}
 
 # Stamp the counter and commit the picked tree, keeping the original message and
 # author; only the committer changes, as on any replay.
@@ -90,11 +141,62 @@ fi
 DONE=" $(git log -n "$n" --format=%H HEAD | while read -r c; do upstream_sha "$c"; done | tr '\n' ' ')"
 
 PICKS=()
+STRANDED=()
+seen_vendor=
 while IFS=$'\t' read -r c subj; do
-  case "$subj" in vendor:*) ;; *) continue ;; esac
-  case "$DONE" in *" $(upstream_sha "$c") "*) continue ;; esac
-  PICKS+=("$c")
+  case "$subj" in
+    vendor:*)
+      seen_vendor=1
+      case "$DONE" in *" $(upstream_sha "$c") "*) continue ;; esac
+      PICKS+=("$c")
+      ;;
+    *)
+      # Below the first vendor commit is the old seed, which is regenerated
+      # rather than replayed. Above it, a non-vendor commit is the buffer's own
+      # work, and the replay has no place to put it.
+      [ -n "$seen_vendor" ] || continue
+      placed "$c" && continue
+      in_base "$c" && continue
+      STRANDED+=("$c")
+      ;;
+  esac
 done < <(git log --reverse --format='%H%x09%s' "$OLDBASE..$OLD")
+
+if [ ${#STRANDED[@]} -gt 0 ]; then
+  echo "Error: ${#STRANDED[@]} commit(s) in $OLDBASE..$OLD vendor nothing," >&2
+  echo "  and the new base does not carry their change:" >&2
+  for c in "${STRANDED[@]}"; do
+    echo >&2
+    echo "  $(git rev-parse --short "$c")  $(git log -1 --format=%s "$c")" >&2
+    git show --stat=76 --format= "$c" | sed '/^$/d; s/^/    /' >&2
+  done
+  cat >&2 <<EOF
+
+Replaying only the vendor commits would leave these out, and it would do it
+without a conflict: a vendor diff taken after such a change landed is neutral
+in the region it touched, so it applies to a tree that lacks it and the region
+stays as it was. Nothing has been replayed yet.
+
+Decide where each change belongs -- usually the commit that first needs it, not
+the one it was written at; see handbook/operations/vendoring/troubleshooting/,
+"Where a patch goes in the chain". Then rerun with one --placed per commit:
+
+  scripts/series-forward-build.sh$(for c in "${STRANDED[@]}"; do
+      printf ' --placed %s' "$(git rev-parse --short "$c")"; done) $OLD $OLDBASE
+
+--placed says the change has been dealt with, whether by folding it into a
+commit this replay will produce -- fold after the replay reaches it, so the
+counter this script reads back from HEAD keeps matching the commits it wrote --
+or by judging it already carried, or obsolete. It is remembered for the rest of
+the replay.
+
+Already carried is a real outcome, not an excuse: this refuses on the two
+cheap tests it has, so a change the new base holds in a shape neither
+recognises is listed here too. Confirm one by reading the base for its effect,
+not by assuming either way.
+EOF
+  exit 1
+fi
 
 [ ${#PICKS[@]} -gt 0 ] || { echo "Nothing to replay: $OLDBASE..$OLD is already on HEAD"; exit 0; }
 echo "replaying ${#PICKS[@]} vendor commit(s) onto $(git rev-parse --short HEAD), counter at $n"
@@ -106,4 +208,5 @@ for c in "${PICKS[@]}"; do
   [ $((n % 100)) -eq 0 ] && echo "$n replayed -> $(git rev-parse --short HEAD)"
 done
 
+rm -f "$PLACED"
 echo "DONE: ${#PICKS[@]} vendor commit(s) replayed -> $(git rev-parse --short HEAD)"


### PR DESCRIPTION
All three series were forwarded onto the current mainline in one pass — `v1.4-andium`, then `v1.5-variegata`, then `main`. Six commits: the change list filed as a record, three handbook changes for what the run established, and two scripts that turn the two traps it walked into into refusals.

Fixes #2545.

## `series-forward-build.sh` refuses instead of dropping

Replaying `vendor:` subjects alone is right for a `-dev` branch, whose other commits belong to `main` and ride in on the regenerated seed. It is wrong for `-build`, which takes no ports: the `patch/` entries stage 3 commits onto the buffer are its own, and the replay had nowhere to put them — so it dropped them without a sound. A vendor diff taken after such an entry landed is neutral in the region it touched, so replaying it onto a tree that lacks the entry applies cleanly and leaves the region as it was: no conflict, no non-zero exit, and a forward whose only symptom is a tree that differs from the buffer it came from.

Every non-vendor commit above the first vendor commit is now classified (below it is the old seed, which is regenerated rather than replayed), and the run refuses to start while any carries a change the new base does not have. Two tests, because each catches what the other misses — reverse-applying the commit's own diff, which holds when `main` landed the change under another subject or bundled with more; and patch-id equality with what the base gained, which holds when the file has moved on and the context no longer matches. On the five commits this arose from, one needed each.

`--placed <sha>` is how the caller says a commit has been dealt with, and it is remembered for the rest of the replay so a conflict stop resumes without it. The error prints the whole rerun command.

Verified against the three live buffers: `main` refuses naming exactly the three entries the first pass lost and neither of the two the base already carries; `v1.5-variegata` replays without comment; `v1.4-andium` refuses on the stray `chore: Auto-update from GitHub Actions` version bump. With `--placed` the replay starts, and a rerun without flags resumes from the ledger.

The script cannot say *where* a change belongs, so it does not try. `series-forward.md` gains the five-step recipe: read it, find the commit that first needs it, acknowledge, fold after the replay reaches it, verify by comparing trees rather than exit statuses.

## `flavor.sh` refuses instead of committing half a rename

`cpp11::cpp_register()` derives the `.Call` prefix from `Package:`, replacing dots with underscores — but only `krlmlr/cpp11` replaces every one, so a two-dot flavor comes out of CRAN's as `_duckdb_1.5.dev_rapi_connect`. The script wrote that, committed it, and exited 0; the next reader was the compiler. A one-dot flavor is correct from either cpp11, so nothing about the run distinguished the two cases.

One grep over the generated `src/cpp11.cpp` now refuses it. And the script was restructured into refuse / prepare / commit: it declines a dirty tree, prepares the whole rename touching no ref, and commits the two commits last, with an EXIT trap that restores the tree unless both were reached. The half-applied flavor a missing prerequisite used to leave is no longer reachable.

Verified: dirty tree refused; good run leaves exactly the two commits, the first touching only `scripts/flavor.patch`; a run with CRAN's cpp11 exits 1 with HEAD, the tree and the untracked set all where they started.

## The record

`plan/history/2026-08-series-forward-glue.md`, plus its `plan/README.md` index row — where `plan/README.md` says a record of work that is over belongs. The handbook can't own the list itself: a per-forward change list ages out at the next forward, which is the lifetime `handbook/meta/handbook/README.md` sends out of the tree. What the run established as a standing fact went into the tree or into a check instead, and the record links it rather than restating it.

- The 39 glue adaptations `main-build` carries, grouped by the upstream change each answered, with the `duckdb/duckdb` PR and the buffer commit for each: members becoming accessors, the const/mutable split in the vector API, `Identifier` replacing `string` for every name, table filters becoming expressions, function binding growing a parameter object. `v1.4-andium` and `v1.5-variegata` needed no glue change at all.
- Where each modification was placed, and the `-dev`-only glue the forward's `-dev` will have to mine — three commits on `main-dev` whose `-build` counterparts carry less or nothing, `RCallbackScope` among them.

## Where the three carried patches go

Each is folded into the vendor commit that brings in the code its patch answers, not the position it held in the buffer:

- `patch/0035` (deprecated `Catalog::GetEntry()` self-delegation) into `duckdb/duckdb@6d4f53284` — the commit that puts the 14 `[[deprecated]]` attributes into `catalog.hpp`; its parent has none.
- `patch/0037` (cast to `void *` in the default aggregate state initializer) into `duckdb/duckdb@2daa4fc9a` — the eager-aggregation change that introduces the `memset` over a non-trivial state.
- `patch/0036` (guard the assert-only plan verifiers) into `duckdb/duckdb@8956cec9b` — the correlated-join change that adds them, growing `planner.cpp` from 268 lines to 339.

An entry gets written when someone reads the diagnostic, which is whenever the platform that raises it next builds a published tip, and the upstream change that raised it sits far below — 312 commits for `patch/0035`, 292 for `patch/0037`, 77 for `patch/0036`. That span is the point: no run covers `-build` at all and the gate that covers `-dev` is one platform, so a diagnostic only macOS or Windows raises is found by bisecting the buffer by hand, and a bisect answers what is asked of it only when every commit in its range is clean of what is being bisected for.

## The handbook changes

**`vendoring/troubleshooting/` gains the rule, and a scope wide enough to hold it.** The leaf already owned the fold for a forward-ported fix, so the general rule — a `patch/` entry belongs in the first commit whose tree carries the code it answers, and how to find that commit — goes beside it. Its scope sentence excluded the topic (a warning from a platform no run covers is not a red vendoring run), which `handbook/meta/handbook/` names as the cheaper defect to check for first, so it is widened rather than a new leaf added. The failure-class list gains the matching entry.

**`vendoring/series-loop/` states what a forward does not carry**, and that the replay now refuses rather than leaves a `patch/` entry behind. The tooling delta of a frozen series' seed is still unreported, and needs no report: the port stage brings it back on the next firing.

**`architecture/glue/` separates the two halves of cpp11**, and `branches/flavors/` links it from the step that runs the generator. The rest of what those two pages said about it is `flavor.sh`'s job now — as is the half-applied-flavor recovery `VENDORING.md` and `series-open.md` used to carry.

## Still open, not acted on here

**`patch/0035` applies to `main`'s engine** and therefore belongs on `main`, where it would come with every future seed; `patch/0036` and `patch/0037` do not apply and are correctly series-specific.

## The refs

The twelve `-fwd-*` refs are on `krlmlr/duckdb-r`. Verified before pushing: the glue syntax gate passes at all three buffer tips, each vendored tree and `patch/` stack is byte-identical to its source buffer, the version counter rises on every vendor commit, and the whole glue delta against the old buffer tips is exactly what `main` gained in the window. For the folded patches, additionally: each patched hunk and its `patch/` file are present at every commit from the fold point to the tip, and absent at the fold commit's parent.

- `main-fwd-build` at `497dbc9a1`, 1133 vendor commits and no non-vendor commit at all; the other three refs at the seed `30ae31408`.
- `v1.5-variegata-fwd-build` at `2d3ab32a2`, 14 vendor commits; seed `8e5255445`.
- `v1.4-andium-fwd-build` at `7aa50fb8f`, 1 vendor commit; seed `8998d32dc`.