### PR TITLE
fix(glue): Widen to R's double explicitly when copying a column out

### DIFF
--- a/src/transform.cpp
+++ b/src/transform.cpp
@@ -18,7 +18,7 @@ static void VectorToR(const Vector &src_vec, size_t count, void *dest, uint64_t 
 	auto &mask = FlatVector::Validity(src_vec);
 	auto dest_ptr = ((DEST *)dest) + dest_offset;
 	for (size_t row_idx = 0; row_idx < count; row_idx++) {
-		dest_ptr[row_idx] = !mask.RowIsValid(row_idx) ? na_val : src_ptr[row_idx];
+		dest_ptr[row_idx] = !mask.RowIsValid(row_idx) ? na_val : static_cast<DEST>(src_ptr[row_idx]);
 	}
 }
 


### PR DESCRIPTION
One topic out of the compiler-hygiene work for #1829: the single `-Wdouble-promotion` site in the glue.

`VectorToR<float, double>()` writes `cond ? na_val : src_ptr[row_idx]`, where `na_val` is the `double` `NA_REAL` and the element is a `float`. The conditional's common type is `double`, so the element is promoted — which is exactly what the function is for, since R has no float vector and a `FLOAT` column arrives as `REAL`.

Spelling the widening as `static_cast<DEST>` makes it a stated conversion instead of a side effect of the conditional's type. It is a no-op for every other instantiation, where `SRC` and `DEST` already agree.

---
_Generated by [Claude Code](https://claude.ai/code/session_0148iKGyG7gmmQsdaDckmA3x)_