### PR TITLE
test(storage): Compare spill paths on one separator spelling

### DIFF
--- a/handbook/testing/suite/README.md
+++ b/handbook/testing/suite/README.md
@@ -38,10 +38,15 @@ Every `helper-*.R` is sourced before the first test,
 and that set is the list.
 Each should open with a header saying why it exists;
 `helper-DBItest.R` and `helper-skip.R` do not yet.
-Two constraints are not obvious from reading one:
+Three constraints are not obvious from reading one:
 `helper-DBItest.R`'s `make_context()` call must stay in the helper,
-and any expectation whose output can carry the package name goes
-through `transform_package_name` from `helper-snapshot.R`.
+any expectation whose output can carry the package name goes
+through `transform_package_name` from `helper-snapshot.R`,
+and two paths that should name the same directory are compared
+with `expect_same_path` from `helper-storage.R` —
+on Windows `dirname()` returns `/` separators while `file.path()`
+and `tempdir()` keep the `\` they were handed,
+so `expect_equal()` reports a difference that is not there.
 `local_con()`, the self-disconnecting connection fixture,
 is package code (`R/test-fixtures.R`);
 the suite runs with the namespace loaded,

--- a/tests/testthat/helper-storage.R
+++ b/tests/testthat/helper-storage.R
@@ -1,3 +1,6 @@
+# Helpers for the storage-location tests: the paths the package resolves to
+# under a mocked session temp dir, and a path comparison that survives Windows.
+
 # The storage paths the package resolves to when `session_temp_dir()` is mocked
 # to "/tmp/sess".
 #
@@ -7,4 +10,18 @@
 # every flavor; see `scripts/flavor-package-name.R` for the rule.
 session_home_path <- function(...) {
   file.path("/tmp/sess", get_package_name(), ...)
+}
+
+# Compare two paths that name the same directory, ignoring which separator each
+# happens to be spelled with.
+#
+# On Windows one directory reaches these tests under two spellings. `dirname()`
+# always returns "/" separators (documented in `?basename`), while `file.path()`
+# and `tempdir()` keep the "\" they were handed -- and on Windows `tempdir()`
+# hands back "\". So `dirname(x)` and `file.path(tempdir(), ...)` differ as
+# strings while naming one directory, and `expect_equal()` reports a difference
+# that is not there. Comparing on a single spelling keeps the assertion about
+# the path. A no-op on Unix, where neither side contains a backslash.
+expect_same_path <- function(object, expected) {
+  expect_equal(chartr("\\", "/", object), chartr("\\", "/", expected))
 }

--- a/tests/testthat/test-storage-home.R
+++ b/tests/testthat/test-storage-home.R
@@ -222,7 +222,7 @@ test_that("resolve_temp_directory redirects in-memory only, honors override", {
 
   # The per-instance spill directory sits under the session spill root ...
   spill_root <- file.path(tmp, get_package_name(), "temp")
-  expect_equal(dirname(resolved$directory), spill_root)
+  expect_same_path(dirname(resolved$directory), spill_root)
   # ... which resolving created, so the engine's own single-level directory
   # creation can create the leaf lazily at first spill.
   expect_true(dir.exists(spill_root))
@@ -292,7 +292,7 @@ test_that("an in-memory database spills to temporary storage out of the box", {
     con,
     "SELECT current_setting('temp_directory') AS dir"
   )$dir
-  expect_equal(dirname(spill), file.path(session_home(), "temp"))
+  expect_same_path(dirname(spill), file.path(session_home(), "temp"))
   expect_false(dir.exists(spill))
 
   # A sort that outgrows the memory limit: it can only complete by offloading


### PR DESCRIPTION
Two expectations added in #2562 fail on every `windows-latest` entry of `rcc-full` (run 31242074202, on `4559f25`):

```
test-storage-home.R:225  Expected `dirname(resolved$directory)` to equal `spill_root`.
- "C:/Users/RUNNER~1/AppData/Local/Temp/Rtmp6PoVYk/file1ec857d02351/duckdb/temp"
+ "C:\Users\RUNNER~1\AppData\Local\Temp\Rtmp6PoVYk\file1ec857d02351/duckdb/temp"

test-storage-home.R:295  Expected `dirname(spill)` to equal `file.path(session_home(), "temp")`.
- "C:/Users/RUNNER~1/AppData/Local/Temp/Rtmp6PoVYk/duckdb/temp"
+ "C:\Users\RUNNER~1\AppData\Local\Temp\Rtmp6PoVYk/duckdb/temp"
```

Both compare a `dirname()` result against a path built with `file.path()`. On Windows those are two spellings of the same directory: `dirname()` returns `/` separators — documented in `?basename`, "on Windows this will accept either `\` or `/` as the path separator, but `dirname` will return a path using `/`" — while `file.path()` and `tempdir()` keep the `\` they were handed, and on Windows `tempdir()` hands back `\`.

The resolved directory is correct. Mixed separators are valid on Windows and the engine accepts them, so nothing in `R/storage-home.R` needs to change; it is the assertion that reads a spelling as a difference.

**Fix.** `expect_same_path()` in `helper-storage.R` compares paths with their separators folded to `/`, and the two spill-directory expectations use it. It is a no-op on Unix, and a genuinely different path still fails.

**Verified.**

- Replayed both failures at string level using the exact values from the CI log: `expect_equal()` fails on each, `expect_same_path()` passes, a differing path (`C:/a/b` vs `C:/a/c`) still fails, and Unix paths are unaffected.
- Full suite green on Linux against a fresh install (`DUCKDB_R_USE_SYSTEM_LIB=1`): no failures, no errors, `_snaps` untouched.

**Why this matters beyond the two red tests.** In `rcc-full` the `update-snapshots` action runs *before* the `check` step, and it fails the job when it opens a snapshot pull request. On the Windows entries it did, so `check` was skipped entirely — R CMD check has not actually run on Windows in these runs. #2577 stops the spurious snapshot pull request; this change is what keeps `check` green once it starts running again. The two are independent and can merge in either order.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EXWk1giPA4U7gGgAymueyY)_