### PR TITLE
docs(handbook): Prefer durable storage for hard-to-reproduce experiment results

### DIFF
--- a/handbook/meta/plans/README.md
+++ b/handbook/meta/plans/README.md
@@ -29,3 +29,12 @@ an experiment records what was measured, when, and on what,
 and the leaf that leans on it links it —
 which is what lets a reader weigh a finding
 without repeating the work.
+
+Prefer durable storage for a result that is hard to reproduce —
+one that needs an old package version, a long build,
+a specific platform, or hours of compute:
+commit the script *and* the recorded output under `experiments/`
+while the result is fresh.
+Session scratch space, chat transcripts, and CI logs all expire,
+and a finding that lived only there
+is the same work waiting to be done again.

--- a/handbook/meta/plans/README.md
+++ b/handbook/meta/plans/README.md
@@ -35,6 +35,7 @@ one that needs an old package version, a long build,
 a specific platform, or hours of compute:
 commit the script *and* the recorded output under `experiments/`
 while the result is fresh.
+The output should be a Markdown file created with `reprex::reprex(si = TRUE)`.
 Session scratch space, chat transcripts, and CI logs all expire,
 and a finding that lived only there
 is the same work waiting to be done again.


### PR DESCRIPTION
Adds one paragraph to `handbook/meta/plans/` (the leaf that owns `plan/` and `experiments/`): a result that is hard to reproduce — an old package version, a long build, a specific platform, hours of compute — is committed under `experiments/` while it is fresh, script and recorded output both. Session scratch space, chat transcripts, and CI logs all expire, and a finding that lived only there is the same work waiting to be done again.

Prompted by the temporary-storage experiment in #2562, whose first runs lived only in session scratch space.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UeVV4xN6pBiCzwkj5SwKAz

---
_Generated by [Claude Code](https://claude.ai/code/session_01UeVV4xN6pBiCzwkj5SwKAz)_