### PR TITLE
fix(rcc): Fetch the record a publish replaces, so a retry's verdict can land

### DIFF
--- a/handbook/operations/ci/per-commit/store/README.md
+++ b/handbook/operations/ci/per-commit/store/README.md
@@ -246,9 +246,22 @@ the old blob — a promised object — and the push dies with
 Since replacement is exactly what a retry does,
 and what the fan-in does when a leg's verdict has changed,
 the failure would have been retry-only and rare.
-`--no-thin` on the push is the fix,
-and [`rcc-store-test.sh`](/scripts/rcc-store-test.sh) covers it:
+`--no-thin` on the push is half the fix,
+and [`rcc-store-test.sh`](/scripts/rcc-store-test.sh) covers that half:
 a verdict is replaced there from a clone that never wrote the first one.
+
+The other half is that `--no-thin` does not hold over https,
+which is the only transport a leg ever uses,
+and the local remote the test pushes to is why that stayed hidden.
+The same replacement — same blobless shallow clone,
+same `GIT_NO_LAZY_FETCH=1`, same `--no-thin` —
+lands against a `file://` remote and dies against GitHub,
+still asking for the old blob.
+So [`rcc-publish.sh`](/scripts/rcc-publish.sh) fetches the blob it is replacing
+while staging it: a record is ~2 KB,
+only a replacement pays, and nothing then depends on the flag holding.
+A test cannot catch this without a network remote,
+so the code no longer relies on the property the test can check.
 
 ## How bad is the race
 

--- a/scripts/rcc-publish.sh
+++ b/scripts/rcc-publish.sh
@@ -107,6 +107,14 @@ stage_if_changed() { # <path-on-branch> <source-file>
   blob="$(git_rcc hash-object -w --stdin < "$2")"
   current="$(git_rcc ls-files --format='%(objectname)' -- "$1")"
   [ "${current}" = "${blob}" ] && return 1
+  # Staging a *replacement*: fetch the blob being replaced, which the push over
+  # https asks for and cannot get. See the push below -- `--no-thin` does not
+  # keep git from wanting it there, and a record is ~2 KB, so paying for it
+  # here is cheaper than the failure it avoids. Only a replacement pays.
+  if [ -n "${current}" ]; then
+    ( unset GIT_NO_LAZY_FETCH; git_rcc cat-file blob "${current}" > /dev/null ) \
+      || echo "could not fetch the blob at $1; the push may fail" >&2
+  fi
   git_rcc update-index --add --cacheinfo "100644,${blob},$1"
   return 0
 }
@@ -163,6 +171,12 @@ while :; do
   # has never held has no base to delta against and pushes fine. That is what
   # makes it worth a comment -- it would have been a retry-only failure, invisible
   # until the one path that needs it most.
+  #
+  # It is also not sufficient, and only over https: the same replacement that
+  # pushes cleanly to a file:// remote with `--no-thin` still asks for the old
+  # blob against GitHub and dies. That is why the flag alone read as a fix and
+  # why rcc-store-test.sh, which pushes to a local remote, agrees that it is
+  # one. stage_if_changed fetches the replaced blob for that reason; keep both.
   if git_rcc push -q --no-thin origin "${commit}:refs/heads/${BRANCH}"; then
     echo "Published ${staged} change(s) to ${BRANCH} on attempt ${attempt}."
     exit 0


### PR DESCRIPTION
`scripts/rcc-publish.sh` builds its commit in a blobless, shallow clone with `GIT_NO_LAZY_FETCH=1`, and pushes with `--no-thin` so that replacing an existing record does not make git reach for the old blob as a delta base. Over https it reaches for it anyway, and the push dies — deterministically, on all 20 attempts, for as long as the record exists.

Only a *replacement* is affected, so a commit's first verdict publishes fine. A **rerun** is the one thing whose whole purpose is to overturn a record that is already there, so `retry-<S>-dev` cannot deliver a result at all: the commit is rebuilt, the `rcc` status flips to `success`, and the store keeps the old record forever. `scripts/rcc-logs.sh` does not repair it either — the backstop only fills in commits with *no* record.

### Evidence

This firing found `main-green` and `v1.5-variegata-green` still wedged behind the two commits #2544 describes, one firing after that firing had already pushed `retry-<S>-dev` at both. The retries built and passed:

- `c02a8f733` — run 31159136205, shard 1: `success (2672s, exit 0)`, `rcc` status success at 09:15Z
- `6434eab20` — run 31159145790, shard 1: `rcc` status success at 08:26Z

Neither verdict reached `rcc2`. Both the leg's own publish and the run's fan-in failed 20/20 with:

```
warning: lazy fetching disabled; some objects may not be available
fatal: could not fetch a733ecca954a27b03f4baf908fa4e29f950301a1 from promisor remote
fatal: the remote end hung up unexpectedly
send-pack: unexpected disconnect while reading sideband packet
error: failed to push some refs
```

`a733ecca9` is `runs2.d/c0/c02a8f733cd2ac1b1f559f1800dfe40efdaa56df.ndjson` on `rcc2` — exactly the record being replaced.

Reduced to a minimal case against a scratch branch at the `rcc2` tip: `git init`, `fetch --filter=blob:none --depth=1`, `read-tree`, replace one record blob, `write-tree --missing-ok`, `commit-tree`, `push --no-thin` — same failure. Fetching that one blob first makes the identical push succeed.

### Why the test agrees `--no-thin` is enough

`scripts/rcc-store-test.sh` covers the replacement case and passes, because it pushes to a local remote. That is the whole difference. The identical replacement, from the identical clone, with `--no-thin`:

- against `file:///…/localremote` → `8f8c943..1144764  -> rcc2`
- against `https://github.com/krlmlr/duckdb-r` → `could not fetch … from promisor remote`

A test cannot catch this without a network remote, so the code should not rely on a property only the test's transport has.

### The change

`stage_if_changed` fetches the blob it is replacing, with lazy fetching allowed for that one object. A record is ~2 KB, only a replacement pays, and the push no longer depends on `--no-thin` holding. `--no-thin` stays: it is still right, and still what keeps the ordinary case from wanting anything.

The handbook section that called `--no-thin` the fix is corrected to say which half it is.

### Unblocking, by hand

The two wedged records were dropped from `rcc2` so the backstop could re-derive them from the fresh statuses; both now read `success`, and `main-green` advanced 31 commits and `v1.5-variegata-green` 6.

Related to #2544, which stops the `pending` record being written in the first place. Neither subsumes the other: #2544 prevents the wedge, this restores the retry that gets out of one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CA6yT6mzXFRgssG6yXYxr

---
_Generated by [Claude Code](https://claude.ai/code/session_012CA6yT6mzXFRgssG6yXYxr)_