### PR TITLE
test(explain): Skip Windows inside each `test_that()` so the snapshot survives

### DIFF
--- a/handbook/testing/snapshots/README.md
+++ b/handbook/testing/snapshots/README.md
@@ -19,6 +19,18 @@ Pass `transform = transform_package_name`
 (`tests/testthat/helper-snapshot.R`) to any expectation whose
 output can carry the name.
 
+**A skip in a snapshot file goes inside `test_that()`.**
+testthat rewrites `_snaps/<file>.md` from the snapshots the run actually
+took, and restores a skipped one only when the skip is recorded against a
+named test.
+A skip at the top of the file aborts before any test starts,
+so nothing is recorded, every snapshot in the file counts as unused,
+and the whole `.md` is deleted —
+which the `update-snapshots` action then publishes as a deletion
+proposed by whichever platform skipped.
+Put `skip_on_os()` and friends in each `test_that()` body instead;
+a file-level skip is safe only in a file that takes no snapshots.
+
 **Accepting a changed snapshot.**
 Every route ends in `testthat::snapshot_accept()`:
 

--- a/tests/testthat/test-explain.R
+++ b/tests/testthat/test-explain.R
@@ -1,8 +1,13 @@
 skip_on_cran()
-skip_on_os(c("windows"))
 local_edition(3)
 
+# The Windows skip must live inside each `test_that()` block, not at the top of
+# the file. testthat only restores a snapshot when the skip is recorded for a
+# named test; a file-level skip aborts before any test starts, so the file's
+# snapshots count as unused and `_snaps/explain.md` gets deleted.
+
 test_that("EXPLAIN gives reasonable output", {
+  skip_on_os("windows")
   con <- local_con()
   expect_snapshot({
     DBI::dbGetQuery(con, "EXPLAIN SELECT 1;")
@@ -10,6 +15,7 @@ test_that("EXPLAIN gives reasonable output", {
 })
 
 test_that("EXPLAIN shows logical, optimized and physical plan", {
+  skip_on_os("windows")
   con <- local_con()
   expect_snapshot({
     DBI::dbExecute(con, "PRAGMA explain_output='all';")
@@ -18,6 +24,7 @@ test_that("EXPLAIN shows logical, optimized and physical plan", {
 })
 
 test_that("EXPLAIN ANALYZE outputs query tree", {
+  skip_on_os("windows")
   con <- local_con()
   rs <- DBI::dbGetQuery(con, "EXPLAIN ANALYZE SELECT 1;")
   expect_true(is(rs, c("duckdb_explain")))
@@ -26,6 +33,7 @@ test_that("EXPLAIN ANALYZE outputs query tree", {
 })
 
 test_that("zero length input is smoothly skipped", {
+  skip_on_os("windows")
   con <- local_con()
   expect_snapshot({
     rs <- DBI::dbGetQuery(con, "SELECT 1;")
@@ -34,6 +42,7 @@ test_that("zero length input is smoothly skipped", {
 })
 
 test_that("wrong type of input forwards handling to the next method", {
+  skip_on_os("windows")
   con <- local_con()
   expect_snapshot({
     rs <- DBI::dbGetQuery(con, "SELECT 1;")


### PR DESCRIPTION
Six Windows matrix entries opened `snapshot-*` pull requests that do nothing but delete `tests/testthat/_snaps/explain.md` — #2568, #2569, #2570, #2571, #2572, #2573, one per R version. This has happened before with the same single-file diff: #1492 (2025-09), #1617–#1621 (2025-10), #2220–#2222 (2026-03), #2364 and #2379–#2383 (2026-06), all closed unmerged.

**Why the deletion.** `tests/testthat/test-explain.R` called `skip_on_os(c("windows"))` at the top of the file. testthat rewrites `_snaps/<file>.md` from the snapshots a run actually took, and restores a skipped one only when the skip is recorded against a named test — `SnapshotReporter$add_result()` returns early unless `self$test` is set. A file-level skip aborts before the first `test_that()` starts, so no test is ever named, every snapshot in the file counts as unused, and `end_file()` writes an empty set, which deletes the `.md`.

**Why it only surfaces sometimes.** The deletion happens on every Windows run of the `update-snapshots` action, but the action only stages and publishes `_snaps` changes when its `test_local()` call reports a failure or warning; otherwise the final `git reset` discards the deletion silently. So the latent deletion gets published whenever something unrelated fails on Windows — which is why these arrive in bursts rather than nightly. No testthat change is involved; the same diff was produced across testthat 3.2.x and 3.3.x.

Only `explain.md` was ever affected: it is the one snapshot file whose test file skipped at file level. The other file-level Windows skips (`arrow`, `arrow_stream`, `extension_path`, `fetch_arrow`, `register_arrow`) take no snapshots, and `test-types.R` already skips inside its `test_that()`.

**Fix.** Move `skip_on_os("windows")` into each of the five `test_that()` bodies. Windows still skips exactly the same tests; the snapshot is now restored rather than dropped, so the failure mode cannot recur regardless of what else is red on Windows.

**Verified** against testthat 3.3.2 with a scratch package containing both layouts, run on an OS the skip fires for: the old layout loses the file, the new layout leaves `explain.md` byte-identical to the committed one.

The handbook's snapshots leaf gains the rule, so the next snapshot file does not rediscover it.

Note that this removes the landmine, not the trigger that set it off this time — that is a separate Windows failure in `tests/testthat/test-storage-home.R`, tracked outside this pull request. Once this merges, the six open `snapshot-*` pull requests can be closed unmerged.