### PR TITLE
docs(authoring): Cut an entry to the shortest correct statement, and split the rest into a leaf

### DIFF
--- a/.claude/skills/docs-consistency/SKILL.md
+++ b/.claude/skills/docs-consistency/SKILL.md
@@ -98,7 +98,11 @@ Helpers are not entry points of their own.
    header punctuation.
    Report the structural findings instead of acting on them:
    unclaimed surface, a grouping that looks wrong,
-   an internal node accreting prose, a leaf outgrowing its scope.
+   an internal node accreting prose, a leaf outgrowing its scope,
+   an entry restating what the experiment, issue, or plan it links
+   already holds
+   ([`handbook/meta/authoring/`](/handbook/meta/authoring/README.md),
+   "How long an entry is").
    One summary at the end; no per-file chatter.
 
 The rules define, this skill enforces:

--- a/handbook/meta/authoring/README.md
+++ b/handbook/meta/authoring/README.md
@@ -45,7 +45,9 @@ the rest move the fact somewhere better than a paragraph.
    and a finding too expensive to re-derive becomes an experiment
    ([`experiments/`](/experiments/README.md)) that the leaf links.
    A one-off derivation stays in the pull request.
-6. **Then write it, and leave a breadcrumb where the reader stands.**
+6. **Then write it — as short as it can be and stay correct
+   ([below](#how-long-an-entry-is)) —
+   and leave a breadcrumb where the reader stands.**
    When detail moves into a leaf,
    the source it came from — a document, a script header,
    an inline comment — keeps its essentials
@@ -108,6 +110,51 @@ the series invariants are enforced by nothing
 ([`branches/invariants/`](/handbook/branches/invariants/README.md)),
 which is why they are written out in full, in one place, and cited from
 everywhere that depends on them.
+
+## How long an entry is
+
+An **entry** — what one change lands on a page —
+is the shortest statement of its fact that is still correct.
+Length is not thoroughness:
+three sentences where one would do
+leave the reader to find the one,
+and every later edit carries the other two.
+Write the fact, what it means for the reader,
+and the link that supports it; then stop.
+Short is not less true —
+what the entry leaves out stays reachable,
+in the source it links or the leaf it splits into,
+and an edit that loses a fact is a regression however short it reads.
+
+**What supports a fact is not part of the fact,**
+and the pull to write the support out is strongest
+where the work was hardest.
+Each source keeps what it is for:
+
+* An **experiment** keeps the method, the full grid,
+  and the day it was true of;
+  the entry takes the finding and links the directory.
+  A grid copied out of one is a second copy of a record that ages,
+  and the leaf is the copy nobody re-runs.
+* An **issue** keeps the report, the reproduction, and the discussion;
+  the entry takes the answer.
+  How the answer was reached is not part of it,
+  and a limitation is one sentence
+  and the issue that will remove it.
+* A **plan** keeps the design, its alternatives, and its sequencing;
+  the entry takes what is true today,
+  and links the plan for the rest.
+
+**Detail that survives all of that is a leaf, not a longer section.**
+A fact needing more than a paragraph or two
+has outgrown the page that cites it,
+and splitting it out is a growth move of its own
+([`meta/handbook/`](/handbook/meta/handbook/README.md)).
+The page that keeps the sentence and the link stays about one thing,
+which is what its scope sentence claims;
+a page that absorbed three such facts instead
+can no longer say what it is about,
+and that — not the length — is the defect.
 
 ## Writing the sentence
 

--- a/handbook/meta/glossary/README.md
+++ b/handbook/meta/glossary/README.md
@@ -21,6 +21,7 @@ one line, so the register stays greppable and diffs per term.
 * **driver / database instance** — `duckdb()` returns a driver owning one database instance; connections share it, and file-backed instances are cached by path ([`usage/connections/`](/handbook/usage/connections/README.md)).
 * **duckplyr** — the dplyr-native downstream package: it drives the relational API rather than generating SQL, and is the closest reverse dependency ([`usage/integrations/`](/handbook/usage/integrations/README.md)).
 * **engine** — the DuckDB database engine embedded in `src/duckdb/` ([`architecture/engine/`](/handbook/architecture/engine/README.md)).
+* **entry** — what one change lands on a page: the shortest statement of its fact that is still correct ([`meta/authoring/`](/handbook/meta/authoring/README.md)).
 * **fast path** — linking a prebuilt engine library instead of compiling the vendored sources ([`build/fast-paths/`](/handbook/build/fast-paths/README.md)).
 * **flavor** — a mechanical rename publishing the one source tree under another package name ([`branches/flavors/`](/handbook/branches/flavors/README.md)).
 * **flavor-name guard** — the scan for the package name hard-coded where the rename cannot reach ([`testing/guards/`](/handbook/testing/guards/README.md)).

--- a/handbook/meta/handbook/README.md
+++ b/handbook/meta/handbook/README.md
@@ -101,7 +101,7 @@ has exactly one place in this tree.
 
 ## Growing a leaf
 
-The tree deepens one leaf per change, by four moves.
+The tree deepens one leaf per change, by five moves.
 Any of them is a complete, mergeable pull request:
 
 1. **Close an issue into its leaf.**
@@ -131,6 +131,17 @@ Any of them is a complete, mergeable pull request:
    The node above it gains a child-list entry, and a scope sentence too
    narrow to admit the new leaf is widened in the same change —
    otherwise the next topic of that kind falls out again.
+5. **Split a fact that has outgrown the page citing it.**
+   Detail too large for the leaf that carries it
+   becomes a leaf of its own beside that one, under the same node,
+   and the page it leaves keeps the shortest statement and the link
+   ([`meta/authoring/`](/handbook/meta/authoring/README.md) says how
+   short).
+   In every other respect it is a new leaf:
+   the node above gains its line in the child list,
+   and the links pointing at the fact move with it.
+   A page left holding nothing but pointers to what it gave away
+   has become an internal node, and is written as one.
 
 Whichever move, the same protocol:
 


### PR DESCRIPTION
An entry supported by an experiment, an issue, or a plan tends to grow to the size of its support: the grid gets copied out, the route to the answer gets retold, the design gets summarised. The material is not the fact, and the leaf is the copy nobody re-runs.

`meta/authoring/` gains a "How long an entry is" section, sitting between what the tree owns and how a sentence is written:

- An **entry** — what one change lands on a page — is the shortest statement of its fact that is still correct. Write the fact, what it means for the reader, and the link that supports it; then stop.
- Short is not less true: what an entry leaves out stays reachable in the source it links or the leaf it splits into, and an edit that loses a fact is still a regression. Correctness is the constraint, not the thing being traded.
- What each supporting source keeps rather than lends — an experiment keeps the method, the full grid, and the day it was true of; an issue keeps the report, the reproduction, and the discussion, and the entry takes only the answer; a plan keeps the design, its alternatives, and its sequencing.
- Detail that survives all of that is a leaf rather than a longer section.

The ladder's last rung now points at the section, so the length rule is reached from where an author already stands.

Because "give it its own leaf" is structure rather than prose, the move itself lands where structure is owned: `meta/handbook/` gains splitting a fact out as a fifth growth move, complete with what the page it leaves behind keeps, and the note that a page holding nothing but pointers has become an internal node. `meta/glossary/` registers **entry**, now that both leaves use it, and the `docs-consistency` skill adds an entry that restates what its experiment, issue, or plan already holds to the findings it reports.

Checks run: the skill's link-integrity walk over `handbook/` is clean, and `docs-readme.R --check` reports the generated `scripts/` index current.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XVaCtUDPCqZqz4bMbAcemv)_