### PR TITLE
docs(connections): State where the instance's settings bind, and both ways `dbConnect()` gets them wrong

### DIFF
--- a/handbook/usage/connections/README.md
+++ b/handbook/usage/connections/README.md
@@ -24,8 +24,15 @@ The load-bearing facts:
   a call that reuses a cached instance ignores them silently
   ([#83](https://github.com/duckdb/duckdb-r/issues/83),
   [#171](https://github.com/duckdb/duckdb-r/issues/171)).
+  `duckdb()` is therefore where they belong.
+  `dbConnect()` takes them too, merged over the driver's,
+  and they land exactly when that call is the one creating the
+  instance — which is why the same `config` argument takes effect
+  beside a `dbdir` naming another file, and is dropped without it.
   To apply new values to a file database,
   release the instance with `duckdb_shutdown()` first.
+  A setting the engine also accepts after startup, `memory_limit`
+  and `threads` among them, can be `SET` on the connection instead.
   Warning in exactly the surprise cases is planned
   ([#126](https://github.com/duckdb/duckdb-r/issues/126)).
 * `dbDisconnect()` closes one connection only;

--- a/handbook/usage/connections/README.md
+++ b/handbook/usage/connections/README.md
@@ -33,8 +33,11 @@ The load-bearing facts:
   release the instance with `duckdb_shutdown()` first.
   A setting the engine also accepts after startup, `memory_limit`
   and `threads` among them, can be `SET` on the connection instead.
-  Warning in exactly the surprise cases is planned
-  ([#126](https://github.com/duckdb/duckdb-r/issues/126)).
+  The silence is provisional in two steps:
+  failing loudly where these arguments collide is
+  [#2560](https://github.com/duckdb/duckdb-r/issues/2560),
+  and taking them out of `dbConnect()` altogether is
+  [#126](https://github.com/duckdb/duckdb-r/issues/126).
 * `dbDisconnect()` closes one connection only;
   its `shutdown` argument is unused.
   Instances are shut down when the driver is garbage-collected

--- a/handbook/usage/connections/README.md
+++ b/handbook/usage/connections/README.md
@@ -19,19 +19,23 @@ The load-bearing facts:
   so reuse is what lets repeated
   `dbConnect(duckdb(dbdir = "my.db"))` calls work at all.
   An in-memory database is never cached.
-* `config`, `read_only`, `home`, and `shared_home`
-  bind when the instance is *created*;
-  a call that reuses a cached instance ignores them silently
+* `dbdir`, `config`, `read_only`, `home`, and `shared_home`
+  all describe the *instance*, so they bind when it is created —
+  and `dbConnect()` accepts every one of them anyway,
+  in two ways, neither of them what a caller wants
   ([#83](https://github.com/duckdb/duckdb-r/issues/83),
   [#171](https://github.com/duckdb/duckdb-r/issues/171)).
-  `duckdb()` is therefore where they belong.
-  `dbConnect()` takes them too, merged over the driver's,
-  and they land exactly when that call is the one creating the
-  instance — which is why the same `config` argument takes effect
-  beside a `dbdir` naming another file, and is dropped without it.
+  `dbdir` wins: it overrides the path the driver was built with,
+  silently, and opens the connection on a driver of its own,
+  leaving the object passed in holding its own database.
+  The rest lose: merged over the driver's, they land only where that
+  call is the one creating the instance — which is why the same
+  `config` argument takes effect beside a `dbdir` naming another
+  file, and is dropped without it.
+  Naming all of them once, in `duckdb()`, is what avoids both.
   To apply new values to a file database,
-  release the instance with `duckdb_shutdown()` first.
-  A setting the engine also accepts after startup, `memory_limit`
+  release the instance with `duckdb_shutdown()` first;
+  a setting the engine also accepts after startup, `memory_limit`
   and `threads` among them, can be `SET` on the connection instead.
   The silence is provisional in two steps:
   failing loudly where these arguments collide is


### PR DESCRIPTION
Two of the "close with a handbook entry" items in #2522, which groups them on one line — and now folds #171's half in here too, so `usage/connections/` carries one rule for the whole argument family rather than two bullets with opposite shapes. PR 2554 is closed in favour of this one.

`usage/connections/` said `config` binds at instance creation and a reuse ignores it. True, but it does not let a reader predict their own call, and it said nothing at all about the other half: that `dbdir` on `dbConnect()` behaves in the opposite direction.

Verified on duckdb 1.5.5:

- `dbConnect(drv, config = list(memory_limit = "1GB"))` on a reused instance reports 12.5 GiB; the same call with `dbdir =` pointing elsewhere reports 953.6 MiB. That is nbc's three-way comparison in #83's thread, and the reason is that the differing path is what makes the call create an instance.
- `dbConnect(duckdb("a.db"), "b.db")` connects to `b.db`, while the driver object passed in still holds `a.db` and its own live instance — so a reader ends up holding a driver their connection is not on, which is what makes `duckdb_shutdown(drv)` on it look inert.
- `SET memory_limit` on the connection works either way, which is the workaround #83's reporter had already found.

The leaf now names `duckdb()` as where all five belong, states both failure directions, and marks the behaviour provisional against the two issues that end it: #2560 for failing loudly on a collision, #126 for taking the arguments out of `dbConnect()` altogether. Previously the warning was credited to #126 alone.

Thanks to SimonCoulombe and nbc on #83, and JosiahParry on #171 — the reprexes in both threads are what make the precedence visible rather than mysterious.

Reopen condition: #2560 or #126 landing, either of which replaces the documentation with a diagnostic.

Note: touches the same leaf as the PR for #179 (2555), in a different bullet; they should merge in either order.

Closes #83. Closes #171.