### PR TITLE
fix(flavor): Catch a renamed file that reached a series under its mainline name

### DIFF
--- a/.github/workflows/custom/after-install/action.yml
+++ b/.github/workflows/custom/after-install/action.yml
@@ -87,4 +87,13 @@ runs:
           )
         }
         writeLines("No hard-coded package name outside scripts/flavor.patch.")
+        unflavored <- flavor_unflavored_paths(".")
+        if (length(unflavored) > 0) {
+          writeLines(unflavored)
+          stop(
+            "A file scripts/flavor.patch renames still carries the mainline ",
+            "name; see scripts/flavor-package-name.R for how to resolve this."
+          )
+        }
+        writeLines("No file left under the mainline name.")
       shell: Rscript {0}

--- a/scripts/flavor-package-name.R
+++ b/scripts/flavor-package-name.R
@@ -99,3 +99,35 @@ flavor_package_name_offenders <- function(root = ".") {
 
   offenders
 }
+
+# The paths `scripts/flavor.patch` renames, as mainline names relative to the
+# package root. A file the patch renames carries the package name in its *name*
+# rather than in its contents, so the scan above cannot see it.
+flavor_renamed_paths <- function(patch_file) {
+  lines <- readLines(patch_file, warn = FALSE)
+  sub("^rename from ", "", lines[grepl("^rename from ", lines)])
+}
+
+# Every file that still carries the mainline name on a flavored checkout.
+#
+# `scripts/flavor.patch` renames these, and it runs once, when a series is
+# seeded. A commit that adds such a file on `main` and is then ported onto a
+# flavored series (.claude/skills/series-loop.md stage 4) brings the mainline
+# name with it, and nothing rewrites it afterwards. The file is then simply not
+# read: `src/duckdb-win.def` on a `duckdb.dev` build is not the export list R's
+# `share/make/winshlib.mk` looks for, so the Windows link falls back to
+# generating one from every object and overruns the PE export table.
+#
+# Empty on the mainline flavor, where the mainline name is the right one.
+flavor_unflavored_paths <- function(root = ".") {
+  package <- sub("^Package: +", "", grep(
+    "^Package: ", readLines(file.path(root, "DESCRIPTION"), warn = FALSE),
+    value = TRUE
+  )[[1]])
+  if (package == "duckdb") {
+    return(character())
+  }
+
+  renamed <- flavor_renamed_paths(file.path(root, "scripts", "flavor.patch"))
+  renamed[file.exists(file.path(root, renamed))]
+}

--- a/tests/testthat/test-flavor-package-name.R
+++ b/tests/testthat/test-flavor-package-name.R
@@ -22,3 +22,12 @@ test_that("the package name is hard-coded only where scripts/flavor.patch rewrit
 
   expect_equal(flavor_package_name_offenders(root), character())
 })
+
+test_that("no file still carries the mainline name that scripts/flavor.patch renames", {
+  root <- lts_source_root()
+  skip_if(is.na(root), "Not running from the package source tree.")
+
+  source(file.path(root, "scripts", "flavor-package-name.R"), local = TRUE)
+
+  expect_equal(flavor_unflavored_paths(root), character())
+})


### PR DESCRIPTION
`scripts/flavor.patch` renames three files whose *names* carry the package name — `src/duckdb-win.def`, `inst/include/duckdb_types.hpp`, `man/duckdb-package.Rd` — and it runs once, when a series is seeded. A commit that adds such a file on `main` and is then ported onto a flavored series (series-loop stage 4) brings the mainline name with it, and nothing rewrites it afterwards.

That is what happened to `src/duckdb-win.def`. `fix(windows): Export only the registration entry point from the DLL` landed on `main` and was ported onto `main-dev` as `d72d16f67` — under the mainline name. The DLL base on that series is `duckdb.dev`, R's `share/make/winshlib.mk` looks for `<dll base>-win.def`, so the file was never read and the export list went on being generated by `nm` over the whole vendored engine. Today's r-universe build of `duckdb.dev` fails on `windows-devel-arm64` and `windows-release-arm64` with

```
ld.lld: error: too many exported symbols (got 68856, max 65535)
Error: package or namespace load failed for 'duckdb.dev' in library.dynam(...):
 DLL 'duckdb.dev' not found: maybe not installed for this architecture?
```

— the exact failure the ported fix exists to prevent. Log: https://duckdb.r-universe.dev/api/actions/logs/92898522488. `v1.5-variegata-dev` carries the same unflavored file today and is only green because that engine's generated export list is still under the limit.

`flavor_package_name_offenders()` cannot see this, because it scans file *contents* and here the *name* is the problem. This PR adds `flavor_unflavored_paths()`, which reads the `rename from` lines out of `scripts/flavor.patch` and reports any of them that still exists on a checkout whose `Package:` is not `duckdb`.

The check is inert on `main` — the mainline flavor, where these names are the right ones — and fires on the series, which is where the port lands. It is wired into both `tests/testthat/test-flavor-package-name.R` and the `after-install` scan, for the same reason the existing check needs both: `R CMD check` runs the tests from a built tarball that has neither the sources nor `scripts/`.

Verified against the real trees: empty on `main` and on the repaired `main-dev`, and it reports `src/duckdb-win.def` on `v1.5-variegata-dev`.

The series-side repair is separate and already pushed (`main-dev` 9bf928782, renaming the file to `src/duckdb.dev-win.def` byte-identically to what `main-fwd-dev` already carries).

---
_Generated by [Claude Code](https://claude.ai/code/session_01JDf6kjC9yau7Fw9pKSye9R)_