### PR TITLE
fix(storage): Make temporary storage usable by default, with the CLI's semantics

### DIFF
--- a/R/Driver.R
+++ b/R/Driver.R
@@ -234,13 +234,6 @@ duckdb <- function(
       maybe_storage_location_message(resolved_home)
     }
   }
-  if (!("temp_directory" %in% names(config))) {
-    temp_directory <- resolve_temp_directory(dbdir)$directory
-    if (!is.null(temp_directory)) {
-      config[["temp_directory"]] <- temp_directory
-    }
-  }
-
   # When extensions are disallowed for this driver, also turn off automatic
   # extension install/load so a query cannot implicitly pull in a prebuilt
   # (libstdc++) extension and crash R (duckdb/duckdb-r#1107). Automatic loading
@@ -264,6 +257,26 @@ duckdb <- function(
     maybe_extensions_message()
   }
 
+  # Temporary storage stays on by default, with the CLI's semantics: an
+  # on-disk database keeps the engine's own `<dbdir>.tmp` default, and an
+  # in-memory database gets a per-instance directory under the session tempdir
+  # (the engine's own default, `.tmp` in the working directory, is not a place
+  # an R package should write). The resolved value goes into the startup
+  # config only, not into the driver's `config` slot: that slot seeds the
+  # instance re-created when `dbConnect()` is called with a different `dbdir`
+  # (see dbConnect__duckdb_driver), which must re-resolve for the new `dbdir`
+  # -- an on-disk database opened as `dbConnect(duckdb(), dbdir = ...)` would
+  # otherwise inherit the in-memory driver's spill path and never use
+  # `<dbdir>.tmp` (the duckdb/duckdb-r#1604 family). An explicit
+  # `temp_directory` in `config` is stored and honored as-is.
+  startup_config <- config
+  if (!("temp_directory" %in% names(config))) {
+    temp_directory <- resolve_temp_directory(dbdir)$directory
+    if (!is.null(temp_directory)) {
+      startup_config[["temp_directory"]] <- temp_directory
+    }
+  }
+
   # Always create new database for in-memory,
   # allows isolation and mixing different configs
   drv <- new(
@@ -272,7 +285,7 @@ duckdb <- function(
     database_ref = rethrow_rapi_startup(
       dbdir,
       read_only,
-      config,
+      startup_config,
       environment_scan,
       ax$allow
     ),

--- a/R/storage-home.R
+++ b/R/storage-home.R
@@ -1,4 +1,6 @@
 # Implementation of the storage-location policy documented in `?duckdb_storage`.
+# Explained in handbook/usage/storage/README.md, and for the temp/spill
+# resolvers at the bottom, handbook/usage/memory/README.md.
 # Extensions and stored secrets live under a single "home" directory that is
 # resolved afresh on every `duckdb()` call; the resolvers and the user-facing
 # status function build on the helpers below.

--- a/R/storage-home.R
+++ b/R/storage-home.R
@@ -226,22 +226,40 @@ temp_directory_override <- function() {
   NULL
 }
 
-# Resolve the temp/spill directory. For in-memory databases DuckDB would spill
-# to a `.tmp` directory in the working directory, so point it at a per-session
-# tempdir instead; for on-disk databases keep DuckDB's `<db>.tmp` default
-# (`directory` is NULL so the setting is left unset). Overridable.
+# Resolve the temp/spill directory. Temporary storage stays on by default, as
+# in the DuckDB CLI. For on-disk databases keep DuckDB's `<db>.tmp` default
+# (`directory` is NULL so the setting is left unset); for in-memory databases
+# DuckDB would spill to a `.tmp` directory in the working directory, so point
+# each instance at its own directory under the session tempdir instead.
+# Overridable; an override is passed through verbatim and never created here,
+# like an explicit `temp_directory` in the CLI.
 resolve_temp_directory <- function(dbdir) {
   override <- temp_directory_override()
   if (!is.null(override)) {
     return(override)
   }
   if (is_memory_dbdir(dbdir)) {
-    return(list(
-      directory = file.path(session_home(), "temp"),
-      source = "session"
-    ))
+    return(list(directory = instance_spill_directory(), source = "session"))
   }
   list(directory = NULL, source = "default")
+}
+
+# The spill directory for one in-memory database instance:
+# `<session_home>/temp/spill-<unique>`. The leaf is not created here -- that is
+# left to the engine, which creates it when a query first spills and removes it
+# again when the instance shuts down, exactly as the CLI's `.tmp` behaves. Only
+# the parent chain is created, because the engine's directory creation is a
+# single-level `mkdir` that cannot make two missing levels: without it, the
+# first spill fails with an IO Error instead (the in-memory corner of the
+# duckdb/duckdb-r#1604 symptom family). The leaf is unique per instance because
+# concurrent instances must not share a spill directory: the engine's spill
+# file names are deterministic (`duckdb_temp_storage_<size>-<index>.tmp`,
+# `duckdb_temp_block-<id>.block`), and a shutting-down instance removes the
+# `duckdb_temp_*` files -- or the whole directory -- it finds in its own.
+instance_spill_directory <- function() {
+  root <- file.path(session_home(), "temp")
+  dir.create(root, recursive = TRUE, showWarnings = FALSE)
+  tempfile("spill-", tmpdir = root)
 }
 
 is_memory_dbdir <- function(dbdir) {

--- a/R/storage-status.R
+++ b/R/storage-status.R
@@ -1,6 +1,7 @@
 # Implementation of the user-facing function that reports where the duckdb R
 # package stores extensions and secrets. It is documented together with the
 # storage policy on the `?duckdb_storage` page (via `@rdname`).
+# Explained in handbook/usage/storage/README.md.
 
 #' @details
 #' `duckdb_storage_status()` reports the directory the package would currently

--- a/R/storage.R
+++ b/R/storage.R
@@ -55,11 +55,22 @@
 #'     setting: `secret_directory`. Placed at `<home>/stored_secrets`, the same
 #'     `<home>`.}
 #'   \item{Temporary / spill files}{Out-of-core intermediates for sorts, hash
-#'     joins, and similar operations. DuckDB settings: `temp_directory`,
-#'     `max_temp_directory_size`. For an in-memory (`:memory:`) database DuckDB's
-#'     own default spills to `.tmp` in the current working directory, so the
-#'     package overrides it with a [tempdir()] sub-directory by default. This is
-#'     a separate setting from the extension/secret home (see below).}
+#'     joins, and similar operations.
+#'     DuckDB settings: `temp_directory`, `max_temp_directory_size`.
+#'     Temporary storage is on by default, with the DuckDB CLI's semantics:
+#'     the directory is created only when a query actually spills,
+#'     and removed again when the database instance shuts down.
+#'     An on-disk database keeps the engine's own default,
+#'     `<dbdir>.tmp` next to the database file.
+#'     For an in-memory (`:memory:`) database the engine's own default
+#'     would spill to `.tmp` in the current working directory,
+#'     so the package points it at a fresh per-instance sub-directory
+#'     below [tempdir()] instead.
+#'     Every in-memory instance gets its own spill directory:
+#'     instances must not share one,
+#'     because the engine's spill file names are deterministic
+#'     and an instance cleans up its directory when it shuts down.
+#'     This is a separate setting from the extension/secret home (see below).}
 #'   \item{Logs and profiling output}{Written only when a path is explicitly
 #'     configured (DuckDB settings `log_query_path`, `http_logging_output`,
 #'     profiling output). They default to *off*, so nothing is written without
@@ -99,16 +110,20 @@
 #'
 #' # Per-location reference
 #'
-#' | Kind           | DuckDB setting        | How to set it                                                         | Default                          |
-#' |----------------|-----------------------|-----------------------------------------------------------------------|----------------------------------|
-#' | Home           | `home_directory`      | --                                                                    | left untouched (not set)         |
-#' | Extensions     | `extension_directory` | `home` arg / `duckdb.home` / `DUCKDB_R_HOME` (as `<home>/extensions`) | `tempdir()` sub-directory (set)  |
-#' | Stored secrets | `secret_directory`    | like extensions (`<home>/stored_secrets`)                             | `tempdir()` sub-directory (set)  |
-#' | Temp/spill     | `temp_directory`      | `duckdb.temp_directory` / `DUCKDB_R_TEMP_DIRECTORY`                   | `tempdir()` sub-directory (set)  |
-#' | Logs           | `log_query_path`      | DuckDB setting                                                        | disabled (off)                   |
+#' | Kind           | DuckDB setting        | How to set it                                                         | Default                                                 |
+#' |----------------|-----------------------|-----------------------------------------------------------------------|---------------------------------------------------------|
+#' | Home           | `home_directory`      | --                                                                    | left untouched (not set)                                |
+#' | Extensions     | `extension_directory` | `home` arg / `duckdb.home` / `DUCKDB_R_HOME` (as `<home>/extensions`) | `tempdir()` sub-directory (set)                         |
+#' | Stored secrets | `secret_directory`    | like extensions (`<home>/stored_secrets`)                             | `tempdir()` sub-directory (set)                         |
+#' | Temp/spill     | `temp_directory`      | `duckdb.temp_directory` / `DUCKDB_R_TEMP_DIRECTORY`                   | memory: `tempdir()` sub-directory (set); disk: `<dbdir>.tmp` |
+#' | Logs           | `log_query_path`      | DuckDB setting                                                        | disabled (off)                                          |
 #'
 #' "set" means `duckdb()` sets the value explicitly in the database config.
 #' The home directory is left untouched so that `~` in user SQL keeps its usual meaning.
+#' The temp/spill setting is left unset for an on-disk database:
+#' the engine's own `<dbdir>.tmp` default already matches the DuckDB CLI,
+#' no matter whether the database is opened through [duckdb()]
+#' or through the `dbdir` argument of [DBI::dbConnect()].
 #' An `extension_directory` / `secret_directory` / `temp_directory`
 #' passed directly in the `config` list is always honored
 #' and takes precedence over the resolution above.

--- a/R/storage.R
+++ b/R/storage.R
@@ -1,6 +1,7 @@
 # Documentation for how the duckdb R package chooses the file-system locations
 # it (and the bundled DuckDB engine) writes to. See `?duckdb_storage`.
-# Explained in handbook/usage/storage/README.md.
+# Explained in handbook/usage/storage/README.md, and for the temp/spill
+# location, handbook/usage/memory/README.md.
 #
 # CRAN rationale (kept out of the user-facing docs deliberately):
 #

--- a/experiments/2026-08-temp-storage-spill/README.md
+++ b/experiments/2026-08-temp-storage-spill/README.md
@@ -1,0 +1,77 @@
+# Temporary storage across duckdb-r versions
+
+What happens when a query outgrows `memory_limit`,
+for the two common connection idioms,
+across four builds of the package.
+Run 2026-08-07/08 on Ubuntu 24.04 (x86_64, 4 cores, 16 GB RAM,
+R 4.5.3), each run rendered with reprex
+(`reprex::reprex(input = <script>, venue = "gh", session_info = TRUE)`);
+supports [`usage/memory/`](/handbook/usage/memory/README.md).
+Gathered for
+[#2562](https://github.com/duckdb/duckdb-r/pull/2562),
+which reviews
+[#1604](https://github.com/duckdb/duckdb-r/issues/1604);
+the four runs quoted in that PR's description are the
+`main-1fc15f5` and `branch-c947f6f` files here, verbatim.
+
+The scripts:
+
+* [`disk-1604.R`](disk-1604.R) —
+  the #1604 report: an on-disk database opened as
+  `dbConnect(duckdb(), dbdir = ...)`,
+  the reported settings and data shape
+  (12,880,502 rows × 5 integer columns, ~257 MB,
+  `memory_limit = '3GB'`),
+  then two harder variants:
+  the same append under a 200 MB limit,
+  and a ~460 MB sort under that limit.
+* [`memory.R`](memory.R) —
+  the default in-memory connection:
+  where `temp_directory` points,
+  a ~460 MB sort under a 300 MB limit,
+  and whether the spill directory appears at first spill
+  and disappears at `duckdb_shutdown()`.
+
+The builds, one rendered markdown per script per build:
+
+* `duckdb-1.3.2` —
+  the version #1604 was reported on,
+  installed as a binary from the Posit Package Manager snapshot
+  `cran/__linux__/noble/2025-09-01`.
+* `duckdb-1.5.5-cran` —
+  the CRAN release current on the run date,
+  installed from Posit Package Manager.
+* `main-1fc15f5` —
+  the repository's `main` before the fix, built from source.
+* `branch-c947f6f` —
+  [#2562](https://github.com/duckdb/duckdb-r/pull/2562)'s fix,
+  built from source.
+
+What was measured:
+
+* **1.3.2** left the engine's defaults untouched,
+  and spilling worked everywhere:
+  the on-disk database spilled to `db.duckdb.tmp`
+  and the in-memory database to `.tmp`
+  in the current working directory.
+  The failure reported in #1604 did not reproduce on this hardware —
+  the reported append passed at the reported 3 GB limit,
+  and again at 200 MB, less than the data itself.
+* **1.5.5 (CRAN) and `main`** redirect both idioms at
+  `<tempdir()>/duckdb/temp`, which nothing creates,
+  so the first actual spill fails with
+  `IO Error: Failed to create directory` —
+  the sort step in both scripts —
+  and the on-disk database never uses `<dbdir>.tmp`.
+  The regression shipped: the release current on the run date
+  is affected.
+* **branch c947f6f** restores the CLI's semantics:
+  the on-disk database keeps the engine's own `<dbdir>.tmp`,
+  the in-memory database gets a per-instance directory
+  below `tempdir()`,
+  created at first spill and removed at shutdown.
+  Every step passes.
+
+To refresh: install the build under test,
+render both scripts with reprex as above,
+and name the output after the build.

--- a/experiments/2026-08-temp-storage-spill/disk-1604-branch-c947f6f.md
+++ b/experiments/2026-08-temp-storage-spill/disk-1604-branch-c947f6f.md
@@ -1,0 +1,135 @@
+``` r
+library(DBI)
+packageVersion("duckdb")
+#> [1] '1.5.5.9010'
+
+# The scenario of duckdb/duckdb-r#1604: append a data.frame to a table of an
+# on-disk database under a memory_limit, with the settings reported there.
+dbdir <- file.path(tempdir(), "db.duckdb")
+con <- dbConnect(duckdb::duckdb(), dbdir = dbdir)
+#> duckdb is storing downloaded extensions and secrets under ~/.duckdb:
+#> ℹ /root/.duckdb
+#> This persists across sessions and is shared with the DuckDB CLI and other clients.
+#> ℹ Run duckdb(shared_home = FALSE) to use a temporary directory instead.
+#> ℹ See ?duckdb_storage for details and alternatives.
+
+dbExecute(con, "SET memory_limit = '3GB'")
+#> [1] 0
+dbExecute(con, "SET max_temp_directory_size = '20GB'")
+#> [1] 0
+dbExecute(con, "SET threads TO 1")
+#> [1] 0
+dbExecute(con, "SET preserve_insertion_order = false")
+#> [1] 0
+
+# Temporary storage is on, beside the database file (the engine's own default):
+dbGetQuery(con, "SELECT current_setting('temp_directory') AS temp_directory")
+#>                  temp_directory
+#> 1 /tmp/Rtmpi49j2A/db.duckdb.tmp
+
+# The reported data: 12,880,502 rows x 5 integer columns, ~257 MB.
+n <- 12880502L
+dat <- data.frame(
+  a = seq_len(n),
+  b = rev(seq_len(n)),
+  c = seq_len(n) %% 1000L,
+  d = seq_len(n) %/% 7L,
+  e = seq_len(n) %% 33333L
+)
+format(object.size(dat), units = "MB")
+#> [1] "245.7 Mb"
+
+# "insert a data.frame into existing database": create the table, then append.
+dbWriteTable(con, "tbl", dat[0, ], overwrite = TRUE)
+dbWriteTable(con, "tbl", dat, append = TRUE) # <- failed in #1604 under 3 GB
+dbGetQuery(con, "SELECT count(*) AS n FROM tbl")
+#>          n
+#> 1 12880502
+
+# Harder than reported: repeat the append with a memory_limit *below* the data
+# size, so it can only succeed by offloading to temporary storage.
+dbExecute(con, "SET memory_limit = '200MB'")
+#> [1] 0
+dbWriteTable(con, "tbl", dat, append = TRUE)
+dbGetQuery(con, "SELECT count(*) AS n FROM tbl")
+#>          n
+#> 1 25761004
+
+# Was the temporary directory used at any point?
+dir.exists(paste0(dbdir, ".tmp"))
+#> [1] FALSE
+
+# Harder still: a full ~460 MB sort under the 200 MB limit.
+dbExecute(con, "SET preserve_insertion_order = true")
+#> [1] 0
+dbExecute(
+  con,
+  "CREATE TABLE big_sort AS SELECT hash(i) AS h, i FROM range(30000000) t(i) ORDER BY h"
+)
+#> [1] 3e+07
+dbGetQuery(con, "SELECT count(*) AS n FROM big_sort")
+#>       n
+#> 1 3e+07
+dir.exists(paste0(dbdir, ".tmp"))
+#> [1] TRUE
+
+dbDisconnect(con)
+```
+
+<sup>Created on 2026-08-07 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
+
+<details style="margin-bottom:10px;">
+
+<summary>
+
+Session info
+</summary>
+
+``` r
+sessioninfo::session_info()
+#> ─ Session info ───────────────────────────────────────────────────────────────
+#>  setting  value
+#>  version  R version 4.5.3 (2026-03-11)
+#>  os       Ubuntu 24.04.4 LTS
+#>  system   x86_64, linux-gnu
+#>  ui       X11
+#>  language (EN)
+#>  collate  C.UTF-8
+#>  ctype    C.UTF-8
+#>  tz       Etc/UTC
+#>  date     2026-08-07
+#>  pandoc   3.9.0.2 @ /usr/local/bin/ (via rmarkdown)
+#>  quarto   1.9.38 @ /usr/local/bin/quarto
+#> 
+#> ─ Packages ───────────────────────────────────────────────────────────────────
+#>  package     * version    date (UTC) lib source
+#>  cli           3.6.6      2026-04-09 [1] RSPM
+#>  DBI         * 1.3.0      2026-02-25 [1] RSPM
+#>  digest        0.6.39     2025-11-19 [1] RSPM
+#>  duckdb        1.5.5.9010 2026-08-07 [1] local
+#>  evaluate      1.0.5      2025-08-27 [1] RSPM
+#>  fastmap       1.2.0      2024-05-15 [1] RSPM
+#>  fs            2.1.0      2026-04-18 [1] RSPM
+#>  glue          1.8.1      2026-04-17 [1] RSPM
+#>  htmltools     0.5.9      2025-12-04 [1] RSPM
+#>  knitr         1.51       2025-12-20 [1] RSPM
+#>  lifecycle     1.0.5      2026-01-08 [1] RSPM
+#>  otel          0.2.0      2025-08-29 [1] RSPM
+#>  pillar        1.11.1     2025-09-17 [1] RSPM
+#>  reprex        2.1.1      2024-07-06 [1] RSPM
+#>  rlang         1.3.0      2026-07-05 [1] RSPM
+#>  rmarkdown     2.31       2026-03-26 [1] RSPM
+#>  sessioninfo   1.2.4      2026-06-04 [1] RSPM
+#>  vctrs         0.7.3      2026-04-11 [1] RSPM
+#>  withr         3.0.3      2026-06-19 [1] RSPM
+#>  xfun          0.60       2026-07-09 [1] RSPM
+#>  yaml          2.3.12     2025-12-10 [1] RSPM
+#> 
+#>  [1] /root/R/x86_64-pc-linux-gnu-library/4.5
+#>  [2] /opt/R/4.5.3/lib/R/library
+#>  * ── Packages attached to the search path.
+#> 
+#> ──────────────────────────────────────────────────────────────────────────────
+```
+
+</details>

--- a/experiments/2026-08-temp-storage-spill/disk-1604-duckdb-1.3.2.md
+++ b/experiments/2026-08-temp-storage-spill/disk-1604-duckdb-1.3.2.md
@@ -1,0 +1,130 @@
+``` r
+library(DBI)
+packageVersion("duckdb")
+#> [1] '1.3.2'
+
+# The scenario of duckdb/duckdb-r#1604: append a data.frame to a table of an
+# on-disk database under a memory_limit, with the settings reported there.
+dbdir <- file.path(tempdir(), "db.duckdb")
+con <- dbConnect(duckdb::duckdb(), dbdir = dbdir)
+
+dbExecute(con, "SET memory_limit = '3GB'")
+#> [1] 0
+dbExecute(con, "SET max_temp_directory_size = '20GB'")
+#> [1] 0
+dbExecute(con, "SET threads TO 1")
+#> [1] 0
+dbExecute(con, "SET preserve_insertion_order = false")
+#> [1] 0
+
+# Temporary storage is on, beside the database file (the engine's own default):
+dbGetQuery(con, "SELECT current_setting('temp_directory') AS temp_directory")
+#>                  temp_directory
+#> 1 /tmp/Rtmp1XsljW/db.duckdb.tmp
+
+# The reported data: 12,880,502 rows x 5 integer columns, ~257 MB.
+n <- 12880502L
+dat <- data.frame(
+  a = seq_len(n),
+  b = rev(seq_len(n)),
+  c = seq_len(n) %% 1000L,
+  d = seq_len(n) %/% 7L,
+  e = seq_len(n) %% 33333L
+)
+format(object.size(dat), units = "MB")
+#> [1] "245.7 Mb"
+
+# "insert a data.frame into existing database": create the table, then append.
+dbWriteTable(con, "tbl", dat[0, ], overwrite = TRUE)
+dbWriteTable(con, "tbl", dat, append = TRUE) # <- failed in #1604 under 3 GB
+dbGetQuery(con, "SELECT count(*) AS n FROM tbl")
+#>          n
+#> 1 12880502
+
+# Harder than reported: repeat the append with a memory_limit *below* the data
+# size, so it can only succeed by offloading to temporary storage.
+dbExecute(con, "SET memory_limit = '200MB'")
+#> [1] 0
+dbWriteTable(con, "tbl", dat, append = TRUE)
+dbGetQuery(con, "SELECT count(*) AS n FROM tbl")
+#>          n
+#> 1 25761004
+
+# Was the temporary directory used at any point?
+dir.exists(paste0(dbdir, ".tmp"))
+#> [1] FALSE
+
+# Harder still: a full ~460 MB sort under the 200 MB limit.
+dbExecute(con, "SET preserve_insertion_order = true")
+#> [1] 0
+dbExecute(
+  con,
+  "CREATE TABLE big_sort AS SELECT hash(i) AS h, i FROM range(30000000) t(i) ORDER BY h"
+)
+#> [1] 3e+07
+dbGetQuery(con, "SELECT count(*) AS n FROM big_sort")
+#>       n
+#> 1 3e+07
+dir.exists(paste0(dbdir, ".tmp"))
+#> [1] TRUE
+
+dbDisconnect(con)
+```
+
+<sup>Created on 2026-08-08 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
+
+<details style="margin-bottom:10px;">
+
+<summary>
+
+Session info
+</summary>
+
+``` r
+sessioninfo::session_info()
+#> ─ Session info ───────────────────────────────────────────────────────────────
+#>  setting  value
+#>  version  R version 4.5.3 (2026-03-11)
+#>  os       Ubuntu 24.04.4 LTS
+#>  system   x86_64, linux-gnu
+#>  ui       X11
+#>  language (EN)
+#>  collate  C.UTF-8
+#>  ctype    C.UTF-8
+#>  tz       Etc/UTC
+#>  date     2026-08-08
+#>  pandoc   3.9.0.2 @ /usr/local/bin/ (via rmarkdown)
+#>  quarto   1.9.38 @ /usr/local/bin/quarto
+#> 
+#> ─ Packages ───────────────────────────────────────────────────────────────────
+#>  package     * version date (UTC) lib source
+#>  cli           3.6.6   2026-04-09 [1] RSPM
+#>  DBI         * 1.3.0   2026-02-25 [1] RSPM
+#>  digest        0.6.39  2025-11-19 [1] RSPM
+#>  duckdb        1.3.2   2025-07-09 [1] RSPM (R 4.5.0)
+#>  evaluate      1.0.5   2025-08-27 [1] RSPM
+#>  fastmap       1.2.0   2024-05-15 [1] RSPM
+#>  fs            2.1.0   2026-04-18 [1] RSPM
+#>  glue          1.8.1   2026-04-17 [1] RSPM
+#>  htmltools     0.5.9   2025-12-04 [1] RSPM
+#>  knitr         1.51    2025-12-20 [1] RSPM
+#>  lifecycle     1.0.5   2026-01-08 [1] RSPM
+#>  otel          0.2.0   2025-08-29 [1] RSPM
+#>  pillar        1.11.1  2025-09-17 [1] RSPM
+#>  reprex        2.1.1   2024-07-06 [1] RSPM
+#>  rlang         1.3.0   2026-07-05 [1] RSPM
+#>  rmarkdown     2.31    2026-03-26 [1] RSPM
+#>  sessioninfo   1.2.4   2026-06-04 [1] RSPM
+#>  vctrs         0.7.3   2026-04-11 [1] RSPM
+#>  withr         3.0.3   2026-06-19 [1] RSPM
+#>  xfun          0.60    2026-07-09 [1] RSPM
+#>  yaml          2.3.12  2025-12-10 [1] RSPM
+#> 
+#>  [1] /root/R/x86_64-pc-linux-gnu-library/4.5
+#>  [2] /opt/R/4.5.3/lib/R/library
+#>  * ── Packages attached to the search path.
+#> 
+#> ──────────────────────────────────────────────────────────────────────────────
+```
+
+</details>

--- a/experiments/2026-08-temp-storage-spill/disk-1604-duckdb-1.5.5-cran.md
+++ b/experiments/2026-08-temp-storage-spill/disk-1604-duckdb-1.5.5-cran.md
@@ -1,0 +1,144 @@
+``` r
+library(DBI)
+packageVersion("duckdb")
+#> [1] '1.5.5'
+
+# The scenario of duckdb/duckdb-r#1604: append a data.frame to a table of an
+# on-disk database under a memory_limit, with the settings reported there.
+dbdir <- file.path(tempdir(), "db.duckdb")
+con <- dbConnect(duckdb::duckdb(), dbdir = dbdir)
+#> duckdb is storing downloaded extensions and secrets under ~/.duckdb:
+#> ℹ /root/.duckdb
+#> This persists across sessions and is shared with the DuckDB CLI and other clients.
+#> ℹ Run duckdb(shared_home = FALSE) to use a temporary directory instead.
+#> ℹ See ?duckdb_storage for details and alternatives.
+
+dbExecute(con, "SET memory_limit = '3GB'")
+#> [1] 0
+dbExecute(con, "SET max_temp_directory_size = '20GB'")
+#> [1] 0
+dbExecute(con, "SET threads TO 1")
+#> [1] 0
+dbExecute(con, "SET preserve_insertion_order = false")
+#> [1] 0
+
+# Temporary storage is on, beside the database file (the engine's own default):
+dbGetQuery(con, "SELECT current_setting('temp_directory') AS temp_directory")
+#>                temp_directory
+#> 1 /tmp/RtmpB931U4/duckdb/temp
+
+# The reported data: 12,880,502 rows x 5 integer columns, ~257 MB.
+n <- 12880502L
+dat <- data.frame(
+  a = seq_len(n),
+  b = rev(seq_len(n)),
+  c = seq_len(n) %% 1000L,
+  d = seq_len(n) %/% 7L,
+  e = seq_len(n) %% 33333L
+)
+format(object.size(dat), units = "MB")
+#> [1] "245.7 Mb"
+
+# "insert a data.frame into existing database": create the table, then append.
+dbWriteTable(con, "tbl", dat[0, ], overwrite = TRUE)
+dbWriteTable(con, "tbl", dat, append = TRUE) # <- failed in #1604 under 3 GB
+dbGetQuery(con, "SELECT count(*) AS n FROM tbl")
+#>          n
+#> 1 12880502
+
+# Harder than reported: repeat the append with a memory_limit *below* the data
+# size, so it can only succeed by offloading to temporary storage.
+dbExecute(con, "SET memory_limit = '200MB'")
+#> [1] 0
+dbWriteTable(con, "tbl", dat, append = TRUE)
+dbGetQuery(con, "SELECT count(*) AS n FROM tbl")
+#>          n
+#> 1 25761004
+
+# Was the temporary directory used at any point?
+dir.exists(paste0(dbdir, ".tmp"))
+#> [1] FALSE
+
+# Harder still: a full ~460 MB sort under the 200 MB limit.
+dbExecute(con, "SET preserve_insertion_order = true")
+#> [1] 0
+dbExecute(
+  con,
+  "CREATE TABLE big_sort AS SELECT hash(i) AS h, i FROM range(30000000) t(i) ORDER BY h"
+)
+#> Error in `duckdb_result()`:
+#> ! Invalid Error: IO Error: Failed to create directory "/tmp/RtmpB931U4/duckdb/temp": No such file or directory
+#> ℹ Context: rapi_execute
+#> ℹ Error type: INVALID
+dbGetQuery(con, "SELECT count(*) AS n FROM big_sort")
+#> Error in `dbSendQuery()`:
+#> ! Catalog Error: Table with name big_sort does not exist!
+#> Did you mean "pg_description"?
+#> 
+#> LINE 1: SELECT count(*) AS n FROM big_sort
+#>                                   ^
+#> ℹ Context: rapi_prepare
+#> ℹ Error type: CATALOG
+dir.exists(paste0(dbdir, ".tmp"))
+#> [1] FALSE
+
+dbDisconnect(con)
+```
+
+<sup>Created on 2026-08-08 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
+
+<details style="margin-bottom:10px;">
+
+<summary>
+
+Session info
+</summary>
+
+``` r
+sessioninfo::session_info()
+#> ─ Session info ───────────────────────────────────────────────────────────────
+#>  setting  value
+#>  version  R version 4.5.3 (2026-03-11)
+#>  os       Ubuntu 24.04.4 LTS
+#>  system   x86_64, linux-gnu
+#>  ui       X11
+#>  language (EN)
+#>  collate  C.UTF-8
+#>  ctype    C.UTF-8
+#>  tz       Etc/UTC
+#>  date     2026-08-08
+#>  pandoc   3.9.0.2 @ /usr/local/bin/ (via rmarkdown)
+#>  quarto   1.9.38 @ /usr/local/bin/quarto
+#> 
+#> ─ Packages ───────────────────────────────────────────────────────────────────
+#>  package     * version date (UTC) lib source
+#>  cli           3.6.6   2026-04-09 [1] RSPM
+#>  DBI         * 1.3.0   2026-02-25 [1] RSPM
+#>  digest        0.6.39  2025-11-19 [1] RSPM
+#>  duckdb        1.5.5   2026-07-25 [1] RSPM (R 4.5.0)
+#>  evaluate      1.0.5   2025-08-27 [1] RSPM
+#>  fastmap       1.2.0   2024-05-15 [1] RSPM
+#>  fs            2.1.0   2026-04-18 [1] RSPM
+#>  glue          1.8.1   2026-04-17 [1] RSPM
+#>  htmltools     0.5.9   2025-12-04 [1] RSPM
+#>  knitr         1.51    2025-12-20 [1] RSPM
+#>  lifecycle     1.0.5   2026-01-08 [1] RSPM
+#>  otel          0.2.0   2025-08-29 [1] RSPM
+#>  pillar        1.11.1  2025-09-17 [1] RSPM
+#>  reprex        2.1.1   2024-07-06 [1] RSPM
+#>  rlang         1.3.0   2026-07-05 [1] RSPM
+#>  rmarkdown     2.31    2026-03-26 [1] RSPM
+#>  sessioninfo   1.2.4   2026-06-04 [1] RSPM
+#>  vctrs         0.7.3   2026-04-11 [1] RSPM
+#>  withr         3.0.3   2026-06-19 [1] RSPM
+#>  xfun          0.60    2026-07-09 [1] RSPM
+#>  yaml          2.3.12  2025-12-10 [1] RSPM
+#> 
+#>  [1] /root/R/x86_64-pc-linux-gnu-library/4.5
+#>  [2] /opt/R/4.5.3/lib/R/library
+#>  * ── Packages attached to the search path.
+#> 
+#> ──────────────────────────────────────────────────────────────────────────────
+```
+
+</details>

--- a/experiments/2026-08-temp-storage-spill/disk-1604-main-1fc15f5.md
+++ b/experiments/2026-08-temp-storage-spill/disk-1604-main-1fc15f5.md
@@ -1,0 +1,144 @@
+``` r
+library(DBI)
+packageVersion("duckdb")
+#> [1] '1.5.5.9010'
+
+# The scenario of duckdb/duckdb-r#1604: append a data.frame to a table of an
+# on-disk database under a memory_limit, with the settings reported there.
+dbdir <- file.path(tempdir(), "db.duckdb")
+con <- dbConnect(duckdb::duckdb(), dbdir = dbdir)
+#> duckdb is storing downloaded extensions and secrets under ~/.duckdb:
+#> ℹ /root/.duckdb
+#> This persists across sessions and is shared with the DuckDB CLI and other clients.
+#> ℹ Run duckdb(shared_home = FALSE) to use a temporary directory instead.
+#> ℹ See ?duckdb_storage for details and alternatives.
+
+dbExecute(con, "SET memory_limit = '3GB'")
+#> [1] 0
+dbExecute(con, "SET max_temp_directory_size = '20GB'")
+#> [1] 0
+dbExecute(con, "SET threads TO 1")
+#> [1] 0
+dbExecute(con, "SET preserve_insertion_order = false")
+#> [1] 0
+
+# Temporary storage is on, beside the database file (the engine's own default):
+dbGetQuery(con, "SELECT current_setting('temp_directory') AS temp_directory")
+#>                temp_directory
+#> 1 /tmp/Rtmp9T5BRV/duckdb/temp
+
+# The reported data: 12,880,502 rows x 5 integer columns, ~257 MB.
+n <- 12880502L
+dat <- data.frame(
+  a = seq_len(n),
+  b = rev(seq_len(n)),
+  c = seq_len(n) %% 1000L,
+  d = seq_len(n) %/% 7L,
+  e = seq_len(n) %% 33333L
+)
+format(object.size(dat), units = "MB")
+#> [1] "245.7 Mb"
+
+# "insert a data.frame into existing database": create the table, then append.
+dbWriteTable(con, "tbl", dat[0, ], overwrite = TRUE)
+dbWriteTable(con, "tbl", dat, append = TRUE) # <- failed in #1604 under 3 GB
+dbGetQuery(con, "SELECT count(*) AS n FROM tbl")
+#>          n
+#> 1 12880502
+
+# Harder than reported: repeat the append with a memory_limit *below* the data
+# size, so it can only succeed by offloading to temporary storage.
+dbExecute(con, "SET memory_limit = '200MB'")
+#> [1] 0
+dbWriteTable(con, "tbl", dat, append = TRUE)
+dbGetQuery(con, "SELECT count(*) AS n FROM tbl")
+#>          n
+#> 1 25761004
+
+# Was the temporary directory used at any point?
+dir.exists(paste0(dbdir, ".tmp"))
+#> [1] FALSE
+
+# Harder still: a full ~460 MB sort under the 200 MB limit.
+dbExecute(con, "SET preserve_insertion_order = true")
+#> [1] 0
+dbExecute(
+  con,
+  "CREATE TABLE big_sort AS SELECT hash(i) AS h, i FROM range(30000000) t(i) ORDER BY h"
+)
+#> Error in `duckdb_result()`:
+#> ! Invalid Error: IO Error: Failed to create directory "/tmp/Rtmp9T5BRV/duckdb/temp": No such file or directory
+#> ℹ Context: rapi_execute
+#> ℹ Error type: INVALID
+dbGetQuery(con, "SELECT count(*) AS n FROM big_sort")
+#> Error in `dbSendQuery()`:
+#> ! Catalog Error: Table with name big_sort does not exist!
+#> Did you mean "pg_description"?
+#> 
+#> LINE 1: SELECT count(*) AS n FROM big_sort
+#>                                   ^
+#> ℹ Context: rapi_prepare
+#> ℹ Error type: CATALOG
+dir.exists(paste0(dbdir, ".tmp"))
+#> [1] FALSE
+
+dbDisconnect(con)
+```
+
+<sup>Created on 2026-08-07 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
+
+<details style="margin-bottom:10px;">
+
+<summary>
+
+Session info
+</summary>
+
+``` r
+sessioninfo::session_info()
+#> ─ Session info ───────────────────────────────────────────────────────────────
+#>  setting  value
+#>  version  R version 4.5.3 (2026-03-11)
+#>  os       Ubuntu 24.04.4 LTS
+#>  system   x86_64, linux-gnu
+#>  ui       X11
+#>  language (EN)
+#>  collate  C.UTF-8
+#>  ctype    C.UTF-8
+#>  tz       Etc/UTC
+#>  date     2026-08-07
+#>  pandoc   3.9.0.2 @ /usr/local/bin/ (via rmarkdown)
+#>  quarto   1.9.38 @ /usr/local/bin/quarto
+#> 
+#> ─ Packages ───────────────────────────────────────────────────────────────────
+#>  package     * version    date (UTC) lib source
+#>  cli           3.6.6      2026-04-09 [1] RSPM
+#>  DBI         * 1.3.0      2026-02-25 [1] RSPM
+#>  digest        0.6.39     2025-11-19 [1] RSPM
+#>  duckdb        1.5.5.9010 2026-08-07 [1] local
+#>  evaluate      1.0.5      2025-08-27 [1] RSPM
+#>  fastmap       1.2.0      2024-05-15 [1] RSPM
+#>  fs            2.1.0      2026-04-18 [1] RSPM
+#>  glue          1.8.1      2026-04-17 [1] RSPM
+#>  htmltools     0.5.9      2025-12-04 [1] RSPM
+#>  knitr         1.51       2025-12-20 [1] RSPM
+#>  lifecycle     1.0.5      2026-01-08 [1] RSPM
+#>  otel          0.2.0      2025-08-29 [1] RSPM
+#>  pillar        1.11.1     2025-09-17 [1] RSPM
+#>  reprex        2.1.1      2024-07-06 [1] RSPM
+#>  rlang         1.3.0      2026-07-05 [1] RSPM
+#>  rmarkdown     2.31       2026-03-26 [1] RSPM
+#>  sessioninfo   1.2.4      2026-06-04 [1] RSPM
+#>  vctrs         0.7.3      2026-04-11 [1] RSPM
+#>  withr         3.0.3      2026-06-19 [1] RSPM
+#>  xfun          0.60       2026-07-09 [1] RSPM
+#>  yaml          2.3.12     2025-12-10 [1] RSPM
+#> 
+#>  [1] /root/R/x86_64-pc-linux-gnu-library/4.5
+#>  [2] /opt/R/4.5.3/lib/R/library
+#>  * ── Packages attached to the search path.
+#> 
+#> ──────────────────────────────────────────────────────────────────────────────
+```
+
+</details>

--- a/experiments/2026-08-temp-storage-spill/disk-1604.R
+++ b/experiments/2026-08-temp-storage-spill/disk-1604.R
@@ -1,0 +1,51 @@
+library(DBI)
+packageVersion("duckdb")
+
+# The scenario of duckdb/duckdb-r#1604: append a data.frame to a table of an
+# on-disk database under a memory_limit, with the settings reported there.
+dbdir <- file.path(tempdir(), "db.duckdb")
+con <- dbConnect(duckdb::duckdb(), dbdir = dbdir)
+
+dbExecute(con, "SET memory_limit = '3GB'")
+dbExecute(con, "SET max_temp_directory_size = '20GB'")
+dbExecute(con, "SET threads TO 1")
+dbExecute(con, "SET preserve_insertion_order = false")
+
+# Temporary storage is on, beside the database file (the engine's own default):
+dbGetQuery(con, "SELECT current_setting('temp_directory') AS temp_directory")
+
+# The reported data: 12,880,502 rows x 5 integer columns, ~257 MB.
+n <- 12880502L
+dat <- data.frame(
+  a = seq_len(n),
+  b = rev(seq_len(n)),
+  c = seq_len(n) %% 1000L,
+  d = seq_len(n) %/% 7L,
+  e = seq_len(n) %% 33333L
+)
+format(object.size(dat), units = "MB")
+
+# "insert a data.frame into existing database": create the table, then append.
+dbWriteTable(con, "tbl", dat[0, ], overwrite = TRUE)
+dbWriteTable(con, "tbl", dat, append = TRUE) # <- failed in #1604 under 3 GB
+dbGetQuery(con, "SELECT count(*) AS n FROM tbl")
+
+# Harder than reported: repeat the append with a memory_limit *below* the data
+# size, so it can only succeed by offloading to temporary storage.
+dbExecute(con, "SET memory_limit = '200MB'")
+dbWriteTable(con, "tbl", dat, append = TRUE)
+dbGetQuery(con, "SELECT count(*) AS n FROM tbl")
+
+# Was the temporary directory used at any point?
+dir.exists(paste0(dbdir, ".tmp"))
+
+# Harder still: a full ~460 MB sort under the 200 MB limit.
+dbExecute(con, "SET preserve_insertion_order = true")
+dbExecute(
+  con,
+  "CREATE TABLE big_sort AS SELECT hash(i) AS h, i FROM range(30000000) t(i) ORDER BY h"
+)
+dbGetQuery(con, "SELECT count(*) AS n FROM big_sort")
+dir.exists(paste0(dbdir, ".tmp"))
+
+dbDisconnect(con)

--- a/experiments/2026-08-temp-storage-spill/memory-branch-c947f6f.md
+++ b/experiments/2026-08-temp-storage-spill/memory-branch-c947f6f.md
@@ -1,0 +1,101 @@
+``` r
+library(DBI)
+packageVersion("duckdb")
+#> [1] '1.5.5.9010'
+
+# The default connection is an in-memory database. The package points its
+# temporary storage below tempdir(), away from the current working directory:
+drv <- duckdb::duckdb()
+#> duckdb is storing downloaded extensions and secrets under ~/.duckdb:
+#> ℹ /root/.duckdb
+#> This persists across sessions and is shared with the DuckDB CLI and other clients.
+#> ℹ Run duckdb(shared_home = FALSE) to use a temporary directory instead.
+#> ℹ See ?duckdb_storage for details and alternatives.
+con <- dbConnect(drv)
+spill <- dbGetQuery(
+  con,
+  "SELECT current_setting('temp_directory') AS temp_directory"
+)[[1]]
+spill
+#> [1] "/tmp/RtmpwzGNVv/duckdb/temp/spill-58f14e4b648b"
+
+# Any operation that outgrows memory_limit must offload to that directory:
+# a ~460 MB sort under a 300 MB limit.
+dbExecute(con, "SET memory_limit = '300MB'")
+#> [1] 0
+dbExecute(
+  con,
+  "CREATE TABLE big_sort AS SELECT hash(i) AS h, i FROM range(30000000) t(i) ORDER BY h"
+)
+#> [1] 3e+07
+dbGetQuery(con, "SELECT count(*) AS n FROM big_sort")
+#>       n
+#> 1 3e+07
+
+# The spill directory exists while the instance is live ...
+dir.exists(spill)
+#> [1] TRUE
+
+dbDisconnect(con)
+duckdb::duckdb_shutdown(drv)
+
+# ... and the engine removes it again at instance shutdown.
+dir.exists(spill)
+#> [1] FALSE
+```
+
+<sup>Created on 2026-08-07 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
+
+<details style="margin-bottom:10px;">
+
+<summary>
+
+Session info
+</summary>
+
+``` r
+sessioninfo::session_info()
+#> ─ Session info ───────────────────────────────────────────────────────────────
+#>  setting  value
+#>  version  R version 4.5.3 (2026-03-11)
+#>  os       Ubuntu 24.04.4 LTS
+#>  system   x86_64, linux-gnu
+#>  ui       X11
+#>  language (EN)
+#>  collate  C.UTF-8
+#>  ctype    C.UTF-8
+#>  tz       Etc/UTC
+#>  date     2026-08-07
+#>  pandoc   3.9.0.2 @ /usr/local/bin/ (via rmarkdown)
+#>  quarto   1.9.38 @ /usr/local/bin/quarto
+#> 
+#> ─ Packages ───────────────────────────────────────────────────────────────────
+#>  package     * version    date (UTC) lib source
+#>  cli           3.6.6      2026-04-09 [1] RSPM
+#>  DBI         * 1.3.0      2026-02-25 [1] RSPM
+#>  digest        0.6.39     2025-11-19 [1] RSPM
+#>  duckdb        1.5.5.9010 2026-08-07 [1] local
+#>  evaluate      1.0.5      2025-08-27 [1] RSPM
+#>  fastmap       1.2.0      2024-05-15 [1] RSPM
+#>  fs            2.1.0      2026-04-18 [1] RSPM
+#>  glue          1.8.1      2026-04-17 [1] RSPM
+#>  htmltools     0.5.9      2025-12-04 [1] RSPM
+#>  knitr         1.51       2025-12-20 [1] RSPM
+#>  lifecycle     1.0.5      2026-01-08 [1] RSPM
+#>  otel          0.2.0      2025-08-29 [1] RSPM
+#>  reprex        2.1.1      2024-07-06 [1] RSPM
+#>  rlang         1.3.0      2026-07-05 [1] RSPM
+#>  rmarkdown     2.31       2026-03-26 [1] RSPM
+#>  sessioninfo   1.2.4      2026-06-04 [1] RSPM
+#>  withr         3.0.3      2026-06-19 [1] RSPM
+#>  xfun          0.60       2026-07-09 [1] RSPM
+#>  yaml          2.3.12     2025-12-10 [1] RSPM
+#> 
+#>  [1] /root/R/x86_64-pc-linux-gnu-library/4.5
+#>  [2] /opt/R/4.5.3/lib/R/library
+#>  * ── Packages attached to the search path.
+#> 
+#> ──────────────────────────────────────────────────────────────────────────────
+```
+
+</details>

--- a/experiments/2026-08-temp-storage-spill/memory-duckdb-1.3.2.md
+++ b/experiments/2026-08-temp-storage-spill/memory-duckdb-1.3.2.md
@@ -1,0 +1,96 @@
+``` r
+library(DBI)
+packageVersion("duckdb")
+#> [1] '1.3.2'
+
+# The default connection is an in-memory database. The package points its
+# temporary storage below tempdir(), away from the current working directory:
+drv <- duckdb::duckdb()
+con <- dbConnect(drv)
+spill <- dbGetQuery(
+  con,
+  "SELECT current_setting('temp_directory') AS temp_directory"
+)[[1]]
+spill
+#> [1] ".tmp"
+
+# Any operation that outgrows memory_limit must offload to that directory:
+# a ~460 MB sort under a 300 MB limit.
+dbExecute(con, "SET memory_limit = '300MB'")
+#> [1] 0
+dbExecute(
+  con,
+  "CREATE TABLE big_sort AS SELECT hash(i) AS h, i FROM range(30000000) t(i) ORDER BY h"
+)
+#> [1] 3e+07
+dbGetQuery(con, "SELECT count(*) AS n FROM big_sort")
+#>       n
+#> 1 3e+07
+
+# The spill directory exists while the instance is live ...
+dir.exists(spill)
+#> [1] TRUE
+
+dbDisconnect(con)
+duckdb::duckdb_shutdown(drv)
+
+# ... and the engine removes it again at instance shutdown.
+dir.exists(spill)
+#> [1] FALSE
+```
+
+<sup>Created on 2026-08-08 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
+
+<details style="margin-bottom:10px;">
+
+<summary>
+
+Session info
+</summary>
+
+``` r
+sessioninfo::session_info()
+#> ─ Session info ───────────────────────────────────────────────────────────────
+#>  setting  value
+#>  version  R version 4.5.3 (2026-03-11)
+#>  os       Ubuntu 24.04.4 LTS
+#>  system   x86_64, linux-gnu
+#>  ui       X11
+#>  language (EN)
+#>  collate  C.UTF-8
+#>  ctype    C.UTF-8
+#>  tz       Etc/UTC
+#>  date     2026-08-08
+#>  pandoc   3.9.0.2 @ /usr/local/bin/ (via rmarkdown)
+#>  quarto   1.9.38 @ /usr/local/bin/quarto
+#> 
+#> ─ Packages ───────────────────────────────────────────────────────────────────
+#>  package     * version date (UTC) lib source
+#>  cli           3.6.6   2026-04-09 [1] RSPM
+#>  DBI         * 1.3.0   2026-02-25 [1] RSPM
+#>  digest        0.6.39  2025-11-19 [1] RSPM
+#>  duckdb        1.3.2   2025-07-09 [1] RSPM (R 4.5.0)
+#>  evaluate      1.0.5   2025-08-27 [1] RSPM
+#>  fastmap       1.2.0   2024-05-15 [1] RSPM
+#>  fs            2.1.0   2026-04-18 [1] RSPM
+#>  glue          1.8.1   2026-04-17 [1] RSPM
+#>  htmltools     0.5.9   2025-12-04 [1] RSPM
+#>  knitr         1.51    2025-12-20 [1] RSPM
+#>  lifecycle     1.0.5   2026-01-08 [1] RSPM
+#>  otel          0.2.0   2025-08-29 [1] RSPM
+#>  reprex        2.1.1   2024-07-06 [1] RSPM
+#>  rlang         1.3.0   2026-07-05 [1] RSPM
+#>  rmarkdown     2.31    2026-03-26 [1] RSPM
+#>  sessioninfo   1.2.4   2026-06-04 [1] RSPM
+#>  withr         3.0.3   2026-06-19 [1] RSPM
+#>  xfun          0.60    2026-07-09 [1] RSPM
+#>  yaml          2.3.12  2025-12-10 [1] RSPM
+#> 
+#>  [1] /root/R/x86_64-pc-linux-gnu-library/4.5
+#>  [2] /opt/R/4.5.3/lib/R/library
+#>  * ── Packages attached to the search path.
+#> 
+#> ──────────────────────────────────────────────────────────────────────────────
+```
+
+</details>

--- a/experiments/2026-08-temp-storage-spill/memory-duckdb-1.5.5-cran.md
+++ b/experiments/2026-08-temp-storage-spill/memory-duckdb-1.5.5-cran.md
@@ -1,0 +1,112 @@
+``` r
+library(DBI)
+packageVersion("duckdb")
+#> [1] '1.5.5'
+
+# The default connection is an in-memory database. The package points its
+# temporary storage below tempdir(), away from the current working directory:
+drv <- duckdb::duckdb()
+#> duckdb is storing downloaded extensions and secrets under ~/.duckdb:
+#> ℹ /root/.duckdb
+#> This persists across sessions and is shared with the DuckDB CLI and other clients.
+#> ℹ Run duckdb(shared_home = FALSE) to use a temporary directory instead.
+#> ℹ See ?duckdb_storage for details and alternatives.
+con <- dbConnect(drv)
+spill <- dbGetQuery(
+  con,
+  "SELECT current_setting('temp_directory') AS temp_directory"
+)[[1]]
+spill
+#> [1] "/tmp/Rtmpgv3ZLZ/duckdb/temp"
+
+# Any operation that outgrows memory_limit must offload to that directory:
+# a ~460 MB sort under a 300 MB limit.
+dbExecute(con, "SET memory_limit = '300MB'")
+#> [1] 0
+dbExecute(
+  con,
+  "CREATE TABLE big_sort AS SELECT hash(i) AS h, i FROM range(30000000) t(i) ORDER BY h"
+)
+#> Error in `duckdb_result()`:
+#> ! Invalid Error: IO Error: Failed to create directory "/tmp/Rtmpgv3ZLZ/duckdb/temp": No such file or directory
+#> ℹ Context: rapi_execute
+#> ℹ Error type: INVALID
+dbGetQuery(con, "SELECT count(*) AS n FROM big_sort")
+#> Error in `dbSendQuery()`:
+#> ! Catalog Error: Table with name big_sort does not exist!
+#> Did you mean "pg_description"?
+#> 
+#> LINE 1: SELECT count(*) AS n FROM big_sort
+#>                                   ^
+#> ℹ Context: rapi_prepare
+#> ℹ Error type: CATALOG
+
+# The spill directory exists while the instance is live ...
+dir.exists(spill)
+#> [1] FALSE
+
+dbDisconnect(con)
+duckdb::duckdb_shutdown(drv)
+
+# ... and the engine removes it again at instance shutdown.
+dir.exists(spill)
+#> [1] FALSE
+```
+
+<sup>Created on 2026-08-08 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
+
+<details style="margin-bottom:10px;">
+
+<summary>
+
+Session info
+</summary>
+
+``` r
+sessioninfo::session_info()
+#> ─ Session info ───────────────────────────────────────────────────────────────
+#>  setting  value
+#>  version  R version 4.5.3 (2026-03-11)
+#>  os       Ubuntu 24.04.4 LTS
+#>  system   x86_64, linux-gnu
+#>  ui       X11
+#>  language (EN)
+#>  collate  C.UTF-8
+#>  ctype    C.UTF-8
+#>  tz       Etc/UTC
+#>  date     2026-08-08
+#>  pandoc   3.9.0.2 @ /usr/local/bin/ (via rmarkdown)
+#>  quarto   1.9.38 @ /usr/local/bin/quarto
+#> 
+#> ─ Packages ───────────────────────────────────────────────────────────────────
+#>  package     * version date (UTC) lib source
+#>  cli           3.6.6   2026-04-09 [1] RSPM
+#>  DBI         * 1.3.0   2026-02-25 [1] RSPM
+#>  digest        0.6.39  2025-11-19 [1] RSPM
+#>  duckdb        1.5.5   2026-07-25 [1] RSPM (R 4.5.0)
+#>  evaluate      1.0.5   2025-08-27 [1] RSPM
+#>  fastmap       1.2.0   2024-05-15 [1] RSPM
+#>  fs            2.1.0   2026-04-18 [1] RSPM
+#>  glue          1.8.1   2026-04-17 [1] RSPM
+#>  htmltools     0.5.9   2025-12-04 [1] RSPM
+#>  knitr         1.51    2025-12-20 [1] RSPM
+#>  lifecycle     1.0.5   2026-01-08 [1] RSPM
+#>  otel          0.2.0   2025-08-29 [1] RSPM
+#>  pillar        1.11.1  2025-09-17 [1] RSPM
+#>  reprex        2.1.1   2024-07-06 [1] RSPM
+#>  rlang         1.3.0   2026-07-05 [1] RSPM
+#>  rmarkdown     2.31    2026-03-26 [1] RSPM
+#>  sessioninfo   1.2.4   2026-06-04 [1] RSPM
+#>  vctrs         0.7.3   2026-04-11 [1] RSPM
+#>  withr         3.0.3   2026-06-19 [1] RSPM
+#>  xfun          0.60    2026-07-09 [1] RSPM
+#>  yaml          2.3.12  2025-12-10 [1] RSPM
+#> 
+#>  [1] /root/R/x86_64-pc-linux-gnu-library/4.5
+#>  [2] /opt/R/4.5.3/lib/R/library
+#>  * ── Packages attached to the search path.
+#> 
+#> ──────────────────────────────────────────────────────────────────────────────
+```
+
+</details>

--- a/experiments/2026-08-temp-storage-spill/memory-main-1fc15f5.md
+++ b/experiments/2026-08-temp-storage-spill/memory-main-1fc15f5.md
@@ -1,0 +1,112 @@
+``` r
+library(DBI)
+packageVersion("duckdb")
+#> [1] '1.5.5.9010'
+
+# The default connection is an in-memory database. The package points its
+# temporary storage below tempdir(), away from the current working directory:
+drv <- duckdb::duckdb()
+#> duckdb is storing downloaded extensions and secrets under ~/.duckdb:
+#> ℹ /root/.duckdb
+#> This persists across sessions and is shared with the DuckDB CLI and other clients.
+#> ℹ Run duckdb(shared_home = FALSE) to use a temporary directory instead.
+#> ℹ See ?duckdb_storage for details and alternatives.
+con <- dbConnect(drv)
+spill <- dbGetQuery(
+  con,
+  "SELECT current_setting('temp_directory') AS temp_directory"
+)[[1]]
+spill
+#> [1] "/tmp/RtmpWQkYXn/duckdb/temp"
+
+# Any operation that outgrows memory_limit must offload to that directory:
+# a ~460 MB sort under a 300 MB limit.
+dbExecute(con, "SET memory_limit = '300MB'")
+#> [1] 0
+dbExecute(
+  con,
+  "CREATE TABLE big_sort AS SELECT hash(i) AS h, i FROM range(30000000) t(i) ORDER BY h"
+)
+#> Error in `duckdb_result()`:
+#> ! Invalid Error: IO Error: Failed to create directory "/tmp/RtmpWQkYXn/duckdb/temp": No such file or directory
+#> ℹ Context: rapi_execute
+#> ℹ Error type: INVALID
+dbGetQuery(con, "SELECT count(*) AS n FROM big_sort")
+#> Error in `dbSendQuery()`:
+#> ! Catalog Error: Table with name big_sort does not exist!
+#> Did you mean "pg_description"?
+#> 
+#> LINE 1: SELECT count(*) AS n FROM big_sort
+#>                                   ^
+#> ℹ Context: rapi_prepare
+#> ℹ Error type: CATALOG
+
+# The spill directory exists while the instance is live ...
+dir.exists(spill)
+#> [1] FALSE
+
+dbDisconnect(con)
+duckdb::duckdb_shutdown(drv)
+
+# ... and the engine removes it again at instance shutdown.
+dir.exists(spill)
+#> [1] FALSE
+```
+
+<sup>Created on 2026-08-07 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
+
+<details style="margin-bottom:10px;">
+
+<summary>
+
+Session info
+</summary>
+
+``` r
+sessioninfo::session_info()
+#> ─ Session info ───────────────────────────────────────────────────────────────
+#>  setting  value
+#>  version  R version 4.5.3 (2026-03-11)
+#>  os       Ubuntu 24.04.4 LTS
+#>  system   x86_64, linux-gnu
+#>  ui       X11
+#>  language (EN)
+#>  collate  C.UTF-8
+#>  ctype    C.UTF-8
+#>  tz       Etc/UTC
+#>  date     2026-08-07
+#>  pandoc   3.9.0.2 @ /usr/local/bin/ (via rmarkdown)
+#>  quarto   1.9.38 @ /usr/local/bin/quarto
+#> 
+#> ─ Packages ───────────────────────────────────────────────────────────────────
+#>  package     * version    date (UTC) lib source
+#>  cli           3.6.6      2026-04-09 [1] RSPM
+#>  DBI         * 1.3.0      2026-02-25 [1] RSPM
+#>  digest        0.6.39     2025-11-19 [1] RSPM
+#>  duckdb        1.5.5.9010 2026-08-07 [1] local
+#>  evaluate      1.0.5      2025-08-27 [1] RSPM
+#>  fastmap       1.2.0      2024-05-15 [1] RSPM
+#>  fs            2.1.0      2026-04-18 [1] RSPM
+#>  glue          1.8.1      2026-04-17 [1] RSPM
+#>  htmltools     0.5.9      2025-12-04 [1] RSPM
+#>  knitr         1.51       2025-12-20 [1] RSPM
+#>  lifecycle     1.0.5      2026-01-08 [1] RSPM
+#>  otel          0.2.0      2025-08-29 [1] RSPM
+#>  pillar        1.11.1     2025-09-17 [1] RSPM
+#>  reprex        2.1.1      2024-07-06 [1] RSPM
+#>  rlang         1.3.0      2026-07-05 [1] RSPM
+#>  rmarkdown     2.31       2026-03-26 [1] RSPM
+#>  sessioninfo   1.2.4      2026-06-04 [1] RSPM
+#>  vctrs         0.7.3      2026-04-11 [1] RSPM
+#>  withr         3.0.3      2026-06-19 [1] RSPM
+#>  xfun          0.60       2026-07-09 [1] RSPM
+#>  yaml          2.3.12     2025-12-10 [1] RSPM
+#> 
+#>  [1] /root/R/x86_64-pc-linux-gnu-library/4.5
+#>  [2] /opt/R/4.5.3/lib/R/library
+#>  * ── Packages attached to the search path.
+#> 
+#> ──────────────────────────────────────────────────────────────────────────────
+```
+
+</details>

--- a/experiments/2026-08-temp-storage-spill/memory.R
+++ b/experiments/2026-08-temp-storage-spill/memory.R
@@ -1,0 +1,30 @@
+library(DBI)
+packageVersion("duckdb")
+
+# The default connection is an in-memory database. The package points its
+# temporary storage below tempdir(), away from the current working directory:
+drv <- duckdb::duckdb()
+con <- dbConnect(drv)
+spill <- dbGetQuery(
+  con,
+  "SELECT current_setting('temp_directory') AS temp_directory"
+)[[1]]
+spill
+
+# Any operation that outgrows memory_limit must offload to that directory:
+# a ~460 MB sort under a 300 MB limit.
+dbExecute(con, "SET memory_limit = '300MB'")
+dbExecute(
+  con,
+  "CREATE TABLE big_sort AS SELECT hash(i) AS h, i FROM range(30000000) t(i) ORDER BY h"
+)
+dbGetQuery(con, "SELECT count(*) AS n FROM big_sort")
+
+# The spill directory exists while the instance is live ...
+dir.exists(spill)
+
+dbDisconnect(con)
+duckdb::duckdb_shutdown(drv)
+
+# ... and the engine removes it again at instance shutdown.
+dir.exists(spill)

--- a/experiments/README.md
+++ b/experiments/README.md
@@ -40,6 +40,11 @@ the directory keeps the method so that is possible.
   which prebuilt extensions DuckDB's repositories serve R's Windows
   builds, and whether the MSVC arm64 artifact can be hand-loaded;
   supports [`usage/extensions/`](/handbook/usage/extensions/README.md).
+* [`2026-08-temp-storage-spill/`](2026-08-temp-storage-spill/) —
+  whether larger-than-memory work actually spills, per connection
+  idiom, on duckdb 1.3.2, the current CRAN release, `main`, and the
+  fix in [#2562](https://github.com/duckdb/duckdb-r/pull/2562);
+  supports [`usage/memory/`](/handbook/usage/memory/README.md).
 
 Adding one: create the directory, name it for the date and the topic,
 open its `README.md` with what and when and on what,

--- a/handbook/usage/memory/README.md
+++ b/handbook/usage/memory/README.md
@@ -34,7 +34,11 @@ and how to keep results from materializing in R.
   writes — those blocks stay pinned, so a very large single append
   can still fail at `COMMIT` under a tight limit
   (engine-side; reported once on 1.3.2 and not reproduced since,
-  [#1604](https://github.com/duckdb/duckdb-r/issues/1604)).
+  [#1604](https://github.com/duckdb/duckdb-r/issues/1604) —
+  not even on 1.3.2 itself, per
+  [`experiments/2026-08-temp-storage-spill/`](/experiments/2026-08-temp-storage-spill/README.md),
+  which measured the spill behavior of both connection idioms
+  across four builds).
 * Larger-than-memory data is best left in DuckDB —
   query it lazily via dbplyr and `collect()` only the reduction;
   [#72](https://github.com/duckdb/duckdb-r/issues/72) is the long

--- a/handbook/usage/memory/README.md
+++ b/handbook/usage/memory/README.md
@@ -19,10 +19,14 @@ and how to keep results from materializing in R.
   a known boundary
   ([#1997](https://github.com/duckdb/duckdb-r/issues/1997)).
 * **Spill:** the engine offloads to `temp_directory` when a query
-  outgrows memory.
-  For an in-memory database the package points it at a session
-  temporary directory so spill works out of the box;
-  a file database is left to the engine's own default, `<dbdir>.tmp`
+  outgrows memory — on by default, as in the CLI.
+  For an in-memory database the package points it at a fresh
+  per-instance directory below the session temporary directory;
+  the engine creates it at first spill and removes it at shutdown,
+  and instances must not share one
+  (spill file names are deterministic,
+  and shutdown cleanup removes what it finds).
+  A file database is left to the engine's own default, `<dbdir>.tmp`
   beside the file (`src/duckdb/src/main/config.cpp`);
   the options that override either are
   [`storage/`](/handbook/usage/storage/README.md)'s.

--- a/man/duckdb_storage.Rd
+++ b/man/duckdb_storage.Rd
@@ -48,11 +48,22 @@ as described below.}
 setting: \code{secret_directory}. Placed at \verb{<home>/stored_secrets}, the same
 \verb{<home>}.}
 \item{Temporary / spill files}{Out-of-core intermediates for sorts, hash
-joins, and similar operations. DuckDB settings: \code{temp_directory},
-\code{max_temp_directory_size}. For an in-memory (\verb{:memory:}) database DuckDB's
-own default spills to \code{.tmp} in the current working directory, so the
-package overrides it with a \code{\link[=tempdir]{tempdir()}} sub-directory by default. This is
-a separate setting from the extension/secret home (see below).}
+joins, and similar operations.
+DuckDB settings: \code{temp_directory}, \code{max_temp_directory_size}.
+Temporary storage is on by default, with the DuckDB CLI's semantics:
+the directory is created only when a query actually spills,
+and removed again when the database instance shuts down.
+An on-disk database keeps the engine's own default,
+\verb{<dbdir>.tmp} next to the database file.
+For an in-memory (\verb{:memory:}) database the engine's own default
+would spill to \code{.tmp} in the current working directory,
+so the package points it at a fresh per-instance sub-directory
+below \code{\link[=tempdir]{tempdir()}} instead.
+Every in-memory instance gets its own spill directory:
+instances must not share one,
+because the engine's spill file names are deterministic
+and an instance cleans up its directory when it shuts down.
+This is a separate setting from the extension/secret home (see below).}
 \item{Logs and profiling output}{Written only when a path is explicitly
 configured (DuckDB settings \code{log_query_path}, \code{http_logging_output},
 profiling output). They default to \emph{off}, so nothing is written without
@@ -98,13 +109,17 @@ forces a per-session \code{\link[=tempdir]{tempdir()}} even if \verb{~/.duckdb} 
    Home \tab \code{home_directory} \tab -- \tab left untouched (not set) \cr
    Extensions \tab \code{extension_directory} \tab \code{home} arg / \code{duckdb.home} / \code{DUCKDB_R_HOME} (as \verb{<home>/extensions}) \tab \code{tempdir()} sub-directory (set) \cr
    Stored secrets \tab \code{secret_directory} \tab like extensions (\verb{<home>/stored_secrets}) \tab \code{tempdir()} sub-directory (set) \cr
-   Temp/spill \tab \code{temp_directory} \tab \code{duckdb.temp_directory} / \code{DUCKDB_R_TEMP_DIRECTORY} \tab \code{tempdir()} sub-directory (set) \cr
+   Temp/spill \tab \code{temp_directory} \tab \code{duckdb.temp_directory} / \code{DUCKDB_R_TEMP_DIRECTORY} \tab memory: \code{tempdir()} sub-directory (set); disk: \verb{<dbdir>.tmp} \cr
    Logs \tab \code{log_query_path} \tab DuckDB setting \tab disabled (off) \cr
 }
 
 
 "set" means \code{duckdb()} sets the value explicitly in the database config.
 The home directory is left untouched so that \code{~} in user SQL keeps its usual meaning.
+The temp/spill setting is left unset for an on-disk database:
+the engine's own \verb{<dbdir>.tmp} default already matches the DuckDB CLI,
+no matter whether the database is opened through \code{\link[=duckdb]{duckdb()}}
+or through the \code{dbdir} argument of \code{\link[DBI:dbConnect]{DBI::dbConnect()}}.
 An \code{extension_directory} / \code{secret_directory} / \code{temp_directory}
 passed directly in the \code{config} list is always honored
 and takes precedence over the resolution above.

--- a/tests/testthat/test-storage-home.R
+++ b/tests/testthat/test-storage-home.R
@@ -214,25 +214,85 @@ test_that("a forced-interactive session does not get ~/.duckdb created for it", 
 })
 
 test_that("resolve_temp_directory redirects in-memory only, honors override", {
-  local_mocked_bindings(session_temp_dir = function() "/tmp/sess")
-  expect_equal(
-    resolve_temp_directory(":memory:"),
-    list(directory = session_home_path("temp"), source = "session")
+  tmp <- withr::local_tempdir()
+  local_mocked_bindings(session_temp_dir = function() tmp)
+
+  resolved <- resolve_temp_directory(":memory:")
+  expect_equal(resolved$source, "session")
+
+  # The per-instance spill directory sits under the session spill root ...
+  spill_root <- file.path(tmp, get_package_name(), "temp")
+  expect_equal(dirname(resolved$directory), spill_root)
+  # ... which resolving created, so the engine's own single-level directory
+  # creation can create the leaf lazily at first spill.
+  expect_true(dir.exists(spill_root))
+  # The leaf itself is left to the engine: nothing exists until a query
+  # actually spills.
+  expect_false(dir.exists(resolved$directory))
+  # Every resolution yields a fresh leaf: concurrent in-memory instances must
+  # not share a spill directory (deterministic file names, shutdown cleanup).
+  expect_false(
+    identical(resolve_temp_directory(":memory:")$directory, resolved$directory)
   )
+
+  # An on-disk database keeps the engine's own `<dbdir>.tmp` default.
   expect_equal(
     resolve_temp_directory("/path/to/my.db"),
     list(directory = NULL, source = "default")
   )
 
-  withr::local_options(duckdb.temp_directory = "/opt/tmp")
+  # An override is passed through verbatim, and never created here.
+  withr::local_options(
+    duckdb.temp_directory = file.path(tmp, "no-such-dir", "spill")
+  )
   expect_equal(
     resolve_temp_directory(":memory:"),
-    list(directory = "/opt/tmp", source = "option")
+    list(directory = file.path(tmp, "no-such-dir", "spill"), source = "option")
   )
   expect_equal(
     resolve_temp_directory("/path/to/my.db"),
-    list(directory = "/opt/tmp", source = "option")
+    list(directory = file.path(tmp, "no-such-dir", "spill"), source = "option")
   )
+  expect_false(dir.exists(file.path(tmp, "no-such-dir", "spill")))
+})
+
+test_that("an in-memory database spills to temporary storage out of the box", {
+  drv <- duckdb()
+  con <- dbConnect(drv)
+  on.exit(
+    {
+      dbDisconnect(con)
+      duckdb_shutdown(drv)
+    },
+    add = TRUE
+  )
+
+  spill <- dbGetQuery(
+    con,
+    "SELECT current_setting('temp_directory') AS dir"
+  )$dir
+  expect_equal(dirname(spill), file.path(session_home(), "temp"))
+  expect_false(dir.exists(spill))
+
+  # A sort that outgrows the memory limit: it can only complete by offloading
+  # to the spill directory, which the engine creates on first use.
+  dbExecute(con, "SET memory_limit = '80MB'")
+  dbExecute(
+    con,
+    "CREATE TABLE spilled AS
+       SELECT hash(i) AS h, i FROM range(10000000) t(i) ORDER BY h"
+  )
+  expect_true(dir.exists(spill))
+  expect_equal(
+    dbGetQuery(con, "SELECT count(*) AS n FROM spilled")$n,
+    10000000
+  )
+
+  # The engine removes the per-instance directory at instance shutdown.
+  dbDisconnect(con)
+  duckdb_shutdown(drv)
+  on.exit()
+  expect_false(dir.exists(spill))
 })
 
 test_that("storage-location message: tempdir wording", {

--- a/tests/testthat/test-storage-home.R
+++ b/tests/testthat/test-storage-home.R
@@ -256,6 +256,27 @@ test_that("resolve_temp_directory redirects in-memory only, honors override", {
   expect_false(dir.exists(file.path(tmp, "no-such-dir", "spill")))
 })
 
+test_that("an on-disk database keeps the engine's `<dbdir>.tmp` spill default", {
+  db <- file.path(withr::local_tempdir(), "spill.duckdb")
+
+  # The common idiom: the driver is created for :memory: and dbConnect() then
+  # re-targets it at the file. The in-memory spill redirect must not ride
+  # along -- the file instance re-resolves and keeps the engine's own default,
+  # as the CLI would (#1604).
+  con <- dbConnect(duckdb(), dbdir = db)
+  # The instance dbConnect() created, via the driver cache; released with a
+  # withr::defer() (LIFO), so it still runs before local_tempdir()'s cleanup.
+  drv_file <- duckdb(dbdir = db)
+  withr::defer({
+    dbDisconnect(con)
+    duckdb_shutdown(drv_file)
+  })
+  expect_equal(
+    dbGetQuery(con, "SELECT current_setting('temp_directory') AS dir")$dir,
+    paste0(normalizePath(db, mustWork = FALSE), ".tmp")
+  )
+})
+
 test_that("an in-memory database spills to temporary storage out of the box", {
   drv <- duckdb()
   con <- dbConnect(drv)


### PR DESCRIPTION
## What this fixes

Temporary storage (spilling larger-than-memory operators to disk) is nominally on by default, but on `main` it does not actually work for the most common connection setups:

- **In-memory databases** (the default connection): `resolve_temp_directory()` points `temp_directory` at `file.path(tempdir(), "duckdb", "temp")`, but nothing ever creates that path. The engine creates the directory only lazily, at the first actual spill, with a single-level `mkdir` (`LocalFileSystem::CreateDirectory()`), which cannot make two missing levels. The first query that outgrows `memory_limit` therefore fails with `IO Error: Failed to create directory "/tmp/Rtmp..../duckdb/temp"` instead of spilling.
- **On-disk databases opened as `dbConnect(duckdb(), dbdir = "db.duckdb")`** (the idiom from the issue, and the most common one): the driver is created for `:memory:` first, so the in-memory redirect gets baked into `drv@config`; when `dbConnect()` re-creates the instance for the file it merges that config over (`config <- utils::modifyList(drv@config, config)`), so the file-backed instance *also* points at the uncreatable tempdir path instead of the engine's own `<dbdir>.tmp`. Same IO error at first spill, and `db.duckdb.tmp` never appears — "temporary directory does not used", as the issue title puts it.

Only the direct `duckdb(dbdir = "db.duckdb")` route kept the engine default and could spill. Both failure modes ship in the current CRAN release: 1.5.5 fails the same way (see Experiments below).

## The change

Two small pieces, both R-side:

- `resolve_temp_directory()` now hands every in-memory instance its own spill directory, `<tempdir()>/duckdb/temp/spill-<unique>`, and creates the *parent* chain so the engine's own lazy, single-level directory creation succeeds. The leaf itself is left to the engine, which preserves the CLI's lifecycle: the directory appears only when a query actually spills, and is removed again when the instance shuts down. Per-instance uniqueness matters because concurrent in-memory instances are the norm in R (every `duckdb()` call creates a fresh instance) and they must not share a spill directory: the engine's spill file names are deterministic (`duckdb_temp_storage_<size>-<index>.tmp`, `duckdb_temp_block-<id>.block`), and a shutting-down instance deletes the `duckdb_temp_*` files — or the whole directory — it finds in its own.
- `duckdb()` now applies the auto-resolved `temp_directory` to the engine startup config only, without storing it in the driver's `config` slot. That slot's one consumer is the instance re-creation in `dbConnect()` with a different `dbdir`, which now re-resolves for the actual database: an on-disk database gets the engine's own `<dbdir>.tmp` default no matter how it was opened. An explicit `temp_directory` in `config` (or the `duckdb.temp_directory` option / `DUCKDB_R_TEMP_DIRECTORY` variable) is stored and honored as-is, like an explicit setting in the CLI.

Resulting semantics, mirroring the DuckDB CLI:

- Temporary storage is on by default, with `max_temp_directory_size` at the engine default (90% of available disk space).
- An on-disk database spills to `<dbdir>.tmp` next to the database file (the engine default, left unset).
- An in-memory database spills to a per-instance directory below `tempdir()` (where the CLI uses `.tmp` in the working directory, which is not a place an R package should write).
- The directory is created lazily at first spill, removed at instance shutdown, and overridable.

## Review of #1604

The report (duckdb-r 1.3.2, on-disk database): a ~257 MB `dbWriteTable(append = TRUE)` under `memory_limit = '3GB'` failed at commit with `failed to pin block of size 256.0 KiB (2.7 GiB/2.7 GiB used)`, and `db.duckdb.tmp` was never created.

- duckdb-r 1.3.2 did not touch `temp_directory` or `use_temporary_directory` at all (checked against the CRAN archive sources), so the engine's defaults were active — temporary storage on, `db.duckdb.tmp` beside the file. An absent `.tmp` directory does not by itself mean spilling was off: the engine creates it only at the first actual spill. The reported commit-time failure is engine-side 1.3.x behavior (a transaction's own uncommitted writes stay pinned and cannot offload), not the R package disabling anything.
- The reported scenario does not reproduce on the current build — nor on 1.3.2 itself (see Experiments): the reprex below runs the reported settings verbatim (passes), then an append with `memory_limit` *below* the data size (passes, without even needing temporary storage — the optimistic write path handles it), then a ~460 MB sort under a 200 MB limit (passes, with `db.duckdb.tmp` visibly in use).
- On `main`, however, that same script's sort step fails with the IO error above, because the `dbConnect(duckdb(), dbdir = ...)` idiom inherited the in-memory redirect. So the issue's *title* symptom is reproducible on `main` even though the originally reported commit failure is not; both are gone with this PR.

## Reprexes

`packageVersion()` prints `1.5.5.9010` in all four runs: the two "main" runs were rendered against an installation of current `main` (1fc15f5), the other two against this branch.

<details><summary><b>#1604 scenario (on-disk), on main — the sort step fails, <code>db.duckdb.tmp</code> never used</b></summary>

`````
``` r
library(DBI)
packageVersion("duckdb")
#> [1] '1.5.5.9010'

# The scenario of duckdb/duckdb-r#1604: append a data.frame to a table of an
# on-disk database under a memory_limit, with the settings reported there.
dbdir <- file.path(tempdir(), "db.duckdb")
con <- dbConnect(duckdb::duckdb(), dbdir = dbdir)
#> duckdb is storing downloaded extensions and secrets under ~/.duckdb:
#> ℹ /root/.duckdb
#> This persists across sessions and is shared with the DuckDB CLI and other clients.
#> ℹ Run duckdb(shared_home = FALSE) to use a temporary directory instead.
#> ℹ See ?duckdb_storage for details and alternatives.

dbExecute(con, "SET memory_limit = '3GB'")
#> [1] 0
dbExecute(con, "SET max_temp_directory_size = '20GB'")
#> [1] 0
dbExecute(con, "SET threads TO 1")
#> [1] 0
dbExecute(con, "SET preserve_insertion_order = false")
#> [1] 0

# Temporary storage is on, beside the database file (the engine's own default):
dbGetQuery(con, "SELECT current_setting('temp_directory') AS temp_directory")
#>                temp_directory
#> 1 /tmp/Rtmp9T5BRV/duckdb/temp

# The reported data: 12,880,502 rows x 5 integer columns, ~257 MB.
n <- 12880502L
dat <- data.frame(
  a = seq_len(n),
  b = rev(seq_len(n)),
  c = seq_len(n) %% 1000L,
  d = seq_len(n) %/% 7L,
  e = seq_len(n) %% 33333L
)
format(object.size(dat), units = "MB")
#> [1] "245.7 Mb"

# "insert a data.frame into existing database": create the table, then append.
dbWriteTable(con, "tbl", dat[0, ], overwrite = TRUE)
dbWriteTable(con, "tbl", dat, append = TRUE) # <- failed in #1604 under 3 GB
dbGetQuery(con, "SELECT count(*) AS n FROM tbl")
#>          n
#> 1 12880502

# Harder than reported: repeat the append with a memory_limit *below* the data
# size, so it can only succeed by offloading to temporary storage.
dbExecute(con, "SET memory_limit = '200MB'")
#> [1] 0
dbWriteTable(con, "tbl", dat, append = TRUE)
dbGetQuery(con, "SELECT count(*) AS n FROM tbl")
#>          n
#> 1 25761004

# Was the temporary directory used at any point?
dir.exists(paste0(dbdir, ".tmp"))
#> [1] FALSE

# Harder still: a full ~460 MB sort under the 200 MB limit.
dbExecute(con, "SET preserve_insertion_order = true")
#> [1] 0
dbExecute(
  con,
  "CREATE TABLE big_sort AS SELECT hash(i) AS h, i FROM range(30000000) t(i) ORDER BY h"
)
#> Error in `duckdb_result()`:
#> ! Invalid Error: IO Error: Failed to create directory "/tmp/Rtmp9T5BRV/duckdb/temp": No such file or directory
#> ℹ Context: rapi_execute
#> ℹ Error type: INVALID
dbGetQuery(con, "SELECT count(*) AS n FROM big_sort")
#> Error in `dbSendQuery()`:
#> ! Catalog Error: Table with name big_sort does not exist!
#> Did you mean "pg_description"?
#> 
#> LINE 1: SELECT count(*) AS n FROM big_sort
#>                                   ^
#> ℹ Context: rapi_prepare
#> ℹ Error type: CATALOG
dir.exists(paste0(dbdir, ".tmp"))
#> [1] FALSE

dbDisconnect(con)
```

<sup>Created on 2026-08-07 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

<details style="margin-bottom:10px;">

<summary>

Session info
</summary>

``` r
sessioninfo::session_info()
#> ─ Session info ───────────────────────────────────────────────────────────────
#>  setting  value
#>  version  R version 4.5.3 (2026-03-11)
#>  os       Ubuntu 24.04.4 LTS
#>  system   x86_64, linux-gnu
#>  ui       X11
#>  language (EN)
#>  collate  C.UTF-8
#>  ctype    C.UTF-8
#>  tz       Etc/UTC
#>  date     2026-08-07
#>  pandoc   3.9.0.2 @ /usr/local/bin/ (via rmarkdown)
#>  quarto   1.9.38 @ /usr/local/bin/quarto
#> 
#> ─ Packages ───────────────────────────────────────────────────────────────────
#>  package     * version    date (UTC) lib source
#>  cli           3.6.6      2026-04-09 [1] RSPM
#>  DBI         * 1.3.0      2026-02-25 [1] RSPM
#>  digest        0.6.39     2025-11-19 [1] RSPM
#>  duckdb        1.5.5.9010 2026-08-07 [1] local
#>  evaluate      1.0.5      2025-08-27 [1] RSPM
#>  fastmap       1.2.0      2024-05-15 [1] RSPM
#>  fs            2.1.0      2026-04-18 [1] RSPM
#>  glue          1.8.1      2026-04-17 [1] RSPM
#>  htmltools     0.5.9      2025-12-04 [1] RSPM
#>  knitr         1.51       2025-12-20 [1] RSPM
#>  lifecycle     1.0.5      2026-01-08 [1] RSPM
#>  otel          0.2.0      2025-08-29 [1] RSPM
#>  pillar        1.11.1     2025-09-17 [1] RSPM
#>  reprex        2.1.1      2024-07-06 [1] RSPM
#>  rlang         1.3.0      2026-07-05 [1] RSPM
#>  rmarkdown     2.31       2026-03-26 [1] RSPM
#>  sessioninfo   1.2.4      2026-06-04 [1] RSPM
#>  vctrs         0.7.3      2026-04-11 [1] RSPM
#>  withr         3.0.3      2026-06-19 [1] RSPM
#>  xfun          0.60       2026-07-09 [1] RSPM
#>  yaml          2.3.12     2025-12-10 [1] RSPM
#> 
#>  [1] /root/R/x86_64-pc-linux-gnu-library/4.5
#>  [2] /opt/R/4.5.3/lib/R/library
#>  * ── Packages attached to the search path.
#> 
#> ──────────────────────────────────────────────────────────────────────────────
```

</details>
`````

</details>

<details><summary><b>#1604 scenario (on-disk), this PR — comprehensive non-reproducer: everything passes, <code>&lt;dbdir&gt;.tmp</code> in use (session info inside)</b></summary>

`````
``` r
library(DBI)
packageVersion("duckdb")
#> [1] '1.5.5.9010'

# The scenario of duckdb/duckdb-r#1604: append a data.frame to a table of an
# on-disk database under a memory_limit, with the settings reported there.
dbdir <- file.path(tempdir(), "db.duckdb")
con <- dbConnect(duckdb::duckdb(), dbdir = dbdir)
#> duckdb is storing downloaded extensions and secrets under ~/.duckdb:
#> ℹ /root/.duckdb
#> This persists across sessions and is shared with the DuckDB CLI and other clients.
#> ℹ Run duckdb(shared_home = FALSE) to use a temporary directory instead.
#> ℹ See ?duckdb_storage for details and alternatives.

dbExecute(con, "SET memory_limit = '3GB'")
#> [1] 0
dbExecute(con, "SET max_temp_directory_size = '20GB'")
#> [1] 0
dbExecute(con, "SET threads TO 1")
#> [1] 0
dbExecute(con, "SET preserve_insertion_order = false")
#> [1] 0

# Temporary storage is on, beside the database file (the engine's own default):
dbGetQuery(con, "SELECT current_setting('temp_directory') AS temp_directory")
#>                  temp_directory
#> 1 /tmp/Rtmpi49j2A/db.duckdb.tmp

# The reported data: 12,880,502 rows x 5 integer columns, ~257 MB.
n <- 12880502L
dat <- data.frame(
  a = seq_len(n),
  b = rev(seq_len(n)),
  c = seq_len(n) %% 1000L,
  d = seq_len(n) %/% 7L,
  e = seq_len(n) %% 33333L
)
format(object.size(dat), units = "MB")
#> [1] "245.7 Mb"

# "insert a data.frame into existing database": create the table, then append.
dbWriteTable(con, "tbl", dat[0, ], overwrite = TRUE)
dbWriteTable(con, "tbl", dat, append = TRUE) # <- failed in #1604 under 3 GB
dbGetQuery(con, "SELECT count(*) AS n FROM tbl")
#>          n
#> 1 12880502

# Harder than reported: repeat the append with a memory_limit *below* the data
# size, so it can only succeed by offloading to temporary storage.
dbExecute(con, "SET memory_limit = '200MB'")
#> [1] 0
dbWriteTable(con, "tbl", dat, append = TRUE)
dbGetQuery(con, "SELECT count(*) AS n FROM tbl")
#>          n
#> 1 25761004

# Was the temporary directory used at any point?
dir.exists(paste0(dbdir, ".tmp"))
#> [1] FALSE

# Harder still: a full ~460 MB sort under the 200 MB limit.
dbExecute(con, "SET preserve_insertion_order = true")
#> [1] 0
dbExecute(
  con,
  "CREATE TABLE big_sort AS SELECT hash(i) AS h, i FROM range(30000000) t(i) ORDER BY h"
)
#> [1] 3e+07
dbGetQuery(con, "SELECT count(*) AS n FROM big_sort")
#>       n
#> 1 3e+07
dir.exists(paste0(dbdir, ".tmp"))
#> [1] TRUE

dbDisconnect(con)
```

<sup>Created on 2026-08-07 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

<details style="margin-bottom:10px;">

<summary>

Session info
</summary>

``` r
sessioninfo::session_info()
#> ─ Session info ───────────────────────────────────────────────────────────────
#>  setting  value
#>  version  R version 4.5.3 (2026-03-11)
#>  os       Ubuntu 24.04.4 LTS
#>  system   x86_64, linux-gnu
#>  ui       X11
#>  language (EN)
#>  collate  C.UTF-8
#>  ctype    C.UTF-8
#>  tz       Etc/UTC
#>  date     2026-08-07
#>  pandoc   3.9.0.2 @ /usr/local/bin/ (via rmarkdown)
#>  quarto   1.9.38 @ /usr/local/bin/quarto
#> 
#> ─ Packages ───────────────────────────────────────────────────────────────────
#>  package     * version    date (UTC) lib source
#>  cli           3.6.6      2026-04-09 [1] RSPM
#>  DBI         * 1.3.0      2026-02-25 [1] RSPM
#>  digest        0.6.39     2025-11-19 [1] RSPM
#>  duckdb        1.5.5.9010 2026-08-07 [1] local
#>  evaluate      1.0.5      2025-08-27 [1] RSPM
#>  fastmap       1.2.0      2024-05-15 [1] RSPM
#>  fs            2.1.0      2026-04-18 [1] RSPM
#>  glue          1.8.1      2026-04-17 [1] RSPM
#>  htmltools     0.5.9      2025-12-04 [1] RSPM
#>  knitr         1.51       2025-12-20 [1] RSPM
#>  lifecycle     1.0.5      2026-01-08 [1] RSPM
#>  otel          0.2.0      2025-08-29 [1] RSPM
#>  pillar        1.11.1     2025-09-17 [1] RSPM
#>  reprex        2.1.1      2024-07-06 [1] RSPM
#>  rlang         1.3.0      2026-07-05 [1] RSPM
#>  rmarkdown     2.31       2026-03-26 [1] RSPM
#>  sessioninfo   1.2.4      2026-06-04 [1] RSPM
#>  vctrs         0.7.3      2026-04-11 [1] RSPM
#>  withr         3.0.3      2026-06-19 [1] RSPM
#>  xfun          0.60       2026-07-09 [1] RSPM
#>  yaml          2.3.12     2025-12-10 [1] RSPM
#> 
#>  [1] /root/R/x86_64-pc-linux-gnu-library/4.5
#>  [2] /opt/R/4.5.3/lib/R/library
#>  * ── Packages attached to the search path.
#> 
#> ──────────────────────────────────────────────────────────────────────────────
```

</details>
`````

</details>

<details><summary><b>In-memory spill, on main — the first spill fails with the IO error</b></summary>

`````
``` r
library(DBI)
packageVersion("duckdb")
#> [1] '1.5.5.9010'

# The default connection is an in-memory database. The package points its
# temporary storage below tempdir(), away from the current working directory:
drv <- duckdb::duckdb()
#> duckdb is storing downloaded extensions and secrets under ~/.duckdb:
#> ℹ /root/.duckdb
#> This persists across sessions and is shared with the DuckDB CLI and other clients.
#> ℹ Run duckdb(shared_home = FALSE) to use a temporary directory instead.
#> ℹ See ?duckdb_storage for details and alternatives.
con <- dbConnect(drv)
spill <- dbGetQuery(
  con,
  "SELECT current_setting('temp_directory') AS temp_directory"
)[[1]]
spill
#> [1] "/tmp/RtmpWQkYXn/duckdb/temp"

# Any operation that outgrows memory_limit must offload to that directory:
# a ~460 MB sort under a 300 MB limit.
dbExecute(con, "SET memory_limit = '300MB'")
#> [1] 0
dbExecute(
  con,
  "CREATE TABLE big_sort AS SELECT hash(i) AS h, i FROM range(30000000) t(i) ORDER BY h"
)
#> Error in `duckdb_result()`:
#> ! Invalid Error: IO Error: Failed to create directory "/tmp/RtmpWQkYXn/duckdb/temp": No such file or directory
#> ℹ Context: rapi_execute
#> ℹ Error type: INVALID
dbGetQuery(con, "SELECT count(*) AS n FROM big_sort")
#> Error in `dbSendQuery()`:
#> ! Catalog Error: Table with name big_sort does not exist!
#> Did you mean "pg_description"?
#> 
#> LINE 1: SELECT count(*) AS n FROM big_sort
#>                                   ^
#> ℹ Context: rapi_prepare
#> ℹ Error type: CATALOG

# The spill directory exists while the instance is live ...
dir.exists(spill)
#> [1] FALSE

dbDisconnect(con)
duckdb::duckdb_shutdown(drv)

# ... and the engine removes it again at instance shutdown.
dir.exists(spill)
#> [1] FALSE
```

<sup>Created on 2026-08-07 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

<details style="margin-bottom:10px;">

<summary>

Session info
</summary>

``` r
sessioninfo::session_info()
#> ─ Session info ───────────────────────────────────────────────────────────────
#>  setting  value
#>  version  R version 4.5.3 (2026-03-11)
#>  os       Ubuntu 24.04.4 LTS
#>  system   x86_64, linux-gnu
#>  ui       X11
#>  language (EN)
#>  collate  C.UTF-8
#>  ctype    C.UTF-8
#>  tz       Etc/UTC
#>  date     2026-08-07
#>  pandoc   3.9.0.2 @ /usr/local/bin/ (via rmarkdown)
#>  quarto   1.9.38 @ /usr/local/bin/quarto
#> 
#> ─ Packages ───────────────────────────────────────────────────────────────────
#>  package     * version    date (UTC) lib source
#>  cli           3.6.6      2026-04-09 [1] RSPM
#>  DBI         * 1.3.0      2026-02-25 [1] RSPM
#>  digest        0.6.39     2025-11-19 [1] RSPM
#>  duckdb        1.5.5.9010 2026-08-07 [1] local
#>  evaluate      1.0.5      2025-08-27 [1] RSPM
#>  fastmap       1.2.0      2024-05-15 [1] RSPM
#>  fs            2.1.0      2026-04-18 [1] RSPM
#>  glue          1.8.1      2026-04-17 [1] RSPM
#>  htmltools     0.5.9      2025-12-04 [1] RSPM
#>  knitr         1.51       2025-12-20 [1] RSPM
#>  lifecycle     1.0.5      2026-01-08 [1] RSPM
#>  otel          0.2.0      2025-08-29 [1] RSPM
#>  pillar        1.11.1     2025-09-17 [1] RSPM
#>  reprex        2.1.1      2024-07-06 [1] RSPM
#>  rlang         1.3.0      2026-07-05 [1] RSPM
#>  rmarkdown     2.31       2026-03-26 [1] RSPM
#>  sessioninfo   1.2.4      2026-06-04 [1] RSPM
#>  vctrs         0.7.3      2026-04-11 [1] RSPM
#>  withr         3.0.3      2026-06-19 [1] RSPM
#>  xfun          0.60       2026-07-09 [1] RSPM
#>  yaml          2.3.12     2025-12-10 [1] RSPM
#> 
#>  [1] /root/R/x86_64-pc-linux-gnu-library/4.5
#>  [2] /opt/R/4.5.3/lib/R/library
#>  * ── Packages attached to the search path.
#> 
#> ──────────────────────────────────────────────────────────────────────────────
```

</details>
`````

</details>

<details><summary><b>In-memory spill, this PR — spills, per-instance directory, removed at shutdown (session info inside)</b></summary>

`````
``` r
library(DBI)
packageVersion("duckdb")
#> [1] '1.5.5.9010'

# The default connection is an in-memory database. The package points its
# temporary storage below tempdir(), away from the current working directory:
drv <- duckdb::duckdb()
#> duckdb is storing downloaded extensions and secrets under ~/.duckdb:
#> ℹ /root/.duckdb
#> This persists across sessions and is shared with the DuckDB CLI and other clients.
#> ℹ Run duckdb(shared_home = FALSE) to use a temporary directory instead.
#> ℹ See ?duckdb_storage for details and alternatives.
con <- dbConnect(drv)
spill <- dbGetQuery(
  con,
  "SELECT current_setting('temp_directory') AS temp_directory"
)[[1]]
spill
#> [1] "/tmp/RtmpwzGNVv/duckdb/temp/spill-58f14e4b648b"

# Any operation that outgrows memory_limit must offload to that directory:
# a ~460 MB sort under a 300 MB limit.
dbExecute(con, "SET memory_limit = '300MB'")
#> [1] 0
dbExecute(
  con,
  "CREATE TABLE big_sort AS SELECT hash(i) AS h, i FROM range(30000000) t(i) ORDER BY h"
)
#> [1] 3e+07
dbGetQuery(con, "SELECT count(*) AS n FROM big_sort")
#>       n
#> 1 3e+07

# The spill directory exists while the instance is live ...
dir.exists(spill)
#> [1] TRUE

dbDisconnect(con)
duckdb::duckdb_shutdown(drv)

# ... and the engine removes it again at instance shutdown.
dir.exists(spill)
#> [1] FALSE
```

<sup>Created on 2026-08-07 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

<details style="margin-bottom:10px;">

<summary>

Session info
</summary>

``` r
sessioninfo::session_info()
#> ─ Session info ───────────────────────────────────────────────────────────────
#>  setting  value
#>  version  R version 4.5.3 (2026-03-11)
#>  os       Ubuntu 24.04.4 LTS
#>  system   x86_64, linux-gnu
#>  ui       X11
#>  language (EN)
#>  collate  C.UTF-8
#>  ctype    C.UTF-8
#>  tz       Etc/UTC
#>  date     2026-08-07
#>  pandoc   3.9.0.2 @ /usr/local/bin/ (via rmarkdown)
#>  quarto   1.9.38 @ /usr/local/bin/quarto
#> 
#> ─ Packages ───────────────────────────────────────────────────────────────────
#>  package     * version    date (UTC) lib source
#>  cli           3.6.6      2026-04-09 [1] RSPM
#>  DBI         * 1.3.0      2026-02-25 [1] RSPM
#>  digest        0.6.39     2025-11-19 [1] RSPM
#>  duckdb        1.5.5.9010 2026-08-07 [1] local
#>  evaluate      1.0.5      2025-08-27 [1] RSPM
#>  fastmap       1.2.0      2024-05-15 [1] RSPM
#>  fs            2.1.0      2026-04-18 [1] RSPM
#>  glue          1.8.1      2026-04-17 [1] RSPM
#>  htmltools     0.5.9      2025-12-04 [1] RSPM
#>  knitr         1.51       2025-12-20 [1] RSPM
#>  lifecycle     1.0.5      2026-01-08 [1] RSPM
#>  otel          0.2.0      2025-08-29 [1] RSPM
#>  reprex        2.1.1      2024-07-06 [1] RSPM
#>  rlang         1.3.0      2026-07-05 [1] RSPM
#>  rmarkdown     2.31       2026-03-26 [1] RSPM
#>  sessioninfo   1.2.4      2026-06-04 [1] RSPM
#>  withr         3.0.3      2026-06-19 [1] RSPM
#>  xfun          0.60       2026-07-09 [1] RSPM
#>  yaml          2.3.12     2025-12-10 [1] RSPM
#> 
#>  [1] /root/R/x86_64-pc-linux-gnu-library/4.5
#>  [2] /opt/R/4.5.3/lib/R/library
#>  * ── Packages attached to the search path.
#> 
#> ──────────────────────────────────────────────────────────────────────────────
```

</details>
`````

</details>

## Experiments

The scripts and every rendered run live durably in [`experiments/2026-08-temp-storage-spill/`](https://github.com/duckdb/duckdb-r/tree/claude/temp-storage-dir-creation-bjpx3r/experiments/2026-08-temp-storage-spill): the four runs quoted above, verbatim, plus the same two scripts rerun on 2026-08-08 against two released versions:

- **duckdb 1.3.2** (the version #1604 was reported on; binary from the Posit Package Manager snapshot `2025-09-01`): engine defaults untouched, and spilling worked everywhere — the on-disk database spills to `db.duckdb.tmp`, the in-memory one to `.tmp` in the working directory, and the reported append passes at the reported 3 GB limit and again at 200 MB. The reported commit-time failure does not reproduce on this hardware even on the reported version.
- **duckdb 1.5.5** (the CRAN release current today, from Posit Package Manager): affected exactly like `main` — both connection idioms point at the uncreatable `<tempdir()>/duckdb/temp`, the sort step fails with the IO error in both scripts, and `db.duckdb.tmp` is never used. The regression has shipped; this PR fixes what current CRAN users hit.

## Tests and docs

- The `resolve_temp_directory()` unit test now covers the per-instance leaf, the created parent, uniqueness across calls, the untouched on-disk default, and that overrides pass through verbatim without being created by the package.
- New live tests: an on-disk database opened via `dbConnect(duckdb(), dbdir = ...)` reports `<dbdir>.tmp` as its `temp_directory`; an in-memory database completes a larger-than-memory sort out of the box, with the spill directory appearing at first spill and disappearing at `duckdb_shutdown()`.
- `?duckdb_storage` and the handbook memory page now state the on-by-default, CLI-matching semantics; the memory page links the experiment, and the storage code headers backreference their handbook nodes.

Full test suite: 0 failures, 0 warnings, 1288 passes (60 pre-existing environment-dependent skips).

Closes #1604.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UeVV4xN6pBiCzwkj5SwKAz