### PR TITLE
docs(connections): State that `dbConnect()`'s `dbdir` overrides the driver's

### DIFF
--- a/handbook/usage/connections/README.md
+++ b/handbook/usage/connections/README.md
@@ -13,6 +13,13 @@ The load-bearing facts:
 * `duckdb()` returns a driver that owns a *database instance*;
   `dbConnect()` opens connections to it,
   and many connections share one instance.
+* **The path can be named in two places, and `dbConnect()`'s wins.**
+  `dbConnect(drv, dbdir = )` overrides the path the driver was built
+  with, silently, and opens the connection on a driver of its own;
+  the object passed in keeps its own database
+  ([#171](https://github.com/duckdb/duckdb-r/issues/171)).
+  Naming the path once, in `duckdb()`, is what keeps the driver a
+  reader holds and the database they are querying the same thing.
 * For a file-based `dbdir` the instance is **cached**,
   keyed by the normalized path —
   DuckDB allows only one read-write handle per database file,


### PR DESCRIPTION
One of the "close with a handbook entry" items in #2522.

The issue asks why `dbdir` can be given in two places and which one wins. `usage/connections/` covered instance caching and `config` binding, but never stated the precedence or its consequence.

Verified on duckdb 1.5.5: `dbConnect(duckdb("a.db"), "b.db")` connects to `b.db`; the driver object passed in still holds `a.db` and its own live instance, and `con@driver` is a different object. So the reader ends up holding a driver that is not the one their connection is on — which is what makes `duckdb_shutdown(drv)` on it look like it does nothing.

Thanks @JosiahParry for the report and the three-line reprex that makes the precedence visible.

Reopen condition: #126, which is where the error-or-warning this issue asks for would land; documenting the precedence is not the same as removing it.

Note: touches the same leaf as the PRs for #83 and #179, in different bullets; they should merge in either order.

Closes #171.

---
_Generated by [Claude Code](https://claude.ai/code/session_018Q8xAHiMNanPzMPqiL6njb)_