### PR TITLE
refactor(series-loop): Read verdicts from the `each-rcc` runs, keep `rcc2` as the fallback

### DIFF
--- a/.claude/skills/series-loop.md
+++ b/.claude/skills/series-loop.md
@@ -82,7 +82,8 @@ Set up first, then work through the stages in order;
 each stage is skippable when it has nothing to do, the setup is not.
 Five scripts carry the mechanical parts:
 `scripts/series-check.sh`
-(read-only — walks every series, classifies from the harvest,
+(read-only — walks every series, classifies from the `rcc2` store,
+which is stage 2's fallback source, not its first one;
 prints one verdict each:
 ADVANCE / WAIT / RETRY `<sha>` / REPAIR `<sha>` / IDLE,
 plus a CUTOVER line for a forward series that has caught up —
@@ -129,6 +130,19 @@ and every one of those meets the graft boundary
 and answers wrong or refuses.
 Tags are not optional either:
 `vendor-one.sh` reads `git describe --tags` for the version it stamps.
+
+**Establish how this firing reads results, once.**
+Verdicts and logs come from the `each-rcc` runs that produced them (stage 2),
+which needs Actions read access to the repository those runs live in.
+Probe it here rather than per commit:
+list the most recent `each-rcc` runs.
+If that answers, the firing is on the run path for every stage below.
+If it does not — no such access from this session at all —
+the firing falls back to the `rcc2` store,
+which still works, at the store's latency and inside its 30-day window.
+Record which one served: the store exists to work around a log access
+problem that may have passed, and retiring it waits on firings
+that report they never had to open it.
 
 **Read the open PRs, and use judgement about them.**
 List the ones touching `.github/`, `scripts/` or `.claude/` —
@@ -223,26 +237,108 @@ do not edit `src/duckdb/` by hand in this stage.
 
 ### 2. Repair the oldest `<S>-dev` failure
 
-Read the verdict store on branch `rcc2`
-for every commit in `<S>-green..<S>-dev` —
-one record per commit at `runs2.d/<xx>/<sha>.ndjson`.
+Every commit in `<S>-green..<S>-dev` was decided by an `each-rcc` leg,
+and **the leg's own run is where its result is read**.
 That range is the loop's whole world:
 nothing at or before `<S>-green` is ever re-examined.
-A commit **missing** from the harvest has not completed —
-wait, do not guess.
-`each.yaml`'s legs publish a record within seconds of deciding a commit
-(see [`per-commit builds`](/handbook/operations/ci/per-commit/store/README.md)),
-so missing now means undecided, not merely uncollected.
 
-If a commit is still missing after **12 hours**, presume its run lost —
-but only after trying hard to rule that out from what git can see:
-the harvest may be stale
-(check the age of the `rcc2` branch tip against its 30-minute schedule),
-and the run may simply be queued
-(runner throughput is roughly 35–40 commits per hour,
-so a long tail behind a large push is normal).
-Review whatever CI state is reachable before concluding loss.
-Only then self-heal:
+#### Read the results from the runs that produced them
+
+List the `each-rcc` runs on `<S>-dev` and on `retry-<S>-dev`,
+newest first, back to when `<S>-green` last moved,
+and take each run's `each-logs-<shard>-<attempt>` artifacts —
+one per leg, holding, for the commits that leg decided,
+exactly what the `rcc2` store holds for them, in the same bytes.
+Unzipped:
+
+```
+index.ndjson         one line per commit that leg decided
+parts/<sha>.ndjson   the record, published as runs2.d/<xx>/<sha>.ndjson
+<sha>.log            the log, published as logs2.d/<xx>/<sha>.log
+```
+
+`each-shard.sh` writes those files and then *copies* the last two onto the
+branch, so the two sources cannot disagree about a verdict —
+they differ in reach and in latency, never in content.
+Where a commit appears in more than one run —
+a retry, a re-run of a leg that died —
+the **higher run id wins**, the same rule the fan-in applies
+([`store/`](/handbook/operations/ci/per-commit/store/README.md)).
+
+Fetch through whatever Actions access the firing has:
+the GitHub tools (list the workflow's runs, list a run's artifacts,
+ask for an artifact's download URL, then `curl` and `unzip` it),
+or `gh run download` where a `gh` exists.
+Unzip to disk and grep there.
+A leg's artifact is tens of megabytes of build output,
+and nothing below needs any of it in context:
+what a firing reads is one state per commit,
+and the tail of the one log it is about to classify.
+
+Artifacts keep for **14 days**, far longer than a commit normally waits
+between being pushed and being repaired.
+Past that the leg's **job log** carries the same content
+inline — `::group::<sha>` opens the commit's section,
+its log is printed inside, and `<sha>: <state> (<n>s, exit <rc>)` closes it —
+and GitHub keeps job logs far longer than either the artifact
+or the store's 30-day window.
+Which shard holds which commit is the run's `each-plan` artifact (7 days),
+or the group markers themselves.
+
+Two deliberate behaviours mislead a reader who skips them.
+A leg **exits 0 even when commits failed** —
+a red commit is a result, not a broken leg —
+so a run's `conclusion` says nothing about any commit in it,
+and asking that run only for its *failed* jobs answers with the jobs that
+broke, which are the ones a red commit is not in.
+Take the shard jobs, all of them.
+And a leg that resumed skips what a previous attempt decided
+(`already decided, skipping`), so its artifact covers only what it rebuilt;
+the older attempt's artifact is still there, named per attempt, and still counts.
+
+#### When a run cannot be read, consult the store
+
+That is what it is for:
+`scripts/series-check.sh`, or `git show origin/rcc2:runs2.d/<xx>/<sha>.ndjson`
+with `logs2.d/<xx>/<sha>.log` beside it.
+Three cases reach for it —
+the firing has no Actions access to the repository the runs live in,
+the deciding run has aged out,
+or the run is there and its results are not
+(a leg that died before it uploaded anything).
+Nothing else in this stage changes; the bytes are the same either way.
+
+`series-check.sh` reads the store and only the store.
+Its ref geometry — in flight, buffered, the retry ledger, a ready cutover —
+does not depend on where verdicts come from, so run it every firing;
+but where its verdict and a run disagree, the run is right,
+because the store is the copy.
+A store that stopped being written would make the script confidently wrong,
+which is a stage 7 PR — teach it the run route — never a repair on the series.
+
+#### A commit with no verdict
+
+It has not been judged: wait, do not guess.
+The run list says which kind of waiting it is:
+
+* a run on the branch is queued or in progress — it is coming;
+  throughput is roughly 35–40 commits per hour,
+  so a long tail behind a large push is normal;
+* a completed run planned it but its leg deferred it at the leg deadline,
+  or could not check it out — the ordinary rule replans it on the next push;
+* no run covers it at all — nothing was ever triggered;
+  push, or dispatch `each-rcc` on the branch.
+
+The store answers this one badly, which is worth the run list even on a firing
+whose verdicts came from the store:
+an absent record can equally mean a stale harvest
+(its tip against the 30-minute schedule), a queued run, or a lost one.
+
+Only when none of those explains it,
+and the run that should have decided it finished hours ago saying nothing
+about it, presume that run lost.
+**12 hours** is the outer bound on being patient, not a licence to skip the
+question. Only then self-heal:
 push `retry-<S>-dev` at the first commit with missing state
 (*Rerun one commit*, below).
 A missing status needs nothing forced —
@@ -258,7 +354,10 @@ check the open PRs read during setup:
 a failure an earlier firing already wrote up
 is one to work around, not to re-derive.
 
-Classify each `failure` by what its log (`logs2.d/<xx>/<sha>.log`) **contains**:
+Classify each `failure` by what the commit's log **contains** —
+`<sha>.log` in the leg's artifact, that commit's `::group::` section in the
+leg's job log, or `logs2.d/<xx>/<sha>.log` on the store, whichever the firing
+is reading; they are the same bytes:
 
 | evidence | meaning | action |
 |---|---|---|
@@ -316,7 +415,7 @@ or the stages the repair touches when it does not;
 `git clean -fdx -- src/` first either way.
 (Until #59 is available:
 `R CMD INSTALL` plus `testthat::test_local()`.)
-A CI round trip costs ~35 minutes plus queue and harvest;
+A CI round trip costs ~35 minutes plus queue;
 a local pass costs ~10.
 One local pass that catches a bad repair saves a full cycle,
 and a repair that was not run locally is a guess.
@@ -424,7 +523,7 @@ against R-devel, release and oldrel,
 and runs `R CMD check` on each.
 So a series can be green at every commit
 and still publish a package that does not compile —
-and nothing on branch `rcc` would ever say so.
+and no `each-rcc` run, on any platform it covers, would ever say so.
 This is the read that closes that gap:
 
 ```sh
@@ -487,8 +586,8 @@ to escape a failure on a platform the gate never covered.
 Green stays. The finding travels forward.
 
 **State the finding in the commit message on `-dev`.**
-An r-universe failure has no record on branch `rcc`
-and no commit of its own;
+An r-universe failure has no per-commit record anywhere —
+not in an `each-rcc` run, not in the store — and no commit of its own;
 it lives in a job log that ages out,
 in a universe that rebuilds over it.
 So write it where the series keeps its memory:
@@ -757,9 +856,12 @@ Exception: a series with a **live** forward counterpart
 (`<S>-fwd-build` exists and is not cutover litter)
 is being replaced —
 verify and promote it, but do not extend it.
-`each.yaml` triggers one `rcc` run per new commit;
-`rcc-logs.yaml` harvests results to branch `rcc2` every 30 minutes,
-which is below build time (~35 min).
+The push triggers one `each-rcc` run for the commits it added,
+and every verdict that run reaches is readable from it
+as soon as the leg has written it —
+there is nothing to wait for a harvest for.
+The store's own writers (the leg's publish, the fan-in,
+`rcc-logs.yaml` every 30 minutes) only fill the fallback copy behind it.
 
 ### 6. Suggest a cutover — never perform one
 
@@ -911,23 +1013,31 @@ the failure a retry branch sits on is REPAIR, never RETRY.
 One ref per series, so it records the retry in flight,
 not the history of them.
 
-The verdict reaches the loop the ordinary way.
-A commit's record lives once on `rcc2`,
-at `runs2.d/<xx>/<sha>.ndjson`, published by the leg within seconds,
-so `each-harvest.sh` and the leg both *replace* it rather than appending;
-that is the one case where a decided commit legitimately changes state.
+The verdict reaches the loop the ordinary way — from the rerun's own run.
+That run is on `retry-<S>-dev`, so its results name that branch
+and carry a higher run id than the run that first judged the commit,
+which is what tells the two apart while both exist.
+The pre-retry `failure` does not disappear when the retry is pushed:
+it stays the newest result for that SHA until the rerun reports,
+and repairing on it amends a commit that is about to go green.
+The store applies the same newest-run-wins rule to its copy,
+so `each-harvest.sh` and the leg both *replace* a record rather than append —
+the one case where a decided commit legitimately changes state.
 
-**To drop a commit's result by hand**, remove
-`runs2.d/<xx>/<sha>.ndjson` and `logs2.d/<xx>/<sha>.log`;
-then the scheduled backstop re-derives both from the fresh status,
+**Dropping a result by hand is a store-side operation**,
+and only concerns a firing that is reading the store:
+remove `runs2.d/<xx>/<sha>.ndjson` and `logs2.d/<xx>/<sha>.log`,
+and the scheduled backstop re-derives both from the fresh status,
 provided the commit is still inside the store's 30-day window.
+A run's own results are immutable;
+there a newer run is the only thing that supersedes an older one.
 
 **Both mechanisms live in the tree at the commit under retry.**
 `each.yaml` and its scripts are read from the retried ref, not from `main`,
 so a series whose commits predate them retries by hand:
 push the branch, dispatch `each-rcc` on `retry-<S>-dev`
 with `force=true` and `max-commits=1`,
-and drop the stale record from `rcc` once the rerun is green —
+and — on the store path only — drop the stale record once the rerun is green,
 both copies of it, per above.
 A rebase onto a newer mainline (`series-rebase.md`)
 is what carries the automatic path into a forward series.
@@ -1004,13 +1114,16 @@ is what carries the automatic path into a forward series.
   a replay done by hand is checked the same way,
   because one that silently froze the counter
   looks exactly like one that did not.
-- Git alone is sufficient in principle:
-  even a rerun is one pushed ref —
+- **Every ref move is git alone.**
+  Even a rerun is one pushed ref —
   `retry-<S>-dev`, which asks for one commit to be judged again
   without rewriting anything —
-  and `each.yaml` schedules runs
-  for any commit in `<S>-green..tip` without a status.
-  When richer tools are available
-  (CI log retrieval, the Actions API),
-  use them — they shorten diagnosis —
-  but never depend on them.
+  and `each.yaml` plans runs
+  for any commit in `<S>-green..tip` that has no verdict.
+  Nothing a firing *writes* needs an API.
+- **What a firing reads comes from the runs, and falls back to git.**
+  The `each-rcc` run that decided a commit is the source of its verdict
+  and its log; the `rcc2` store is a copy, reachable with git alone,
+  for a firing that cannot read the runs.
+  Neither source may be *required*: a firing that has only one of them
+  still finishes, and says in its report which one it had.

--- a/handbook/operations/ci/per-commit/contract/README.md
+++ b/handbook/operations/ci/per-commit/contract/README.md
@@ -14,12 +14,24 @@ How the to-do list is computed is
   the record is keyed by SHA, so a rewritten commit has none.
   To re-judge one on the SHA it already has, push a `retry-<S>-dev`
   branch at it; to replan a whole range, dispatch with `force`.
-* **Results** — on the `rcc2` branch:
-  `runs2.d/<xx>/<sha>.ndjson` for the record,
-  `logs2.d/<xx>/<sha>.log` for the log.
-  One file per commit, and no aggregate;
-  what the store keeps and for how long is
-  [`store/`](/handbook/operations/ci/per-commit/store/README.md)'s.
+* **Results** — one record and, for a failure, one log per commit,
+  published in two places from the same bytes:
+  * in the **run** that decided the commit —
+    `parts/<sha>.ndjson` and `<sha>.log` in the leg's
+    `each-logs-<shard>-<attempt>` artifact (14 days),
+    and the same content inline in the leg's job log,
+    between that commit's `::group::<sha>` and its
+    `<sha>: <state> (<n>s, exit <rc>)` line;
+  * on the **`rcc2` branch** — `runs2.d/<xx>/<sha>.ndjson`
+    and `logs2.d/<xx>/<sha>.log`, one file per commit, no aggregate;
+    what the store keeps and for how long is
+    [`store/`](/handbook/operations/ci/per-commit/store/README.md)'s.
+
+  The store is a copy of the run's files, not a second computation,
+  so a consumer may read whichever it can reach.
+  A **run's conclusion is not a verdict**: a leg exits 0 whatever its commits
+  did, deliberately, so that a red commit reads as a result rather than as a
+  broken job.
 * **Gate applied per commit** — style, snapshots, roxygen, clean tree,
   `R CMD check`, pkgdown. The *order* is the contract;
   the list is `rcc-one.sh`'s `ALL_GATES`.
@@ -51,8 +63,18 @@ so the working tree keeps its diff and the `clean` gate still fails the commit.
 This is why the `build` job needs `contents: write`.
 
 The commit status is a display surface: nothing decides from it.
-Selection reads the verdict store on the `rcc2` branch instead.
+Selection reads the verdict store on the `rcc2` branch instead —
+CI-side, that is what "decided" means, in the planner
+([`each-plan.sh`](/scripts/each-plan.sh)), in a leg's resume check,
+and in the backstop, all of them through
+[`rcc-decided.sh`](/scripts/rcc-decided.sh).
 [`series-check.sh`](/scripts/series-check.sh) and
 [`series-advance.sh`](/scripts/series-advance.sh) read the per-commit record,
 so they see a verdict minutes after it happens rather than at the end of a run.
 [`rcc-logs.sh`](/scripts/rcc-logs.sh) writes records to the same place.
+
+The **series loop reads the runs first** and treats the store as its fallback
+([`.claude/skills/series-loop.md`](/.claude/skills/series-loop.md), stage 2):
+the store was built so that an agent with no API access could still read a
+verdict and a log, and one that can read the run reads the source instead.
+Nothing about the CI-side use above changes with it.

--- a/handbook/operations/ci/per-commit/operating/README.md
+++ b/handbook/operations/ci/per-commit/operating/README.md
@@ -51,7 +51,8 @@ which is enough to tell a compile error from a failing test.
 Setting the variable to `0` turns the excerpts off.
 
 The excerpt is not the record.
-The whole per-commit log still goes to `logs2.d/<xx>/<sha>.log` on `rcc2`,
+The whole per-commit log goes to `<sha>.log` in the leg's artifact —
+where the series loop reads it — and to `logs2.d/<xx>/<sha>.log` on `rcc2`,
 which is what [`series-check.sh`](/scripts/series-check.sh) classifies against;
 the summary is the fast path for a human.
 Two details make it work in practice:

--- a/handbook/operations/ci/per-commit/store/README.md
+++ b/handbook/operations/ci/per-commit/store/README.md
@@ -19,6 +19,17 @@ runs2.d/<xx>/<sha>.ndjson     the verdict, one line of JSON, ~2 KB
 logs2.d/<xx>/<sha>.log        the harvested output of a failure, ~1 MB
 ```
 
+**It is a copy, and that is what it is for.**
+A leg writes both files into its own artifact and publishes the same bytes
+here ([`contract/`](/handbook/operations/ci/per-commit/contract/README.md)),
+so the branch buys one thing the run does not:
+a reader with git and nothing else.
+That reader was the series loop, from a session with no API access.
+A firing that *can* read the run now reads it there
+and keeps this branch as its fallback
+([`.claude/skills/series-loop.md`](/.claude/skills/series-loop.md), stage 2);
+CI-side selection reads the store and only the store, unchanged.
+
 Two writers recording different commits touch different paths,
 so there is nothing to conflict on,
 and a loser of the ref race re-reads the tip and re-commits its own files.

--- a/handbook/operations/vendoring/series-loop/README.md
+++ b/handbook/operations/vendoring/series-loop/README.md
@@ -20,8 +20,12 @@ to do, and they run in this order:
 * **Vendor onto `<S>-build`** — extend the buffer with `vendor-one.sh`,
   fixing glue where the gate stops;
   red never blocks the buffer.
-* **Repair the oldest `<S>-dev` failure** — classify by what a
-  log positively contains: the tree's fault is folded into the
+* **Repair the oldest `<S>-dev` failure** — read each commit's verdict
+  and log from the `each-rcc` run that decided it, falling back to the
+  `rcc2` store when a run cannot be reached
+  ([`ci/per-commit/contract/`](/handbook/operations/ci/per-commit/contract/README.md)),
+  and classify by what a log positively contains:
+  the tree's fault is folded into the
   offending commit and the tail replayed;
   the infrastructure's fault is retried once via a `retry-` ref
   that also serves as the ledger.

--- a/handbook/operations/vendoring/troubleshooting/README.md
+++ b/handbook/operations/vendoring/troubleshooting/README.md
@@ -12,6 +12,11 @@ where a forward counterpart has caught up —
 from the harvest on the orphan `rcc2` branch,
 which stores one record per commit and failing commits'
 logs ([`ci/per-commit/store/`](/handbook/operations/ci/per-commit/store/README.md)).
+Those records are copies of what the `each-rcc` run that decided each
+commit already holds, so a reader with Actions access can go to the run
+instead — and the series loop does
+([`series-loop/`](/handbook/operations/vendoring/series-loop/README.md)).
+The store is what answers when the run cannot be reached.
 What is vendored where:
 
 ```sh

--- a/plan/PLAN-vendoring-simplification.md
+++ b/plan/PLAN-vendoring-simplification.md
@@ -214,7 +214,10 @@ written by the leg that decided the commit — with the run fan-in and the
 scheduled backstop recovering what a dead leg could not publish —
 and replaced only by an explicit retry.
 Git-native, batch-readable in one blobless fetch, reachable from a
-Claude web session without API access.
+Claude web session without API access —
+which is the assumption §10.6 now puts under test:
+a session that can read the `each-rcc` run reads the record and the log
+at their source, and the store is what it falls back to.
 Commit statuses become a **write-only display surface**;
 today they are still selection's input, which is what D1 changes.
 
@@ -675,3 +678,12 @@ Phase 2.
 5. **Review artifacts.** Should routine-generated review digests
    (like `main-dev-review.md`) land under `plan/` by convention,
    or in PR comments only?
+6. **Does the store still earn its keep?** It exists because an agent
+   firing could not read CI logs; that is no longer true where the
+   firing has Actions access, so `series-loop.md` now reads the run
+   and falls back to `rcc2`. Every firing records which path served.
+   If the fallback goes unused across a full cycle, the question is
+   what the store is still *for* — CI-side selection reads it too
+   (D1), so retiring it means replacing that read as well, and the
+   answer may be "keep it, cheaply" rather than "delete it".
+   Decide on the evidence, not on this paragraph.

--- a/scripts/series-check.sh
+++ b/scripts/series-check.sh
@@ -19,6 +19,16 @@
 # Classification is by positive evidence only (.claude/skills/series-loop.md);
 # "Job is waiting for a hosted runner" appears in every log and means nothing.
 #
+# The store is the *copy* of what an `each-rcc` leg wrote, not the source: the
+# leg writes the same record and log into its artifact and publishes them here
+# (scripts/each-shard.sh). A firing reads the run first and this branch only
+# when it cannot (.claude/skills/series-loop.md stage 2), so where a verdict
+# here and one read from a run disagree, the run is right. The ref geometry
+# below -- in flight, buffered, the retry ledger, a ready cutover -- does not
+# depend on the source at all, which is why this stays worth running either way.
+# Teaching it to read runs directly needs API access this script does not
+# assume; that is a change to make when a firing needs it, not before.
+#
 # The record decides before the log does, for the one thing the log cannot say:
 # a commit the shard's `timeout` killed at its budget (exit 124) stops mid-run
 # with its stage output still buffered, which reads exactly like a cancelled


### PR DESCRIPTION
The verdict store on the orphan `rcc2` branch exists to work around one problem: an agent firing could not read CI logs, so a leg's record and log were copied onto a branch that git alone can reach. Maintaining that branch is a lot of machinery — a per-commit publish, a run fan-in, a half-hourly backstop, a manual consolidation — for a problem that may have passed.

Where a firing has Actions access, the copy is no longer the only route to a result. A leg already writes both files into its `each-logs-<shard>-<attempt>` artifact and publishes the *same bytes* to the branch (`scripts/each-shard.sh`), and it prints each commit's whole log inline in its job log, between `::group::<sha>` and the closing `<sha>: <state> (<n>s, exit <rc>)` line. The run holds the source; the store holds the copy.

So stage 2 of `.claude/skills/series-loop.md` now reads the runs first, and consults `rcc2` only when a run cannot be read — no Actions access from the session, a run aged out, or a leg that died before uploading anything. Because the two sources are the same bytes, taking the fallback at any point cannot change a verdict, only its reach and its latency.

**What the run route adds beyond reachability.** A better answer to "no verdict yet": the run list distinguishes a queued or in-progress run, a commit a leg deferred at its deadline, and a commit nothing was ever triggered for — where an absent record cannot tell a stale harvest from a lost run. It also lets the skill name two traps the API route walks into: a leg exits 0 whatever its commits did, so a run's `conclusion` is not a verdict and its "failed jobs" are not where a red commit is; and a resumed leg's artifact covers only what that attempt rebuilt, the earlier attempt's artifact still counting.

**Nothing that writes changes.** The legs, the fan-in and `rcc-logs.yaml` keep filling the store, and CI-side selection (`each-plan.sh`, the leg's resume check, the backstop, all via `rcc-decided.sh`) still reads it and only it. `series-check.sh` keeps reading the store too — its ref geometry is source-independent, so it stays worth running every firing — and the skill states that where its verdict and a run disagree, the run is right. Teaching it the run route needs API access the script cannot assume; that is a change for a firing that needs it, which is what stage 7 is for.

Setup now establishes which path the firing is on, once, and the firing reports which one served. Retiring the store is a decision that wants firings which never had to open it, so `plan/PLAN-vendoring-simplification.md` records it as an open question (§10.6) rather than a plan, and marks the "reachable without API access" assumption in §3.1 as under test.

**Verified while writing this**: from this session, the GitHub Actions tooling lists a repository's workflow runs, returns job log content, lists a run's artifacts, and hands back an artifact download URL that `curl` fetches and `unzip` opens. That is the capability the primary path assumes; the fallback covers the sessions where it is absent.

Docs kept in step: the per-commit `contract/` page now states that results are published in both places from the same bytes and that a run's conclusion is not a verdict; `store/` says it is a copy and what that buys; `operating/` and the vendoring `troubleshooting/` and `series-loop/` pages point at the run first. Handbook link check and the generated `scripts/README.md` check both pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_012tt3NGj6usJ25safMzbHTp)_