### PR TITLE
fix(storage): Anchor the `~/.duckdb` consent default at `interactive()`

### DIFF
--- a/R/storage-home.R
+++ b/R/storage-home.R
@@ -168,10 +168,22 @@ check_home_arg <- function(home) {
 # askYesNo()'s TRUE / FALSE / NA (NA when the prompt is cancelled); the caller
 # treats anything but TRUE as a decline. Mockable seam: tests bind this directly
 # rather than driving the console.
+#
+# The default is anchored at `interactive()`, not the `is_interactive()` that
+# gates the prompt in resolve_storage_home(). The two can disagree: setting
+# `rlang_interactive = TRUE` (a common idiom in reverse dependencies' tests)
+# makes `is_interactive()` report an interactive session in a process where
+# `readline()` cannot reach a human -- it returns "" at once, and askYesNo()
+# takes that empty answer as its `default`. With a hardcoded TRUE the package
+# would then consent on the user's behalf and create `~/.duckdb` during
+# `R CMD check`, exactly what this policy exists to prevent. Anchoring the
+# default at `interactive()` makes the unanswerable prompt a "no", which falls
+# through to the per-session tempdir. A human at a console still gets the
+# convenient "yes" default.
 consent_to_create_home <- function(path) {
   utils::askYesNo(
     paste0("duckdb: create ", path, "?\n"),
-    default = TRUE
+    default = interactive()
   )
 }
 

--- a/handbook/usage/storage/README.md
+++ b/handbook/usage/storage/README.md
@@ -16,4 +16,9 @@ genuinely shared with the DuckDB CLI and the other clients,
 not a private copy.
 The home root is resolved afresh for every new database instance.
 
+The offer to create `~/.duckdb` defaults to `interactive()`,
+not to the `is_interactive()` that opens it:
+a prompt nobody can answer is a "no",
+so forcing `rlang_interactive` never creates the directory.
+
 *To deepen: absorb the resolution order from `?duckdb_storage`.*

--- a/tests/testthat/test-storage-home.R
+++ b/tests/testthat/test-storage-home.R
@@ -168,6 +168,51 @@ test_that("an explicit no proceeds with a tempdir, no error", {
   expect_false(dir.exists(shared))
 })
 
+# The two tests below drive the *un-mocked* prompt, so they need a process where
+# `readline()` cannot be answered -- which is every automated run, but not a
+# developer's `devtools::test()`. There the prompt would block on real input, so
+# they skip. That leaves the other half of `default = interactive()` -- a real
+# console, where the default is still "yes" -- outside the suite; verify it by
+# hand in an interactive R session, with the package attached and no ~/.duckdb:
+#
+#   dir.exists("~/.duckdb")            # FALSE to start
+#   con <- DBI::dbConnect(duckdb())
+#   #> duckdb: create /home/you/.duckdb? (Yes/no/cancel)
+#   # press Enter: the capitalized "Yes" is the default, ~/.duckdb is created
+
+test_that("consent_to_create_home declines when it cannot be answered", {
+  skip_if(interactive(), "the prompt would wait for real input")
+
+  # readline() returns "" at once here, so askYesNo() falls back to its default.
+  out <- capture.output(answer <- consent_to_create_home("/tmp/nope/.duckdb"))
+  expect_false(answer)
+  expect_match(out, "/tmp/nope/.duckdb", all = FALSE, fixed = TRUE)
+})
+
+test_that("a forced-interactive session does not get ~/.duckdb created for it", {
+  skip_if(interactive(), "the prompt would wait for real input")
+
+  # `rlang_interactive = TRUE` is a common idiom in reverse dependencies' test
+  # suites. It opens the prompt tier of resolve_storage_home() in a process that
+  # cannot answer, so the un-mocked seam must decline rather than consent --
+  # otherwise `R CMD check` writes to the user's home directory.
+  shared <- file.path(withr::local_tempdir(), ".duckdb")
+  withr::local_options(duckdb.home = NULL, rlang_interactive = TRUE)
+  withr::local_envvar(DUCKDB_R_HOME = NA)
+  storage_message_state[["home_prompt_declined"]] <- NULL
+  local_mocked_bindings(
+    duckdb_shared_home = function() shared,
+    session_temp_dir = function() "/tmp/sess"
+  )
+
+  # consent_to_create_home() is deliberately left un-mocked.
+  out <- capture.output(resolved <- resolve_storage_home())
+
+  expect_match(out, "create", all = FALSE)
+  expect_equal(resolved, list(root = session_home_path(), source = "session"))
+  expect_false(dir.exists(shared))
+})
+
 test_that("resolve_temp_directory redirects in-memory only, honors override", {
   local_mocked_bindings(session_temp_dir = function() "/tmp/sess")
   expect_equal(


### PR DESCRIPTION
`consent_to_create_home()` asked with `askYesNo(default = TRUE)`, and that default could be taken without anyone answering — creating `~/.duckdb` during a reverse dependency's `R CMD check`.

## The hole

The prompt is gated by `is_interactive()`, which honors the `rlang_interactive` option ahead of everything else — ahead of the `TESTTHAT` check that otherwise keeps test runs quiet. Setting that option is a common idiom in test suites, directly or via `rlang::local_interactive()`, and it is how a package tests its own interactive branches.

Forcing the option does not make `readline()` answerable. In a non-interactive process it returns `""` immediately, and `askYesNo()` treats an empty answer as its `default`:

```
$ Rscript -e 'utils::askYesNo("duckdb: create ~/.duckdb?", default = TRUE)'
interactive(): FALSE
askYesNo returned: TRUE
```

So `resolve_storage_home()` reached `dir.create(shared, recursive = TRUE)` with no human involved, and the prompt it printed went to a stdout nobody was reading. A reverse dependency that sets the option anywhere near a `duckdb()` call wrote to the user's home directory during checks — the one outcome this policy exists to prevent.

It only fires where `~/.duckdb` does not already exist, since an existing directory short-circuits the tier earlier. That is exactly a clean check machine.

## Found via querychat

`posit-dev/querychat`'s `tests/testthat/test-QueryChat.R` sets `withr::local_options(rlang_interactive = TRUE)` for one test, and builds a `DataFrameSource` fixture inside that scope. The fixture's default engine is duckdb, so `duckdb()` ran believing it could prompt. Reproduced against this repo's own sources with `HOME` pointed at an empty directory:

```
~/.duckdb exists before: FALSE
duckdb: create .../fakehome/.duckdb?
 (Yes/no/cancel)
duckdb: created .../fakehome/.duckdb.
resolved source: created
~/.duckdb exists after:  TRUE
```

querychat is worth fixing on its own side too, but the package should not be consenting on a user's behalf regardless of what a caller sets.

## The fix

`default = interactive()`. That splits the two notions apart: `is_interactive()` still decides whether to *offer*, while `interactive()` decides what an unanswerable prompt *means*. A session that only reports itself as interactive gets "no" and falls through to the per-session tempdir. A human at a console still gets the convenient "yes" default, unchanged — including the capitalized `Yes` in the prompt.

`?duckdb_storage` is untouched: it already says the offer is interactive-only, and which notion of interactive backs that is not a user's concern. The distinction is recorded in `handbook/usage/storage/`, four lines.

## Tests

Two new tests in `test-storage-home.R` cover the unanswerable half, one directly on the seam and one end to end through `resolve_storage_home()` with `consent_to_create_home()` deliberately left un-mocked. They assert the answer is "no", the resolved source is `session`, and the directory is not created.

Both skip under `devtools::test()`, where `interactive()` is `TRUE` and the prompt would block on real input. That leaves the console half — the default still being "yes" for a real human — outside the suite; the procedure for checking it by hand is written out above the tests.

Existing tests are unaffected: every one of them mocks the seam rather than driving the console. Suite on Linux, `DUCKDB_R_USE_SYSTEM_LIB=1`: `FAIL 0 | WARN 0 | SKIP 60 | PASS 1276`.