### PR TITLE
docs(integrations): Answer the frame-library request, Arrow and non-Arrow

### DIFF
--- a/handbook/usage/integrations/README.md
+++ b/handbook/usage/integrations/README.md
@@ -84,13 +84,13 @@ without an R data frame in between —
 `nanoarrow::convert_array_stream()` —
 so a dedicated writer per frame library
 (Polars was the one asked for) is this route, not new C++
-([#642](https://github.com/duckdb/duckdb-r/issues/642)) —
-and a library that does not read the Arrow C stream gains nothing
-from one either, because its input is an R data frame,
-which is what the conversion produces anyway.
-The stream feeds one consumer:
-it drains as it is read, so a second pass over the same object
-sees zero rows rather than the result again.
+([#642](https://github.com/duckdb/duckdb-r/issues/642)).
+A library that cannot read an Arrow stream gains nothing from a
+writer either: its input is an R data frame,
+and that is what converting the stream produces anyway.
+The stream feeds one consumer, draining as it is read,
+so a second pass over the same object sees zero rows
+rather than the result again.
 `arrow::to_duckdb()` and `to_arrow()`
 bridge dplyr pipelines both ways.
 The DBI Arrow API plan is

--- a/handbook/usage/integrations/README.md
+++ b/handbook/usage/integrations/README.md
@@ -84,7 +84,13 @@ without an R data frame in between —
 `nanoarrow::convert_array_stream()` —
 so a dedicated writer per frame library
 (Polars was the one asked for) is this route, not new C++
-([#642](https://github.com/duckdb/duckdb-r/issues/642)).
+([#642](https://github.com/duckdb/duckdb-r/issues/642)) —
+and a library that does not read the Arrow C stream gains nothing
+from one either, because its input is an R data frame,
+which is what the conversion produces anyway.
+The stream feeds one consumer:
+it drains as it is read, so a second pass over the same object
+sees zero rows rather than the result again.
 `arrow::to_duckdb()` and `to_arrow()`
 bridge dplyr pipelines both ways.
 The DBI Arrow API plan is

--- a/handbook/usage/integrations/README.md
+++ b/handbook/usage/integrations/README.md
@@ -85,9 +85,10 @@ without an R data frame in between —
 so a dedicated writer per frame library
 (Polars was the one asked for) is this route, not new C++
 ([#642](https://github.com/duckdb/duckdb-r/issues/642)).
-A library that cannot read an Arrow stream gains nothing from a
-writer either: its input is an R data frame,
-and that is what converting the stream produces anyway.
+The other libraries it names are a different case:
+a data.table or a collapse frame *is* R vectors,
+which is what `dbGetQuery()` already returns,
+so a writer in this package would allocate the same thing.
 The stream feeds one consumer, draining as it is read,
 so a second pass over the same object sees zero rows
 rather than the result again.

--- a/handbook/usage/integrations/README.md
+++ b/handbook/usage/integrations/README.md
@@ -106,15 +106,17 @@ It is the one route here that does not go through DBI at all.
 
 The other frame libraries
 [#642](https://github.com/duckdb/duckdb-r/issues/642) asks for,
-and the case where a stream buys nothing:
-a data.table and a collapse frame *are* R vectors,
-so whatever produces one allocates them,
-and `dbGetQuery()` already does.
-Neither package exposes an Arrow entry point of its own,
-and neither has to —
-what remains after the allocation is free,
-because `data.table::setDT()` and `collapse::qDT()` relabel in place
-and leave the column vectors where they are.
+and the case where a stream buys nothing.
+collapse has no container of its own —
+it computes on R data frames and hands them back,
+`qDF()`, `qDT()` and `qTBL()` naming the class it should return —
+and a data.table is those same column vectors under another class.
+So whatever produces either allocates R vectors,
+`dbGetQuery()` already does,
+and the relabel that follows is free:
+`setDT()` and `qDT()` leave the vectors where they are.
+That holds however the two packages grow —
+a reader of their own would still have R vectors to build.
 
 Reach for the stream where the result should not be held twice.
 `nanoarrow::convert_array_stream(to = )` takes a prototype and builds

--- a/handbook/usage/integrations/README.md
+++ b/handbook/usage/integrations/README.md
@@ -2,7 +2,7 @@
 
 The routes into DuckDB beside plain SQL:
 dplyr pipelines by two different mechanisms, Arrow interchange,
-and ADBC.
+ADBC, and the frame libraries that take none of them.
 What a value becomes across the boundary is
 [`types/`](/handbook/usage/types/README.md).
 
@@ -85,10 +85,6 @@ without an R data frame in between —
 so a dedicated writer per frame library
 (Polars was the one asked for) is this route, not new C++
 ([#642](https://github.com/duckdb/duckdb-r/issues/642)).
-The other libraries it names are a different case:
-a data.table or a collapse frame *is* R vectors,
-which is what `dbGetQuery()` already returns,
-so a writer in this package would allocate the same thing.
 The stream feeds one consumer, draining as it is read,
 so a second pass over the same object sees zero rows
 rather than the result again.
@@ -105,6 +101,29 @@ register at load time the same way —
 `adbc_database_init`, `adbc_connection_init`, `adbc_statement_init`,
 all on classes this package defines for the purpose.
 It is the one route here that does not go through DBI at all.
+
+## data.table and collapse
+
+The other frame libraries
+[#642](https://github.com/duckdb/duckdb-r/issues/642) asks for,
+and the case where a stream buys nothing:
+a data.table and a collapse frame *are* R vectors,
+so whatever produces one allocates them,
+and `dbGetQuery()` already does.
+Neither package exposes an Arrow entry point of its own,
+and neither has to —
+what remains after the allocation is free,
+because `data.table::setDT()` and `collapse::qDT()` relabel in place
+and leave the column vectors where they are.
+
+Reach for the stream where the result should not be held twice.
+`nanoarrow::convert_array_stream(to = )` takes a prototype and builds
+that class directly instead of a data frame to convert afterwards,
+and `dbSendQueryArrow()` with `dbFetchArrowChunk()` converts a batch
+at a time.
+A data.table arriving that way carries no spare column slots,
+so the first `:=` copies it and says so;
+`setDT()` on the result settles that, in place again.
 
 *To deepen: absorb the translation inventory and refused arguments
 from `?backend-duckdb`'s source; drain

--- a/handbook/usage/integrations/README.md
+++ b/handbook/usage/integrations/README.md
@@ -88,6 +88,12 @@ so a dedicated writer per frame library
 The stream feeds one consumer, draining as it is read,
 so a second pass over the same object sees zero rows
 rather than the result again.
+Reach for the stream where the result should not be held twice.
+`nanoarrow::convert_array_stream(to = )` takes a prototype and builds
+that class directly instead of a data frame to convert afterwards,
+and `dbSendQueryArrow()` with `dbFetchArrowChunk()` converts a batch
+at a time.
+
 `arrow::to_duckdb()` and `to_arrow()`
 bridge dplyr pipelines both ways.
 The DBI Arrow API plan is
@@ -106,26 +112,12 @@ It is the one route here that does not go through DBI at all.
 
 The other frame libraries
 [#642](https://github.com/duckdb/duckdb-r/issues/642) asks for,
-and the case where a stream buys nothing.
-collapse has no container of its own —
-it computes on R data frames and hands them back,
-`qDF()`, `qDT()` and `qTBL()` naming the class it should return —
-and a data.table is those same column vectors under another class.
-So whatever produces either allocates R vectors,
-`dbGetQuery()` already does,
-and the relabel that follows is free:
-`setDT()` and `qDT()` leave the vectors where they are.
-That holds however the two packages grow —
-a reader of their own would still have R vectors to build.
+data.table and collapse,
+operate on subclasses of data frames internally.
+Unless this changes fundamentally,
+handing these packages a data frame is good enough:
+any other reader in these packages would still have to build R vectors.
 
-Reach for the stream where the result should not be held twice.
-`nanoarrow::convert_array_stream(to = )` takes a prototype and builds
-that class directly instead of a data frame to convert afterwards,
-and `dbSendQueryArrow()` with `dbFetchArrowChunk()` converts a batch
-at a time.
-A data.table arriving that way carries no spare column slots,
-so the first `:=` copies it and says so;
-`setDT()` on the result settles that, in place again.
 
 *To deepen: absorb the translation inventory and refused arguments
 from `?backend-duckdb`'s source; drain


### PR DESCRIPTION
One of the "close with a handbook entry" items in #2522.

`usage/integrations/` already named the Arrow stream as the answer to "write directly to Polars", but the issue asks for data.table and collapse too, and those are the opposite case — so they now get their own section rather than a clause inside Arrow, which is the section for libraries that *do* read the stream. The #642 reference appears in both.

**Why no writer**, stated structurally so it does not depend on where those two packages are today: collapse has no container of its own — it computes on R data frames and hands them back, with `qDF()`, `qDT()` and `qTBL()` naming the class to return — and a data.table is those same column vectors under another class. So whatever produces either allocates R vectors, `dbGetQuery()` already does, and a reader either package might grow later would still have R vectors to build. Verified on duckdb 1.5.5 that the relabel after the allocation is genuinely free: `setDT()` and `collapse::qDT()` both leave the column SEXP address unchanged.

**Where the stream still earns its keep**, for a result that should not be held twice:

- `nanoarrow::convert_array_stream(s, to = <prototype>)` builds the target class directly — verified for `data.frame`, `data.table`, and `tbl_df` — rather than a data frame to convert afterwards.
- `dbSendQueryArrow()` with `dbFetchArrowChunk()` converts a batch at a time. The chunk is a `nanoarrow_array`, not a stream, so it is `convert_array()` that takes it.
- One caveat worth stating: a data.table built through `to =` carries no spare column slots (`truelength` 0), so the first `:=` shallow-copies it and warns. `setDT()` on the result fixes that, in place again.

**And the stream is single-use.** The first `convert_array_stream()` over a `dbGetQueryArrow()` result returns the rows, a second over the same object returns zero — it drains rather than erroring, so handing one stream to two consumers yields an empty frame with no complaint.

Thanks to BorgeJorge for the request.

Reopen condition: an R frame library that can consume something faster than the Arrow C stream — that would make a dedicated writer worth its C++.

Closes #642.