### PR TITLE
fix(patch): Make the vendored tree compile without warnings

### DIFF
--- a/patch/0009-Remove-stderr-for-zstd.patch
+++ b/patch/0009-Remove-stderr-for-zstd.patch
@@ -3,16 +3,34 @@ From: =?UTF-8?q?Kirill=20M=C3=BCller?= <kirill@cynkra.com>
 Date: Fri, 20 Dec 2024 20:40:37 +0100
 Subject: [PATCH] Remove stderr for zstd
 
+Emptying DISPLAYUPDATE leaves the progress clock it read with no reader:
+ZDICT_clockSpan() and the two locals it timed are dead once this patch
+applies, and -Wunused-function / -Wunused-variable say so. Remove them
+here, with the change that orphaned them, rather than in a patch of
+their own -- upstream has nothing to fix.
 ---
- src/duckdb/third_party/zstd/dict/zdict.cpp | 8 +-------
- 1 file changed, 1 insertion(+), 7 deletions(-)
+ src/duckdb/third_party/zstd/dict/zdict.cpp | 12 +-----------
+ 1 file changed, 1 insertion(+), 11 deletions(-)
 
 diff --git a/src/duckdb/third_party/zstd/dict/zdict.cpp b/src/duckdb/third_party/zstd/dict/zdict.cpp
-index 069691d19..8529e9442 100644
+index 7381e505d..069691d19 100644
 --- a/src/duckdb/third_party/zstd/dict/zdict.cpp
 +++ b/src/duckdb/third_party/zstd/dict/zdict.cpp
-@@ -479,15 +479,9 @@ static size_t ZDICT_trainBuffer_legacy(dictItem* dictList, U32 dictListSize,
-     clock_t const refreshRate = CLOCKS_PER_SEC * 3 / 10;
+@@ -80,8 +80,6 @@
+ #undef  DISPLAYLEVEL
+ #define DISPLAYLEVEL(l, ...) do { if (notificationLevel>=l) { DISPLAY(__VA_ARGS__); } } while (0)    /* 0 : no display;   1: errors;   2: default;  3: details;  4: debug */
+ 
+-static clock_t ZDICT_clockSpan(clock_t nPrevious) { return clock() - nPrevious; }
+-
+ static void ZDICT_printHex(const void* ptr, size_t length)
+ {
+     const BYTE* const b = (const BYTE*)ptr;
+@@ -475,19 +473,11 @@
+     BYTE* doneMarks = (BYTE*)malloc((bufferSize+16)*sizeof(*doneMarks));   /* +16 for overflow security */
+     U32* filePos = (U32*)malloc(nbFiles * sizeof(*filePos));
+     size_t result = 0;
+-    clock_t displayClock = 0;
+-    clock_t const refreshRate = CLOCKS_PER_SEC * 3 / 10;
  
  #   undef  DISPLAYUPDATE
 +// CRAN does not allow stderr references
@@ -30,4 +48,3 @@ index 069691d19..8529e9442 100644
      /* init */
 -- 
 2.43.0
-

--- a/patch/0035-Annotate-the-zstd-switch-fallthroughs.patch
+++ b/patch/0035-Annotate-the-zstd-switch-fallthroughs.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kirill =?UTF-8?q?M=C3=BCller?= <kirill@cynkra.com>
+Date: Sun, 9 Aug 2026 12:00:00 +0200
+Subject: [PATCH] Annotate the zstd switch fallthroughs
+
+ZSTD_FALLTHROUGH is what zstd writes at every deliberate fallthrough,
+but the vendored copy of compiler.h defines it as nothing, so ten of
+them read as accidents and -Wimplicit-fallthrough reports each one.
+Define it the way upstream zstd does. The vendored tree is compiled as
+C++17, so [[fallthrough]] is what it resolves to here.
+---
+  src/duckdb/third_party/zstd/include/zstd/common/compiler.h | 10 +++++++++-
+  1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/src/duckdb/third_party/zstd/include/zstd/common/compiler.h b/src/duckdb/third_party/zstd/include/zstd/common/compiler.h
+index f880f0b..5d36e2e 100644
+--- a/src/duckdb/third_party/zstd/include/zstd/common/compiler.h
++++ b/src/duckdb/third_party/zstd/include/zstd/common/compiler.h
+@@ -258,7 +258,15 @@
+  * - Else: __attribute__((__fallthrough__))
+  */
+ #ifndef ZSTD_FALLTHROUGH
+-# define ZSTD_FALLTHROUGH
++# if defined(__cplusplus) && __cplusplus >= 201703L
++#  define ZSTD_FALLTHROUGH [[fallthrough]]
++# elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
++#  define ZSTD_FALLTHROUGH [[fallthrough]]
++# elif defined(__GNUC__) && __GNUC__ >= 7
++#  define ZSTD_FALLTHROUGH __attribute__((__fallthrough__))
++# else
++#  define ZSTD_FALLTHROUGH
++# endif
+ #endif
+ 
+ /*-**************************************************************
+-- 
+2.43.0

--- a/patch/0036-Mark-two-assert-only-bindings-used.patch
+++ b/patch/0036-Mark-two-assert-only-bindings-used.patch
@@ -1,0 +1,41 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kirill =?UTF-8?q?M=C3=BCller?= <kirill@cynkra.com>
+Date: Sun, 9 Aug 2026 12:00:00 +0200
+Subject: [PATCH] Mark two assert-only bindings used
+
+With NDEBUG, D_ASSERT is assert(), which expands to ((void)0) -- the
+operand is discarded unparsed, so a binding that only ever appears
+inside one is unused in a release build and -Wunused-variable says so.
+Say it is used, the way the engine already does in ~37 other places:
+(void)binding;
+---
+  src/duckdb/src/storage/table/row_group.cpp                   | 1 +
+  src/duckdb/src/storage/table/variant/variant_unshredding.cpp | 1 +
+  2 files changed, 2 insertions(+)
+
+diff --git a/src/duckdb/src/storage/table/row_group.cpp b/src/duckdb/src/storage/table/row_group.cpp
+index f551263..3515c8c 100644
+--- a/src/duckdb/src/storage/table/row_group.cpp
++++ b/src/duckdb/src/storage/table/row_group.cpp
+@@ -1162,6 +1162,7 @@ vector<RowGroupWriteData> RowGroup::WriteToDisk(RowGroupWriteInfo &info,
+ 	idx_t column_count = row_groups[0].get().GetColumnCount();
+ 	for (auto &row_group : row_groups) {
+ 		D_ASSERT(column_count == row_group.get().GetColumnCount());
++		(void)row_group;
+ 		RowGroupWriteData write_data;
+ 		write_data.states.reserve(column_count);
+ 		write_data.statistics.reserve(column_count);
+diff --git a/src/duckdb/src/storage/table/variant/variant_unshredding.cpp b/src/duckdb/src/storage/table/variant/variant_unshredding.cpp
+index d991dd3..42f694c 100644
+--- a/src/duckdb/src/storage/table/variant/variant_unshredding.cpp
++++ b/src/duckdb/src/storage/table/variant/variant_unshredding.cpp
+@@ -186,6 +186,7 @@ static vector<VariantValue> Unshred(UnifiedVariantVectorData &variant, Vector &s
+ 		D_ASSERT(shredded.GetType().id() == LogicalTypeId::STRUCT);
+ 		auto &child_entries = StructVector::GetEntries(shredded);
+ 		D_ASSERT(child_entries.size() <= 2);
++		(void)child_entries;
+ 		typed_value_ref = *child_vectors[VariantColumnData::TYPED_VALUE_INDEX];
+ 		if (child_vectors.size() > 1) {
+ 			D_ASSERT(child_vectors.size() == 2);
+-- 
+2.43.0

--- a/patch/0037-Compile-an-assert-only-helper-only-when-asserts-are-on.patch
+++ b/patch/0037-Compile-an-assert-only-helper-only-when-asserts-are-on.patch
@@ -1,0 +1,35 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kirill =?UTF-8?q?M=C3=BCller?= <kirill@cynkra.com>
+Date: Sun, 9 Aug 2026 12:00:00 +0200
+Subject: [PATCH] Compile an assert-only helper only when asserts are on
+
+IsVariantStringType() is called from one D_ASSERT and nowhere else, so
+a release build defines it and never calls it, which -Wunused-function
+reports. Guard it with D_ASSERT_IS_ENABLED, the way the engine already
+guards assert-only code elsewhere (e.g. tuple_data_segment.cpp).
+---
+  src/duckdb/src/function/variant/variant_shredding.cpp | 2 ++
+  1 file changed, 2 insertions(+)
+
+diff --git a/src/duckdb/src/function/variant/variant_shredding.cpp b/src/duckdb/src/function/variant/variant_shredding.cpp
+index fd5252b..d7ab0a0 100644
+--- a/src/duckdb/src/function/variant/variant_shredding.cpp
++++ b/src/duckdb/src/function/variant/variant_shredding.cpp
+@@ -39,6 +39,7 @@ static void WriteShreddedDecimal(UnifiedVariantVectorData &variant, Vector &resu
+ 	}
+ }
+ 
++#ifdef D_ASSERT_IS_ENABLED
+ static bool IsVariantStringType(VariantLogicalType type_id) {
+ 	switch (type_id) {
+ 	case VariantLogicalType::GEOMETRY:
+@@ -51,6 +52,7 @@ static bool IsVariantStringType(VariantLogicalType type_id) {
+ 		return false;
+ 	}
+ }
++#endif
+ 
+ static void WriteShreddedString(UnifiedVariantVectorData &variant, Vector &result, const SelectionVector &sel,
+                                 const SelectionVector &value_index_sel, const SelectionVector &result_sel,
+-- 
+2.43.0

--- a/patch/0038-Initialize-every-member-of-DependencySubject.patch
+++ b/patch/0038-Initialize-every-member-of-DependencySubject.patch
@@ -1,0 +1,42 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kirill =?UTF-8?q?M=C3=BCller?= <kirill@cynkra.com>
+Date: Sun, 9 Aug 2026 12:00:00 +0200
+Subject: [PATCH] Initialize every member of DependencySubject
+
+Both DependencySubject aggregates leave oid out, which
+-Wmissing-field-initializers reports. optional_idx's default
+constructor already produces the invalid index the omission
+value-initializes to, so naming it changes nothing beyond making the
+third member as visible as the two the call sites already comment.
+---
+  src/duckdb/src/catalog/dependency_manager.cpp | 8 +++++---
+  1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/src/duckdb/src/catalog/dependency_manager.cpp b/src/duckdb/src/catalog/dependency_manager.cpp
+index 32ef30e..6212c09 100644
+--- a/src/duckdb/src/catalog/dependency_manager.cpp
++++ b/src/duckdb/src/catalog/dependency_manager.cpp
+@@ -288,8 +288,9 @@ void DependencyManager::CreateDependencies(CatalogTransaction transaction, const
+ 
+ 	// add the object to the dependents_map of each object that it depends on
+ 	for (auto &dependency : dependencies.Set()) {
+-		DependencyInfo info {/*dependent = */ DependencyDependent {GetLookupProperties(object), dependency_flags},
+-		                     /*subject = */ DependencySubject {dependency.entry, DependencySubjectFlags()}};
++		DependencyInfo info {
++		    /*dependent = */ DependencyDependent {GetLookupProperties(object), dependency_flags},
++		    /*subject = */ DependencySubject {dependency.entry, DependencySubjectFlags(), optional_idx()}};
+ 		CreateDependency(transaction, info);
+ 	}
+ }
+@@ -808,7 +809,8 @@ void DependencyManager::AddOwnership(CatalogTransaction transaction, CatalogEntr
+ 
+ 	DependencyInfo info {
+ 	    /*dependent = */ DependencyDependent {GetLookupProperties(owner), DependencyDependentFlags().SetOwnedBy()},
+-	    /*subject = */ DependencySubject {GetLookupProperties(entry), DependencySubjectFlags().SetOwnership()}};
++	    /*subject = */
++	    DependencySubject {GetLookupProperties(entry), DependencySubjectFlags().SetOwnership(), optional_idx()}};
+ 	CreateDependency(transaction, info);
+ }
+ 
+-- 
+2.43.0

--- a/src/duckdb/src/catalog/dependency_manager.cpp
+++ b/src/duckdb/src/catalog/dependency_manager.cpp
@@ -288,8 +288,9 @@ void DependencyManager::CreateDependencies(CatalogTransaction transaction, const
 
 	// add the object to the dependents_map of each object that it depends on
 	for (auto &dependency : dependencies.Set()) {
-		DependencyInfo info {/*dependent = */ DependencyDependent {GetLookupProperties(object), dependency_flags},
-		                     /*subject = */ DependencySubject {dependency.entry, DependencySubjectFlags()}};
+		DependencyInfo info {
+		    /*dependent = */ DependencyDependent {GetLookupProperties(object), dependency_flags},
+		    /*subject = */ DependencySubject {dependency.entry, DependencySubjectFlags(), optional_idx()}};
 		CreateDependency(transaction, info);
 	}
 }
@@ -808,7 +809,8 @@ void DependencyManager::AddOwnership(CatalogTransaction transaction, CatalogEntr
 
 	DependencyInfo info {
 	    /*dependent = */ DependencyDependent {GetLookupProperties(owner), DependencyDependentFlags().SetOwnedBy()},
-	    /*subject = */ DependencySubject {GetLookupProperties(entry), DependencySubjectFlags().SetOwnership()}};
+	    /*subject = */
+	    DependencySubject {GetLookupProperties(entry), DependencySubjectFlags().SetOwnership(), optional_idx()}};
 	CreateDependency(transaction, info);
 }
 

--- a/src/duckdb/src/function/variant/variant_shredding.cpp
+++ b/src/duckdb/src/function/variant/variant_shredding.cpp
@@ -39,6 +39,7 @@ static void WriteShreddedDecimal(UnifiedVariantVectorData &variant, Vector &resu
 	}
 }
 
+#ifdef D_ASSERT_IS_ENABLED
 static bool IsVariantStringType(VariantLogicalType type_id) {
 	switch (type_id) {
 	case VariantLogicalType::GEOMETRY:
@@ -51,6 +52,7 @@ static bool IsVariantStringType(VariantLogicalType type_id) {
 		return false;
 	}
 }
+#endif
 
 static void WriteShreddedString(UnifiedVariantVectorData &variant, Vector &result, const SelectionVector &sel,
                                 const SelectionVector &value_index_sel, const SelectionVector &result_sel,

--- a/src/duckdb/src/storage/table/row_group.cpp
+++ b/src/duckdb/src/storage/table/row_group.cpp
@@ -1162,6 +1162,7 @@ vector<RowGroupWriteData> RowGroup::WriteToDisk(RowGroupWriteInfo &info,
 	idx_t column_count = row_groups[0].get().GetColumnCount();
 	for (auto &row_group : row_groups) {
 		D_ASSERT(column_count == row_group.get().GetColumnCount());
+		(void)row_group;
 		RowGroupWriteData write_data;
 		write_data.states.reserve(column_count);
 		write_data.statistics.reserve(column_count);

--- a/src/duckdb/src/storage/table/variant/variant_unshredding.cpp
+++ b/src/duckdb/src/storage/table/variant/variant_unshredding.cpp
@@ -186,6 +186,7 @@ static vector<VariantValue> Unshred(UnifiedVariantVectorData &variant, Vector &s
 		D_ASSERT(shredded.GetType().id() == LogicalTypeId::STRUCT);
 		auto &child_entries = StructVector::GetEntries(shredded);
 		D_ASSERT(child_entries.size() <= 2);
+		(void)child_entries;
 		typed_value_ref = *child_vectors[VariantColumnData::TYPED_VALUE_INDEX];
 		if (child_vectors.size() > 1) {
 			D_ASSERT(child_vectors.size() == 2);

--- a/src/duckdb/third_party/zstd/dict/zdict.cpp
+++ b/src/duckdb/third_party/zstd/dict/zdict.cpp
@@ -80,8 +80,6 @@ static const U32 g_selectivity_default = 9;
 #undef  DISPLAYLEVEL
 #define DISPLAYLEVEL(l, ...) do { if (notificationLevel>=l) { DISPLAY(__VA_ARGS__); } } while (0)    /* 0 : no display;   1: errors;   2: default;  3: details;  4: debug */
 
-static clock_t ZDICT_clockSpan(clock_t nPrevious) { return clock() - nPrevious; }
-
 static void ZDICT_printHex(const void* ptr, size_t length)
 {
     const BYTE* const b = (const BYTE*)ptr;
@@ -475,8 +473,6 @@ static size_t ZDICT_trainBuffer_legacy(dictItem* dictList, U32 dictListSize,
     BYTE* doneMarks = (BYTE*)malloc((bufferSize+16)*sizeof(*doneMarks));   /* +16 for overflow security */
     U32* filePos = (U32*)malloc(nbFiles * sizeof(*filePos));
     size_t result = 0;
-    clock_t displayClock = 0;
-    clock_t const refreshRate = CLOCKS_PER_SEC * 3 / 10;
 
 #   undef  DISPLAYUPDATE
 // CRAN does not allow stderr references

--- a/src/duckdb/third_party/zstd/include/zstd/common/compiler.h
+++ b/src/duckdb/third_party/zstd/include/zstd/common/compiler.h
@@ -258,7 +258,15 @@
  * - Else: __attribute__((__fallthrough__))
  */
 #ifndef ZSTD_FALLTHROUGH
-# define ZSTD_FALLTHROUGH
+# if defined(__cplusplus) && __cplusplus >= 201703L
+#  define ZSTD_FALLTHROUGH [[fallthrough]]
+# elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+#  define ZSTD_FALLTHROUGH [[fallthrough]]
+# elif defined(__GNUC__) && __GNUC__ >= 7
+#  define ZSTD_FALLTHROUGH __attribute__((__fallthrough__))
+# else
+#  define ZSTD_FALLTHROUGH
+# endif
 #endif
 
 /*-**************************************************************


### PR DESCRIPTION
The vendored half of the compiler-hygiene work for #1829. All 341 vendored translation units compiled with `-Wall -Wextra`; what is left after the not-enforced categories and the generated files are set aside is 19 sites, and these four patches fix all of them. One patch per warning category, as with the glue PRs.

## What the vendored tree is not held to

- **`-Wunused-parameter`** and **`-Wredundant-move`** — not enforced in either scope. Thousands of hits from templated engine headers for the first; upstream's house style, at no cost, for the second (#2607).
- **Generated sources** — `src_backend_parser_gram.cpp` (bison) and `yyjson.cpp` (upstream's amalgamation). An editable fix does not exist for a file its generator rewrites, this repository vendors the outputs and none of the generators, and the warning cannot be forwarded either — it is about generated text, not about the input that produced it. Their four warnings are ignored outright. The earlier revision of this PR patched both; that is reverted.

## The patches

- **`0035-Annotate-the-zstd-switch-fallthroughs`** — 10 `-Wimplicit-fallthrough` sites, one root cause. zstd writes `ZSTD_FALLTHROUGH` at every deliberate fallthrough, but the vendored `compiler.h` defines that macro as nothing, so all ten read as accidents. Defining it the way upstream zstd does — `[[fallthrough]]` here, since the tree is compiled as C++17 — fixes every site with one hunk.
- **`0036-Mark-two-assert-only-bindings-used`** — see below.
- **`0037-Compile-an-assert-only-helper-only-when-asserts-are-on`** — `IsVariantStringType()` is called from one `D_ASSERT` and nowhere else, so a release build defines it and never calls it. `(void)` cannot say "used" about a function definition, so this one is guarded with `D_ASSERT_IS_ENABLED`, the way the engine already guards assert-only code (e.g. `tuple_data_segment.cpp`). Verified to compile with and without `-DDEBUG` / `-DDUCKDB_FORCE_ASSERT`.
- **`0038-Initialize-every-member-of-DependencySubject`** — both aggregates omit `oid`. `optional_idx`'s default constructor already produces the invalid index that omission value-initializes to, so naming it changes nothing at runtime.

## Why `D_ASSERT` does not already mark its operand used

It is a fair expectation, and the answer is in `assert.hpp`: outside a debug build `D_ASSERT` **is** `assert` from `<assert.h>`, and with `NDEBUG` the C standard requires `assert(x)` to expand to `((void)0)`. The operand is discarded without being parsed as an expression, so nothing in it is used, or even type-checked. A binding that appears only inside a `D_ASSERT` is therefore genuinely unused in a release build.

A macro could fix the whole class at once — `((void)sizeof((condition) ? 1 : 0))` keeps the operand named without evaluating it — but that changes an engine-wide header for every `D_ASSERT` in the tree, and belongs upstream if anywhere. Upstream's own answer is the local one: `(void)binding;`, in ~37 places already, including `variant_shredding.cpp` a few lines from one of these sites. So `0036` does that, and the previous revision's restructuring (an index loop, a deduplicated `StructVector::GetEntries()` call) is gone — those changes fixed the warning by rearranging code, which is a bigger claim than the warning justifies.

## Why `0009` is regenerated instead of getting a companion

`0009-Remove-stderr-for-zstd` empties `DISPLAYUPDATE`, which is what leaves `ZDICT_clockSpan()` and the two locals it timed with no reader — the `-Wunused-function` and `-Wunused-variable` hits in `zdict.cpp` are caused by this repository's own patch, not by upstream. There is nothing to send to `duckdb/duckdb`, so the cleanup belongs in the patch that caused it rather than in a new one that would have to be ordered after it.

## Verification

Reconstructed a pristine tree (`0009` reverse-applied), forward-applied `0009` and `0035`–`0038` with `patch -p1`, and diffed against the working tree: byte-identical. Every affected object rebuilt clean.

## Not in scope here

The `-Wunused-function` flood from `numeric_cast.hpp` quoted in #1829 does **not** reproduce against the currently vendored engine: `duckdb/ub_src_common_sort.cpp` compiles clean with GCC 13 under `-Wall` at `-O0` and `-O2`. Whatever caused it upstream has since changed.