### PR TITLE
fix(glue): Build a `string_t` from R's `const char*` without a cast

### DIFF
--- a/src/types.cpp
+++ b/src/types.cpp
@@ -431,7 +431,7 @@ double RIntegralType::DoubleCast<>(hugeint_t val) {
 }
 
 string_t RStringSexpType::Convert(SEXP val) {
-	return string_t((char *)CHAR(val));
+	return string_t(CHAR(val));
 }
 
 bool RStringSexpType::IsNull(SEXP val) {


### PR DESCRIPTION
A follow-up to #2609, same topic: the one `-Wcast-qual` site that PR missed.

`RStringSexpType::Convert()` casts `CHAR(val)` — a `const char *` — to `char *` before constructing a `string_t`. `string_t` has a `const char *` constructor, so the cast was never buying anything; dropping it removes the warning and the pointless narrowing of R's guarantee.

Found by running the whole glue scope through the gate being built for #1829, rather than the file-by-file sweep that produced #2609.

---
_Generated by [Claude Code](https://claude.ai/code/session_0148iKGyG7gmmQsdaDckmA3x)_