### PR TITLE
fix(dbplyr): Render `n_distinct()` through the exported `sql_glue()`, and warn on an older dbplyr

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,7 +53,7 @@ Suggests:
     callr,
     clock,
     DBItest,
-    dbplyr,
+    dbplyr (>= 2.6.0),
     dplyr,
     nanoarrow,
     rlang,

--- a/R/backend-dbplyr__duckdb_connection.R
+++ b/R/backend-dbplyr__duckdb_connection.R
@@ -72,11 +72,10 @@ duckdb_grepl <- function(pattern, x, ignore.case = FALSE, perl = FALSE, fixed = 
 
 duckdb_n_distinct <- function(..., na.rm = FALSE) {
   sql <- pkg_method("sql", "dbplyr")
-  glue_sql2 <- pkg_method("glue_sql2", "dbplyr")
-  sql_current_con <- pkg_method("sql_current_con", "dbplyr")
+  # `sql_glue()` reads the active connection itself, and `{...}` renders the
+  # dots comma-separated, the way `{.col {list(...)}*}` did before dbplyr 2.6.0.
+  sql_glue <- pkg_method("sql_glue", "dbplyr")
   check_dots_unnamed <- pkg_method("check_dots_unnamed", "rlang")
-
-  con <- sql_current_con()
 
   if (missing(...)) {
     stop("`...` is absent, but must be supplied.")
@@ -87,19 +86,18 @@ duckdb_n_distinct <- function(..., na.rm = FALSE) {
   if (!identical(na.rm, FALSE)) {
     if (length(list(...)) == 1L) {
       # in case of only one column fall back to the "simple" version
-      return(glue_sql2(con, "COUNT(DISTINCT {.col {list(...)}*})"))
+      return(sql_glue("COUNT(DISTINCT {...})"))
     } else {
       str_null_check <-
         sql(paste0(paste0(list(...), " IS NOT NULL"), collapse = " AND "))
 
-      return(glue_sql2(
-        con,
-        "COUNT(DISTINCT row({.col {list(...)}*})) FILTER (",
+      return(sql_glue(paste0(
+        "COUNT(DISTINCT row({...})) FILTER (",
         str_null_check, ")"
-      ))
+      )))
     }
   } else {
-    return(glue_sql2(con, "COUNT(DISTINCT row({.col {list(...)}*}))"))
+    return(sql_glue("COUNT(DISTINCT row({...}))"))
   }
 }
 

--- a/R/dbplyr-version.R
+++ b/R/dbplyr-version.R
@@ -1,0 +1,48 @@
+# Explained in handbook/usage/integrations/README.md.
+
+# The dbplyr release the backend needs. `test-dbplyr-version.R` pins this to the
+# `Suggests` floor in DESCRIPTION, so the two cannot drift apart.
+dbplyr_min_version <- function() {
+  "2.6.0"
+}
+
+# The version of the dbplyr that is *loaded*, which is not always the one on
+# disk: a library copy can be replaced under a running session, and
+# `packageVersion()` re-reads DESCRIPTION from that path, so it would report a
+# version this session will never call. The `"spec"` namespace info is recorded
+# when the namespace loads, so it names what the backend will actually reach --
+# the same way `get_package_version()` reads this package's own version.
+loaded_dbplyr_version <- function() {
+  package_version(getNamespaceInfo(asNamespace("dbplyr"), "spec")[["version"]])
+}
+
+# Warn when the loaded dbplyr is older than the backend needs. Silent -- and
+# careful not to load dbplyr itself -- when dbplyr is absent: the backend is
+# only reachable once something else has loaded it.
+warn_if_dbplyr_too_old <- function() {
+  if (!isNamespaceLoaded("dbplyr")) {
+    return(invisible(FALSE))
+  }
+
+  min_version <- dbplyr_min_version()
+  version <- loaded_dbplyr_version()
+  if (version >= min_version) {
+    return(invisible(FALSE))
+  }
+
+  warning(
+    sprintf(
+      paste0(
+        "%s's dbplyr backend needs dbplyr %s or later, but dbplyr %s is loaded.\n",
+        "Translations such as `n_distinct()` will fail.\n",
+        "Install a newer dbplyr and restart R."
+      ),
+      get_package_name(),
+      min_version,
+      version
+    ),
+    call. = FALSE
+  )
+
+  invisible(TRUE)
+}

--- a/R/dbplyr-version.R
+++ b/R/dbplyr-version.R
@@ -3,7 +3,7 @@
 # The dbplyr release the backend needs. `test-dbplyr-version.R` pins this to the
 # `Suggests` floor in DESCRIPTION, so the two cannot drift apart.
 dbplyr_min_version <- function() {
-  "2.6.0"
+  package_version("2.6.0")
 }
 
 # The version of the dbplyr that is *loaded*, which is not always the one on

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -13,6 +13,13 @@
     "duckdb_connection_adbc"
   )
 
+  # Catches a dbplyr that loads after this package. Armed here rather than in
+  # `.onAttach()` because `.onLoad()` runs exactly once per namespace load,
+  # whereas a detach/reattach cycle would stack a second copy of the hook.
+  setHook(packageEvent("dbplyr", "onLoad"), function(...) {
+    warn_if_dbplyr_too_old()
+  })
+
   if (requireNamespace("rlang", quietly = TRUE)) {
     is_interactive <<- rlang::is_interactive
     rapi_error <<- rapi_error_rlang
@@ -23,6 +30,14 @@
     rethrow_restore()
     # Overwrite rapi_error with base version when rlang is not available
   }
+
+  invisible()
+}
+
+.onAttach <- function(...) {
+  # The other order: dbplyr was already loaded when this package was attached,
+  # so the `onLoad` hook armed above will never fire for it.
+  warn_if_dbplyr_too_old()
 
   invisible()
 }

--- a/experiments/2026-08-09-dbplyr-version-warning/README.md
+++ b/experiments/2026-08-09-dbplyr-version-warning/README.md
@@ -1,0 +1,108 @@
+# Telling a session its dbplyr is too old
+
+*What it measures:* which R API reports the version of the dbplyr a
+session has actually *loaded* rather than the one now sitting in the
+library, when a `packageEvent()` hook fires, and what a condition raised
+from inside one can and cannot do to the load it interrupts.
+
+*When and on what:* 2026-08-09, Linux x86_64, R 4.5.3,
+dbplyr 2.6.0 from the ordinary library and dbplyr 2.5.0 from the
+Posit Package Manager snapshot `2025-06-02`.
+Three scripts, each with its recorded output:
+[`version-apis.R`](version-apis.R) / [`.out`](version-apis.out),
+[`hook-mechanics.R`](hook-mechanics.R) / [`.out`](hook-mechanics.out),
+[`orders.R`](orders.R) / [`.out`](orders.out).
+
+*What it supports:* the dbplyr floor and its warning in
+[`usage/integrations/`](/handbook/usage/integrations/README.md).
+
+## Why a warning at all
+
+[#1982](https://github.com/duckdb/duckdb-r/issues/1982) moved
+`n_distinct()` off dbplyr's private `glue_sql2()` and onto the exported
+`sql_glue()`, which dbplyr 2.6.0 is the first release to carry.
+`Suggests` now floors dbplyr at 2.6.0, but a `Suggests` floor is
+advisory: nothing stops an older dbplyr from being loaded next to this
+package, and the failure it produces then — `could not find function
+"sql_glue"`, from inside a translation — names neither package nor
+remedy.
+
+## `packageVersion()` answers a different question
+
+Both APIs read the *loaded namespace's path*, so `pkgload::load_all()`
+on a source tree is not where they part company: both report the tree's
+version. They diverge when the library copy at that path is replaced
+while the session runs, which is what `install.packages()` does:
+
+```
+loaded 1.0.0        packageVersion()=1.0.0  getNamespaceVersion()=1.0.0
+library now 2.0.0   packageVersion()=2.0.0  getNamespaceVersion()=1.0.0
+```
+
+The session is still running 1.0.0 and will until R restarts.
+`packageVersion()` re-reads the installed metadata each call and so
+reports the upgrade immediately; `getNamespaceVersion()` returns the
+`"spec"` recorded when the namespace loaded, which is the version whose
+code is actually reachable.
+
+That difference is the whole point here, not a technicality. Measured
+end to end: a session holding dbplyr 2.5.0 that then installs 2.6.0
+still has no `sql_glue()` in its namespace, so `n_distinct()` is still
+broken — and a `packageVersion()` check would have gone quiet at exactly
+the moment the warning is worth reading, since its remedy is *restart R*.
+
+The package already reads its own version this way, through
+`get_package_version()`; `loaded_dbplyr_version()` is the same move
+pointed at a soft dependency.
+
+## The hook catches a load, not an attach
+
+`setHook(packageEvent("dbplyr", "onLoad"), …)` fires on
+`loadNamespace()`, so it catches `dbplyr::x` and dbplyr arriving as
+somebody else's dependency, not just `library(dbplyr)`. The version is
+readable by the time it runs. It fires once per namespace load, which is
+why `.onLoad()` arms it: `.onAttach()` runs again after every
+`detach()`/`library()` cycle and would stack duplicates.
+
+The hook can only ever catch dbplyr loading *after* this package. The
+other order — dbplyr already loaded when this package is attached —
+never fires it, and is covered by a check in `.onAttach()`.
+
+## `warning()` is safe here, and harder to lose
+
+Raised from inside a hook, a `warning()` cannot break the load it
+interrupts: R calls hooks under `try()`, so even `options(warn = 2)`
+turns it into a caught-and-printed error while `library(dbplyr)`
+completes and attaches.
+
+`suppressPackageStartupMessages()` does not muffle it, where it does
+muffle `packageStartupMessage()`. For an incompatibility that will
+produce a real failure later, surviving the suppression a user applies
+out of habit is the property worth having.
+
+One detail: without `call. = FALSE`, R attributes the warning to its own
+hook caller — `In fun(pkgname, pkgpath) : …` — which tells a reader
+nothing.
+
+## As shipped
+
+Against a real dbplyr 2.5.0, one warning arrives in each order that puts
+both packages in a session, and nothing arrives when it should not:
+
+* dbplyr loaded first, then this package attached — warns at attach.
+* This package attached first, then dbplyr loaded — warns from the hook.
+* This package loaded but never attached, then dbplyr — warns from the
+  hook. The backend is reachable through `dplyr::tbl()` without ever
+  attaching this package, so the check follows *loaded*, not *attached*.
+* Current dbplyr, either order — silent.
+* This package attached with dbplyr absent — silent, and dbplyr is not
+  loaded to find out.
+* dbplyr 2.5.0 loaded, then upgraded to 2.6.0 mid-session — still warns,
+  because the session still has no `sql_glue()`.
+
+The false positive this accepts: a session that loads both packages but
+drives dbplyr against some other backend is warned about a translation
+it will never call. It is warned anyway, because by then this package
+has already registered its methods into dbplyr, and distinguishing the
+two would mean waiting for a failure that the warning exists to
+pre-empt.

--- a/experiments/2026-08-09-dbplyr-version-warning/README.md
+++ b/experiments/2026-08-09-dbplyr-version-warning/README.md
@@ -2,16 +2,18 @@
 
 *What it measures:* which R API reports the version of the dbplyr a
 session has actually *loaded* rather than the one now sitting in the
-library, when a `packageEvent()` hook fires, and what a condition raised
-from inside one can and cannot do to the load it interrupts.
+library, when a `packageEvent()` hook fires, what a condition raised
+from inside one can and cannot do to the load it interrupts, and which
+of those conditions `R CMD check` objects to.
 
 *When and on what:* 2026-08-09, Linux x86_64, R 4.5.3,
 dbplyr 2.6.0 from the ordinary library and dbplyr 2.5.0 from the
 Posit Package Manager snapshot `2025-06-02`.
-Three scripts, each with its recorded output:
+Four scripts, each with its recorded output:
 [`version-apis.R`](version-apis.R) / [`.out`](version-apis.out),
 [`hook-mechanics.R`](hook-mechanics.R) / [`.out`](hook-mechanics.out),
-[`orders.R`](orders.R) / [`.out`](orders.out).
+[`orders.R`](orders.R) / [`.out`](orders.out),
+[`cran-check.R`](cran-check.R) / [`.out`](cran-check.out).
 
 *What it supports:* the dbplyr floor and its warning in
 [`usage/integrations/`](/handbook/usage/integrations/README.md).
@@ -83,6 +85,39 @@ out of habit is the property worth having.
 One detail: without `call. = FALSE`, R attributes the warning to its own
 hook caller — `In fun(pkgname, pkgpath) : …` — which tells a reader
 nothing.
+
+## What CRAN actually objects to
+
+Two separate mechanisms bear on `warning()` versus
+`packageStartupMessage()` in `.onAttach()`, and conflating them gives
+the wrong answer.
+
+The R-code check flags *message-generating* calls, and its list is
+exactly `cat`, `message`, `print`, `writeLines` (plus `library`,
+`require`, `installed.packages`, `library.dynam` in `.onAttach`, and
+`packageStartupMessage` in `.onLoad`) — `tools:::.bad_call_names_in_startup_functions`.
+`message()` earns *"Package startup functions should use
+`packageStartupMessage` to generate messages"*, which is the "Good
+practice" section of `?.onAttach`. `warning()` is not on that list and
+draws nothing; `tools:::.check_package_code_startup_functions()` reports
+0 offending calls for this package.
+
+The install check is the one with teeth here. `R CMD INSTALL` attaches
+the package to test it, so anything `.onAttach()` warns about lands in
+`00install.out`, and `R CMD check` greps it:
+
+```
+* checking whether package 'startuptest' can be installed ... WARNING
+Found the following significant warnings:
+  Warning: too old
+```
+
+That fires for an *unconditional* warning. This package's warning is
+conditional on an old dbplyr being loaded, and nothing loads a `Suggests`
+package during install — installing with dbplyr 2.5.0 first on the
+library path is silent, and `packageStartupMessage()` would buy nothing.
+The rule to take from this is not "startup output must be a message" but
+"`.onAttach()` must be silent on a healthy install".
 
 ## As shipped
 

--- a/experiments/2026-08-09-dbplyr-version-warning/cran-check.R
+++ b/experiments/2026-08-09-dbplyr-version-warning/cran-check.R
@@ -1,0 +1,56 @@
+# What does `R CMD check` say about each way of speaking from `.onAttach()`?
+#
+# Two separate mechanisms bear on the choice, and they are easy to conflate:
+# the R-code check (which flags message-generating calls) and the install
+# check (which greps `R CMD INSTALL` output for warnings).
+
+pkg <- file.path(tempdir(), "startuptest")
+
+write_pkg <- function(body) {
+  unlink(pkg, recursive = TRUE)
+  dir.create(file.path(pkg, "R"), recursive = TRUE)
+  writeLines(
+    c(
+      "Package: startuptest", "Version: 1.0.0", "Title: Startup Test",
+      "Description: Checks what R CMD check says about startup functions.",
+      "Author: N <n@e.com>", "Maintainer: N <n@e.com>",
+      "License: MIT + file LICENSE", "Encoding: UTF-8"
+    ),
+    file.path(pkg, "DESCRIPTION")
+  )
+  writeLines("MIT", file.path(pkg, "LICENSE"))
+  writeLines("export(f)", file.path(pkg, "NAMESPACE"))
+  writeLines(
+    c("f <- function() 1", "", ".onAttach <- function(libname, pkgname) {",
+      paste0("  ", body), "  invisible()", "}"),
+    file.path(pkg, "R", "f.R")
+  )
+}
+
+check <- function(label, body) {
+  write_pkg(body)
+  out <- suppressWarnings(system2(
+    file.path(R.home("bin"), "R"),
+    c("CMD", "check", "--no-manual", "--no-build-vignettes", pkg),
+    stdout = TRUE, stderr = TRUE
+  ))
+  keep <- grep("can be installed|R code for possible problems", out)
+  keep <- sort(unique(c(keep, keep + 1, keep + 2, keep + 3, keep + 4, keep + 5, keep + 6)))
+  cat("--", label, "\n")
+  cat(paste0("   ", out[keep[keep <= length(out)]]), sep = "\n")
+  cat("\n")
+  unlink(paste0(basename(pkg), ".Rcheck"), recursive = TRUE)
+}
+
+owd <- setwd(tempdir())
+on.exit(setwd(owd))
+
+check("warning(..., call. = FALSE)", 'warning("too old", call. = FALSE)')
+check("packageStartupMessage()", 'packageStartupMessage("too old")')
+check("message()", 'message("too old")')
+
+# And the check the package itself has to pass: the R-code check reads the
+# sources, so it can be run directly against a package directory.
+cat("-- tools:::.check_package_code_startup_functions() on this package\n")
+found <- tools:::.check_package_code_startup_functions(owd)
+cat("   offending startup calls:", length(unlist(found)), "\n")

--- a/experiments/2026-08-09-dbplyr-version-warning/cran-check.out
+++ b/experiments/2026-08-09-dbplyr-version-warning/cran-check.out
@@ -1,0 +1,50 @@
+-- warning(..., call. = FALSE) 
+   * checking whether package ‘startuptest’ can be installed ... WARNING
+   Found the following significant warnings:
+     Warning: too old
+   See ‘/tmp/RtmpONaLW2/startuptest.Rcheck/00install.out’ for details.
+   * checking installed package size ... OK
+   * checking package directory ... OK
+   * checking DESCRIPTION meta-information ... NOTE
+   * checking R code for possible problems ... OK
+   * checking for missing documentation entries ... WARNING
+   Undocumented code objects:
+     ‘f’
+   All user-level objects in a package should have documentation entries.
+   See chapter ‘Writing R documentation files’ in the ‘Writing R
+   Extensions’ manual.
+
+-- packageStartupMessage() 
+   * checking whether package ‘startuptest’ can be installed ... OK
+   * checking installed package size ... OK
+   * checking package directory ... OK
+   * checking DESCRIPTION meta-information ... NOTE
+   License stub is invalid DCF.
+   Checking should be performed on sources prepared by ‘R CMD build’.
+   * checking top-level files ... OK
+   * checking R code for possible problems ... OK
+   * checking for missing documentation entries ... WARNING
+   Undocumented code objects:
+     ‘f’
+   All user-level objects in a package should have documentation entries.
+   See chapter ‘Writing R documentation files’ in the ‘Writing R
+   Extensions’ manual.
+
+-- message() 
+   * checking whether package ‘startuptest’ can be installed ... OK
+   * checking installed package size ... OK
+   * checking package directory ... OK
+   * checking DESCRIPTION meta-information ... NOTE
+   License stub is invalid DCF.
+   Checking should be performed on sources prepared by ‘R CMD build’.
+   * checking top-level files ... OK
+   * checking R code for possible problems ... NOTE
+   File ‘startuptest/R/f.R’:
+     .onAttach calls:
+       message("too old")
+   
+   Package startup functions should use ‘packageStartupMessage’ to
+     generate messages.
+
+-- tools:::.check_package_code_startup_functions() on this package
+   offending startup calls: 0 

--- a/experiments/2026-08-09-dbplyr-version-warning/hook-mechanics.R
+++ b/experiments/2026-08-09-dbplyr-version-warning/hook-mechanics.R
@@ -1,0 +1,59 @@
+# When does a `packageEvent(pkg, "onLoad")` hook fire, and what can it emit?
+#
+# Two questions the design turns on: whether the hook catches a namespace that
+# is loaded but never attached (`dbplyr::x`), and whether a condition raised
+# from inside it reaches the user without breaking the load it interrupts.
+
+cat("== when the hook fires ==\n")
+arm <- function() {
+  setHook(packageEvent("dbplyr", "onLoad"), function(...) {
+    cat("  [onLoad hook] version readable here:",
+        unname(getNamespaceVersion("dbplyr")), "\n")
+  })
+  setHook(packageEvent("dbplyr", "attach"), function(...) cat("  [attach hook]\n"))
+}
+
+arm()
+cat("loadNamespace() -- what `dbplyr::x` does:\n")
+invisible(loadNamespace("dbplyr"))
+cat("  attached?", "package:dbplyr" %in% search(), "\n")
+
+cat("library() on the already-loaded namespace:\n")
+suppressMessages(library(dbplyr))
+
+cat("library() after unloading:\n")
+unloadNamespace("dbplyr")
+suppressMessages(library(dbplyr))
+
+cat("\n== how a condition from the hook is delivered ==\n")
+case <- function(label, emit, wrap, warn_opt) {
+  script <- sprintf('
+    options(warn = %d)
+    setHook(packageEvent("dbplyr", "onLoad"), function(...) %s(%s))
+    ok <- tryCatch({ %s(library(dbplyr)); "load OK" },
+                   error = function(e) paste("LOAD FAILED:", conditionMessage(e)))
+    cat("<<", ok, "| attached:", "package:dbplyr" %%in%% search(), ">>\n")
+  ', warn_opt, emit,
+     if (emit == "warning") '"too old", call. = FALSE' else '"too old"', wrap)
+  f <- tempfile(fileext = ".R")
+  writeLines(script, f)
+  out <- suppressWarnings(system2("Rscript", f, stdout = TRUE, stderr = TRUE))
+  cat("--", label, "\n")
+  cat(paste0("   ", out[nzchar(out)]), sep = "\n")
+}
+
+case("warning(), warn = 0", "warning", "identity", 0)
+case("warning(), warn = 2", "warning", "identity", 2)
+case("warning() under suppressPackageStartupMessages()",
+     "warning", "suppressPackageStartupMessages", 0)
+case("packageStartupMessage()", "packageStartupMessage", "identity", 0)
+case("packageStartupMessage() under suppressPackageStartupMessages()",
+     "packageStartupMessage", "suppressPackageStartupMessages", 0)
+
+cat("\n-- and without call. = FALSE, R names its own hook caller:\n")
+f <- tempfile(fileext = ".R")
+writeLines('
+  setHook(packageEvent("dbplyr", "onLoad"), function(...) warning("too old"))
+  suppressMessages(library(dbplyr))
+', f)
+cat(paste0("   ", suppressWarnings(system2("Rscript", f, stdout = TRUE, stderr = TRUE))), sep = "\n")

--- a/experiments/2026-08-09-dbplyr-version-warning/hook-mechanics.out
+++ b/experiments/2026-08-09-dbplyr-version-warning/hook-mechanics.out
@@ -1,0 +1,31 @@
+== when the hook fires ==
+loadNamespace() -- what `dbplyr::x` does:
+  [onLoad hook] version readable here: 2.6.0 
+  attached? FALSE 
+library() on the already-loaded namespace:
+  [attach hook]
+library() after unloading:
+  [onLoad hook] version readable here: 2.6.0 
+  [attach hook]
+
+== how a condition from the hook is delivered ==
+-- warning(), warn = 0 
+   Warning message:
+   too old 
+   << load OK | attached: TRUE >>
+-- warning(), warn = 2 
+   Error : (converted from warning) too old
+   << load OK | attached: TRUE >>
+-- warning() under suppressPackageStartupMessages() 
+   Warning message:
+   too old 
+   << load OK | attached: TRUE >>
+-- packageStartupMessage() 
+   too old
+   << load OK | attached: TRUE >>
+-- packageStartupMessage() under suppressPackageStartupMessages() 
+   << load OK | attached: TRUE >>
+
+-- and without call. = FALSE, R names its own hook caller:
+   Warning message:
+   In fun(pkgname, pkgpath) : too old

--- a/experiments/2026-08-09-dbplyr-version-warning/orders.R
+++ b/experiments/2026-08-09-dbplyr-version-warning/orders.R
@@ -1,0 +1,71 @@
+# The warning as shipped, against a real old dbplyr, in every order that puts
+# the two packages in a session -- plus the mid-session upgrade, which is the
+# case that separates the loaded version from the library one.
+#
+# dbplyr 2.5.0 comes from a Posit Package Manager snapshot; the current dbplyr
+# comes from the ordinary library. Both are read-only here: every scenario runs
+# in its own subprocess against a copy.
+
+pkg <- "duckdb"
+snapshot <- "https://packagemanager.posit.co/cran/2025-06-02"
+
+old_lib <- file.path(tempdir(), "old")
+dir.create(old_lib, showWarnings = FALSE)
+install.packages("dbplyr", lib = old_lib, repos = snapshot, type = "source",
+                 dependencies = FALSE, quiet = TRUE)
+cat("old dbplyr:", as.character(packageVersion("dbplyr", lib.loc = old_lib)),
+    "| exports sql_glue():",
+    "sql_glue" %in% names(readRDS(file.path(old_lib, "dbplyr", "Meta", "nsInfo.rds"))$exports),
+    "\n")
+cur_lib <- dirname(find.package("dbplyr"))
+cat("current dbplyr:", as.character(packageVersion("dbplyr")), "\n\n")
+
+run <- function(label, lines, libs = character()) {
+  f <- tempfile(fileext = ".R")
+  writeLines(lines, f)
+  env <- if (length(libs)) paste0("R_LIBS=", paste(c(libs, .libPaths()), collapse = ":")) else character()
+  out <- suppressWarnings(system2("env", c(env, "Rscript", f), stdout = TRUE, stderr = TRUE))
+  out <- out[nzchar(out) & !grepl("^(i|ℹ) |This persists|storing downloaded|^<environment", out)]
+  cat("--", label, "\n")
+  cat(paste0("   ", out), sep = "\n")
+  cat("\n")
+}
+
+banner <- 'cat("[dbplyr", unname(getNamespaceVersion("dbplyr")), "loaded]\n")'
+attach_pkg <- sprintf('suppressMessages(library(%s))', pkg)
+
+run("old dbplyr loaded first, then the package attached",
+    c('suppressMessages(library(dbplyr))', banner, attach_pkg, 'cat("<< end >>\n")'),
+    libs = old_lib)
+
+run("the package attached first, then old dbplyr loaded",
+    c(attach_pkg, 'suppressMessages(library(dbplyr))', banner, 'cat("<< end >>\n")'),
+    libs = old_lib)
+
+run("the package loaded but never attached, then old dbplyr",
+    c(sprintf('invisible(%s::%s())', pkg, pkg), 'suppressMessages(library(dbplyr))',
+      banner, 'cat("<< end >>\n")'),
+    libs = old_lib)
+
+run("current dbplyr loaded first, then the package attached",
+    c('suppressMessages(library(dbplyr))', banner, attach_pkg, 'cat("<< end >>\n")'))
+
+run("the package attached, dbplyr never loaded",
+    c(attach_pkg, 'cat("<< dbplyr loaded:", isNamespaceLoaded("dbplyr"), ">>\n")'))
+
+run("dbplyr upgraded mid-session: library moves, the session does not",
+    sprintf('
+      scratch <- file.path(tempdir(), "lib"); dir.create(scratch)
+      stopifnot(file.copy(file.path("%s", "dbplyr"), scratch, recursive = TRUE))
+      .libPaths(c(scratch, .libPaths()))
+      invisible(loadNamespace("dbplyr"))
+      cat("   after loading  : packageVersion()", as.character(packageVersion("dbplyr")),
+          "| getNamespaceVersion()", unname(getNamespaceVersion("dbplyr")), "\n")
+      stopifnot(file.copy(file.path("%s", "dbplyr"), scratch, recursive = TRUE, overwrite = TRUE))
+      cat("   after upgrading: packageVersion()", as.character(packageVersion("dbplyr")),
+          "| getNamespaceVersion()", unname(getNamespaceVersion("dbplyr")), "\n")
+      cat("   sql_glue() reachable in this session:",
+          "sql_glue" %%in%% getNamespaceExports("dbplyr"), "\n")
+      suppressMessages(library(%s))
+      cat("<< end >>\n")
+    ', old_lib, cur_lib, pkg))

--- a/experiments/2026-08-09-dbplyr-version-warning/orders.out
+++ b/experiments/2026-08-09-dbplyr-version-warning/orders.out
@@ -1,0 +1,44 @@
+old dbplyr: 2.5.0 | exports sql_glue(): FALSE 
+current dbplyr: 2.6.0 
+
+-- old dbplyr loaded first, then the package attached 
+   [dbplyr 2.5.0 loaded]
+   Warning message:
+   duckdb's dbplyr backend needs dbplyr 2.6.0 or later, but dbplyr 2.5.0 is loaded.
+   Translations such as `n_distinct()` will fail.
+   Install a newer dbplyr and restart R. 
+   << end >>
+
+-- the package attached first, then old dbplyr loaded 
+   Warning message:
+   duckdb's dbplyr backend needs dbplyr 2.6.0 or later, but dbplyr 2.5.0 is loaded.
+   Translations such as `n_distinct()` will fail.
+   Install a newer dbplyr and restart R. 
+   [dbplyr 2.5.0 loaded]
+   << end >>
+
+-- the package loaded but never attached, then old dbplyr 
+   Warning message:
+   duckdb's dbplyr backend needs dbplyr 2.6.0 or later, but dbplyr 2.5.0 is loaded.
+   Translations such as `n_distinct()` will fail.
+   Install a newer dbplyr and restart R. 
+   [dbplyr 2.5.0 loaded]
+   << end >>
+
+-- current dbplyr loaded first, then the package attached 
+   [dbplyr 2.6.0 loaded]
+   << end >>
+
+-- the package attached, dbplyr never loaded 
+   << dbplyr loaded: FALSE >>
+
+-- dbplyr upgraded mid-session: library moves, the session does not 
+      after loading  : packageVersion() 2.5.0 | getNamespaceVersion() 2.5.0 
+      after upgrading: packageVersion() 2.6.0 | getNamespaceVersion() 2.5.0 
+      sql_glue() reachable in this session: FALSE 
+   Warning message:
+   duckdb's dbplyr backend needs dbplyr 2.6.0 or later, but dbplyr 2.5.0 is loaded.
+   Translations such as `n_distinct()` will fail.
+   Install a newer dbplyr and restart R. 
+   << end >>
+

--- a/experiments/2026-08-09-dbplyr-version-warning/version-apis.R
+++ b/experiments/2026-08-09-dbplyr-version-warning/version-apis.R
@@ -1,0 +1,71 @@
+# Which R API reports the version of the *loaded* package, and which re-reads
+# the library copy that may have changed underneath it?
+#
+# Builds a throwaway package, loads it, reinstalls a newer one over the top --
+# the shape of `install.packages()` in a running session -- and asks each API.
+
+lib <- file.path(tempdir(), "lib")
+src <- file.path(tempdir(), "fakedep")
+dir.create(lib, showWarnings = FALSE)
+
+make_pkg <- function(version) {
+  unlink(src, recursive = TRUE)
+  dir.create(file.path(src, "R"), recursive = TRUE)
+  writeLines(
+    c(
+      "Package: fakedep", paste0("Version: ", version), "Title: Fake",
+      "Description: Fake.", "Author: N", "Maintainer: N <n@e.com>",
+      "License: MIT + file LICENSE", "Encoding: UTF-8"
+    ),
+    file.path(src, "DESCRIPTION")
+  )
+  writeLines("MIT", file.path(src, "LICENSE"))
+  writeLines("fakedep_marker <- function() 'x'", file.path(src, "R", "f.R"))
+  writeLines("export(fakedep_marker)", file.path(src, "NAMESPACE"))
+  res <- callr::rcmd("INSTALL", c(src, paste0("--library=", lib)), show = FALSE)
+  stopifnot(res$status == 0)
+}
+
+report <- function(when) {
+  cat(sprintf(
+    "%-26s packageVersion()=%-7s packageDescription()=%-7s getNamespaceVersion()=%s\n",
+    when,
+    as.character(utils::packageVersion("fakedep")),
+    utils::packageDescription("fakedep")$Version,
+    unname(getNamespaceVersion("fakedep"))
+  ))
+}
+
+make_pkg("1.0.0")
+invisible(loadNamespace("fakedep", lib.loc = lib))
+report("loaded 1.0.0")
+
+make_pkg("2.0.0")  # reinstalled over the top, session still running
+report("library now 2.0.0")
+
+cat("\nnamespace still loaded:", isNamespaceLoaded("fakedep"), "\n")
+cat("still running the 1.0.0 code:", fakedep::fakedep_marker() == "x", "\n")
+
+# The other direction: a source tree loaded with pkgload, never installed. Here
+# the two agree -- `packageVersion()` follows the namespace's path, which is the
+# source tree, so `load_all()` is not where they diverge.
+src2 <- file.path(tempdir(), "fakedep2")
+unlink(src2, recursive = TRUE)
+dir.create(file.path(src2, "R"), recursive = TRUE)
+writeLines(
+  c(
+    "Package: fakedep2", "Version: 9.9.9", "Title: Fake", "Description: Fake.",
+    "Author: N", "Maintainer: N <n@e.com>", "License: MIT + file LICENSE",
+    "Encoding: UTF-8"
+  ),
+  file.path(src2, "DESCRIPTION")
+)
+writeLines("MIT", file.path(src2, "LICENSE"))
+writeLines("fakedep2_marker <- function() 'x'", file.path(src2, "R", "f.R"))
+writeLines("export(fakedep2_marker)", file.path(src2, "NAMESPACE"))
+suppressMessages(pkgload::load_all(src2, quiet = TRUE))
+cat(sprintf(
+  "\nunder load_all(): packageVersion()=%s getNamespaceVersion()=%s\n",
+  as.character(utils::packageVersion("fakedep2")),
+  unname(getNamespaceVersion("fakedep2"))
+))

--- a/experiments/2026-08-09-dbplyr-version-warning/version-apis.out
+++ b/experiments/2026-08-09-dbplyr-version-warning/version-apis.out
@@ -1,0 +1,7 @@
+loaded 1.0.0               packageVersion()=1.0.0   packageDescription()=1.0.0   getNamespaceVersion()=1.0.0
+library now 2.0.0          packageVersion()=2.0.0   packageDescription()=2.0.0   getNamespaceVersion()=1.0.0
+
+namespace still loaded: TRUE 
+still running the 1.0.0 code: TRUE 
+
+under load_all(): packageVersion()=9.9.9 getNamespaceVersion()=9.9.9

--- a/experiments/README.md
+++ b/experiments/README.md
@@ -63,6 +63,12 @@ the directory keeps the method so that is possible.
   method, how far into dbplyr that reaches, and what `window_order()`
   already states without it; supports
   [`usage/integrations/`](/handbook/usage/integrations/README.md).
+* [`2026-08-09-dbplyr-version-warning/`](2026-08-09-dbplyr-version-warning/) —
+  which API reports the version of the dbplyr a session has loaded
+  rather than the one in the library, when a `packageEvent()` hook
+  fires, and what a warning raised from one can do to the load it
+  interrupts; supports
+  [`usage/integrations/`](/handbook/usage/integrations/README.md).
 * [`2026-08-09-series-carry-scope/`](2026-08-09-series-carry-scope/) —
   how many of a buffer's vendor commits have a fix waiting on the base
   series' `-dev`, what kind, and how much of the raw difference is not a

--- a/handbook/usage/integrations/README.md
+++ b/handbook/usage/integrations/README.md
@@ -19,6 +19,21 @@ the first release to export `sql_glue()` —
 having previously reached the unexported `glue_sql2()`
 that a dbplyr release was free to drop
 ([#1982](https://github.com/duckdb/duckdb-r/issues/1982)).
+
+**A `Suggests` floor is advisory, so the floor also warns.**
+Nothing stops an older dbplyr from being loaded beside this package,
+and what it produces then is a missing-function error
+from inside a translation, naming neither package nor remedy.
+So `warn_if_dbplyr_too_old()` ([`R/dbplyr-version.R`](/R/dbplyr-version.R))
+says it plainly instead, from `.onAttach()` when dbplyr is already loaded
+and from a `packageEvent("dbplyr", "onLoad")` hook when it arrives later.
+It reads the version of the *loaded* namespace, not the library copy:
+those differ for the rest of a session after `install.packages("dbplyr")`,
+and it is the loaded one whose code the backend will reach —
+which is why the warning says to restart R.
+The check never loads dbplyr to perform it, so a session that
+does not use the backend pays nothing and hears nothing
+([`2026-08-09-dbplyr-version-warning/`](/experiments/2026-08-09-dbplyr-version-warning/README.md)).
 Coercions translate to `TRY_CAST()`,
 so a value that will not convert yields `NULL` rather than failing
 the query

--- a/handbook/usage/integrations/README.md
+++ b/handbook/usage/integrations/README.md
@@ -13,6 +13,12 @@ What a value becomes across the boundary is
 is the backend reference.
 dbplyr and dplyr are `Suggests`;
 the methods register at load time, edition 2.
+dbplyr is floored at 2.6.0,
+the first release to export `sql_glue()` —
+`n_distinct()` renders through it,
+having previously reached the unexported `glue_sql2()`
+that a dbplyr release was free to drop
+([#1982](https://github.com/duckdb/duckdb-r/issues/1982)).
 Coercions translate to `TRY_CAST()`,
 so a value that will not convert yields `NULL` rather than failing
 the query
@@ -46,13 +52,6 @@ the boundaries users keep hitting:
   ([#1585](https://github.com/duckdb/duckdb-r/issues/1585),
   blocked on
   [tidyverse/dbplyr#1838](https://github.com/tidyverse/dbplyr/issues/1838)).
-* `n_distinct()` reaches dbplyr's unexported `glue_sql2()` through
-  `getFromNamespace()` — a private-API dependency any dbplyr release
-  can break.
-  The public replacement `sql_glue()` has shipped, so the migration is
-  unblocked; what it still needs is a `dbplyr (>= 2.6.0)` floor, which
-  `DESCRIPTION`'s `Suggests` does not carry
-  ([#1982](https://github.com/duckdb/duckdb-r/issues/1982)).
 
 ## duckplyr
 

--- a/handbook/usage/integrations/README.md
+++ b/handbook/usage/integrations/README.md
@@ -32,7 +32,10 @@ those differ for the rest of a session after `install.packages("dbplyr")`,
 and it is the loaded one whose code the backend will reach —
 which is why the warning says to restart R.
 The check never loads dbplyr to perform it, so a session that
-does not use the backend pays nothing and hears nothing
+does not use the backend pays nothing and hears nothing —
+which is also what keeps `R CMD check` quiet,
+since it reads `R CMD INSTALL`'s output for warnings
+and a `Suggests` package is never loaded there
 ([`2026-08-09-dbplyr-version-warning/`](/experiments/2026-08-09-dbplyr-version-warning/README.md)).
 Coercions translate to `TRY_CAST()`,
 so a value that will not convert yields `NULL` rather than failing

--- a/tests/testthat/_snaps/dbplyr-version.md
+++ b/tests/testthat/_snaps/dbplyr-version.md
@@ -1,0 +1,10 @@
+# the warning wording is stable
+
+    Code
+      warn_if_dbplyr_too_old()
+    Condition
+      Warning:
+      duckdb's dbplyr backend needs dbplyr 2.6.0 or later, but dbplyr 2.5.0 is loaded.
+      Translations such as `n_distinct()` will fail.
+      Install a newer dbplyr and restart R.
+

--- a/tests/testthat/test-dbplyr-version.R
+++ b/tests/testthat/test-dbplyr-version.R
@@ -1,0 +1,83 @@
+test_that("the declared minimum matches the DESCRIPTION floor", {
+  # The declared floor, so reading DESCRIPTION is the point here -- unlike the
+  # runtime check below, which must not.
+  suggests <- packageDescription(get_package_name())[["Suggests"]]
+  entries <- trimws(strsplit(suggests, ",")[[1]])
+  entry <- grep("^dbplyr\\b", entries, value = TRUE)
+
+  expect_length(entry, 1L)
+  expect_equal(entry, paste0("dbplyr (>= ", dbplyr_min_version(), ")"))
+})
+
+test_that("the loaded version is read from the namespace, not the library", {
+  skip_if_not_installed("dbplyr")
+
+  # `getNamespaceInfo(, "spec")` is recorded when the namespace loads, so a
+  # library copy replaced underneath a running session cannot change it --
+  # `packageVersion()` would re-read the DESCRIPTION at that path and report a
+  # version this session never loaded.
+  expect_equal(
+    as.character(loaded_dbplyr_version()),
+    unname(getNamespaceVersion("dbplyr"))
+  )
+})
+
+test_that("an old dbplyr warns, a current one is silent", {
+  local_mocked_bindings(loaded_dbplyr_version = function() package_version("2.5.0"))
+  expect_warning(
+    expect_true(warn_if_dbplyr_too_old()),
+    "needs dbplyr 2.6.0 or later, but dbplyr 2.5.0 is loaded"
+  )
+
+  local_mocked_bindings(loaded_dbplyr_version = function() package_version("2.6.0"))
+  expect_silent(expect_false(warn_if_dbplyr_too_old()))
+
+  local_mocked_bindings(loaded_dbplyr_version = function() package_version("2.7.1"))
+  expect_silent(expect_false(warn_if_dbplyr_too_old()))
+})
+
+test_that("the warning names this package through the flavor seam", {
+  local_mocked_bindings(
+    loaded_dbplyr_version = function() package_version("2.5.0"),
+    get_package_name = function() "someflavor"
+  )
+
+  expect_warning(warn_if_dbplyr_too_old(), "^someflavor's dbplyr backend")
+})
+
+test_that("a dbplyr loading later is caught by a hook", {
+  hooks <- getHook(packageEvent("dbplyr", "onLoad"))
+  expect_gt(length(hooks), 0L)
+
+  # `.onLoad()` armed one of these to run the check. Give it a version that must
+  # warn, and confirm the arrangement as a whole reacts -- the other hooks
+  # registered there only register S3 methods.
+  local_mocked_bindings(loaded_dbplyr_version = function() package_version("2.5.0"))
+  warned <- vapply(
+    hooks,
+    function(hook) {
+      tryCatch(
+        {
+          hook("dbplyr", "")
+          FALSE
+        },
+        warning = function(w) grepl("needs dbplyr", conditionMessage(w), fixed = TRUE)
+      )
+    },
+    logical(1)
+  )
+
+  expect_true(any(warned))
+})
+
+test_that("attaching does not load dbplyr just to check its version", {
+  loaded <- callr::r(
+    function(pkg) {
+      library(pkg, character.only = TRUE)
+      isNamespaceLoaded("dbplyr")
+    },
+    args = list(pkg = get_package_name())
+  )
+
+  expect_false(loaded)
+})

--- a/tests/testthat/test-dbplyr-version.R
+++ b/tests/testthat/test-dbplyr-version.R
@@ -36,6 +36,19 @@ test_that("an old dbplyr warns, a current one is silent", {
   expect_silent(expect_false(warn_if_dbplyr_too_old()))
 })
 
+# --- message wording (snapshot) ----------------------------------------------
+
+test_that("the warning wording is stable", {
+  # The wording carries the package name, so it goes through the flavor
+  # normalisation every snapshot that can name the package uses.
+  local_mocked_bindings(loaded_dbplyr_version = function() package_version("2.5.0"))
+
+  expect_snapshot(
+    warn_if_dbplyr_too_old(),
+    transform = transform_package_name
+  )
+})
+
 test_that("the warning names this package through the flavor seam", {
   local_mocked_bindings(
     loaded_dbplyr_version = function() package_version("2.5.0"),


### PR DESCRIPTION
Closes #1982.

`duckdb_n_distinct()` reached dbplyr's unexported `glue_sql2()` through `getFromNamespace()`, so when the dbplyr development version dropped that function, every `n_distinct()` translation failed with `object 'glue_sql2' not found`. dbplyr 2.6.0 restored `glue_sql2()` to unbreak users, but it is still private and [Hadley asked that we migrate off it](https://github.com/duckdb/duckdb-r/issues/1982#issuecomment-3786916809) so it can be removed for good.

## The fix

- `R/backend-dbplyr__duckdb_connection.R` — `duckdb_n_distinct()` now calls the exported `sql_glue()`. It reads the active connection itself, so the `sql_current_con()` lookup goes away with it, and the glue spec `{...}` renders the dots comma-separated exactly the way `{.col {list(...)}*}` did under `glue_sql2()`.
- `DESCRIPTION` — `Suggests` floors dbplyr at `>= 2.6.0`, the release that first exports `sql_glue()`. Previously it carried no version at all.

Emitted SQL is unchanged. The three call sites were compared old-vs-new against `simulate_dbi()` for one column, one column with `na.rm = TRUE`, two columns, and two columns with `na.rm = TRUE`; the results are identical, and the existing translation tests cover all four shapes unmodified.

```
COUNT(DISTINCT row("x"))
COUNT(DISTINCT "x")
COUNT(DISTINCT row("x", "y"))
COUNT(DISTINCT row("x", "y")) FILTER (x IS NOT NULL AND y IS NOT NULL)
```

## The floor also warns

A `Suggests` floor is advisory. Nothing stops an older dbplyr from being loaded beside this package, and what it produces then is `could not find function "sql_glue"` raised from inside a translation — naming neither package nor remedy. So `warn_if_dbplyr_too_old()` (`R/dbplyr-version.R`) says it plainly instead:

```
duckdb's dbplyr backend needs dbplyr 2.6.0 or later, but dbplyr 2.5.0 is loaded.
Translations such as `n_distinct()` will fail.
Install a newer dbplyr and restart R.
```

It fires from `.onAttach()` when dbplyr is already loaded, and from a `packageEvent("dbplyr", "onLoad")` hook when dbplyr arrives afterwards. The hook is armed in `.onLoad()`, which runs once per namespace load, rather than in `.onAttach()`, where a detach/reattach cycle would stack a second copy.

**The version read is the loaded one, not the library one.** `loaded_dbplyr_version()` reads the namespace's `"spec"`, recorded when the namespace loaded — the same mechanism `get_package_version()` already uses for this package's own version. Both that and `packageVersion()` follow the namespace's path, so they agree under `pkgload::load_all()`; they part company after `install.packages("dbplyr")` mid-session. The library moves, the session does not, and it is the session's copy whose code the backend will reach. Measured: a session holding 2.5.0 that installs 2.6.0 still has no `sql_glue()` in its namespace, so a `packageVersion()` check would have fallen silent at exactly the moment the warning is worth reading — its remedy is *restart R*.

The check never loads dbplyr to perform it, so a session that does not use the backend hears nothing and pays nothing.

## Experiment

`experiments/2026-08-09-dbplyr-version-warning/` records the measurements behind those choices, with re-runnable scripts and their output:

- **Which API reports which version** — `packageVersion()` re-reads installed metadata each call and follows an in-place upgrade; `getNamespaceVersion()` returns what was loaded. They agree under `load_all()`.
- **When the hook fires** — on `loadNamespace()`, so it catches `dbplyr::x` and dbplyr arriving as somebody else's dependency, not just `library(dbplyr)`. The version is readable by the time it runs.
- **What a warning from a hook can do** — it cannot break the load it interrupts: R calls hooks under `try()`, so even `options(warn = 2)` leaves `library(dbplyr)` completing and attached. `suppressPackageStartupMessages()` does not muffle it, where it does muffle `packageStartupMessage()` — which is why this is a warning. Without `call. = FALSE`, R attributes it to its own hook caller (`In fun(pkgname, pkgpath) : …`).
- **What `R CMD check` objects to** — not `warning()`. The R-code check flags message-generating calls (`cat`, `message`, `print`, `writeLines`), and reports no offending startup calls here. The check with teeth is the install check, which greps `R CMD INSTALL` output and would flag an *unconditional* `.onAttach()` warning; this one is conditional on an old dbplyr being loaded, and a `Suggests` package is never loaded during install — verified by installing with dbplyr 2.5.0 first on the library path, which is silent.
- **Behaviour as shipped**, against a real dbplyr 2.5.0 from a P3M snapshot: one warning in each of the three orders that put both packages in a session, silence with current dbplyr in either order, silence when dbplyr is absent, and a warning that correctly persists after a mid-session upgrade.

The README also records the false positive this accepts: a session that loads both packages but drives dbplyr against another backend gets warned about a translation it will never call.

## Verification

Built with `DUCKDB_R_USE_SYSTEM_LIB=1` against dbplyr 2.6.0. The reprex from the issue renders instead of erroring, `scripts/flavor-package-name.R` reports no offenders, and the full suite is `[ FAIL 0 | WARN 0 | SKIP 62 | PASS 1327 ]`.

`tests/testthat/test-dbplyr-version.R` covers the warning thresholds, the flavor seam in the message, the hook being armed, that the declared minimum matches the `Suggests` floor in DESCRIPTION, and that attaching does not drag dbplyr in. The wording itself is recorded in `_snaps/dbplyr-version.md` through `transform_package_name`, since `_snaps/` is not rewritten per flavor and one file has to serve all of them; the skips stay inside `test_that()` so testthat does not delete the file on a platform that skips.

## Follow-up

- Worth filing an issue on dbplyr to let Hadley know this backend no longer uses `glue_sql2()`, which is what he asked for on the issue thread — say the word and I'll open it.
- #2624 fills a handbook gap noticed while writing the snapshot test: the snapshots leaf documents how to accept one but never says when to reach for one.