### PR TITLE
fix(series): Keep stage 5 alive when the buffer is longer than the chunk

### DIFF
--- a/scripts/series-advance.sh
+++ b/scripts/series-advance.sh
@@ -84,6 +84,13 @@ for r in "$green" "$dev" "$build" "$base"; do
   git rev-parse -q --verify "$r" >/dev/null || { echo "Error: missing ${r#"$remote"/}"; exit 1; }
 done
 
+# The first N lines, without closing the pipe on the writer. `head -n N` exits
+# as soon as it has them, and the `git rev-list` feeding it dies of SIGPIPE --
+# 141 through `pipefail`, which `set -e` turns into a silent abort of the whole
+# stage. Only a buffer longer than the chunk ever reaches that, which is why it
+# surfaced on main-fwd and on no other series.
+first_n() { sed -n "1,${1}p"; }
+
 state_of() {
   local rec
   # One record per commit, and only that; see scripts/rcc-lib.sh and the
@@ -400,7 +407,7 @@ declare -A CARRY=()
 carries=0
 glue_drift=()
 if [ -n "$base_dev" ]; then
-  for c in $(git rev-list --reverse "$anchor..$build" | head -n "$n"); do
+  for c in $(git rev-list --reverse "$anchor..$build" | first_n "$n"); do
     d=$(twin_of "$c")
     [ -n "$d" ] || continue
     [ -n "$(carry_paths "$c" "$d")" ] || continue
@@ -526,12 +533,12 @@ else
     # The rest of the same chunk, not a fresh one: nothing was pushed, so the
     # anchor is where it was, and the resumed commit is somewhere inside the
     # list this run already computed. Take what follows it.
-    remaining=$(git rev-list --reverse "$anchor..$build" | head -n "$n" |
+    remaining=$(git rev-list --reverse "$anchor..$build" | first_n "$n" |
                   awk -v c="$rc" 'seen { print } $0 == c { seen = 1 }')
   else
     wt=$(mktemp -d)
     git worktree add --detach -q "$wt" "$dev"
-    remaining=$(git rev-list --reverse "$anchor..$build" | head -n "$n")
+    remaining=$(git rev-list --reverse "$anchor..$build" | first_n "$n")
   fi
 
   # `--empty=drop`, as series-port.sh already does: a buffer commit whose content


### PR DESCRIPTION
`scripts/series-advance.sh` read its chunk with `git rev-list --reverse <range> | head -n "$n"`. `head` exits as soon as it has its N lines, so on a buffer holding more than N commits `git rev-list` is still writing and dies of `SIGPIPE`. `pipefail` turns that into status 141 and `set -e` aborts the stage — after stage 3 has already pushed `-green` and `-build-base`, and without a word about why `-dev` never moved.

This reads the first N lines with `sed -n "1,${n}p"` instead, which drains the pipe and lets the writer finish. The same construct appears three times (the carry scan, the resumed-chunk remainder, and the fresh chunk); all three go through one `first_n()` helper.

## How it showed up

Today's series-loop firing, on `main-fwd`: the buffer held 441 commits against a chunk of 100. Three runs in a row printed

```
green unchanged at 96e9d8a1f
3 of 100 buffered commit(s) carry a fix from origin/main-dev
```

and exited 141 with `-dev` untouched. `bash -x` puts the abort at the assignment right after the worktree is created:

```
+ git worktree add --detach -q /tmp/tmp.CHtkBrJ8Wn origin/main-fwd-dev
++ git rev-list --reverse 7f6bcccfb..origin/main-fwd-build
++ head -n 100
```

The carry scan on line 403 survives the same SIGPIPE only because a command substitution in a `for` word list does not carry its status into `set -e`; the two `remaining=$(...)` assignments do.

Every other series in the firing had a buffer shorter than its chunk, so `head` reached EOF on its own and the stage looked healthy everywhere else — which is why this survived until a buffer got long.

The firing worked around it by hand (running a patched copy of the script) and `main-fwd-dev` was extended by 100 as intended, so nothing here is needed to unblock the current state.

## Test

`scripts/series-advance-test.sh` — 47 passed, 0 failed.

---
_Generated by [Claude Code](https://claude.ai/code/session_013etTggYdZFuLoXkbzjmZ5T)_