### PR TITLE
fix(flavor): Answer rather than error when a series has no `README.Rmd`

### DIFF
--- a/scripts/flavor-package-name.R
+++ b/scripts/flavor-package-name.R
@@ -65,13 +65,23 @@ flavor_scanned_files <- function(root) {
   # the source instead is also where a fix would have to be made.
   top_level_md <- setdiff(dir(root, pattern = "[.]md$"), "README.md")
 
+  # `README.Rmd` is the one entry named literally rather than found by `dir()`,
+  # so it is the only one that can be absent -- and on a frozen series it is:
+  # the commit that adds it is not ported there
+  # (.claude/skills/series-loop.md stage 4), while the tooling sync brings this
+  # scan and the `scripts/flavor.patch` that keys it. Reading it unconditionally
+  # turned that combination into an error rather than a verdict. Every other
+  # entry is discovered, so a missing one there would be a real problem and is
+  # left to fail.
+  readme_rmd <- if (file.exists(file.path(root, "README.Rmd"))) "README.Rmd"
+
   r_level <- c(
     flavor_dir(root, "R", "[.]R$"),
     flavor_dir(root, "man", "[.]Rd$"),
     flavor_dir(root, "tests", "[.]R$"),
     flavor_dir(root, "vignettes", "[.](R|Rmd|qmd)$"),
     top_level_md,
-    "README.Rmd"
+    readme_rmd
   )
 
   glue <- c(


### PR DESCRIPTION
`flavor_scanned_files()` names `README.Rmd` literally, where every other entry is discovered by `dir()`. It is therefore the one entry that can be absent — and on a frozen series it is.

A frozen series keeps the R code it was seeded with, so the commit that added `README.Rmd` (#2558) is not ported there, while `scripts/series-port.sh`'s tooling sync does bring this scan and the `scripts/flavor.patch` that keys it. `flavor_package_name_offenders()` then reaches an unconditional `readLines()` on a file that does not exist and stops with an error rather than returning a verdict:

```
Error in file(con, "r") : cannot open the connection
In addition: Warning message:
In file(con, "r") : cannot open file './README.Rmd': No such file or directory
```

## Where it was hit

`v1.4-andium-fwd-dev` at krlmlr/duckdb-r `6d4cb1001` — the tooling sync of today's series-loop firing — while checking that commit locally before pushing it.

**This is not a CI redness.** It is worth being precise, because the first read of it was wrong: the per-commit gate `scripts/rcc-one.sh` is a documented subset of `rcc-smoke` that does not include the flavor scan, and `rcc` itself only triggers on `main`/`master`/`release`/`next`/`cran-*`, never on a `-dev` branch. So the series is green, and the effect is narrower but still real — the scan cannot be run against a frozen series at all, by hand or through `testthat::test_local()`, which is what the loop is told to do before force-pushing a repair.

## The change

Include `README.Rmd` only when it exists. Only the literal entry is made conditional: every other entry is discovered, so a missing one there would be a real problem and is left to fail.

## Verification

On this branch (`main`, `README.Rmd` present):

```
main offenders: 0
```

Against `v1.4-andium-fwd-dev` at `6d4cb1001`, which has no `README.Rmd` — an error before, a verdict now:

```
offenders: 4
R/Driver.R:70: # This is deliberately kept under the "duckdb" directory
R/extensions.R:2: tools::R_user_dir("duckdb", "data")
tests/testthat/test-arrow_stream.R:3: skip_if_not(get_package_name() == "duckdb")
tests/testthat/test-arrow.R:20: skip_if_not(get_package_name() == "duckdb")
```

Those four are pre-existing on that series and unrelated to this change — the same four its own copy of the scan reports at its green tip, `26f84c860`. They are visible here only because the scan now finishes. Whether a frozen series should satisfy a `flavor.patch` regenerated against `main`'s newer R code is a separate question, and not one this PR answers.

Independent of #2575, which is about the same commit's READMEs but a different defect.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tevbde5psmDRhK4C34FZzQ)_