### PR TITLE
fix(glue): Drop a stray semicolon after a constructor body

### DIFF
--- a/src/register.cpp
+++ b/src/register.cpp
@@ -125,7 +125,8 @@ unique_ptr<TableRef> duckdb::EnvironmentScanReplacement(ClientContext &context, 
 class RArrowTabularStreamFactory {
 public:
 	RArrowTabularStreamFactory(SEXP export_fun_p, SEXP arrow_scannable_p, ClientProperties config_)
-	    : arrow_scannable(arrow_scannable_p), export_fun(export_fun_p), config(std::move(config_)) {};
+	    : arrow_scannable(arrow_scannable_p), export_fun(export_fun_p), config(std::move(config_)) {
+	}
 
 	static unique_ptr<ArrowArrayStreamWrapper> Produce(uintptr_t factory_p, ArrowStreamParameters &parameters) {
 		auto res = make_uniq<ArrowArrayStreamWrapper>();


### PR DESCRIPTION
One topic out of the compiler-hygiene work for #1829, and the smallest one: the single `-Wextra-semi` site in the glue.

`RArrowTabularStreamFactory`'s in-class constructor body was followed by a `;`, which declares nothing — C++11 tolerates it, C++98 did not. `clang-format` then reflows the body onto its own line, which is the second line of the diff.

Rebased onto `main` after #2608 landed, which rewrote the same line for a different reason.