### PR TITLE
docs(style): Spell out the tidyverse rules R here answers to, and the deviations

### DIFF
--- a/.claude/skills/docs-consistency/docs-readme.R
+++ b/.claude/skills/docs-consistency/docs-readme.R
@@ -163,7 +163,7 @@ groups <- list(
     globs = c("format.py", "python_helpers.py")
   ),
   list(
-    owner = "handbook/architecture/r-layer",
+    owner = "handbook/architecture/r-layer/conventions",
     globs = c("rethrow.R")
   ),
   list(

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,8 @@ This page only routes there.
 | build from source, the way CRAN does | [`build/source-build/`](/handbook/build/source-build/README.md) |
 | find the build knobs and what they cost | [`build/configuration/`](/handbook/build/configuration/README.md) |
 | run the suite, or one test file | [`testing/suite/`](/handbook/testing/suite/README.md) |
-| write R the way this package does, flavor seam included | [`architecture/r-layer/`](/handbook/architecture/r-layer/README.md) |
+| write R the way this package does, flavor seam included | [`architecture/r-layer/conventions/`](/handbook/architecture/r-layer/conventions/README.md) |
+| know which tidyverse rules are enforced here, and where we deviate | [`architecture/r-layer/style/`](/handbook/architecture/r-layer/style/README.md) |
 | write C++ glue the way this package does | [`architecture/glue/`](/handbook/architecture/glue/README.md) |
 | operate the vendoring loop | [`operations/vendoring/series-loop/`](/handbook/operations/vendoring/series-loop/README.md) and `.claude/skills/` |
 

--- a/handbook/architecture/README.md
+++ b/handbook/architecture/README.md
@@ -14,7 +14,7 @@ so the first thing a leaf says about a file is which of those it is —
 and a correction goes to the producer,
 never to the file in front of you.
 
-* [`r-layer/`](r-layer/) — R conventions and the flavor seam
+* [`r-layer/`](r-layer/) — the R this package writes: where it lives, how it reads
 * [`glue/`](glue/) — the R ↔ DuckDB bridge in `src/`
 * [`engine/`](engine/) — the embedded DuckDB engine
 * [`rfuns/`](rfuns/) — the extension that gives the engine R's semantics

--- a/handbook/architecture/r-layer/README.md
+++ b/handbook/architecture/r-layer/README.md
@@ -1,47 +1,20 @@
 # The R layer
 
-Everything under `R/`:
-where a method lives, which files are generated and by what,
-and how the package refers to itself without writing its own name.
+Everything under `R/` and the tests that exercise it:
+the R this package writes, where it lives and how it is written.
 The C++ half of the interface is
 [`glue/`](/handbook/architecture/glue/README.md).
 
-**One file per method.**
-`R/` is flat, and every S4 method lives in a file named
-`<generic>__<signature>.R` —
-the naming convention is the index.
-Closely-paired signatures may share a file;
-unrelated methods never do.
-Constructors, helpers, and non-S4 interfaces group by topic
-(`Driver.R`, `Connection.R`, `relational.R`, `storage.R`, …).
+**Almost nothing about this layer is this package's own invention.**
+The generics it implements belong to a standard,
+the shape its arguments and its messages take belongs to guides
+written outside this repository,
+and the names it may spell belong to the rename it has to survive.
+So a rule on these pages is a citation and a deviation:
+what the outside standard says,
+and where this package cannot follow it — with the reason.
+A deviation nobody wrote down is one the next contributor
+reports as a bug, and the one after that copies.
 
-**Generated files are edited at their producer.**
-Each opens with a header saying so:
-
-* `R/cpp11.R` — by `cpp11::cpp_register()`,
-  after a change to the `[[cpp11::register]]` surface in `src/`
-* `R/rethrow-gen.R` — by `scripts/rethrow.R`,
-  run by `.Rprofile` on every R start in the repo
-* `R/version.R` — by `scripts/rconfigure.py`, during vendoring
-
-R code calls the `rethrow_rapi_*()` wrappers, not `rapi_*()` directly —
-the wrapper re-raises C++ errors pointing at the user's call.
-
-**Never hard-code the package name.**
-The package publishes under several names
-([`branches/flavors/`](/handbook/branches/flavors/README.md)),
-so a literal `duckdb` works on `main` and breaks everywhere else.
-[`R/package.R`](/R/package.R) is the seam —
-its accessors are the only supported way to spell the name.
-`simulate_duckdb()` exposes `get_package_name()` and
-`get_package_env()` as `$pkg` and `$env`, which is what
-`@examplesIf simulate_duckdb()$env$examples_enabled()` relies on.
-The same rule holds in roxygen prose:
-inline chunks go through the seam, never a `:::` qualifier.
-The guard that scans for offenders is
-[`testing/guards/`](/handbook/testing/guards/README.md)'s.
-
-*To deepen: state the S4 class inventory and the deferred S3
-registration for Suggests packages; drain
-[#98](https://github.com/duckdb/duckdb-r/issues/98),
-[#1052](https://github.com/duckdb/duckdb-r/issues/1052).*
+* [`conventions/`](conventions/) — where a method lives, what is generated, and the flavor seam
+* [`style/`](style/) — the tidyverse rules this code follows, and where it does not

--- a/handbook/architecture/r-layer/conventions/README.md
+++ b/handbook/architecture/r-layer/conventions/README.md
@@ -1,0 +1,46 @@
+# Conventions
+
+Where a method lives, which files are generated and by what,
+and how the package refers to itself without writing its own name.
+How the code inside those files is written is
+[`style/`](/handbook/architecture/r-layer/style/README.md).
+
+**One file per method.**
+`R/` is flat, and every S4 method lives in a file named
+`<generic>__<signature>.R` —
+the naming convention is the index.
+Closely-paired signatures may share a file;
+unrelated methods never do.
+Constructors, helpers, and non-S4 interfaces group by topic
+(`Driver.R`, `Connection.R`, `relational.R`, `storage.R`, …).
+
+**Generated files are edited at their producer.**
+Each opens with a header saying so:
+
+* `R/cpp11.R` — by `cpp11::cpp_register()`,
+  after a change to the `[[cpp11::register]]` surface in `src/`
+* `R/rethrow-gen.R` — by `scripts/rethrow.R`,
+  run by `.Rprofile` on every R start in the repo
+* `R/version.R` — by `scripts/rconfigure.py`, during vendoring
+
+R code calls the `rethrow_rapi_*()` wrappers, not `rapi_*()` directly —
+the wrapper re-raises C++ errors pointing at the user's call.
+
+**Never hard-code the package name.**
+The package publishes under several names
+([`branches/flavors/`](/handbook/branches/flavors/README.md)),
+so a literal `duckdb` works on `main` and breaks everywhere else.
+[`R/package.R`](/R/package.R) is the seam —
+its accessors are the only supported way to spell the name.
+`simulate_duckdb()` exposes `get_package_name()` and
+`get_package_env()` as `$pkg` and `$env`, which is what
+`@examplesIf simulate_duckdb()$env$examples_enabled()` relies on.
+The same rule holds in roxygen prose:
+inline chunks go through the seam, never a `:::` qualifier.
+The guard that scans for offenders is
+[`testing/guards/`](/handbook/testing/guards/README.md)'s.
+
+*To deepen: state the S4 class inventory and the deferred S3
+registration for Suggests packages; drain
+[#98](https://github.com/duckdb/duckdb-r/issues/98),
+[#1052](https://github.com/duckdb/duckdb-r/issues/1052).*

--- a/handbook/architecture/r-layer/style/README.md
+++ b/handbook/architecture/r-layer/style/README.md
@@ -1,0 +1,112 @@
+# Style
+
+How the R in this package is written —
+names, signatures, messages, reference prose —
+and the deviations from the guides that decide it.
+Where that code lives and what generates it is
+[`conventions/`](/handbook/architecture/r-layer/conventions/README.md).
+
+Two guides decide this, and neither is restated here:
+the [tidyverse style guide](https://style.tidyverse.org/)
+for how code reads,
+and [tidy design principles](https://design.tidyverse.org/)
+for what an interface promises.
+Follow them by default, in `R/` and in the tests alike.
+What this page adds is the handful of rules a change here
+is most often caught on,
+and the deviations — which are the reason the page exists,
+since everything else is a link.
+
+## The rules worth spelling out
+
+**Layout is the formatter's, not the reviewer's.**
+Indentation, line breaks, spacing and call wrapping are
+[air](https://posit-dev.github.io/air/)'s output,
+and no review argues them.
+Nothing runs air over this repository today:
+the pull-request formatter
+([`.github/workflows/style/action.yml`](/.github/workflows/style/action.yml))
+reformats R only when the repository carries an `air.toml`,
+and this one carries only `.clang-format`,
+so that job formats the C++ and leaves the R alone.
+`R/` and `tests/` have drifted from what air prints as a result,
+which makes reformatting-in-passing expensive:
+a change matches the file it is editing
+and leaves the lines it did not come for alone.
+
+**An error message is a contract, not a sentence.**
+The guide's [error chapter](https://style.tidyverse.org/errors.html)
+assumes `cli::cli_abort()`, which this package cannot call
+([below](#where-this-package-deviates));
+its wording rules survive the downgrade to `stop()` intact,
+and they are what a review checks.
+A problem statement first, in sentence case, ending in a full stop;
+**must** where the expectation can be stated
+("`n` must have length 1, not length 2")
+and **can't** where it cannot;
+the offending argument in backticks,
+and what the caller actually passed rather than only what was wanted.
+
+**`...` goes after the required arguments**
+([design guide](https://design.tidyverse.org/dots-after-required.html)),
+which forces every optional argument to be named at the call site
+and lets a later one be added without breaking a positional call.
+Required arguments take
+[no default](https://design.tidyverse.org/required-no-defaults.html),
+so the signature alone says what is optional.
+An argument whose values are a small set of strings
+[enumerates them](https://design.tidyverse.org/enumerate-options.html)
+as its default and resolves it with `match.arg()`,
+putting the allowed values where autocomplete and tooltips show them —
+`tz_out_convert = c("with", "force")` is the form to copy.
+A `...` that exists only to force naming is checked to be empty
+rather than quietly ignored, and never also forwarded.
+
+**snake_case for everything this package names**,
+and `TRUE`/`FALSE` never abbreviated to `T`/`F`,
+which are ordinary variables and can be reassigned.
+The camelCase in `R/` is DBI's, and it stops at the generic:
+a helper, an argument, a local, or a test file this package invents
+is snake_case whatever the generic above it is called.
+
+**Reference pages are markdown roxygen.**
+`Roxygen: list(markdown = TRUE)` is set in
+[`DESCRIPTION`](/DESCRIPTION), so a cross-reference is `[dbConnect()]`
+and code is backticked;
+some pages still carry the older `\code{\link{}}` spelling,
+and converting one is an ordinary edit.
+Each `@param` is a sentence — capitalised, ending in a full stop.
+
+## Where this package deviates
+
+* **DBI names the generics, and the method files follow.**
+  `dbConnect()`, `dbWriteTable()`, and the `<generic>__<signature>.R`
+  files are the standard's spelling and the dispatch's, not a house style.
+* **DBI names some arguments too**, in base R's dot.case —
+  `row.names`, `field.types`.
+  A method implements its generic's signature exactly,
+  so these are copied rather than chosen.
+  `duckdb_read_csv()` is dot.case throughout for the same reason
+  one level down — it forwards to `utils::read.csv()` — and it is
+  published, so it keeps the spelling it shipped with.
+* **`duckdb()` and `dbConnect()` carry optional arguments before `...`.**
+  The design guide would put them after.
+  Both signatures are published and called positionally in the wild,
+  so moving one is a breaking change and they stay as they are;
+  an argument added to either goes after the `...`,
+  and a new function has nothing before it that is not required.
+* **cli and rlang are not dependencies.**
+  Both are `Suggests`, so the guide's `cli_abort()` examples
+  become `stop()` here, and its bulleted structure and inline markup
+  are not available — the wording rules above are all a message has.
+  [`R/rlang.R`](/R/rlang.R) holds base fallbacks for the few rlang
+  functions the package uses, swapped for the real ones at load
+  when rlang is installed.
+* **The package never writes its own name**, in code or in roxygen —
+  stricter than either guide asks,
+  and the only rule on this page with a guard behind it.
+
+*To deepen: settle whether an R-level `stop()` passes `call. = FALSE`
+or leans on the rethrow wrappers — both spellings are in the tree —
+and land the `air.toml` that turns the formatting rule above
+from a paragraph into a check.*

--- a/handbook/architecture/r-layer/style/README.md
+++ b/handbook/architecture/r-layer/style/README.md
@@ -31,6 +31,8 @@ and this one carries only `.clang-format`,
 so that job formats the C++ and leaves the R alone.
 `R/` and `tests/` have drifted from what air prints as a result,
 which makes reformatting-in-passing expensive:
+until the config lands
+([#2614](https://github.com/duckdb/duckdb-r/issues/2614)),
 a change matches the file it is editing
 and leaves the lines it did not come for alone.
 
@@ -46,6 +48,11 @@ A problem statement first, in sentence case, ending in a full stop;
 and **can't** where it cannot;
 the offending argument in backticks,
 and what the caller actually passed rather than only what was wanted.
+It is raised with `call. = FALSE`, and through rlang where that is
+installed, as the `rethrow_` wrappers do — so the message points at the
+user's call and not at the internal check that noticed
+([#2615](https://github.com/duckdb/duckdb-r/issues/2615),
+which both spellings in the tree are still being converted to).
 
 **`...` goes after the required arguments**
 ([design guide](https://design.tidyverse.org/dots-after-required.html)),
@@ -73,7 +80,8 @@ is snake_case whatever the generic above it is called.
 `Roxygen: list(markdown = TRUE)` is set in
 [`DESCRIPTION`](/DESCRIPTION), so a cross-reference is `[dbConnect()]`
 and code is backticked;
-some pages still carry the older `\code{\link{}}` spelling,
+a few pages still carry the older `\code{\link{}}` spelling
+([#2616](https://github.com/duckdb/duckdb-r/issues/2616)),
 and converting one is an ordinary edit.
 Each `@param` is a sentence — capitalised, ending in a full stop.
 
@@ -102,11 +110,12 @@ Each `@param` is a sentence — capitalised, ending in a full stop.
   [`R/rlang.R`](/R/rlang.R) holds base fallbacks for the few rlang
   functions the package uses, swapped for the real ones at load
   when rlang is installed.
-* **The package never writes its own name**, in code or in roxygen —
-  stricter than either guide asks,
-  and the only rule on this page with a guard behind it.
 
-*To deepen: settle whether an R-level `stop()` passes `call. = FALSE`
-or leans on the rethrow wrappers — both spellings are in the tree —
-and land the `air.toml` that turns the formatting rule above
-from a paragraph into a check.*
+*To deepen: state the rules once the three sweeps that make the code
+match them have run — `air.toml`
+([#2614](https://github.com/duckdb/duckdb-r/issues/2614)),
+the error-raising spelling
+([#2615](https://github.com/duckdb/duckdb-r/issues/2615)),
+and the roxygen conversion
+([#2616](https://github.com/duckdb/duckdb-r/issues/2616)) —
+and add the rules a review has enforced twice since.*

--- a/handbook/branches/flavors/README.md
+++ b/handbook/branches/flavors/README.md
@@ -44,7 +44,7 @@ and `README.md` and `.github/README.md` are written from it
 so the rename is spelled once rather than in three files kept in step
 by hand.
 Everywhere else the package asks for its name at run time
-([`architecture/r-layer/`](/handbook/architecture/r-layer/README.md));
+([`architecture/r-layer/conventions/`](/handbook/architecture/r-layer/conventions/README.md));
 the scan that keeps it that way is
 [`testing/guards/`](/handbook/testing/guards/README.md)'s.
 

--- a/handbook/contributors/workflow/README.md
+++ b/handbook/contributors/workflow/README.md
@@ -17,7 +17,13 @@ Little of this is codified; what is settled:
   ([`testing/suite/`](/handbook/testing/suite/README.md));
   the full suite can also be left to CI.
   Add a test with every bug fix.
-* Formatting is suggested on the PR by CI;
+* Write R to the tidyverse style and design guides,
+  and read the deviations before assuming a rule applies here
+  ([`architecture/r-layer/style/`](/handbook/architecture/r-layer/style/README.md));
+  the C++ has house rules of its own
+  ([`architecture/glue/conventions/`](/handbook/architecture/glue/conventions/README.md)).
+* Layout is a formatter's output, never a review comment.
+  Where CI suggests formatting on the pull request,
   accept it rather than arguing with it.
   A snapshot the change legitimately moved is accepted deliberately
   ([`testing/snapshots/`](/handbook/testing/snapshots/README.md)).

--- a/handbook/operations/ci/workflows/README.md
+++ b/handbook/operations/ci/workflows/README.md
@@ -29,7 +29,6 @@ which is the part of this a reader can check from the tree.
 | [`rhub.yaml`](/.github/workflows/rhub.yaml) | push to `cran-*`; dispatch | R-hub checks ([`releases/cran/`](/handbook/operations/releases/cran/README.md)) |
 | [`revdep.yaml`](/.github/workflows/revdep.yaml) | push to `revdep*` | one old-vs-new `rcmdcheck` per reverse dependency ([`testing/revdep/`](/handbook/testing/revdep/README.md)) |
 | [`lock.yaml`](/.github/workflows/lock.yaml) | daily cron | locks a thread after a year without activity |
-| [`HighPriorityIssues.yml`](/.github/workflows/HighPriorityIssues.yml) | issue labeled | mirrors High-Priority issues internally |
 | [`copilot-setup-steps.yaml`](/.github/workflows/copilot-setup-steps.yaml) | changes to itself | environment bootstrap for coding agents |
 
 *To deepen: cover the composite actions beside these files —

--- a/handbook/operations/review/README.md
+++ b/handbook/operations/review/README.md
@@ -12,7 +12,9 @@ What is settled:
   ([`contributors/workflow/`](/handbook/contributors/workflow/README.md)).
 * A review checks the change against the owning leaves of this
   handbook — the invariants, the flavor seam, the no-suppression
-  policy — and that snapshots changed only where the diff explains
+  policy, the tidyverse rules R answers to
+  ([`architecture/r-layer/style/`](/handbook/architecture/r-layer/style/README.md))
+  — and that snapshots changed only where the diff explains
   them ([`testing/snapshots/`](/handbook/testing/snapshots/README.md)).
 * The author drives CI to green.
 * An agent may be asked to watch a pull request — CI, review comments,

--- a/handbook/usage/statements/README.md
+++ b/handbook/usage/statements/README.md
@@ -11,7 +11,7 @@ DBI's own reference pages define what each generic promises,
 and this package implements them one file per method,
 named for the generic and the signature —
 so `R/` is the list
-([`architecture/r-layer/`](/handbook/architecture/r-layer/README.md)).
+([`architecture/r-layer/conventions/`](/handbook/architecture/r-layer/conventions/README.md)).
 A reader asking "does `dbAppendTable()` work here" answers it by
 finding the file, not by consulting an inventory that can go stale.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -19,7 +19,7 @@ Root of the documentation tree: [`handbook/`](/handbook/README.md).
 | [`format.py`](format.py) | Format the source directory; driven by the Makefile's format-* targets. |
 | [`python_helpers.py`](python_helpers.py) | Shared file helpers for the Python scripts in this directory (imported by format.py). |
 
-## [`architecture/r-layer/`](/handbook/architecture/r-layer/README.md)
+## [`architecture/r-layer/conventions/`](/handbook/architecture/r-layer/conventions/README.md)
 
 | File | Purpose |
 |---|---|


### PR DESCRIPTION
The handbook said nothing about how R in this package is written. A contributor had no way to tell a house rule from an accident, and a reviewer had nothing to cite. This gives the topic a leaf.

## `architecture/r-layer/style/` (new)

States the baseline and does not restate it — the [tidyverse style guide](https://style.tidyverse.org/) for how code reads, [tidy design principles](https://design.tidyverse.org/) for what an interface promises — then only what those leave open here:

- **Layout is the formatter's.** `air` is that formatter, and nothing runs it over this repository today: the pull-request formatter keys on an `air.toml` and this repo carries only `.clang-format`, so the job formats the C++ and leaves the R alone. Until #2614 lands, a change matches the file it is editing rather than reformatting it.
- **The error-message contract survives the downgrade** from `cli::cli_abort()` to `stop()`: problem statement first, sentence case, full stop, "must" where the expectation can be stated and "can't" where it cannot, the argument in backticks, and what the caller actually passed. Raised with `call. = FALSE` and through rlang where installed, as the `rethrow_` wrappers do (#2615).
- **Signatures:** `...` after the required arguments, required arguments without defaults, a small set of string values enumerated in the default and resolved with `match.arg()`, and a naming-only `...` checked empty rather than quietly ignored.
- **snake_case for everything this package names**, `TRUE`/`FALSE` never abbreviated.
- **Markdown roxygen**, since `Roxygen: list(markdown = TRUE)` is set in `DESCRIPTION` (#2616 drains the stragglers).

Then the part the page exists for — **where this package deviates**, each with its reason: DBI naming the generics and some arguments, `duckdb()` and `dbConnect()` carrying optional arguments before `...` (published signatures, called positionally in the wild), and cli and rlang being `Suggests` with base fallbacks in `R/rlang.R`.

## Structure

`architecture/r-layer/` becomes an internal node over `conventions/` and the new `style/`. The handbook's own rules say an internal node is a scope sentence, its principles, and a child list and nothing else, so every fact the old page carried — one file per method, generated files and their producers, the rethrow wrappers, and the flavor seam — moved to `conventions/` verbatim. Only the H1 and the scope sentence differ from the old page; git scored the pair below its rename threshold, so the diff reads as a rewrite plus an addition rather than as a move.

Inbound links move to the leaf that owns the fact rather than to the node, and the generated `scripts/` index follows its mapping.

Also drops a row in `operations/ci/workflows/` for `HighPriorityIssues.yml`, deleted in #2603; the handbook link check flagged it.

## Not in this PR

Nothing here changes code. The survey behind the leaf found it diverging from the rules in several places; the three biggest now have issues, cited from the facts they govern so a reader can tell "how it works" from "how it works for now":

- **#2614** — no `air.toml` anywhere in the history, so air has never run: 36 of 74 files in `R/` and 48 of 74 in `tests/testthat/` would be reformatted today.
- **#2615** — error messages vary in case, punctuation, backticking and whether they pass `call. = FALSE`.
- **#2616** — `\code{\link{}}` still in the dbplyr backend.

Not yet tracked: `duckdb_read_csv()` warns that `...` is unused and then forwards it to `utils::read.csv()`, and carries `sep = delim` alongside `delim`; `bigint`, `array`, `geometry` and `map` default to a single string with hand-rolled validation while `tz_out_convert` in the same signature uses the enumerated form; `T`/`F` in `test-array.R` and `test-read.R`; `1:length()` in `test-relational.R`; `sapply()` in `csv.R`.

## Checks

Handbook link integrity (no dangling, no upward `../`), generated-index freshness via `docs-readme.R --check`, and every handbook directory carrying a `README.md`.

https://claude.ai/code/session_01TGVDTpvH9vovCRqyp699Zr
