### PR TITLE
fix(flavor): Catch a generated README that reached a series under the mainline name

### DIFF
--- a/.github/workflows/custom/after-install/action.yml
+++ b/.github/workflows/custom/after-install/action.yml
@@ -96,4 +96,13 @@ runs:
           )
         }
         writeLines("No file left under the mainline name.")
+        readmes <- flavor_mainline_readme_offenders(".")
+        if (length(readmes) > 0) {
+          writeLines(readmes)
+          stop(
+            "A generated README still tells a reader to install the mainline ",
+            "package; see scripts/flavor-package-name.R for how to resolve this."
+          )
+        }
+        writeLines("No generated README pointing at the mainline package.")
       shell: Rscript {0}

--- a/handbook/testing/guards/README.md
+++ b/handbook/testing/guards/README.md
@@ -47,3 +47,34 @@ or teach `scripts/flavor.patch` the rename.
 The scan covers what ships;
 `handbook/` is outside it and is written for the mainline flavor
 ([`branches/flavors/`](/handbook/branches/flavors/README.md)).
+
+**Two companion scans, for what reading file contents cannot see.**
+The rename runs *once*, when a series is seeded,
+so anything that arrives on a flavored branch afterwards —
+a commit ported from `main`
+([`operations/vendoring/series-loop/`](/handbook/operations/vendoring/series-loop/README.md))
+— brings the mainline name with it and nothing rewrites it.
+Both scans are empty on the mainline flavor, where that name is the right one.
+
+* `flavor_unflavored_paths()` catches a file the patch *renames*
+  arriving under its mainline name.
+  Such a file carries the name in its name rather than its contents,
+  so the content scan looks straight past it —
+  and the file is then simply not read.
+  `src/duckdb-win.def` on a `duckdb.dev` build
+  is not the export list R's `share/make/winshlib.mk` looks for,
+  so the Windows link generates one from every object
+  and overruns the PE export table.
+* `flavor_mainline_readme_offenders()` catches an install call
+  naming the mainline package in `README.md` or `.github/README.md`.
+  Those two are *generated* from `README.Rmd`,
+  which is what the content scan reads in their place;
+  they pass whether or not their source was flavored,
+  so a ported README lands mainline text on a flavored branch unseen.
+  `.github/README.md` is the front page GitHub renders for the branch,
+  which makes it the likeliest of the three to be read by a user.
+
+All three run in the same `rcc-smoke` step
+(`.github/workflows/custom/after-install/action.yml`)
+and are wrapped for the suite by
+`tests/testthat/test-flavor-package-name.R`.

--- a/scripts/flavor-package-name.R
+++ b/scripts/flavor-package-name.R
@@ -141,3 +141,55 @@ flavor_unflavored_paths <- function(root = ".") {
   renamed <- flavor_renamed_paths(file.path(root, "scripts", "flavor.patch"))
   renamed[file.exists(file.path(root, renamed))]
 }
+
+# The generated READMEs, as paths relative to the package root. Both are written
+# from `README.Rmd` by `make readme`, and neither is scanned above: a hit in a
+# generated file would be keyed under a path `scripts/flavor.patch` no longer
+# names, and would read as an offender however well the rename is handled.
+flavor_generated_readmes <- c("README.md", file.path(".github", "README.md"))
+
+# Every place a generated README still tells a reader to install the mainline
+# package, on a checkout that is not the mainline flavor.
+#
+# The two READMEs are generated, but only when something regenerates them, and
+# on a series nothing does: `scripts/flavor.sh` renders them once, when the
+# series is seeded. After that they are ordinary tracked files, and a `main`
+# commit touching them is cherry-picked onto the series whole
+# (.claude/skills/series-loop.md stage 4), which lands mainline text on a
+# flavored branch. `.github/README.md` is the front page GitHub renders, so the
+# first thing a reader is told there is to install a package these sources do
+# not build.
+#
+# `scripts/series-port.sh` keeps that file out of its sync commit for this
+# reason, but the exclusion guards the sync, not the pick that first adds it --
+# and neither scan above can see it, because both READMEs pass whether their
+# source was flavored or not.
+#
+# Only the install calls are checked, and only against the mainline name: the
+# READMEs also mention `duckdb/duckdb-r` and the DuckDB project itself, neither
+# of which the rename touches.
+#
+# Empty on the mainline flavor, where the mainline name is the right one.
+flavor_mainline_readme_offenders <- function(root = ".") {
+  package <- sub("^Package: +", "", grep(
+    "^Package: ", readLines(file.path(root, "DESCRIPTION"), warn = FALSE),
+    value = TRUE
+  )[[1]])
+  if (package == "duckdb") {
+    return(character())
+  }
+
+  offenders <- character()
+
+  for (path in flavor_generated_readmes) {
+    file <- file.path(root, path)
+    if (!file.exists(file)) next
+    lines <- readLines(file, warn = FALSE)
+
+    for (hit in grep('install\\.packages\\("duckdb"', lines)) {
+      offenders <- c(offenders, paste0(path, ":", hit, ": ", trimws(lines[[hit]])))
+    }
+  }
+
+  offenders
+}

--- a/tests/testthat/test-flavor-package-name.R
+++ b/tests/testthat/test-flavor-package-name.R
@@ -31,3 +31,12 @@ test_that("no file still carries the mainline name that scripts/flavor.patch ren
 
   expect_equal(flavor_unflavored_paths(root), character())
 })
+
+test_that("no generated README tells a reader to install the mainline package", {
+  root <- lts_source_root()
+  skip_if(is.na(root), "Not running from the package source tree.")
+
+  source(file.path(root, "scripts", "flavor-package-name.R"), local = TRUE)
+
+  expect_equal(flavor_mainline_readme_offenders(root), character())
+})


### PR DESCRIPTION
`README.md` and `.github/README.md` are generated from `README.Rmd` — but only when something regenerates them, and on a series nothing does: `scripts/flavor.sh` renders them once, when the series is seeded. After that they are ordinary tracked files, and stage 4 of the series loop cherry-picks a `main` commit that touches them whole, which lands mainline text on a flavored branch.

`scripts/series-port.sh` already keeps `.github/README.md` out of its sync commit for exactly this reason, and says so in a comment. But that exclusion guards the sync, not the pick that first adds the file. Neither existing scan sees it either: `flavor_package_name_offenders()` reads `README.Rmd` in place of the generated pair, and passes whether the source was flavored or not; `flavor_unflavored_paths()` only looks at the paths the patch renames.

So the defect is silent — CI is green either way.

## How it showed up

It happened in today's series-loop firing, porting #2558 onto `main-fwd-dev` and `v1.5-variegata-fwd-dev`. `.github/README.md` arrived new (git flagged no conflict) carrying:

```
## Installation from CRAN
...
install.packages("duckdb")
```

on branches that build `duckdb.dev` and `duckdb.1.5.dev`. That is the front page GitHub renders for those branches, telling a reader to install a package those sources do not build — the defect #2517 and #2518 were about, in the file most likely to be read. `README.md` conflicted and was resolved by hand; `.github/README.md` did not, so nothing asked.

Both were corrected by hand, folded into the ported commit (krlmlr/duckdb-r `main-fwd-dev` at 24936d871, `v1.5-variegata-fwd-dev` at d39c2a8d1). This PR is what stops the next port needing that.

## The change

`flavor_mainline_readme_offenders()` scans the two generated READMEs for install calls naming the mainline package. It is empty on the mainline flavor, where that name is the right one. Only install calls are checked: the READMEs also mention `duckdb/duckdb-r` and the DuckDB project itself, neither of which the rename touches.

Wired into the same `rcc-smoke` step as the other two scans, and into `tests/testthat/test-flavor-package-name.R` beside them.

## Handbook

[`testing/guards/`](https://github.com/duckdb/duckdb-r/blob/main/handbook/testing/guards/README.md) is the leaf that owns this guard, and it described `flavor_package_name_offenders()` alone — one of two scans since #2559, one of three with this branch. The page now states all three.

Documenting the renamed-path scan is #2559's gap rather than this branch's, but the two exist for the same reason — the rename runs once, at seed time, so what arrives on a flavored branch afterwards is never rewritten — and they belong in one paragraph.

## Verification

Base R only, so it runs against a plain checkout. On this branch:

```
main offenders: 0
```

Against a fixture that is `main`'s two READMEs with `Package: duckdb.dev` — the state the port produced:

```
offenders: 6
README.md:13: install.packages("duckdb")
README.md:26: install.packages("duckdb", repos = sprintf(
README.md:40: install.packages("duckdb", repos = c("https://duckdb.r-universe.dev", "https://cloud.r-project.org"))
.github/README.md:19: install.packages("duckdb")
.github/README.md:32: install.packages("duckdb", repos = sprintf(
.github/README.md:46: install.packages("duckdb", repos = c("https://duckdb.r-universe.dev", "https://cloud.r-project.org"))
```

This catches the class rather than preventing it. Regenerating the pair from a flavored `README.Rmd` after a port would prevent it, but that needs the flavor patch applied to the source mid-port, which is a larger change than the one that unblocks the loop.