### PR TITLE
docs(types): State the UTF-8 repair that works, not the one that looks like it

### DIFF
--- a/handbook/usage/types/README.md
+++ b/handbook/usage/types/README.md
@@ -11,7 +11,17 @@ and [`src/transform.cpp`](/src/transform.cpp) (the way back).
   DuckDB checks string validity and rejects invalid UTF-8;
   this is deliberate engine behavior, not a bug
   ([#12](https://github.com/duckdb/duckdb-r/issues/12)).
-  Convert first: `iconv(x, to = "UTF-8")` or `enc2utf8()`.
+  R is the lenient side: it carries the bytes and prints them,
+  so `validUTF8()`, not the console, is what agrees with the engine.
+  Repairing means naming the encoding the bytes are actually in —
+  `iconv(x, from = "latin1", to = "UTF-8")` —
+  and `iconv()` yields `NA` for what it cannot convert
+  unless `sub =` says otherwise,
+  so a repair that fails shows up as missing data.
+  `enc2utf8()` re-encodes only what R has marked, and a string read
+  from a file whose encoding the reader was not told is marked
+  `"unknown"`: it passes through untouched, still invalid.
+  Which is why the cheapest place to fix this is the reader.
 * **Geometry comes back as WKB by default.**
   `dbConnect(geometry = )` chooses: `"blob"`, the default set in
   [`R/dbConnect__duckdb_driver.R`](/R/dbConnect__duckdb_driver.R),


### PR DESCRIPTION
One of the "close with a handbook entry" items in #2522.

`usage/types/` already said UTF-8 strictness is deliberate, but the recipe it offered — `iconv(x, to = "UTF-8")` or `enc2utf8()` — does nothing for the case the issue is about. Verified on duckdb 1.5.5: for `"Est\xe2ncia"`, `Encoding()` is `"unknown"`, so `enc2utf8()` returns it unchanged and still invalid; `read.csv()` on a latin1 file produces exactly that. Only `iconv(x, from = "latin1", to = "UTF-8")` repairs it, and `iconv()` signals failure as `NA` rather than an error.

So the leaf now names the source encoding, points at `validUTF8()` as the test that agrees with the engine (the console does not — R prints the bytes happily), and says the cheapest fix is at the reader, which is the answer given in the thread.

Thanks to ajdamico for the report and the reprex, and to eli-daniels for the note that already-corrupted data hits this too.

Reopen condition: a string that `validUTF8()` accepts but DuckDB still rejects — that would be an engine bug rather than an encoding one.

Closes #12.