### PR TITLE
docs(handbook): Record the untyped-`NULL` mapping as designed, declining the flip to logical `NA`

### DIFF
--- a/handbook/testing/revdep/README.md
+++ b/handbook/testing/revdep/README.md
@@ -32,7 +32,7 @@ When the runs happen — an early pass and a go/no-go gate before the
 tag — is
 [`operations/releases/process/`](/handbook/operations/releases/process/README.md)'s.
 duckplyr, the closest downstream, also gates individual changes
-(for instance the typed-`NA` flip,
+(for instance flipping untyped `NULL` results to logical `NA`,
 [#155](https://github.com/duckdb/duckdb-r/issues/155)).
 
 *To deepen: state what blocks a release versus what is noted and

--- a/handbook/testing/revdep/README.md
+++ b/handbook/testing/revdep/README.md
@@ -32,8 +32,8 @@ When the runs happen — an early pass and a go/no-go gate before the
 tag — is
 [`operations/releases/process/`](/handbook/operations/releases/process/README.md)'s.
 duckplyr, the closest downstream, also gates individual changes
-(for instance flipping untyped `NULL` results to logical `NA`,
-[#155](https://github.com/duckdb/duckdb-r/issues/155)).
+(for instance the untyped-`NULL` flip,
+declined in [#155](https://github.com/duckdb/duckdb-r/issues/155)).
 
 *To deepen: state what blocks a release versus what is noted and
 waved through, from the last release's record.*

--- a/handbook/usage/relational/README.md
+++ b/handbook/usage/relational/README.md
@@ -28,6 +28,19 @@ Expressions are built separately (`expr_reference()`, `expr_constant()`,
 so a caller assembles a tree rather than splicing text,
 and the engine never parses a string the caller built.
 
+**Untyped `NULL` constants.**
+`expr_constant(NA)` builds an untyped `NULL`
+([#143](https://github.com/duckdb/duckdb-r/pull/143)),
+so a nested `NA` adopts its siblings' type —
+`greatest(NA, a)` binds to `a`'s.
+One that survives to a result column materializes as `NA_integer_`,
+the engine's own `SELECT NULL` behavior.
+Mapping that to logical `NA` was declined, closing
+[#155](https://github.com/duckdb/duckdb-r/issues/155):
+the exchange is engine-side,
+flipping it would change SQL results package-wide,
+and duckplyr casts a typed `NULL` where it needs one.
+
 **How a result comes back.**
 `rel_to_altrep()` wraps an unexecuted relation as a data frame:
 nothing runs until R touches the values, materialization is budgeted by

--- a/handbook/usage/types/README.md
+++ b/handbook/usage/types/README.md
@@ -24,41 +24,13 @@ and [`src/transform.cpp`](/src/transform.cpp) (the way back).
   Native `sf` support is roadmapped in
   [#117](https://github.com/duckdb/duckdb-r/issues/117).
 * **An untyped `NULL` comes back as `NA_integer_`,**
-  not logical `NA` — verified on a v1.5.5 vendored build.
-  A logical `NA` crosses into DuckDB as one of two things.
-  Typed contexts — a scanned logical column, a bound `NA`
-  parameter — use a `BOOLEAN` NULL and round-trip as logical `NA`
-  (`RApiTypes::SexpToValue()` in [`src/utils.cpp`](/src/utils.cpp),
-  `typed_logical_null = true`).
-  `expr_constant(NA)` instead deliberately produces an *untyped*
-  NULL (`SQLNULL`,
-  [#143](https://github.com/duckdb/duckdb-r/pull/143)):
-  `SQLNULL` implicitly casts to anything,
-  so a nested `NA` adopts its siblings' type —
-  `greatest(NA, a)` with `a` `DOUBLE` binds `DOUBLE` —
-  where a `BOOLEAN` constant could not
-  (no implicit cast from `BOOLEAN` to numeric).
-  The glitch is at top level:
-  the engine exchanges an untyped `NULL` that survives to a result
-  column to `INTEGER` (`ExpressionBinder::ExchangeNullType()` in
-  [`src/duckdb/src/planner/expression_binder.cpp`](/src/duckdb/src/planner/expression_binder.cpp)),
-  so a projected `expr_constant(NA)` and SQL `SELECT NULL`
-  both return `NA_integer_`.
-  Flipping that to logical `NA` is decided and pending
-  ([#155](https://github.com/duckdb/duckdb-r/issues/155));
-  the candidate fix is the engine-side exchange to `BOOLEAN`
-  ([#156](https://github.com/duckdb/duckdb-r/pull/156)),
-  held because it changes SQL-level results for every user
-  and is therefore gated on the duckplyr revdep check
-  ([`testing/revdep/`](/handbook/testing/revdep/README.md)).
-  duckplyr does not wait for it:
-  its translation emits a `___null()` macro,
-  `CAST(NULL AS BOOLEAN)`, for a top-level bare `NA`,
-  and keeps `expr_constant(NA)` for nested ones.
-  A `SQLNULL` column itself never reaches the R conversion layer
-  today; if the engine ever lets one through,
-  `duckdb_r_typeof()` in [`src/transform.cpp`](/src/transform.cpp)
-  has no case for it and errors.
+  matching the engine's own `SELECT NULL`;
+  mapping it to logical `NA` instead was declined
+  ([#155](https://github.com/duckdb/duckdb-r/issues/155)).
+  A typed `NULL` — a scanned logical column, a bound `NA`
+  parameter — round-trips as logical `NA`,
+  and the `expr_constant(NA)` corner is
+  [`relational/`](/handbook/usage/relational/README.md)'s.
 * **MAP columns** round-trip since 1.5.4
   ([#200](https://github.com/duckdb/duckdb-r/issues/200)),
   but writing one back without `field.types` needs

--- a/handbook/usage/types/README.md
+++ b/handbook/usage/types/README.md
@@ -23,9 +23,42 @@ and [`src/transform.cpp`](/src/transform.cpp) (the way back).
   ([#1670](https://github.com/duckdb/duckdb-r/issues/1670)).
   Native `sf` support is roadmapped in
   [#117](https://github.com/duckdb/duckdb-r/issues/117).
-* **`NULL` arrives as logical `NA`** in untyped contexts;
-  making the relational API return typed `NA`s instead is decided
-  and pending ([#155](https://github.com/duckdb/duckdb-r/issues/155)).
+* **An untyped `NULL` comes back as `NA_integer_`,**
+  not logical `NA` — verified on a v1.5.5 vendored build.
+  A logical `NA` crosses into DuckDB as one of two things.
+  Typed contexts — a scanned logical column, a bound `NA`
+  parameter — use a `BOOLEAN` NULL and round-trip as logical `NA`
+  (`RApiTypes::SexpToValue()` in [`src/utils.cpp`](/src/utils.cpp),
+  `typed_logical_null = true`).
+  `expr_constant(NA)` instead deliberately produces an *untyped*
+  NULL (`SQLNULL`,
+  [#143](https://github.com/duckdb/duckdb-r/pull/143)):
+  `SQLNULL` implicitly casts to anything,
+  so a nested `NA` adopts its siblings' type —
+  `greatest(NA, a)` with `a` `DOUBLE` binds `DOUBLE` —
+  where a `BOOLEAN` constant could not
+  (no implicit cast from `BOOLEAN` to numeric).
+  The glitch is at top level:
+  the engine exchanges an untyped `NULL` that survives to a result
+  column to `INTEGER` (`ExpressionBinder::ExchangeNullType()` in
+  [`src/duckdb/src/planner/expression_binder.cpp`](/src/duckdb/src/planner/expression_binder.cpp)),
+  so a projected `expr_constant(NA)` and SQL `SELECT NULL`
+  both return `NA_integer_`.
+  Flipping that to logical `NA` is decided and pending
+  ([#155](https://github.com/duckdb/duckdb-r/issues/155));
+  the candidate fix is the engine-side exchange to `BOOLEAN`
+  ([#156](https://github.com/duckdb/duckdb-r/pull/156)),
+  held because it changes SQL-level results for every user
+  and is therefore gated on the duckplyr revdep check
+  ([`testing/revdep/`](/handbook/testing/revdep/README.md)).
+  duckplyr does not wait for it:
+  its translation emits a `___null()` macro,
+  `CAST(NULL AS BOOLEAN)`, for a top-level bare `NA`,
+  and keeps `expr_constant(NA)` for nested ones.
+  A `SQLNULL` column itself never reaches the R conversion layer
+  today; if the engine ever lets one through,
+  `duckdb_r_typeof()` in [`src/transform.cpp`](/src/transform.cpp)
+  has no case for it and errors.
 * **MAP columns** round-trip since 1.5.4
   ([#200](https://github.com/duckdb/duckdb-r/issues/200)),
   but writing one back without `field.types` needs


### PR DESCRIPTION
Closes #155.

The types leaf stated the inverse of actual behavior: an untyped `NULL` comes back as `NA_integer_`, not logical `NA` (verified on a v1.5.5 vendored build; detail in [the review comment](https://github.com/duckdb/duckdb-r/issues/155#issuecomment-5220188635)). This documents the behavior as designed and records the decision to decline the flip to logical `NA`, closing the issue.

- `handbook/usage/types/README.md`: one short bullet — an untyped `NULL` comes back as `NA_integer_`, matching the engine's own `SELECT NULL`; the flip was declined (#155); typed `NULL`s (scanned logical columns, bound `NA` parameters) round-trip as logical `NA`.
- `handbook/usage/relational/README.md`: a short note where `expr_constant()` lives — `expr_constant(NA)` builds an untyped `NULL` (#143) so nested `NA`s adopt their siblings' type; one that survives to a result column materializes as `NA_integer_`; the flip was declined because the exchange is engine-side, changing it would flip SQL results package-wide, and duckplyr casts a typed `NULL` where it needs one.
- `handbook/testing/revdep/README.md`: names the declined flip as the example of a duckplyr-gated change.

Documentation only; no behavior changes. The handbook link-integrity and generated-index checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BCBYL4eN1YfNgoez8G2Gcw