### PR TITLE
docs(testing): Say when a snapshot is the right tool, not only how to accept one

### DIFF
--- a/handbook/testing/snapshots/README.md
+++ b/handbook/testing/snapshots/README.md
@@ -12,6 +12,14 @@ so snapshots drift whenever a vendored DuckDB changes its output,
 and snapshot repair is a routine part of vendoring
 ([`operations/vendoring/series-loop/`](/handbook/operations/vendoring/series-loop/README.md)).
 
+**Record the output where the output is the assertion.**
+Generated text a reader has to approve — a translated query,
+a printed relational expression, the wording of a message,
+warning or error — belongs in `_snaps/`,
+because a recorded file puts the whole of it in the diff,
+where a regex goes on matching wording nobody would ship.
+An expectation that names one value stays one.
+
 A snapshot must never record the package's own name:
 [`scripts/flavor.patch`](/scripts/flavor.patch) does not rewrite
 `_snaps/`, so one recorded file has to serve every flavor.


### PR DESCRIPTION
Noticed while adding a snapshot test in #2605: I reached the convention by reading the suite, not the handbook.

`handbook/testing/snapshots/README.md` opens by promising "what the recorded snapshot output asserts", but the body only carries mechanics — where `_snaps/` files live, the `transform_package_name` normalisation, where a skip goes, and how a change is accepted. Nothing says *when* to reach for a snapshot in the first place, so a contributor adding a new user-facing message has nothing pointing them at one.

The convention itself is consistent across the suite, and stated nowhere:

- `test-backend-dbplyr__duckdb_connection.R` records translated SQL.
- `test-relational.R` records printed relational expressions (29 of them).
- `test-extensions-libcxx.R` records message wording under a `# --- message wording (snapshot) ---` banner; `test-storage-home.R` and `test-error-handling.R` record message and error wording.

This adds one entry stating the trigger, placed before the mechanics it governs. By the authoring ladder's step 5 — "the leaf gets the trigger and the action, never the anatomy" — this leaf had the action twice over and no trigger.

## Not changed, but worth a maintainer's eye

The `transform_package_name` requirement is stated in two leaves: here (lines 15–20) and in `handbook/testing/suite/README.md` (as one of three helper constraints). That reads like a paraphrase, which "leaves explain, once" forbids — but the suite leaf frames it as a property of the helpers rather than of snapshots, and the redundancy is arguably load-bearing for a reader who arrives from the helper side. Left alone deliberately; collapsing it is a judgment call, not a cleanup.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GeNHZLYKcEQwrLQK5emDhr)_