### PR TITLE
fix(signal): State the interrupt handler's invariants where they are used

### DIFF
--- a/src/include/signal.hpp
+++ b/src/include/signal.hpp
@@ -19,7 +19,12 @@ namespace duckdb {
 class ScopedInterruptHandler {
 private:
 	shared_ptr<ClientContext> context;
-	bool interrupted = false;
+
+	// Written by the signal handler and read by HandleInterrupt() outside it,
+	// which is the one round trip the standard only guarantees for a
+	// volatile sig_atomic_t: a plain bool leaves the compiler free to keep
+	// the read in a register across the call the handler interrupts.
+	volatile sig_atomic_t interrupted = 0;
 
 	// oldhandler stores the old signal handler
 	// so that it can be restored when the object is destroyed.

--- a/src/include/signal.hpp
+++ b/src/include/signal.hpp
@@ -22,9 +22,11 @@ private:
 	bool interrupted = false;
 
 	// oldhandler stores the old signal handler
-	// so that it can be restored when the object is destroyed
+	// so that it can be restored when the object is destroyed.
+	// An instance constructed without a context installs nothing, so the
+	// initializer is what keeps the unused slot from holding a stale handler.
 	typedef void (*sig_t)(int);
-	sig_t oldhandler;
+	sig_t oldhandler = SIG_DFL;
 
 	static ScopedInterruptHandler *instance;
 

--- a/src/signal.cpp
+++ b/src/signal.cpp
@@ -37,7 +37,12 @@ ScopedInterruptHandler::ScopedInterruptHandler(shared_ptr<ClientContext> context
 
 ScopedInterruptHandler::~ScopedInterruptHandler() {
 	Disable();
-	instance = nullptr;
+	// Only the instance that installed itself clears the slot: an instance
+	// constructed without a context never took it, and must not release
+	// another one's claim on the way out.
+	if (instance == this) {
+		instance = nullptr;
+	}
 }
 
 void ScopedInterruptHandler::HandleInterrupt() const {

--- a/src/signal.cpp
+++ b/src/signal.cpp
@@ -74,7 +74,7 @@ void ScopedInterruptHandler::Disable() {
 
 void ScopedInterruptHandler::signal_handler(int signum) {
 	if (instance) {
-		instance->interrupted = true;
+		instance->interrupted = 1;
 		instance->context->Interrupt();
 	}
 }

--- a/src/signal.cpp
+++ b/src/signal.cpp
@@ -66,6 +66,12 @@ void ScopedInterruptHandler::HandleInterrupt() const {
 }
 
 void ScopedInterruptHandler::Disable() {
+	// Restores unconditionally, and so discards a handler an extension
+	// installed during the call and did not remove itself. That is the
+	// deliberate half of the trade: declining to restore would leave R with
+	// someone else's handler for the rest of the session, which is the worse
+	// of the two. An extension that removes its own -- MotherDuck's sign-in
+	// wait does -- nests correctly here and loses nothing.
 	if (context) {
 		std::signal(SIGINT, oldhandler);
 		context.reset();


### PR DESCRIPTION
Three small changes to `ScopedInterruptHandler`, none of which changes behaviour on a reachable path. The class guards a process-wide slot, which is what makes a DuckDB call entered while another is running fail fast with `Connection already working on another query` rather than deadlock.

## The slot is released only by whoever took it

The constructor establishes everything in one place:

```cpp
if (instance) { throw ...; }                          // past here, instance is null
if (context) { instance = this; oldhandler = ...; }   // all three, together, nothing fallible between
```

So `context` non-null ⟺ we took the slot ⟺ `oldhandler` was assigned. The destructor cleared the slot unconditionally, which would drop another call's claim — unreachable today, because an instance with no context can only exist while the slot is already free, and instances are strict-stack-nested locals. Clearing it only when we hold it makes that local, rather than a property every call site has to preserve. `SIG_DFL` bounds `oldhandler` for the same reason: `Disable()` reads it only under `if (context)`, so it is never read unassigned, but a future path that sets a context without installing then restores a defined disposition.

Every construction site passes a context that cannot be null — `rapi_prepare` and `rapi_execute_impl` take the connection's, and `ClientContextWrapper::GetContext()` throws rather than returning null for a closed connection.

## The interrupt flag is typed for the handler that sets it

`interrupted` is written by the SIGINT handler and read by `HandleInterrupt()` outside it. `volatile sig_atomic_t` is the one object type the standard guarantees for that round trip; a plain `bool` leaves the compiler free to hold the read in a register across the call the handler interrupts, and only the opaque cross-translation-unit call in between forces the reload today — reasoning link-time optimization is entitled to undo. No observable change on any toolchain this builds with; the point is that it no longer depends on one.

## `Disable()` restores unconditionally, on purpose

It discards a handler an extension installed during the call and did not remove itself, which reads like an oversight, so the comment now says it is a choice. Extensions do install handlers — MotherDuck installs one around its sign-in wait (#202, measured in #2596) — but it removes its own before returning, so the restores nest correctly and nothing is lost.

Detecting the other case means reading the disposition without writing it, which `std::signal` cannot do and `sigaction` can, at the cost of a second platform path. And declining to restore is the worse failure: R would run someone else's handler for the rest of the session, one belonging to an extension that believes it is still waiting.

## Not addressed

`instance` is a raw pointer to a stack object dereferenced from a handler the kernel may run on any thread with SIGINT unblocked, which includes the engine's workers. If the signal lands on one while the main thread finishes `Disable()` and pops the frame, the handler writes into a dead frame. The window is the handler's own few instructions, and closing it needs SIGINT masked across teardown — `pthread_sigmask`, so a Windows path — which is more than this PR is for.

Suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CbyvdBFbjee8zNWmjCTXt9