### PR TITLE
docs(data-import): Say what a virtual `filename` column changes

### DIFF
--- a/handbook/usage/data-import/README.md
+++ b/handbook/usage/data-import/README.md
@@ -22,6 +22,11 @@ and reading many files at once.
   exposes them to dplyr —
   that, not the wrapper, is the supported way to a `filename`
   column or many-file reads today.
+  Since DuckDB 1.3 `filename` is a *virtual* column:
+  selecting it by name works with no option set at all,
+  and `filename = true` only promotes it into `SELECT *`.
+  A wrapper that forwards nothing therefore withholds less than it
+  looks like — what it withholds is the column in `SELECT *`.
 * **Out:** `COPY ... TO 'file.parquet'` in SQL;
   writing from dplyr pipelines is duckplyr's `compute_parquet()`.
 * **R data frames** need no import at all:


### PR DESCRIPTION
One of the "close with a handbook entry" items in #2522.

`usage/data-import/` already named `tbl_function(con, "read_csv('*.csv', filename = true)")` as the route, and #1511 as the rewrite that retires the wrapper's sniffing. What it did not answer is the question the reporter actually raised in the thread — "I am not sure what to make of the 'virtual column' detail."

Verified on duckdb 1.5.5: `SELECT filename FROM read_csv(…)` returns the path with no option set, `SELECT *` omits it, and `filename = true` is what puts it into `SELECT *`. So the gap in `duckdb_read_csv()` is narrower than it reads: the data is reachable today, just not through the wrapper.

Thanks to tjmahr for the report — the side-by-side reprex is what makes the difference between the two routes legible.

Reopen condition: #1511, the rewrite on the engine's native `read_csv`, which is where the wrapper stops needing a workaround at all.

Closes #1733.