### PR TITLE
fix(rcc): Stop the backstop recording a `pending` status as a verdict

### DIFF
--- a/handbook/operations/ci/per-commit/selection/README.md
+++ b/handbook/operations/ci/per-commit/selection/README.md
@@ -92,3 +92,13 @@ The `pending` status is a **display** artifact:
 it tells a human looking at the commit list that something is happening.
 `each-shard.sh` treats it as undecided,
 because it is the state a killed leg leaves behind.
+
+The backstop is the one writer that reads statuses at all,
+and it honours the same rule:
+[`scripts/rcc-logs.sh`](/scripts/rcc-logs.sh) reconstructs a record
+only from a status that is a verdict — `success`, `failure` or `error` —
+and leaves a commit whose status is still `pending` undecided.
+Recording it would be durable,
+and a durable `pending` is the one state nothing can leave:
+selection reads presence, so the planner would skip the commit for good,
+while `series-check.sh` read the state and waited for it for good.

--- a/scripts/rcc-logs.sh
+++ b/scripts/rcc-logs.sh
@@ -13,7 +13,8 @@
 # branch (deduped by SHA) and, for each commit with no record:
 #   1. Reads the `rcc` commit status from
 #      repos/{owner}/{repo}/commits/<sha>/statuses
-#      (skipping commits with no rcc status; they are retried next time).
+#      (skipping commits with no rcc status, and commits whose status is not yet
+#      a verdict; both are retried next time).
 #   2. Parses the workflow run id from the status `target_url`.
 #   3. Fetches the run object for the latest run_attempt and skips it if the
 #      run is not yet `completed` (also retried next time).
@@ -136,6 +137,23 @@ while IFS= read -r sha; do
     skipped_no_status=$((skipped_no_status + 1))
     continue
   fi
+
+  # A record is a decision, and scripts/rcc-decided.sh reads presence alone, so
+  # writing one whose `.status.state` is still `pending` marks the commit decided
+  # forever: the planner skips it and nothing ever replaces the record. That is
+  # what a cancelled leg leaves behind -- the run completes, the status it set on
+  # entry never does -- and it wedges the series until somebody pushes
+  # `retry-<S>-dev` by hand. Leave such a commit undecided instead; the ordinary
+  # rule replans it on the next push.
+  status_state="$(jq -r '.state // ""' <<<"${status_json}")"
+  case "${status_state}" in
+    success | failure | error) ;;
+    *)
+      echo "Commit ${sha}: rcc status is ${status_state:-empty}, not a verdict -- leaving it undecided"
+      skipped_pending=$((skipped_pending + 1))
+      continue
+      ;;
+  esac
 
   target_url="$(jq -r '.target_url // ""' <<<"${status_json}")"
   run_id="$(printf '%s' "${target_url}" \


### PR DESCRIPTION
`scripts/rcc-logs.sh` skips a run that has not completed, but never checks the state of the `rcc` commit status it reconstructs the record from. A cancelled leg leaves those two disagreeing: the run reaches `completed`, and the `pending` status the leg POSTed on entry never does. The backstop then writes a record whose `.status.state` is `pending`.

That record is durable, and durable is the one thing `pending` may not be. `scripts/rcc-decided.sh` decides by presence, so from then on `each-plan.sh` skips the commit and `each-shard.sh` would too; `scripts/series-check.sh` reads the state and reports the series as waiting for a run nothing will ever schedule again. The commit is wedged, and it holds the series' green behind it, until somebody pushes `retry-<S>-dev` at it by hand.

`handbook/operations/ci/per-commit/selection/README.md` already states the rule this breaks — "The `pending` status is a **display** artifact ... `each-shard.sh` treats it as undecided, because it is the state a killed leg leaves behind". The backstop is the one writer that reads statuses at all, and it was the one writer not honouring it.

### Evidence

Two `each-rcc` shards were cancelled mid-build on 2026-08-06:

- run 31114983396, job 92662227651 (`main-dev`, shard 1) — cancelled 16:17:59 during "Build the shard", leaving `c02a8f733` at `pending`
- run 31115008274, job 92662875847 (`v1.5-variegata-dev`, shard 2) — same shape, leaving `6434eab20` at `pending`

The next `rcc-logs` tick recorded both as `pending` records. A manual `each-rcc` dispatch on both `-dev` branches at 20:48 rebuilt nothing for them, because they now read as decided. Sixteen hours later this firing found `main-green` still held at `82d457211` by `c02a8f733`, the oldest commit in its in-flight range, and `v1.5-variegata-green` held six commits short. Both were unwedged by hand with `retry-<S>-dev`.

### The change

Record only a status that is a verdict — `success`, `failure` or `error` — and leave anything else undecided, so the ordinary build-it-if-it-has-no-record rule replans the commit on the next push. The handbook page gains the corresponding sentence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CB5Cemb9sgLQzC5LUP6v9j

---
_Generated by [Claude Code](https://claude.ai/code/session_01CB5Cemb9sgLQzC5LUP6v9j)_