### PR TITLE
docs(handbook): Close the last three days' issues into their leaves

### DIFF
--- a/handbook/usage/README.md
+++ b/handbook/usage/README.md
@@ -27,4 +27,4 @@ and is what turns the announcement off.
 * [`storage/`](storage/) — where extensions and secrets live
 * [`integrations/`](integrations/) — dbplyr, duckplyr, and Arrow
 * [`relational/`](relational/) — the internal lazy-relation API
-* [`interactive/`](interactive/) — the progress display and the Connections pane
+* [`interactive/`](interactive/) — what a session does while you work

--- a/handbook/usage/extensions/README.md
+++ b/handbook/usage/extensions/README.md
@@ -44,23 +44,45 @@ and how to get more.
   whose build matrix and platform coverage are its own —
   what one repository carries says nothing about the other.
 * **Windows** fetches extensions for the `windows_amd64_mingw` platform,
-  which DuckDB has distributed since 1.4.1 —
-  as a per-extension subset:
-  a core extension can opt out of the mingw flavor upstream,
-  and the `NOT MINGW` guards in duckdb/duckdb's
-  [`.github/config/extensions`](https://github.com/duckdb/duckdb/tree/main/.github/config/extensions)
-  are the list.
-  As of 2026-08, `INSTALL postgres` is a 404
-  where `INSTALL spatial` works
-  ([#1581](https://github.com/duckdb/duckdb-r/issues/1581));
-  the troubleshooting link in the download error
-  looks up the failing extension, version, and platform.
+  and that directory is a per-extension subset of the MSVC
+  `windows_amd64` one beside it.
+  An extension built in duckdb/duckdb's own tree opts out through the
+  `NOT MINGW` guards in
+  [`.github/config/extensions`](https://github.com/duckdb/duckdb/tree/main/.github/config/extensions);
+  one built in a repository of its own decides there instead,
+  so no single list covers both — the repository does.
+  A `HEAD` request for
+  `extensions.duckdb.org/<version>/<platform>/<name>.duckdb_extension.gz`
+  answers for one name, on one platform, at one version,
+  and is what the troubleshooting link in the download error looks up.
+  Probe it rather than remember it:
+  the answer moves in both directions,
+  and `spatial` published for mingw at 1.3.2, not at 1.4.0,
+  and again from 1.4.1 on
+  ([#100](https://github.com/duckdb/duckdb-r/issues/100)).
+* **Every mingw gap today is an extension built outside the engine's
+  tree** — which on its own predicts nothing,
+  because `spatial` and `sqlite_scanner` are built that way and publish.
+  The 2026-08 probe at 1.5.5 finds `aws`, `azure`, `iceberg`,
+  `motherduck`, `mysql_scanner` and `postgres_scanner` absent,
+  and every other name probed present
+  ([#100](https://github.com/duckdb/duckdb-r/issues/100)).
+  A missing build is asked for at the extension's own repository —
+  [`duckdb/duckdb-postgres`](https://github.com/duckdb/duckdb-postgres)
+  for `postgres_scanner`
+  ([#1581](https://github.com/duckdb/duckdb-r/issues/1581),
+  [#2503](https://github.com/duckdb/duckdb-r/issues/2503)) —
+  where such a pull request is
+  [accepted](https://github.com/duckdb/duckdb-r/issues/2425#issuecomment-5182746870);
+  `motherduck` has no public repository to ask at.
   The standing gaps are the toolchain epic
   ([#2234](https://github.com/duckdb/duckdb-r/issues/2234),
   upstream
-  [duckdb/duckdb#24431](https://github.com/duckdb/duckdb/issues/24431)),
-  and the fix for a missing flavor is an upstream pull request per extension
-  ([#2425, maintainer's offer](https://github.com/duckdb/duckdb-r/issues/2425#issuecomment-5182746870)).
+  [duckdb/duckdb#24431](https://github.com/duckdb/duckdb/issues/24431)).
+  Reaching one of these extensions from R meanwhile means leaving this
+  package's engine for a DuckDB ADBC driver built with the toolchain the
+  platform's own DuckDB uses
+  ([`integrations/`](/handbook/usage/integrations/README.md)).
 * **Some platforms are not covered**, and which ones is DuckDB's to say
   and does change:
   [Extension Distribution](https://duckdb.org/docs/stable/extensions/extension_distribution)

--- a/handbook/usage/integrations/README.md
+++ b/handbook/usage/integrations/README.md
@@ -108,6 +108,22 @@ register at load time the same way —
 all on classes this package defines for the purpose.
 It is the one route here that does not go through DBI at all.
 
+The driver manager also loads a DuckDB ADBC driver that is *not* this
+package's — a library built by whatever toolchain the platform's own
+DuckDB build uses — and that is the one way to reach an extension this
+package cannot install, because the extensions a driver can install
+follow the platform it was built for
+([`extensions/`](/handbook/usage/extensions/README.md),
+[reported working on Windows](https://github.com/duckdb/duckdb-r/issues/100#issuecomment-4095552832)).
+It costs everything this package adds:
+the DBI methods, the relational API, registration and the R type
+mapping are this package's rather than the driver's,
+and a second engine in the session shares nothing with this one.
+Both routes need `adbcdrivermanager`, which rules out Windows arm64:
+there it has no binary to install and does not build from source
+([`operations/ci/matrix/`](/handbook/operations/ci/matrix/README.md)
+carries what CI does about that).
+
 ## data.table and collapse
 
 The other frame libraries

--- a/handbook/usage/interactive/README.md
+++ b/handbook/usage/interactive/README.md
@@ -1,9 +1,8 @@
 # Interactive use
 
-What a session does while a query runs, rather than what the call
-returns once it is over:
-the progress display, how far Ctrl+C reaches, and the RStudio
-Connections pane.
+What a session does while you work, rather than what a call returns
+once it is over — and whether this package does it,
+or hands it to something that does.
 
 ## The progress display
 
@@ -55,5 +54,22 @@ It queries `information_schema` to decide which object types the
 database actually has, so a database with no views does not advertise
 them, and it tells the IDE when a connection closes.
 
-*To deepen: state what turns the progress display on and off, and what
-the pane does with a connection the user closes from the IDE.*
+## The DuckDB UI
+
+The DuckDB UI is a browser interface the engine serves,
+and it arrives as the `ui` extension rather than as part of this
+package: `INSTALL ui` once, then `CALL start_ui()` on a connection
+starts the server and opens a browser at it
+([#1083](https://github.com/duckdb/duckdb-r/issues/1083)).
+Nothing about it is R-side — no function to call, nothing to configure —
+so what the UI can do, and whether it installs on a platform at all,
+are the extension's and its repository's
+([`extensions/`](/handbook/usage/extensions/README.md)).
+The DuckDB CLI's `-ui` flag is that program's own installation
+and says nothing about this one's;
+a page that comes up empty is the extension's to answer, in
+[duckdb/duckdb-ui](https://github.com/duckdb/duckdb-ui).
+
+*To deepen: state what turns the progress display on and off, what
+the pane does with a connection the user closes from the IDE, and how
+much of a connection's own state the UI sees.*


### PR DESCRIPTION
A sweep of the 26 issues closed since 2026-08-05, against the rule that a close without a code change is a close *with* a documentation change (`handbook/operations/triage/`).

Most were already carried: #155, #179, #162, #642, #200, #1670, #12, #83, #171, #1604, #1733, #2306, #1581, #2425 and #2488 landed with their leaf edits, #2494 is in `branches/mirrors/` as the Pull app, #2545 is in `operations/vendoring/series-loop/` plus the script's own refusal to start, and #2541 is in `testing/guards/` — the flavored series had `src/duckdb-win.def` under the mainline name, so the link fell back to a generated export list, and #2559 added the scan that catches it. Three were not, and one leaf carried a claim the extension repository contradicts.

**`usage/extensions/`** said `windows_amd64_mingw` had been distributed "since 1.4.1". A `HEAD` sweep of `extensions.duckdb.org` says otherwise: `spatial` publishes for mingw at 1.3.2, is absent at 1.4.0, and publishes again from 1.4.1 on. So the version claim is replaced by the probe that establishes coverage for one name, on one platform, at one version — the only answer that does not go stale — plus the observation that a 404 is worth re-probing rather than remembering. The gap itself gets its shape from #100: every extension missing on mingw is built outside duckdb/duckdb's tree, though that predicts nothing on its own (`spatial` and `sqlite_scanner` are built that way and publish), the 2026-08 snapshot at 1.5.5 is `aws`, `azure`, `iceberg`, `motherduck`, `mysql_scanner` and `postgres_scanner`, and a missing build is asked for at the extension's own repository — where #2425 records that such pull requests are accepted, and where #2503 was sent.

I re-ran the probe rather than copying the numbers from #100: the missing set, the present set, `ui` on mingw, and the `spatial` version history all reproduce as written.

**`usage/integrations/`** gains the escape those gaps leave, in the ADBC section: the driver manager also loads a DuckDB ADBC driver that is not this package's, built with the toolchain the platform's own DuckDB uses, and that is the one route from R to an extension this package cannot install — at the cost of the DBI methods, the relational API, registration and the R type mapping. Both ADBC routes need `adbcdrivermanager`, which rules out Windows arm64.

**`usage/interactive/`** had no home for #1083. The DuckDB UI answered there as its own section, after #2596's: `INSTALL ui` once, `CALL start_ui()` on a connection, nothing R-side to call or configure, and an empty page belongs in duckdb/duckdb-ui. The scope sentence is widened along the way — both the version this branch started from and the one #2596 wrote name their children, and a query-scoped boundary ("while a query runs") is what excluded a UI that has nothing to do with a running query. It now says what the leaf is bounded by rather than what is in it, and the `usage/` child-list phrase follows.

Rebased on `main` after #2596; its interrupt section is untouched, and the deepen line carries both its open questions and the one this change leaves.

Checks: the link walker and the generated-index check from the `docs-consistency` skill both pass.

One thing left undone deliberately: the closing comments on #100 and #1083 predate these leaves, so they do not link them, which the growth protocol asks for. Say the word and I will add the two pointers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nF6kDxkTEn4dy1HE4xTqx