### PR TITLE
fix(glue): Return without a redundant `std::move()`

### DIFF
--- a/src/register.cpp
+++ b/src/register.cpp
@@ -119,7 +119,7 @@ unique_ptr<TableRef> duckdb::EnvironmentScanReplacement(ClientContext &context, 
 	// binds (e.g. during rel_to_altrep()) do not need to look up the data
 	// frame from the environment again.
 	table_function->external_dependency = make_shared_ptr<ExternalDependency>();
-	return std::move(table_function);
+	return table_function;
 }
 
 class RArrowTabularStreamFactory {
@@ -350,7 +350,7 @@ unique_ptr<TableRef> duckdb::ArrowScanReplacement(ClientContext &context, Replac
 		children.push_back(
 		    make_uniq<ConstantExpression>(Value::POINTER((uintptr_t)RArrowTabularStreamFactory::GetSchema)));
 		table_function->function = make_uniq<FunctionExpression>("arrow_scan", std::move(children));
-		return std::move(table_function);
+		return table_function;
 	}
 	return nullptr;
 }

--- a/src/scan.cpp
+++ b/src/scan.cpp
@@ -637,7 +637,7 @@ static duckdb::unique_ptr<GlobalTableFunctionState> DataFrameScanInitGlobal(Clie
                                                                             TableFunctionInitInput &input) {
 	auto result = make_uniq<DataFrameGlobalState>(DataFrameScanMaxThreads(context, input.bind_data.get()));
 	result->position = 0;
-	return std::move(result);
+	return result;
 }
 
 static bool DataFrameScanParallelStateNext(ClientContext &context, const FunctionData *bind_data_p,
@@ -669,7 +669,7 @@ static unique_ptr<LocalTableFunctionState> DataFrameScanInitLocal(ExecutionConte
 
 	result->column_ids = input.column_ids;
 	DataFrameScanParallelStateNext(context.client, input.bind_data.get(), *result, gstate);
-	return std::move(result);
+	return result;
 }
 
 static void DataFrameScanFunc(ClientContext &context, TableFunctionInput &data, DataChunk &output) {


### PR DESCRIPTION
One topic out of the compiler-hygiene work for #1829: the four `-Wredundant-move` sites in the glue.

All four return a local `unique_ptr<Derived>` from a function declared to return `unique_ptr<Base>` — the two replacement scans in `src/register.cpp`, and the global/local table function state initialisers in `src/scan.cpp`. The named return value is already treated as an rvalue there, so the `std::move()` does nothing.

This is P1825, applied as a defect report against C++11, so it is not a C++20-only rule: GCC has implemented it since 9 and Clang since 13, both far below anything that can build a package requiring R >= 4.2. The move is redundant on every compiler this package supports, which is exactly what `-Wredundant-move` reports.

Note that the same warning fires ~630 times inside the vendored engine, where it is upstream's house style rather than a defect; that category is deliberately not enforced against `src/duckdb/`.

---
_Generated by [Claude Code](https://claude.ai/code/session_0148iKGyG7gmmQsdaDckmA3x)_