### PR TITLE
docs: An entry that wraps its subject applies everywhere, so applying proves nothing

### DIFF
--- a/handbook/operations/vendoring/troubleshooting/README.md
+++ b/handbook/operations/vendoring/troubleshooting/README.md
@@ -97,15 +97,34 @@ The loop's own statement of the rule is in its repair stage
 ## Where a patch goes in the chain
 
 A `patch/` entry belongs in the first commit whose tree carries the code
-it answers, which is the first commit whose tree it applies to.
+it answers.
 That is rarely the commit at which it was written:
 an entry answering a compiler diagnostic is written when someone reads
 the diagnostic, and the upstream change that raised it can be far below.
-Finding the right one is mechanical — the answer can only change where
-the patched file changes, so walk that file's commits and take the first
-whose tree `patch --dry-run` accepts.
 Fold the entry and its effect on the vendored tree into that commit
 together, with an `R-side fix` section, as a forward-ported fix is folded.
+
+**Where the entry applies is a lower bound, not the answer.**
+For one that edits the code it answers the two coincide, and walking the
+patched file's commits for the first tree `patch --dry-run` accepts
+finds it.
+One that merely wraps its subject does not move with it —
+a diagnostic scoped off around a translation unit applies to every
+version of that unit, including the versions with nothing to warn about,
+so the walk answers with the seed.
+Look for where the thing being answered arrives, which is often in
+another file than the one the entry edits, and use `patch --dry-run`
+only to confirm the entry can live there.
+
+**The same distinction decides which branch an entry lives on.**
+A fix is series-specific when the code it answers is not on `main`,
+and an entry that wraps rather than edits will apply to `main` either
+way, so applying there is no evidence it belongs there.
+Landing one whose subject `main`'s engine does not carry adds a
+suppression with nothing to suppress —
+against the rule that nothing is suppressed at all
+([`architecture/glue/`](/handbook/architecture/glue/README.md)) —
+and it is the series' until `main`'s engine reaches the code.
 
 The buffer is where the choice is load-bearing.
 No run covers it at all

--- a/plan/history/2026-08-series-forward-glue.md
+++ b/plan/history/2026-08-series-forward-glue.md
@@ -215,7 +215,7 @@ brings in the code its patch answers:
 
 * `patch/0035`, silencing the deprecated `Catalog::GetEntry()`
   self-delegation, into `duckdb/duckdb@6d4f53284` —
-  the commit that puts the 14 `[[deprecated]]` attributes into
+  the commit that puts the `[[deprecated]]` declarations into
   `catalog.hpp`; its parent has none.
 * `patch/0037`, casting to `void *` in the default aggregate state
   initializer, into `duckdb/duckdb@2daa4fc9a` —
@@ -357,16 +357,29 @@ level first, which is what
 [#2433](https://github.com/duckdb/duckdb-r/pull/2433) did for the
 previous one.
 
-**One of the three carried patches belongs on `main`.**
-Stage 3's routing rule is that a fix is series-specific only when the
-code it touches is not on `main`.
-Tested against `main`'s tree: `patch/0036` and `patch/0037` do not apply
-— their code arrived after the engine `main` vendors — so they are
-correctly the series'.
-`patch/0035` **does** apply.
-Landing it on `main` would put it in every future seed and end its
-per-forward carry;
-until then every forward of every series has to place it by hand.
+**All three carried patches are the series', and reading that off
+applicability got it wrong once.**
+Stage 3's routing rule is that a fix is series-specific when the code it
+answers is not on `main`.
+`patch/0036` and `patch/0037` do not even apply to `main`'s tree —
+their code arrived after the engine `main` vendors — so they are plainly
+the series'.
+`patch/0035` does apply, and this record first read that as a verdict:
+land it on `main`, and every future seed carries it.
+That was wrong.
+The entry scopes a diagnostic off around a whole translation unit, so it
+applies to every version of that file, including versions with nothing
+to warn about — and `main`'s is one.
+`main` vendors DuckDB 1.5.5, whose `catalog.hpp` carries no
+`[[deprecated]]` declaration at all;
+the forward's tip carries them.
+Landing the entry there would add a suppression with nothing to
+suppress.
+The rule that separates the two is
+[`vendoring/troubleshooting/`](/handbook/operations/vendoring/troubleshooting/README.md)'s:
+where an entry applies bounds where it may go, and never locates it.
+`patch/0035` reaches `main` when `main`'s engine reaches the
+deprecation, and not before.
 
 **`patch/0034` is two files.**
 `main-build` carries both


### PR DESCRIPTION
Follow-up to #2543, which merged one commit short and left a conclusion behind that the missing commit would have blocked.

## The commit the squash lost

`vendoring/troubleshooting/` on `main` still says a `patch/` entry belongs in the first commit whose tree carries the code it answers, "which is the first commit whose tree it applies to", and offers a mechanical way to find it: walk the patched file's commits and take the first tree `patch --dry-run` accepts.

That holds for an entry that edits the code it answers, which is two of the three the August forward folded. It fails for one that merely wraps it. `patch/0035` scopes a diagnostic off around `src/duckdb/src/catalog/catalog.cpp`, so it applies to every version of that file — the seed's included — and the walk answers with the seed, missing the commit it belongs to by 779. What it answers is in `catalog.hpp`, not the file it edits: the `[[deprecated]]` declarations that its parent does not have.

So: where an entry applies is a lower bound on where it may go, and never locates it. Restored, with the reason.

## The conclusion that reading produced

The record's last finding said `patch/0035` belongs on `main` — `patch/0036` and `patch/0037` do not apply to `main`'s tree, `patch/0035` does, so land it there and every future seed carries it.

It does apply. It does not belong.

- `main` vendors DuckDB 1.5.5, whose `catalog.hpp` carries **no** `[[deprecated]]` declaration; the forward's tip carries them.
- `patch/0036` and `patch/0037` are the same class checked properly: `planner.cpp` on `main` has no assert-only verifiers, `aggregate_executor.hpp` no `memset`.

Landing `patch/0035` on `main` would add a suppression with nothing to suppress, against `architecture/glue/`'s rule that nothing is suppressed at all. All three entries are the series' by engine version; `patch/0035` reaches `main` when `main`'s engine reaches the deprecation, and not before.

`vendoring/troubleshooting/` gains that consequence beside the rule, because which branch an entry lives on is decided by the same distinction as which commit — and stage 3's routing rule ("series-specific when the code it answers is not on `main`") is just as easy to answer with applicability and just as wrong.

Also drops a count the record had wrong: 13 `[[deprecated]]` declarations and one comment mentioning the word, read as 14. The durable form names the thing, not the tally.

## Not changed

`main-fwd-build` is unaffected — all three entries are folded where the rule puts them, and that was verified against the pushed ref: each patched hunk and its `patch/` file present at every commit from the fold point to the tip, absent at the fold commit's parent, the tip's `src/duckdb/` and `patch/` byte-identical to `main-build`'s, and the counter stepping 1→1133 with no gap.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U57LFAUSFcUDW12p5SwtmR)_