### PR TITLE
docs(types): Give the geometry write side its route, not just its absence

### DIFF
--- a/handbook/usage/types/README.md
+++ b/handbook/usage/types/README.md
@@ -17,10 +17,15 @@ and [`src/transform.cpp`](/src/transform.cpp) (the way back).
   [`R/dbConnect__duckdb_driver.R`](/R/dbConnect__duckdb_driver.R),
   returns raw vectors; `"wk"` returns `wk_wkb`, which
   `sf::st_as_sfc()` converts onward.
-  There is no automatic conversion on the *write* side —
-  write WKB blobs and use `ST_GeomFromWKB()` in DuckDB;
-  the duckspatial and duckdbfs packages wrap this
-  ([#1670](https://github.com/duckdb/duckdb-r/issues/1670)).
+  There is no automatic conversion on the *write* side,
+  and an `sf` object handed to `dbWriteTable()` fails rather than
+  finding one ([#1670](https://github.com/duckdb/duckdb-r/issues/1670)).
+  The route is WKB in a `BLOB` column —
+  `sf::st_as_binary()` produces the raw vectors, and a list of them
+  writes as `BLOB` — with `ST_GeomFromWKB()` reading it back,
+  either per query or once, through
+  `ALTER TABLE … ALTER COLUMN … SET DATA TYPE GEOMETRY USING`.
+  The duckspatial and duckdbfs packages wrap this.
   Native `sf` support is roadmapped in
   [#117](https://github.com/duckdb/duckdb-r/issues/117).
 * **`NULL` arrives as logical `NA`** in untyped contexts;


### PR DESCRIPTION
One of the "close with a handbook entry" items in #2522.

`usage/types/` already said there is no automatic conversion on the write side and named `ST_GeomFromWKB()`, but not what produces the blobs, not where the conversion goes, and not what actually happens when you hand `dbWriteTable()` an `sf` object — which is the state the reader arrives in.

Verified on duckdb 1.5.5 with the spatial extension: a list-of-raw column writes as `BLOB`, `ST_GeomFromWKB()` reads it, and `ALTER TABLE … ALTER COLUMN … SET DATA TYPE GEOMETRY USING ST_GeomFromWKB(…)` converts the column in place.

Thanks to rruiz-s for the report, and to Cidree for posting the working recipe in the thread — this is that recipe, compressed to its shape.

Reopen condition: `dbWriteTable()` growing a geometry write path, which is the roadmap item #117, not this one.

Note: touches the same leaf as the PR for #12 (2551), in a different bullet; they should merge in either order.

Closes #1670.