### PR TITLE
fix(glue): Suffix constructor parameters that shadow their member

### DIFF
--- a/src/altrepdataframe_relation.cpp
+++ b/src/altrepdataframe_relation.cpp
@@ -5,8 +5,8 @@
 namespace duckdb {
 
 AltrepDataFrameRelation::AltrepDataFrameRelation(duckdb::shared_ptr<Relation> p, cpp11::list df,
-                                                 duckdb::shared_ptr<AltrepRelationWrapper> altrep)
-    : Relation(p->context, RelationType::EXTENSION_RELATION), dataframe(df), altrep(std::move(altrep)),
+                                                 duckdb::shared_ptr<AltrepRelationWrapper> altrep_)
+    : Relation(p->context, RelationType::EXTENSION_RELATION), dataframe(df), altrep(std::move(altrep_)),
       parent(std::move(p)) {
 	TryBindRelation(columns);
 }

--- a/src/register.cpp
+++ b/src/register.cpp
@@ -124,8 +124,8 @@ unique_ptr<TableRef> duckdb::EnvironmentScanReplacement(ClientContext &context, 
 
 class RArrowTabularStreamFactory {
 public:
-	RArrowTabularStreamFactory(SEXP export_fun_p, SEXP arrow_scannable_p, ClientProperties config)
-	    : arrow_scannable(arrow_scannable_p), export_fun(export_fun_p), config(config) {};
+	RArrowTabularStreamFactory(SEXP export_fun_p, SEXP arrow_scannable_p, ClientProperties config_)
+	    : arrow_scannable(arrow_scannable_p), export_fun(export_fun_p), config(std::move(config_)) {};
 
 	static unique_ptr<ArrowArrayStreamWrapper> Produce(uintptr_t factory_p, ArrowStreamParameters &parameters) {
 		auto res = make_uniq<ArrowArrayStreamWrapper>();

--- a/src/scan.cpp
+++ b/src/scan.cpp
@@ -566,7 +566,7 @@ struct DataFrameScanBindData : public TableFunctionData {
 };
 
 struct DataFrameGlobalState : public GlobalTableFunctionState {
-	DataFrameGlobalState(idx_t max_threads) : max_threads(max_threads) {
+	DataFrameGlobalState(idx_t max_threads_) : max_threads(max_threads_) {
 	}
 
 	mutex lock;


### PR DESCRIPTION
One topic out of the compiler-hygiene work for #1829: the `-Wshadow` sites in the glue.

Three constructors named a parameter exactly like the member it initialises — `AltrepDataFrameRelation::altrep`, `RArrowTabularStreamFactory::config`, `DataFrameGlobalState::max_threads`. Inside such a constructor the name resolves to the parameter, not the member, which is fine here but is the shape that hides a bug the moment the body grows.

They now carry the `_` suffix the glue already uses for exactly this in `AltrepRelationWrapper`, so parameter and member are distinct names everywhere.

One incidental improvement: `RArrowTabularStreamFactory` takes its `ClientProperties` by value, so the member is now move-initialised from the parameter instead of copied.

`src/rfuns.cpp` also has two `-Wshadow` sites, but it is vendored from `duckdb-rfuns` and is handled separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_0148iKGyG7gmmQsdaDckmA3x)_