### PR TITLE
fix(series-advance): Clamp the replay anchor to the merge base

### DIFF
--- a/scripts/series-advance.sh
+++ b/scripts/series-advance.sh
@@ -207,6 +207,15 @@ else
   anchor=$(git log --format='%H %s' "$build" | grep -m 1 "duckdb@$dev_up" | cut -d' ' -f1 || true)
   [ -n "$anchor" ] ||
     { echo "Error: no -build commit vendors duckdb@$dev_up — mirror the fold in -build first"; exit 1; }
+  # `vendored_sha` walks past commits that vendor nothing, and on a -dev that has
+  # none of its own it walks past the seed too — answering with what the branch
+  # the seed was cut from had vendored. That is every series on its first firing
+  # once stage 4 has ported: -dev is the seed plus tooling picks, so the fast
+  # path above no longer applies and this one reaches below the divergence.
+  # The buffer starts at the merge base whatever -dev's newest vendor commit is.
+  if git merge-base --is-ancestor "$anchor" "$mb"; then
+    anchor=$mb
+  fi
 fi
 ahead=$(git rev-list --count "$anchor..$build")
 if [ "$ahead" -eq 0 ]; then


### PR DESCRIPTION
Stage 5 replays buffer commits onto `-dev` from an anchor: the `-build` commit equivalent to `-dev`'s newest vendor commit. `vendored_sha` finds that by walking subjects and looking past commits that vendor nothing — and on a `-dev` that has no vendor commit of its own it walks past the seed as well, answering with what the branch the seed was cut from had vendored.

That is every series on its first firing, as soon as stage 4 has ported: `-dev` is the seed plus tooling picks, so it is no longer an ancestor of `-build` and the `mb = dev` fast path stops applying. The anchor then lands below the divergence point, and `anchor..build` reaches back into the base branch — so the replay cherry-picks commits `-dev` already has.

### Evidence

All three forward series created yesterday hit this on their first firing. On `main-fwd`:

```
mb      = 30ae31408  chore: Add fifth version component        (the seed)
dev_up  = d8cdaa33…                                            (main's own last vendor commit)
anchor  = f0579b6ef  vendor: … (tag v1.5.5) to duckdb@d8cdaa33 (an ancestor of mb)
anchor..build = 1298 commits, for a 1133-commit buffer
```

The extra 165 are `main`'s own pre-seed commits. The replay stopped on the first that touched a file the seed also carries:

```
Auto-merging revdep/README.md
CONFLICT (content): Merge conflict in revdep/README.md
…
error: could not apply 235b66433... chore: Results for revdepchecks
Error: replay conflicted — extend by hand
```

The conflict is not a real one — the commit is already in `-dev`'s history — so the "judgement, not mechanics" note the code attaches to a conflicting replay sends the reader looking for a repair that does not exist.

### The change

The buffer begins at the merge base whatever `-dev`'s newest vendor commit is, so clamp the anchor to it. A `-dev` that carries its own vendor commits is unaffected: its anchor is already above the merge base, and `merge-base --is-ancestor` leaves it alone.

With the clamp, this firing extended all three forward series without further intervention — `main-fwd` +100, `v1.5-variegata-fwd` +14, `v1.4-andium-fwd` +1 — which is how it was applied by hand here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CA6yT6mzXFRgssG6yXYxr

---
_Generated by [Claude Code](https://claude.ai/code/session_012CA6yT6mzXFRgssG6yXYxr)_