### PR TITLE
docs(statements): Move the multi-statement prepare rule to the leaf that owns it

### DIFF
--- a/handbook/usage/connections/README.md
+++ b/handbook/usage/connections/README.md
@@ -32,16 +32,6 @@ The load-bearing facts:
   its `shutdown` argument is unused.
   Instances are shut down when the driver is garbage-collected
   or the session ends.
-* In a multi-statement string,
-  everything before the final statement executes at prepare time,
-  and `?` placeholders bind only in the last statement
-  ([#179](https://github.com/duckdb/duckdb-r/issues/179)).
-  DBI's `immediate = TRUE` is no way around this and no way to opt out:
-  the driver has no unprepared path — every route reaches
-  [`src/statement.cpp`](/src/statement.cpp)'s prepare, which is where the
-  earlier statements run — and the argument lands in `...` unread,
-  which it will stop doing
-  ([#2498](https://github.com/duckdb/duckdb-r/issues/2498)).
 
 *To deepen: absorb the instance and caching section of `?duckdb`;
 drain [#172](https://github.com/duckdb/duckdb-r/issues/172),

--- a/handbook/usage/statements/README.md
+++ b/handbook/usage/statements/README.md
@@ -16,7 +16,7 @@ A reader asking "does `dbAppendTable()` work here" answers it by
 finding the file, not by consulting an inventory that can go stale.
 
 The departures from that baseline are what this leaf owns.
-The one already stated:
+One so far:
 
 * In a multi-statement string,
   everything before the final statement executes at prepare time,

--- a/handbook/usage/statements/README.md
+++ b/handbook/usage/statements/README.md
@@ -15,11 +15,23 @@ so `R/` is the list
 A reader asking "does `dbAppendTable()` work here" answers it by
 finding the file, not by consulting an inventory that can go stale.
 
-What this leaf will own is where DuckDB departs from the DBI baseline —
-what a transaction does to an in-flight result, what `dbWriteTable()`
-does about types it cannot round-trip, and which identifiers need
-quoting the engine would otherwise fold.
+The departures from that baseline are what this leaf owns.
+The one already stated:
 
-*To deepen: state the departures from the DBI baseline for
-transactions, table writes, and quoting, each with the test that
-pins it.*
+* In a multi-statement string,
+  everything before the final statement executes at prepare time,
+  and `?` placeholders bind only in the last statement
+  ([#179](https://github.com/duckdb/duckdb-r/issues/179)).
+  DBI's `immediate = TRUE` is no way around this and no way to opt out:
+  the driver has no unprepared path — every route reaches
+  [`src/statement.cpp`](/src/statement.cpp)'s prepare, which is where the
+  earlier statements run — and the argument lands in `...` unread,
+  which it will stop doing
+  ([#2498](https://github.com/duckdb/duckdb-r/issues/2498)).
+  One statement per call is the way to keep execution where the
+  caller put it.
+
+*To deepen: state the remaining departures — what a transaction does to
+an in-flight result, what `dbWriteTable()` does about types it cannot
+round-trip, and which identifiers need quoting the engine would
+otherwise fold — each with the test that pins it.*


### PR DESCRIPTION
One of the "close with a handbook entry" items in #2522, which names `usage/statements/` as the owner.

The fact was already written, but in `usage/connections/`, whose scope is instances, their caching, and shutdown. Where a `?` binds and when the earlier statements of a multi-statement string run is a statement fact. Moving it also gives `statements/` its first stated departure from the DBI baseline — the thing that leaf said it would own — so its "to deepen" note now lists only what is still missing.

Re-verified on duckdb 1.5.5 before moving it: `?` in the last statement binds; `?` in the first fails with "Values were not provided"; and after merely preparing `"insert into probe values (1); select 1"`, `probe` holds a row. Text unchanged apart from one added sentence naming the way out (one statement per call).

Thanks to ggrothendieck for the report — the two-case reprex is what makes the rule visible rather than mysterious.

Reopen condition: #2498, which will make `immediate =` a read argument rather than one silently absorbed by `...`.

Note: touches the same leaf as the PR for #83 and #171 (2553), in a different bullet; they should merge in either order.

Closes #179.