### PR TITLE
fix(glue): Comment out the names of unused parameters

### DIFF
--- a/src/database.cpp
+++ b/src/database.cpp
@@ -12,7 +12,7 @@
 
 using namespace duckdb;
 
-static bool CastRstringToVarchar(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
+static bool CastRstringToVarchar(Vector &source, Vector &result, idx_t count, CastParameters & /* parameters */) {
 	GenericExecutor::ExecuteUnary<PrimitiveType<uintptr_t>, PrimitiveType<string_t>>(
 	    source, result, count,
 	    [&](PrimitiveType<uintptr_t> input) { return StringVector::AddString(result, (const char *)input.val); });

--- a/src/register.cpp
+++ b/src/register.cpp
@@ -66,7 +66,7 @@ using namespace duckdb;
 	}
 }
 
-unique_ptr<TableRef> duckdb::EnvironmentScanReplacement(ClientContext &context, ReplacementScanInput &input,
+unique_ptr<TableRef> duckdb::EnvironmentScanReplacement(ClientContext & /* context */, ReplacementScanInput &input,
                                                         optional_ptr<ReplacementScanData> data_p) {
 	auto &data = (ReplacementDataDBWrapper &)*data_p;
 	auto db_wrapper = data.wrapper;
@@ -334,7 +334,7 @@ private:
 	}
 };
 
-unique_ptr<TableRef> duckdb::ArrowScanReplacement(ClientContext &context, ReplacementScanInput &input,
+unique_ptr<TableRef> duckdb::ArrowScanReplacement(ClientContext & /* context */, ReplacementScanInput &input,
                                                   optional_ptr<ReplacementScanData> data_p) {
 	auto table_name = input.table_name;
 	ReplacementDataDBWrapper &data = static_cast<ReplacementDataDBWrapper &>(*data_p);

--- a/src/reltoaltrep.cpp
+++ b/src/reltoaltrep.cpp
@@ -377,8 +377,8 @@ struct AltrepVectorWrapper {
 	cpp11::sexp transformed_vector;
 };
 
-Rboolean RelToAltrep::RownamesInspect(SEXP x, int pre, int deep, int pvec,
-                                      void (*inspect_subtree)(SEXP, int, int, int)) {
+Rboolean RelToAltrep::RownamesInspect(SEXP x, int /* pre */, int /* deep */, int /* pvec */,
+                                      void (* /* inspect_subtree */)(SEXP, int, int, int)) {
 	BEGIN_CPP11
 	AltrepRownamesWrapper::Get(x); // make sure this is alive
 	Rprintf("DUCKDB_ALTREP_REL_ROWNAMES\n");
@@ -386,7 +386,8 @@ Rboolean RelToAltrep::RownamesInspect(SEXP x, int pre, int deep, int pvec,
 	END_CPP11_EX(Rboolean::FALSE)
 }
 
-Rboolean RelToAltrep::RelInspect(SEXP x, int pre, int deep, int pvec, void (*inspect_subtree)(SEXP, int, int, int)) {
+Rboolean RelToAltrep::RelInspect(SEXP x, int /* pre */, int /* deep */, int /* pvec */,
+                                 void (* /* inspect_subtree */)(SEXP, int, int, int)) {
 	BEGIN_CPP11
 	auto wrapper = AltrepVectorWrapper::Get(x); // make sure this is alive
 	auto &col = wrapper->rel->rel->Columns()[wrapper->column_index];
@@ -416,7 +417,7 @@ R_xlen_t RelToAltrep::RownamesLength(SEXP x) {
 	END_CPP11_EX(0)
 }
 
-int RelToAltrep::RownamesElt(SEXP x, R_xlen_t i) {
+int RelToAltrep::RownamesElt(SEXP /* x */, R_xlen_t i) {
 	BEGIN_CPP11
 	return static_cast<int>(i + 1);
 	END_CPP11_EX(NA_INTEGER)
@@ -440,15 +441,15 @@ R_xlen_t RelToAltrep::RownamesGetRegion(SEXP x, R_xlen_t start, R_xlen_t size, i
 	END_CPP11_EX(0)
 }
 
-int RelToAltrep::RownamesIsSorted(SEXP x) {
+int RelToAltrep::RownamesIsSorted(SEXP /* x */) {
 	return SORTED_INCR;
 }
 
-int RelToAltrep::RownamesNoNA(SEXP x) {
+int RelToAltrep::RownamesNoNA(SEXP /* x */) {
 	return TRUE;
 }
 
-SEXP RelToAltrep::RownamesSum(SEXP x, Rboolean na_rm) {
+SEXP RelToAltrep::RownamesSum(SEXP x, Rboolean /* na_rm */) {
 	BEGIN_CPP11
 	auto rownames_wrapper = AltrepRownamesWrapper::Get(x);
 	auto n = rownames_wrapper->RowCount();
@@ -457,7 +458,7 @@ SEXP RelToAltrep::RownamesSum(SEXP x, Rboolean na_rm) {
 	END_CPP11
 }
 
-SEXP RelToAltrep::RownamesMin(SEXP x, Rboolean na_rm) {
+SEXP RelToAltrep::RownamesMin(SEXP x, Rboolean /* na_rm */) {
 	BEGIN_CPP11
 	auto rownames_wrapper = AltrepRownamesWrapper::Get(x);
 	auto n = rownames_wrapper->RowCount();
@@ -469,7 +470,7 @@ SEXP RelToAltrep::RownamesMin(SEXP x, Rboolean na_rm) {
 	END_CPP11
 }
 
-SEXP RelToAltrep::RownamesMax(SEXP x, Rboolean na_rm) {
+SEXP RelToAltrep::RownamesMax(SEXP x, Rboolean /* na_rm */) {
 	BEGIN_CPP11
 	auto rownames_wrapper = AltrepRownamesWrapper::Get(x);
 	auto n = rownames_wrapper->RowCount();
@@ -490,14 +491,14 @@ SEXP RelToAltrep::MakeRowNamesSexp(duckdb::shared_ptr<AltrepRelationWrapper> rel
 	return R_new_altrep(RelToAltrep::rownames_class, ptr, R_NilValue);
 }
 
-SEXP RelToAltrep::RownamesDuplicate(SEXP x, Rboolean deep) {
+SEXP RelToAltrep::RownamesDuplicate(SEXP x, Rboolean /* deep */) {
 	BEGIN_CPP11
 	auto rownames_wrapper = AltrepRownamesWrapper::Get(x);
 	return MakeRowNamesSexp(rownames_wrapper->rel);
 	END_CPP11
 }
 
-void *RelToAltrep::RownamesDataptr(SEXP x, Rboolean writeable) {
+void *RelToAltrep::RownamesDataptr(SEXP x, Rboolean /* writeable */) {
 	BEGIN_CPP11
 	return DoRownamesDataptrGet(x);
 	END_CPP11
@@ -528,7 +529,7 @@ R_xlen_t RelToAltrep::VectorLength(SEXP x) {
 	END_CPP11_EX(0)
 }
 
-void *RelToAltrep::VectorDataptr(SEXP x, Rboolean writeable) {
+void *RelToAltrep::VectorDataptr(SEXP x, Rboolean /* writeable */) {
 	BEGIN_CPP11
 	return AltrepVectorWrapper::Get(x)->Dataptr();
 	END_CPP11

--- a/src/scan.cpp
+++ b/src/scan.cpp
@@ -585,7 +585,7 @@ struct DataFrameLocalState : public LocalTableFunctionState {
 	idx_t count;
 };
 
-static duckdb::unique_ptr<FunctionData> DataFrameScanBind(ClientContext &context, TableFunctionBindInput &input,
+static duckdb::unique_ptr<FunctionData> DataFrameScanBind(ClientContext & /* context */, TableFunctionBindInput &input,
                                                           vector<LogicalType> &return_types, vector<string> &names) {
 	data_frame df((SEXP)input.inputs[0].GetPointer());
 
@@ -627,7 +627,7 @@ static duckdb::unique_ptr<FunctionData> DataFrameScanBind(ClientContext &context
 	return make_uniq<DataFrameScanBindData>(df, row_count, rtypes, data_ptrs, named_list_map, input.named_parameters);
 }
 
-static idx_t DataFrameScanMaxThreads(ClientContext &context, const FunctionData *bind_data_p) {
+static idx_t DataFrameScanMaxThreads(ClientContext & /* context */, const FunctionData *bind_data_p) {
 	D_ASSERT(bind_data_p);
 	auto bind_data = (const DataFrameScanBindData *)bind_data_p;
 	return ceil((double)bind_data->row_count / bind_data->rows_per_task);
@@ -640,7 +640,7 @@ static duckdb::unique_ptr<GlobalTableFunctionState> DataFrameScanInitGlobal(Clie
 	return std::move(result);
 }
 
-static bool DataFrameScanParallelStateNext(ClientContext &context, const FunctionData *bind_data_p,
+static bool DataFrameScanParallelStateNext(ClientContext & /* context */, const FunctionData *bind_data_p,
                                            DataFrameLocalState &local_state, DataFrameGlobalState &global_state) {
 	auto &bind_data = bind_data_p->Cast<DataFrameScanBindData>();
 
@@ -709,12 +709,13 @@ static void DataFrameScanFunc(ClientContext &context, TableFunctionInput &data, 
 	operator_data.position += this_count;
 }
 
-static unique_ptr<NodeStatistics> DataFrameScanCardinality(ClientContext &context, const FunctionData *bind_data_p) {
+static unique_ptr<NodeStatistics> DataFrameScanCardinality(ClientContext & /* context */,
+                                                           const FunctionData *bind_data_p) {
 	auto &bind_data = bind_data_p->Cast<DataFrameScanBindData>();
 	return make_uniq<NodeStatistics>(bind_data.row_count, bind_data.row_count);
 }
 
-static InsertionOrderPreservingMap<string> DataFrameScanToString(TableFunctionToStringInput &input) {
+static InsertionOrderPreservingMap<string> DataFrameScanToString(TableFunctionToStringInput & /* input */) {
 	InsertionOrderPreservingMap<string> result;
 	result["Text"] = "data.frame";
 	return result;

--- a/src/signal.cpp
+++ b/src/signal.cpp
@@ -78,7 +78,7 @@ void ScopedInterruptHandler::Disable() {
 	}
 }
 
-void ScopedInterruptHandler::signal_handler(int signum) {
+void ScopedInterruptHandler::signal_handler(int /* signum */) {
 	if (instance) {
 		instance->interrupted = 1;
 		instance->context->Interrupt();


### PR DESCRIPTION
One topic out of the compiler-hygiene work for #1829: every `-Wunused-parameter` site in the hand-written glue.

The glue implements engine and R callbacks whose signatures it does not always use in full — replacement scans that ignore the `ClientContext`, ALTREP methods that ignore `deep`/`pvec`/`na_rm`, a cast function that ignores its `CastParameters`. Each name is commented out rather than deleted, so it stays where a reader looks for it while saying nothing to the compiler.

Only definitions change; the declarations in the headers keep their names, so nothing about the documented signatures moves. No behaviour changes.

Files: `src/database.cpp`, `src/register.cpp`, `src/reltoaltrep.cpp`, `src/scan.cpp`, `src/signal.cpp`.

`src/rfuns.cpp` has the same warnings but is vendored from `duckdb-rfuns` by `scripts/vendor-rfuns.sh`, so it is deliberately left out of this PR and handled separately.

How it was found: the glue translation units compiled with `-Wall -Wextra` plus a curated set of extra warnings, with diagnostics attributed to the file they point at, so warnings raised inside the vendored engine headers are not counted against the glue.