### PR TITLE
fix(rfuns): Unshadow two locals

### DIFF
--- a/src/rfuns.cpp
+++ b/src/rfuns.cpp
@@ -22,13 +22,13 @@ void BaseRAddFunctionInteger(DataChunk &args, ExpressionState &state, Vector &re
 	BinaryExecutor::ExecuteWithNulls<int32_t, int32_t, int32_t>(
 	    parts.lefts, parts.rights, result, args.size(),
 	    [&](int32_t left, int32_t right, ValidityMask &mask, idx_t idx) {
-		    int64_t result = (int64_t)left + right;
-		    if (result > INT_MAX || result < (INT_MIN + 1)) {
+		    int64_t sum = (int64_t)left + right;
+		    if (sum > INT_MAX || sum < (INT_MIN + 1)) {
 			    // FIXME: Need warning: NAs produced by integer overflow
 			    mask.SetInvalid(idx);
 			    return 0;
 		    }
-		    return (int32_t)result;
+		    return (int32_t)sum;
 	    });
 }
 
@@ -834,12 +834,12 @@ void InExecute(DataChunk &args, ExpressionState &state, Vector &result) {
 		return false;
 	};
 
-	auto in_loop = [&](idx_t count, const LHS_TYPE *x_data, bool *result_data, const ValidityMask &mask) {
+	auto in_loop = [&](idx_t row_count, const LHS_TYPE *x_data, bool *result_data, const ValidityMask &mask) {
 		idx_t base_idx = 0;
-		auto entry_count = ValidityMask::EntryCount(count);
+		auto entry_count = ValidityMask::EntryCount(row_count);
 		for (idx_t entry_idx = 0; entry_idx < entry_count; entry_idx++) {
 			auto validity_entry = mask.GetValidityEntry(entry_idx);
-			idx_t next = MinValue<idx_t>(base_idx + ValidityMask::BITS_PER_VALUE, count);
+			idx_t next = MinValue<idx_t>(base_idx + ValidityMask::BITS_PER_VALUE, row_count);
 
 			if (ValidityMask::AllValid(validity_entry)) {
 				for (; base_idx < next; base_idx++) {


### PR DESCRIPTION
One topic out of the compiler-hygiene work for #1829, kept apart from the glue PRs because `src/rfuns.cpp` is not glue.

**This file is vendored.** `scripts/vendor-rfuns.sh` regenerates it by concatenating `src/*.cpp` from a `duckdb-rfuns` checkout, and unlike `src/duckdb/` it has no patch stack to re-apply changes afterwards. The same change therefore has to reach `duckdb-rfuns`, or the next import silently reverts this one. Merging this on its own buys a clean build now; it does not keep it that way.

Two `-Wshadow` sites:

- The integer `+` names its overflow-checked sum `result`, inside a lambda whose enclosing function has a `Vector &result` parameter — renamed to `sum`.
- `InExecute()`'s inner `in_loop` lambda names its length `count`, shadowing the enclosing `count` it also captures by reference — renamed to `row_count`.

No behaviour changes.

The 28 `-Wunused-parameter` sites this PR also carried are gone from it: that category is not enforced in either scope, because the engine is not held to it and the extension implements the engine's own callback signatures.