### PR TITLE
fix(glue): Stop casting away `const` on R's read-only data pointers

### DIFF
--- a/src/scan.cpp
+++ b/src/scan.cpp
@@ -12,6 +12,16 @@
 using namespace duckdb;
 using namespace cpp11;
 
+// R hands out a read-only view of a vector's payload (DATAPTR_RO()), and the
+// scan only ever reads through it -- but the pointer travels on as a
+// data_ptr_t, because that is what AppendAnyColumnSegment() takes and what
+// DataFrameScanBindData stores. Drop the qualifier once, here, rather than
+// with a C-style cast at every call site: -Wcast-qual then still catches an
+// unintended const removal anywhere else in the glue.
+static data_ptr_t ReadOnlyDataPtr(const void *ptr) {
+	return const_cast<data_ptr_t>(static_cast<const_data_ptr_t>(ptr));
+}
+
 static data_ptr_t GetColDataPtr(const RType &rtype, SEXP coldata) {
 	switch (rtype.id()) {
 	case RType::LOGICAL:
@@ -26,7 +36,7 @@ static data_ptr_t GetColDataPtr(const RType &rtype, SEXP coldata) {
 		// TODO What about factors that use numeric?
 		return (data_ptr_t)INTEGER_POINTER(coldata);
 	case RType::STRING:
-		return (data_ptr_t)DATAPTR_RO(coldata);
+		return ReadOnlyDataPtr(DATAPTR_RO(coldata));
 	case RType::TIMESTAMP:
 		return (data_ptr_t)NUMERIC_POINTER(coldata);
 	case RType::INTERVAL_SECONDS:
@@ -53,9 +63,9 @@ static data_ptr_t GetColDataPtr(const RType &rtype, SEXP coldata) {
 		return (data_ptr_t)INTEGER_POINTER(coldata);
 	case RType::LIST_OF_NULLS:
 	case RType::BLOB:
-		return (data_ptr_t)DATAPTR_RO(coldata);
+		return ReadOnlyDataPtr(DATAPTR_RO(coldata));
 	case RTypeId::LIST:
-		return (data_ptr_t)DATAPTR_RO(coldata);
+		return ReadOnlyDataPtr(DATAPTR_RO(coldata));
 	case RTypeId::MATRIX:
 	case RTypeId::STRUCT:
 		// Will bind child columns dynamically. Could also optimize by descending early and recording.
@@ -201,7 +211,7 @@ static void AppendMapEntriesListColumnSegment(const RType &rtype, SEXP *source_d
 }
 
 template <class SRC, class DST, class RTYPE>
-static inline void AppendMatrixSegmentAtomic(SRC *src_ptr, int nrows, int ncols, idx_t sexp_offset,
+static inline void AppendMatrixSegmentAtomic(const SRC *src_ptr, int nrows, int ncols, idx_t sexp_offset,
                                              Vector &child_vector, idx_t count) {
 	auto child_data = FlatVector::GetData<DST>(child_vector);
 	auto &child_mask = FlatVector::Validity(child_vector);
@@ -255,11 +265,11 @@ static void AppendMatrixColumnSegment(const RType &rtype, bool experimental, SEX
 	case RType::STRING: // STRSXP
 		if (experimental) {
 			D_ASSERT(result.GetType().id() == LogicalTypeId::POINTER);
-			AppendMatrixSegmentAtomic<SEXP, uintptr_t, DedupPointerEnumType>((SEXP *)DATAPTR_RO(source_data), nrows,
-			                                                                 ncols, sexp_offset, child_vector, count);
+			AppendMatrixSegmentAtomic<SEXP, uintptr_t, DedupPointerEnumType>(
+			    (const SEXP *)DATAPTR_RO(source_data), nrows, ncols, sexp_offset, child_vector, count);
 		} else {
-			AppendMatrixSegmentAtomic<SEXP, string_t, RStringSexpType>((SEXP *)DATAPTR_RO(source_data), nrows, ncols,
-			                                                           sexp_offset, child_vector, count);
+			AppendMatrixSegmentAtomic<SEXP, string_t, RStringSexpType>((const SEXP *)DATAPTR_RO(source_data), nrows,
+			                                                           ncols, sexp_offset, child_vector, count);
 		}
 		break;
 

--- a/src/transform.cpp
+++ b/src/transform.cpp
@@ -426,7 +426,7 @@ static void TransformArrayVector(const Vector &src_vec, const SEXP dest, idx_t d
 void duckdb_r_transform(const Vector &src_vec, const SEXP dest, idx_t dest_offset, idx_t n,
                         const duckdb::ConvertOpts &convert_opts, const string &name) {
 	if (src_vec.GetType().GetAlias() == R_STRING_TYPE_NAME) {
-		ptrdiff_t sexp_header_size = (data_ptr_t)DATAPTR_RO(R_BlankString) - (data_ptr_t)R_BlankString;
+		ptrdiff_t sexp_header_size = (const_data_ptr_t)DATAPTR_RO(R_BlankString) - (const_data_ptr_t)R_BlankString;
 
 		auto child_ptr = FlatVector::GetData<uintptr_t>(src_vec);
 		auto &mask = FlatVector::Validity(src_vec);


### PR DESCRIPTION
One topic out of the compiler-hygiene work for #1829: the `-Wcast-qual` sites in the glue, all of them C-style casts that drop the `const` R's `DATAPTR_RO()` puts on its return value.

Two of the three shapes did not need the cast at all:

- `AppendMatrixSegmentAtomic()` only reads its source, so it now takes a `const SRC *`, and the two matrix string branches pass a `const SEXP *`. Every other caller passes a non-const pointer, which converts implicitly.
- `duckdb_r_transform()` uses the pointers only to measure a header offset, so `const_data_ptr_t` on both operands is enough.

The third is genuine: `GetColDataPtr()` hands its result to `AppendAnyColumnSegment()` and stores it in `DataFrameScanBindData`, both of which speak `data_ptr_t`. Rather than repeat a C-style cast at each `DATAPTR_RO()` call, the removal happens once in a named helper that records why the scan is allowed to do it. That keeps `-Wcast-qual` enforceable: an *unintended* const removal anywhere else in the glue still fails.

Making the whole chain `const_data_ptr_t` would be the deeper fix, but it stops at `RTypeId::MATRIX` and `RTypeId::STRUCT`, where the stored "data pointer" is really the `SEXP` itself and has to come back out as one — so the const removal would simply move to those two sites. That refactor belongs to a change that reworks the plumbing, not to a warning cleanup.

---
_Generated by [Claude Code](https://claude.ai/code/session_0148iKGyG7gmmQsdaDckmA3x)_