### PR TITLE
fix(glue): Suffix the one shadowing parameter left in a header

### DIFF
--- a/src/include/rapi.hpp
+++ b/src/include/rapi.hpp
@@ -158,8 +158,8 @@ typedef cpp11::external_pointer<RStatement> stmt_eptr_t;
 
 struct RelationWrapper {
 	RelationWrapper() = delete;
-	RelationWrapper(duckdb::shared_ptr<Relation> rel_p, ConvertOpts convert_opts)
-	    : rel(std::move(rel_p)), convert_opts(std::move(convert_opts)) {
+	RelationWrapper(duckdb::shared_ptr<Relation> rel_p, ConvertOpts convert_opts_)
+	    : rel(std::move(rel_p)), convert_opts(std::move(convert_opts_)) {
 	}
 	duckdb::shared_ptr<Relation> rel;
 	const ConvertOpts convert_opts;


### PR DESCRIPTION
A follow-up to #2608, same topic: `RelationWrapper`'s constructor names its parameter exactly like the member it initialises, which `-Wshadow` reports.

It was missed the first time because it lives in `src/include/rapi.hpp` rather than in a translation unit, and the sweep that found the other three read only the `.cpp` files. The scope rule in the gate being built for #1829 is "the glue owns everything under `src/` that is not `src/duckdb/`", headers included, which is how this one surfaced.

Same fix as the others: the `_` suffix the glue already uses in `AltrepRelationWrapper`.

---
_Generated by [Claude Code](https://claude.ai/code/session_0148iKGyG7gmmQsdaDckmA3x)_