### PR TITLE
docs(rcc): Say plainly that the verdict store is live, plan its retirement as D6, and sync the buffer's tooling

### DIFF
--- a/.claude/skills/series-loop.md
+++ b/.claude/skills/series-loop.md
@@ -312,9 +312,15 @@ or the run is there and its results are not
 (a leg that died before it uploaded anything).
 Nothing else in this stage changes; the bytes are the same either way.
 
-**The store is an emergency route, and it is not kept warm.**
+**The store is an emergency route *for a firing*, and it is not kept warm.**
 One writer is still automatic, and it covers almost all of it:
 a leg publishes its own verdict seconds after deciding a commit.
+That publish is not a copy kept for this stage's benefit:
+CI plans and resumes from the store and from nothing else
+(`scripts/rcc-decided.sh`),
+so the branch is load-bearing even in a cycle where no firing opens it,
+and a steady trickle of pushes to `rcc2` is the system working
+rather than a retired branch still ticking.
 Everything else has been retired in the loop's direction of travel —
 the per-run fan-in, which reconciled onto the branch
 whatever a leg could not publish,
@@ -1263,7 +1269,10 @@ is what carries the automatic path into a forward series.
   for a firing that cannot read the runs.
   Neither source may be *required*: a firing that has only one of them
   still finishes, and says in its report which one it had.
-  The fallback is an emergency route and is not kept warm:
+  The fallback is an emergency route *for the firing*, and is not kept warm:
   `rcc-logs.yaml` is dispatched, never scheduled,
   so a firing that needs the copy complete asks for it
   and reads the answer on a later pass — it never blocks on one.
+  On the CI side the store is nobody's fallback:
+  selection reads it and only it,
+  which is why the leg's per-commit publish stays automatic.

--- a/.claude/skills/series-loop.md
+++ b/.claude/skills/series-loop.md
@@ -139,7 +139,7 @@ list the most recent `each-rcc` runs.
 If that answers, the firing is on the run path for every stage below.
 If it does not — no such access from this session at all —
 the firing falls back to the `rcc2` store,
-which still works, inside its 30-day window,
+which still works, inside its 180-day window,
 but is now an **emergency route** rather than a warm copy:
 `rcc-logs.yaml` is dispatch-only,
 so a firing that needs the store complete has to ask for it

--- a/.claude/skills/series-loop.md
+++ b/.claude/skills/series-loop.md
@@ -757,6 +757,28 @@ CI reads workflows and scripts from the branch it checks,
 so this is what puts a fix into effect —
 never park a tooling change to wait for a forward.
 
+**Every ref of the series owes that identity, `<S>-build` included.**
+A workflow fires from the branch it sits on,
+so a ref nobody ports runs the tooling of the day it was seeded,
+and a push filter written back then decides what fires today.
+The buffer takes no *ports* — its line is upstream commits
+and the glue they need — but its **tooling is synced**,
+and `series-port.sh` does it in the same run:
+one commit appended to `<S>-build` when its tooling differs from `main`'s.
+This is not a precaution. `v1.4-andium-build` still carried a
+2026-03-26 `R-CMD-check.yaml` whose release pattern matches
+the buffer's own name, so pushes to it started the template check
+and `R-CMD-check-status.yaml` stamped an `rcc` status
+on a commit no `each-rcc` leg had decided —
+a status with no record, on a ref the model calls untested.
+
+The sync commit vendors nothing,
+so the consumption anchor and the vendored-SHA scans look past it
+by subject, and stage 5 replays it onto `-dev` like any buffer commit,
+where it drops as empty because `-dev` already carries that tooling.
+Where `main` moved between the two syncs it conflicts instead;
+resolve toward `main`'s tooling, which is what both refs converge on.
+
 ```sh
 scripts/series-port.sh <S>                  # list candidates + identity check
 scripts/series-port.sh <S> --apply          # cherry-pick all, sync, push

--- a/handbook/branches/model/README.md
+++ b/handbook/branches/model/README.md
@@ -44,6 +44,19 @@ so there is never a "no green yet" state.
 The buffer is deliberately untested on CI/CD,
 so vendoring can run ahead while CI catches up
 ([`ci/per-commit/selection/`](/handbook/operations/ci/per-commit/selection/README.md)).
+
+**Untested is a property of the tooling on the ref, not of the ref's name.**
+A workflow fires from the branch it sits on,
+so what keeps the buffer quiet is that the workflows it carries
+match no branch it is called —
+and a buffer carrying the copies it was seeded with
+is judged by that day's filters instead.
+`v1.4-andium-build` was: a 2026-03-26 `R-CMD-check.yaml`
+whose release pattern matches the buffer's own name
+put an `rcc` status on a commit no per-commit leg had decided.
+So the port stage syncs the buffer's tooling too
+([`operations/vendoring/series-loop/`](/handbook/operations/vendoring/series-loop/README.md)),
+and the model's "no CI" holds because something maintains it.
 Rebasing a series happens *beside* it as a `<S>-fwd` counterpart,
 verified from scratch and swapped in by a human-run cutover;
 a serving `-green` never moves sideways on its own.

--- a/handbook/meta/glossary/README.md
+++ b/handbook/meta/glossary/README.md
@@ -53,5 +53,5 @@ one line, so the register stays greppable and diffs per term.
 * **triage verdicts** — the dispositions issue intake assigns, exactly one per open item ([`operations/triage/`](/handbook/operations/triage/README.md)).
 * **vendor commit** — one commit advancing `src/duckdb/` by exactly one upstream commit ([`operations/vendoring/model/`](/handbook/operations/vendoring/model/README.md)).
 * **vendoring** — keeping a dependency's sources inside the depending repository ([`operations/vendoring/model/`](/handbook/operations/vendoring/model/README.md)).
-* **verdict store** / **`rcc2` branch** — the orphan branch holding each commit's build verdict and log, one file per commit ([`operations/ci/per-commit/store/`](/handbook/operations/ci/per-commit/store/README.md)). Its predecessor `rcc` is retired, and kept whole in the archive.
+* **verdict store** / **`rcc2` branch** — the orphan branch holding each commit's build verdict and log, one file per commit, and what per-commit CI selects its work from ([`operations/ci/per-commit/store/`](/handbook/operations/ci/per-commit/store/README.md)). Its predecessor `rcc` is retired, and kept whole in the archive.
 * **WKB** — well-known binary, the geometry interchange across the R boundary ([`usage/types/`](/handbook/usage/types/README.md)).

--- a/handbook/operations/ci/per-commit/selection/README.md
+++ b/handbook/operations/ci/per-commit/selection/README.md
@@ -21,8 +21,10 @@ Branches without a green sibling fall back to first-parent history since `SINCE`
 
 That fallback is the one path that can reach past the store's retention window
 ([`store/`](/handbook/operations/ci/per-commit/store/README.md#retention-is-one-window)):
-`SINCE` defaults to a fixed date months back, while records are dropped after 30
-days, so a commit older than the window reads as undecided and is replanned.
+`SINCE` defaults to a fixed date, while records are dropped after 180 days,
+so a commit older than the window reads as undecided and is replanned —
+and because `SINCE` is fixed and the window is not,
+the gap between them widens with every month that passes.
 A series branch never sees it — `<S>-green` is far newer than the window — and
 the cost where it does bite is a rebuild, never a wrong verdict.
 Narrow `SINCE` on a branch with no green sibling if the rebuild is not wanted.

--- a/handbook/operations/ci/per-commit/store/README.md
+++ b/handbook/operations/ci/per-commit/store/README.md
@@ -327,6 +327,17 @@ a run cancelled whole, so that no leg ever published —
 is the reason to dispatch it.
 What is left is the leg's own publish, which is where a verdict comes from.
 
+## Where this is going
+
+**The store is on its way out**, and D6 of
+[`plan/PLAN-vendoring-simplification.md`](/plan/PLAN-vendoring-simplification.md)
+is the cut: selection moves to a batched read of the `rcc` commit status,
+[`series-check.sh`](/scripts/series-check.sh) reads a failure's log from the run
+that decided it rather than from `logs2.d/`,
+and the branch goes with its writers.
+Nothing on this page is deprecated — it is what runs today —
+but a change to any of it is worth weighing against a plan to delete it.
+
 *To deepen: state what the first live cutover, the first live consolidation and
 the first live publish against the real remote changed, and fold the
 vendoring-simplification plan's remaining per-commit items

--- a/handbook/operations/ci/per-commit/store/README.md
+++ b/handbook/operations/ci/per-commit/store/README.md
@@ -81,9 +81,10 @@ and that is what makes the concurrency work without a lock.
 
 ## Retention is one window
 
-The store keeps `RCC_RETENTION_DAYS` (30) of history,
+The store keeps `RCC_RETENTION_DAYS` (180) of history,
 **records and logs alike**,
-and [`rcc-consolidate.sh`](/scripts/rcc-consolidate.sh) enforces it.
+and [`rcc-consolidate.sh`](/scripts/rcc-consolidate.sh) enforces it —
+by hand, so nothing is dropped until an operator dispatches it.
 Logs are still the bulk of what goes — about a megabyte each against ~2 KB for
 a record — but keeping a verdict for a commit decided months ago and long since
 repaired only postpones the same deletion,
@@ -303,10 +304,18 @@ which is what the 256-way fan-out is for.
 A single flat directory of ten thousand records would rewrite the whole tree on
 every push.
 
-And none of it is load-bearing.
+And none of it is load-bearing *for the leg that pays it*.
 Legs still upload their artifacts, which is what a firing reads.
 A failed publish is logged and ignored — it never fails the leg —
 and the verdict is in the artifact and in the job log regardless.
+Where it is felt is the next run:
+selection reads this branch and only this branch
+([`selection/`](/handbook/operations/ci/per-commit/selection/README.md)),
+so a commit whose record never landed reads as undecided
+and is built again.
+Cheap and survivable, then, but not optional —
+the publish is the one write that keeps CI
+from rebuilding what it has already decided.
 
 Two writers have been retired since, in the same direction.
 The per-run fan-in reconciled onto the branch whatever a leg could not publish;

--- a/handbook/operations/ci/workflows/README.md
+++ b/handbook/operations/ci/workflows/README.md
@@ -20,7 +20,7 @@ which is the part of this a reader can check from the tree.
 | [`R-CMD-check-dev.yaml`](/.github/workflows/R-CMD-check-dev.yaml) | daily cron; push to `cran-*`, tags | the check against r-universe dev builds of each dependency, one job per dependency |
 | [`R-CMD-check-status.yaml`](/.github/workflows/R-CMD-check-status.yaml) | `rcc` runs starting/finishing | mirrors run state onto commit statuses |
 | [`each.yaml`](/.github/workflows/each.yaml) | push to `*-dev` and `each-*`; dispatch | per-commit sharded builds ([`per-commit/`](/handbook/operations/ci/per-commit/README.md)); fork only |
-| [`rcc-logs.yaml`](/.github/workflows/rcc-logs.yaml) | half-hourly cron | harvests run records onto the `rcc2` branch |
+| [`rcc-logs.yaml`](/.github/workflows/rcc-logs.yaml) | dispatch; push when its own files change | backstop harvest onto the `rcc2` branch, for a commit no leg published ([`per-commit/store/`](/handbook/operations/ci/per-commit/store/README.md)) |
 | [`rcc-consolidate.yaml`](/.github/workflows/rcc-consolidate.yaml) | dispatch | rewrites the `rcc2` branch (dry run by default) |
 | [`fledge.yaml`](/.github/workflows/fledge.yaml) | daily cron; dispatch; push only when this file changes | version bump and `NEWS.md` via fledge ([`releases/versioning/`](/handbook/operations/releases/versioning/README.md)) |
 | [`format-suggest.yaml`](/.github/workflows/format-suggest.yaml) | `pull_request_target` | posts formatting suggestions; treats fork code strictly as data |
@@ -28,8 +28,8 @@ which is the part of this a reader can check from the tree.
 | [`pkgdown.yaml`](/.github/workflows/pkgdown.yaml) | push to `docs*`, `cran-*`; dispatch | builds the site (main is covered by `rcc`) |
 | [`rhub.yaml`](/.github/workflows/rhub.yaml) | push to `cran-*`; dispatch | R-hub checks ([`releases/cran/`](/handbook/operations/releases/cran/README.md)) |
 | [`revdep.yaml`](/.github/workflows/revdep.yaml) | push to `revdep*` | one old-vs-new `rcmdcheck` per reverse dependency ([`testing/revdep/`](/handbook/testing/revdep/README.md)) |
+| [`revdep2.yaml`](/.github/workflows/revdep2.yaml) | dispatch | the same comparison sharded across runners, dealt by measured check cost |
 | [`lock.yaml`](/.github/workflows/lock.yaml) | daily cron | locks a thread after a year without activity |
-| [`HighPriorityIssues.yml`](/.github/workflows/HighPriorityIssues.yml) | issue labeled | mirrors High-Priority issues internally |
 | [`copilot-setup-steps.yaml`](/.github/workflows/copilot-setup-steps.yaml) | changes to itself | environment bootstrap for coding agents |
 
 *To deepen: cover the composite actions beside these files —

--- a/handbook/operations/vendoring/series-loop/README.md
+++ b/handbook/operations/vendoring/series-loop/README.md
@@ -38,7 +38,11 @@ to do, and they run in this order:
   message of the `-dev` commit that answers it, which is where the
   next forward reads it.
 * **Forward-port** — bring `main`'s R-side work onto the series
-  ([`scripts/series-port.sh`](/scripts/series-port.sh)).
+  ([`scripts/series-port.sh`](/scripts/series-port.sh)),
+  and bring every ref's tooling level with `main` —
+  the buffer included, which takes no ports but does take the sync,
+  because a workflow fires from the branch it sits on
+  ([`branches/model/`](/handbook/branches/model/README.md)).
   A series seeded from a release branch rather than from `main` takes
   no wholesale port: its R side belongs to that line, so only the
   tooling sync and fixes named by hand apply.

--- a/plan/PLAN-vendoring-simplification.md
+++ b/plan/PLAN-vendoring-simplification.md
@@ -9,7 +9,9 @@ this file is the proposal, and where the two disagree the leaf is right.
 Status: **in progress** (2026-07-30, branch `claude/vendoring-tooling-design-3swawc`;
 Phase 1 landed as #87, the README root as #88, Phase 3 as the fork
 move (#2534) — see §9;
-revised after a clean-context review of this document against `origin/main`).
+revised after a clean-context review of this document against `origin/main`;
+revised again 2026-08-09 — question 6 is settled, the verdict store is to be
+retired, and §3.3's D6 is the cut).
 Inputs: `BRANCHES.md`, `scripts/VENDORING.md`, `scripts/EACH.md`,
 `scripts/VENDORING-LOOP.md` (historical), the four skills in `.claude/skills/`,
 the loop scripts (`series-*.sh`, `each-*`, `rcc-*`, `vendor*`),
@@ -65,6 +67,11 @@ one layout on a new branch — `runs2.d/<xx>/<sha>.ndjson` and
 `logs2.d/<xx>/<sha>.log` on `rcc2`, written by three producers through one
 publisher, with `rcc` left behind whole. See
 [`operations/ci/per-commit/store/`](/handbook/operations/ci/per-commit/store/README.md).
+The writer count has come down twice more since:
+the per-run fan-in and the 30-minute sweep both went in #2578,
+leaving one automatic writer (the leg's own publish),
+one dispatched (`rcc-logs.yaml`) and one manual (consolidation).
+D6 takes the last of them.
 | Scripts | 26 shell/python executables + 3 data/jq files serve the loop |
 | Skills | 4 (`series-loop`, `series-forward`, `series-rebase`, `series-open`) |
 | Workflows | `each.yaml`, `rcc-logs.yaml`, `rcc-consolidate.yaml` — the legacy dispatch path, which also spanned `cancel-rcc-dispatch.yaml`, is retired (D4). `R-CMD-check.yaml` (whose workflow *name* is `rcc`) and `R-CMD-check-status.yaml` stay: the ordinary push/PR check and the commit status branch protection reads, both core-set from `cynkra/cynkratemplate` |
@@ -289,6 +296,7 @@ as one checklist; this plan is analysis, not a routing node:
 | D3 | State `-build-base`'s contract: maintained and self-guarded by the loop, an input to no decision, consumed by humans (compare URLs and badges, §3.4) | the recurring temptation to treat it as coordination state — or to drop it and lose the only clean "buffered" range |
 | D4 | Retire the legacy dispatch path whole: `vendor-gate.sh`, `each-rcc.sh` + `each.yaml`'s dispatch mode, `cancel-rcc-dispatch.yaml`, ~~and `R-CMD-check-status.yaml`'s rcc role~~ (that last one was wrong — see the status note below). `R-CMD-check.yaml` itself stays — it is also the ordinary push/PR check — it only stops being dispatched per commit | four legacy surfaces that still have to be reasoned about on every change |
 | D5 | State the concurrency design in one place: per-series group + durable idempotent verdicts; **no pending markers, by design** | the recurring "did we lose the running marker" doubt (F3). The pieces exist in `each.yaml` and `EACH.md`; the one-place statement is what is missing |
+| D6 | Retire the verdict store: the three readers of a *state* — `each-plan.sh`, `each-shard.sh`'s resume check, `series-advance.sh`'s frontier walk — read the per-commit **commit status** in one batched query, `series-check.sh` reads a failure's log from the run that decided it, and the `rcc2` branch goes with its writers | the branch itself, `rcc-publish.sh`, `rcc-decided.sh`, `rcc-logs.{sh,yaml}`, `rcc-consolidate.{sh,yaml}`, `rcc-cutover.sh`, `rcc-store-test.sh`, `rcc-lib.sh` entire, the retention window and its two-way rule, and two handbook leaves |
 
 *Status of D4:* landed, minus one item this document had wrong.
 `vendor-gate.sh`, `each-rcc.sh`, `each.yaml`'s dispatch mode and
@@ -325,6 +333,72 @@ after the sweep, a range read is N 2-KB `git show`s,
 which is how the loop reads the range today anyway;
 the single-fetch convenience has no consumer left.
 Order matters only once: sweep, then readers, then the file.
+
+*D6 in full:* **this is not D1 reversed.**
+D1's defect was two stores reconciled against each other,
+not the store it picked;
+it picked records because the reader that mattered — a Claude firing —
+had git and no API.
+#2549 removed that constraint:
+a firing reads the deciding `each-rcc` run first
+and falls back to the branch.
+With the constraint gone, the one surviving store can be the one
+CI already writes for free, and the branch goes with its machinery.
+
+What selection reads instead is the `rcc` commit status the leg
+already POSTs in the same step as the verdict —
+which is what selection read *before* D1:
+`each-plan.sh` scanned statuses by GraphQL and `each-shard.sh`'s resume
+check by REST, so the read is recoverable from this repository's own
+history rather than code to invent.
+The batching question is therefore already answered;
+what has to be re-decided is only the REST resume check,
+which wants the same batched query rather than one call per commit.
+What does not come back is the reconciliation a *second* store needed:
+decided is `success` or `failure`, `pending` or absent is undecided,
+and no `PENDING_TTL_HOURS` returns with it —
+a commit mid-build reads as undecided under the record store too,
+and what prevents double work is the per-branch concurrency group,
+which is F3's finding and D5's statement.
+
+**Four readers, and only one of them is hard.**
+Three want a *state* and nothing else, so they follow selection onto the
+status: `each-plan.sh`, `each-shard.sh`'s resume check, and —
+the one easy to miss, because it is not selection and does not go
+through `rcc-decided.sh` — `series-advance.sh`'s `state_of()`,
+which `git show`s a record to decide what `-green` may pass over.
+Miss it and the ref-mover is the last thing reading a branch
+everything else has stopped writing.
+
+**The blocker is the fourth: logs, not verdicts.**
+`series-check.sh` classifies a failure by what its harvested log
+positively contains, and a status carries no log.
+Its replacement is the run that decided the commit —
+the `each-logs-*` artifact for 14 days, the job log for longer —
+which is the read the series loop already makes at stage 2.
+Porting `series-check.sh` off `git show` is the one piece of real work
+in D6; everything after it is deletion.
+
+**What D6 spends** is the property the branch was built for:
+a reader with git and nothing else.
+After D6 a firing with no API access has nothing to fall back to,
+where today it has a stale-but-readable copy.
+That is a trade to make on evidence rather than on this paragraph,
+and #2549 already instruments it —
+every firing records which path served — so the evidence is a report away.
+
+**One wrinkle to settle before the cut.**
+The `rcc` context is not the leg's alone:
+`R-CMD-check-status.yaml` writes the same context for the ordinary check,
+and branch protection reads it.
+Nothing else writes it on a series branch today
+(`R-CMD-check.yaml` does not fire on `*-dev`),
+so selection would be correct as-is — but reading a context that a
+template-owned workflow also writes rebuilds F1's coupling in miniature.
+Giving the per-commit verdict its own context (`each-rcc`) costs one line
+in `each-shard.sh` and ends the question;
+what it costs back is the commit list, where one context is what a reader
+scans. Decide it with D6, not after.
 
 ### 3.4 Human-facing lag: compare URLs and badges
 
@@ -666,13 +740,20 @@ of the kernel.
 | **0 (PR #86, this PR)** | this plan; router in `AGENTS.md`; badge semantics + pointers in `scripts/VENDORING.md` and `scripts/EACH.md` | none — docs only |
 | **1 — landed (#87)** | the port stage: `scripts/series-port.sh` plus the amended `series-loop` / `series-forward` / `series-rebase` skills | first real `--apply` still runs supervised |
 | **1a (follow-up)** | resolve the subject-vs-path contradiction (§4), in order: harden `vendor-one.sh` and `vendor.sh`'s subject scans to bounded-and-loud; relax `classify()` to subject-decided; rewrite the landed rationale in `series-port.sh`'s header and `series-loop.md` stage 4; stage 1 invokes `main`'s `vendor-one.sh` against the buffer worktree | wider than first scoped — two scanners, one classifier, two rationale blocks, one skill rule; each independently shippable |
-| **2** | single verdict store (D1: selection and resume by record; backstop stops writing, its schedule dispatches idle undecided work); one sweep, then drop the aggregate outright (D2); the fan-in stays (per-commit logs, §3.2) | verdicts are already dual-written today; rollback = read statuses again |
+| **2 — landed, and further than written** | single verdict store (D1: selection and resume by record; backstop stops writing, its schedule dispatches idle undecided work); one sweep, then drop the aggregate outright (D2); ~~the fan-in stays (per-commit logs, §3.2)~~ — it did not: the fan-in and the backstop's schedule both went in #2578, leaving the leg's own publish as the store's one automatic writer | verdicts are already dual-written today; rollback = read statuses again |
 | **3 — landed (#2534)** | replace the standalone repo with a fresh fork (§6), configured with the Pull app so the release-branch mirrors stay current without a job of our own | one-time move; the replaced repository is kept as `krlmlr/duckdb-r-old` |
 | **4** | docs tree (§8): README root landed (#88); next the moves, then node rewrites (including `AGENTS.md`'s and `BRANCHES.md`'s stale rows); `docs-tree` skill | docs only |
 | **5** | kernel extraction + `rigraph` port (config file, generalized subject marker, igraph cost estimator or constant weight) | new repo consumed `@main`; rollback = vendored copy of the kernel |
+| **6** | retire the verdict store (D6), in four steps: read the "which path served" evidence; port `series-check.sh` to read the deciding run; move selection to a batched status query; delete the branch and its scripts | each step reverts on its own, and the branch is deleted last — once nothing reads it, deleting it is the cheapest step rather than the risky one |
 
-Phases 1a and 2 are independently shippable; the deletions concentrate in
-Phase 2.
+Phase 1a is independently shippable.
+The deletions concentrated in Phase 2, and the larger set is Phase 6's.
+That selection moves twice — onto records in D1, onto statuses in D6 —
+is worth stating rather than glossing:
+the first move is what makes the second one small,
+because it left one store to replace instead of two to reconcile.
+Doing them in the other order would have meant
+reconciling two stores in between, which is F1 exactly.
 
 ## 10. Open questions
 
@@ -681,9 +762,13 @@ Phase 2.
    dropping them automatically) or squash into one port commit per
    firing (fewer CI verdicts, but squashing breaks the patch-id match
    and with it the automatic drop)? Leaning individual.
-2. **Record-store scale.** One commit per record keeps `rcc` growing
-   (~1 commit/record; consolidation squashes). Is the current
-   consolidation cadence enough once statuses stop being a second copy?
+2. ~~**Record-store scale.**~~ *Absorbed by D6:* a store that is going
+   away does not need a cadence. One commit per record keeps `rcc2`
+   growing, consolidation is manual, and the retention window is 180
+   days — so nothing is dropped until an operator dispatches it, and
+   the branch grows by one small commit per verdict in the meantime.
+   That is the standing cost of keeping it, and it is bounded, dull,
+   and about to be moot.
 3. ~~**Fork migration depth (§6).**~~ *Settled by the move:* `rcc2`
    came across whole, and everything else — the retired `rcc`, the
    snapshot branches, the ref litter, the finished topic branches —
@@ -695,12 +780,16 @@ Phase 2.
 5. **Review artifacts.** Should routine-generated review digests
    (like `main-dev-review.md`) land under `plan/` by convention,
    or in PR comments only?
-6. **Does the store still earn its keep?** It exists because an agent
-   firing could not read CI logs; that is no longer true where the
-   firing has Actions access, so `series-loop.md` now reads the run
-   and falls back to `rcc2`. Every firing records which path served.
-   If the fallback goes unused across a full cycle, the question is
-   what the store is still *for* — CI-side selection reads it too
-   (D1), so retiring it means replacing that read as well, and the
-   answer may be "keep it, cheaply" rather than "delete it".
-   Decide on the evidence, not on this paragraph.
+6. ~~**Does the store still earn its keep?**~~ *Settled: it does not,
+   and §3.3's D6 is the cut.* The question asked to be decided on
+   evidence: the store exists because a firing could not read CI
+   logs, which stopped being true when `series-loop.md` began reading
+   the deciding run and falling back to `rcc2` (#2549), and every
+   firing since records which path served it. What settled it is the
+   goal that evidence was serving — the infrastructure around the
+   branch is to go, and the store is most of it. So the evidence
+   becomes D6's first step rather than its gate: it says whether the
+   git-only route can be dropped now or wants a cycle of notice
+   first. The question was right that CI-side selection has to be
+   replaced too, and wrong about which read costs — selection becomes
+   a status query, while `series-check.sh`'s log read is the work.

--- a/plan/PLAN-vendoring-simplification.md
+++ b/plan/PLAN-vendoring-simplification.md
@@ -494,6 +494,23 @@ and a commit that cannot work against the series' engine
 is excluded by applying an explicit subset
 and fixed on `main` instead.
 
+*Widened since:* the identity goal covers **every ref of the series**,
+not `<S>-dev` alone.
+`<S>-build` takes no ports — its line is upstream commits and their glue —
+but it does take the sync,
+because a workflow fires from the branch it sits on:
+a ref nobody ports runs the tooling of the day it was seeded,
+and a push filter written back then decides what fires today.
+`v1.4-andium-build` was carrying a 2026-03-26 `R-CMD-check.yaml`
+whose release pattern matches the buffer's own name,
+so pushes to it started the template check
+and `R-CMD-check-status.yaml` stamped an `rcc` status
+on a commit no `each-rcc` leg had decided —
+a status with no record, on the one ref the model calls untested.
+Which also says what "untested" was resting on:
+not the ref's name, but the tooling the ref happens to carry,
+and nothing was maintaining that.
+
 **The vendor-strand exclusion, and an unresolved contradiction.**
 Vendor-strand commits are listed and never auto-picked —
 `main`'s engine is not this series' engine.

--- a/plan/PLAN-vendoring-simplification.md
+++ b/plan/PLAN-vendoring-simplification.md
@@ -383,9 +383,42 @@ in D6; everything after it is deletion.
 a reader with git and nothing else.
 After D6 a firing with no API access has nothing to fall back to,
 where today it has a stale-but-readable copy.
-That is a trade to make on evidence rather than on this paragraph,
-and #2549 already instruments it —
-every firing records which path served — so the evidence is a report away.
+That is a trade to make on evidence rather than on this paragraph.
+#2549 does instrument it — every firing records which path served —
+but into its **report**, and a report has no durable home
+(question 5, still open).
+Checked on 2026-08-09: no firing's read path is recorded anywhere in
+this repository — not in `plan/`, `plan/history/`, `experiments/`, or
+the handbook; the only occurrences of the phrase are the instruction in
+`series-loop.md` and the request in this document.
+So D6's first step is not "read the evidence", because there is none to
+read. It is the three measurements below, which are better evidence
+anyway: they ask whether the *replacement* works, not whether the
+fallback happened to be used.
+
+*The evidence step, concretely.*
+All three read durable state, all three are re-runnable,
+and all three need access to `krlmlr/duckdb-r` — the fork is where the
+`each-rcc` runs, the series refs and the store itself live, so none of
+them can be taken from this repository:
+
+1. **Has the store's gap ever been felt?** Count `workflow_dispatch`
+   runs of `rcc-logs.yaml` in the fork since #2578 (2026-08-08).
+   A dispatch is a firing saying it needed the store and found it
+   incomplete; zero across a full cycle is the answer question 6
+   wanted. In `duckdb/duckdb-r` the count is structurally zero —
+   both store workflows carry `if: github.repository ==
+   'krlmlr/duckdb-r'`, so every run here is skipped.
+2. **Would the replacement agree?** For each live series, compare
+   `scripts/rcc-decided.sh` against the `rcc` commit statuses over
+   `<S>-green..tip`. Any commit decided in one and not the other is
+   what would break D6's status read — and finding none is the go
+   signal, since it says the two stores have stayed in step with only
+   one of them being written for.
+3. **What is keeping it costing?** Commits on `rcc2`, its size, and
+   the age of the oldest surviving record — consolidation is manual
+   and the window is 180 days, so this is the standing bill for
+   deferring D6.
 
 **One wrinkle to settle before the cut.**
 The `rcc` context is not the leg's alone:
@@ -744,7 +777,7 @@ of the kernel.
 | **3 — landed (#2534)** | replace the standalone repo with a fresh fork (§6), configured with the Pull app so the release-branch mirrors stay current without a job of our own | one-time move; the replaced repository is kept as `krlmlr/duckdb-r-old` |
 | **4** | docs tree (§8): README root landed (#88); next the moves, then node rewrites (including `AGENTS.md`'s and `BRANCHES.md`'s stale rows); `docs-tree` skill | docs only |
 | **5** | kernel extraction + `rigraph` port (config file, generalized subject marker, igraph cost estimator or constant weight) | new repo consumed `@main`; rollback = vendored copy of the kernel |
-| **6** | retire the verdict store (D6), in four steps: read the "which path served" evidence; port `series-check.sh` to read the deciding run; move selection to a batched status query; delete the branch and its scripts | each step reverts on its own, and the branch is deleted last — once nothing reads it, deleting it is the cheapest step rather than the risky one |
+| **6** | retire the verdict store (D6), in four steps: take the three measurements (§3.3 — all need the fork); port `series-check.sh` to read the deciding run; move the three state readers to a batched status query; delete the branch and its scripts | each step reverts on its own, and the branch is deleted last — once nothing reads it, deleting it is the cheapest step rather than the risky one |
 
 Phase 1a is independently shippable.
 The deletions concentrated in Phase 2, and the larger set is Phase 6's.

--- a/scripts/rcc-consolidate.sh
+++ b/scripts/rcc-consolidate.sh
@@ -44,7 +44,7 @@
 #
 # Environment variables:
 #   OUT_DIR             - the `rcc2` worktree to consolidate (default: runs)
-#   RCC_RETENTION_DAYS  - keep records and logs at most this old (default: 30);
+#   RCC_RETENTION_DAYS  - keep records and logs at most this old (default: 180);
 #                         0 keeps everything, and then only the squash happens
 #   APPLY               - if non-empty, commit and force-push; otherwise report
 #                         what would change and leave the branch alone

--- a/scripts/rcc-cutover.sh
+++ b/scripts/rcc-cutover.sh
@@ -56,7 +56,7 @@
 #                         report only, never written
 #   BRANCH              - the branch to create (default: rcc2)
 #   REMOTE              - remote to push to (default: origin)
-#   RCC_RETENTION_DAYS  - keep records and logs at most this old (default: 30)
+#   RCC_RETENTION_DAYS  - keep records and logs at most this old (default: 180)
 #   APPLY               - if non-empty, commit and push; otherwise report what
 #                         would happen and leave everything alone
 #   FORCE               - if non-empty, push even when BRANCH already exists on

--- a/scripts/rcc-lib.sh
+++ b/scripts/rcc-lib.sh
@@ -27,7 +27,7 @@
 #
 # ## Retention
 #
-# The store keeps `RCC_RETENTION_DAYS` (default 30) of history, records and logs
+# The store keeps `RCC_RETENTION_DAYS` (default 180) of history, records and logs
 # alike, and `rcc-consolidate.sh` enforces it. That is one window rather than
 # two, and it is load-bearing in both directions: a producer must not look
 # further back than the window, or it re-derives every tick what consolidation

--- a/scripts/series-advance.sh
+++ b/scripts/series-advance.sh
@@ -347,7 +347,7 @@ if git rev-parse -q --verify "$remote/$S-fwd-build" >/dev/null &&
   exit 0
 fi
 # Pending work does not hold the buffer (.claude/skills/series-loop.md stage 5):
-# each.yaml plans every commit in green..tip that has no status, so a longer tip
+# each.yaml plans every commit in green..tip that has no record, so a longer tip
 # is more work planned in the same pass, not work deferred. A known failure does
 # hold it: stage 2 will fold a fix into that commit and replay everything above,
 # so anything appended now is minted only to be re-minted. The stage-3 walk above

--- a/scripts/series-port.sh
+++ b/scripts/series-port.sh
@@ -6,6 +6,25 @@
 # paths — .github/, scripts/, .claude/ — of <S>-dev are byte-identical to
 # `main`'s, and a tooling change never waits for a forward.
 #
+# **<S>-build owes the same identity, and is synced here too.** A workflow
+# fires from the branch it sits on, so a ref nobody ports runs the tooling of
+# the day it was seeded, and a push filter written back then decides what fires
+# today. The buffer takes no *ports* — its line is upstream commits and the glue
+# they need — but its tooling is brought level, by one commit appended when it
+# differs. Measured rather than feared: `v1.4-andium-build` still carried a
+# 2026-03-26 R-CMD-check.yaml whose release pattern matches the buffer's own
+# name, so pushes to it started the template check and R-CMD-check-status.yaml
+# stamped an `rcc` status on a commit no per-commit leg had decided — a status
+# with no record, which is exactly what breaks a reader trusting one against
+# the other.
+#
+# To every reader of the vendor strand the sync commit is invisible: it vendors
+# nothing, so the consumption anchor and the vendored-SHA scans look past it by
+# subject. Stage 5 replays it onto -dev like any other buffer commit, where
+# `cherry-pick --empty=drop` retires it because -dev already carries that
+# tooling. Where `main` moved between the two syncs it conflicts instead, and
+# the resolution is main's tooling — which is what both refs converge on.
+#
 # The script lists EVERY commit on `main` since the series' base that has no
 # patch-id equivalent on <S>-dev (`git cherry`), oldest first, classified by
 # what it touches: TOOLING (only tooling paths), MIXED (tooling and more),
@@ -229,6 +248,18 @@ else
   echo "tooling: differs from main —$(git diff --shortstat "$dev" "$main" -- "${tooling[@]}")"
 fi
 
+# The buffer's own answer to the same question. Reported even when it is
+# identical, because "nothing to say about -build" and "-build has no tooling
+# delta" are different sentences and only one of them is reassuring.
+buildref="$remote/$S-build"
+if ! git rev-parse -q --verify "$buildref" > /dev/null; then
+  echo "buffer tooling: no $S-build on $remote"
+elif git diff --quiet "$buildref" "$main" -- "${tooling[@]}"; then
+  echo "buffer tooling: identical to main"
+else
+  echo "buffer tooling: differs from main —$(git diff --shortstat "$buildref" "$main" -- "${tooling[@]}")"
+fi
+
 [ -n "$apply" ] || exit 0
 
 # A pick can still meet DESCRIPTION's `Version:` -- a named VERSION commit, a
@@ -284,7 +315,34 @@ next=$(git -C "$wt" rev-parse HEAD)
 git worktree remove --force "$wt"
 if [ "$next" = "$(git rev-parse "$dev")" ]; then
   echo "nothing to port"
+else
+  git push "$remote" "$next:refs/heads/$S-dev"
+  echo "dev -> $(git rev-parse --short "$next")"
+fi
+
+# The buffer, brought level the same way and for the same reason (see the
+# header). An append, never a rewrite: `-build`'s force-push is reserved for
+# mirroring a fold, and nothing here touches an upstream commit.
+#
+# A series with no buffer -- one pending cutover -- has nothing to sync, and
+# that is an ordinary state rather than an error.
+git rev-parse -q --verify "$buildref" > /dev/null || exit 0
+if git diff --quiet "$buildref" "$main" -- "${tooling[@]}"; then
   exit 0
 fi
-git push "$remote" "$next:refs/heads/$S-dev"
-echo "dev -> $(git rev-parse --short "$next")"
+
+bwt=$(mktemp -d)
+git worktree add --detach -q "$bwt" "$buildref"
+git -C "$bwt" rm -qr --ignore-unmatch -- "${tooling[@]}"
+git -C "$bwt" checkout "$main" -- "${tooling[@]}"
+git -C "$bwt" commit -q -m "chore(series): Sync buffer tooling with main" \
+  -m "Takes main's ${tooling[*]} verbatim onto the buffer, so a workflow firing
+from this ref is main's rather than the seed's. Vendors nothing, so stage 5
+replays it onto -dev and drops it as empty."
+git -C "$bwt" diff --quiet "$main" -- "${tooling[@]}" ||
+  { echo "Error: buffer tooling still differs after sync; worktree kept at $bwt"; exit 1; }
+
+bnext=$(git -C "$bwt" rev-parse HEAD)
+git worktree remove --force "$bwt"
+git push "$remote" "$bnext:refs/heads/$S-build"
+echo "build -> $(git rev-parse --short "$bnext")"


### PR DESCRIPTION
What is true about `rcc2` today, where it is going, and one rule that had to widen along the way.

## Why the branch looked retired

The pushes come from the `each-rcc` legs — `scripts/each-shard.sh` calls `scripts/rcc-publish.sh` once per commit decided, ~2/min at `max-parallel: 20`. That write is load-bearing: `scripts/rcc-decided.sh` reads the branch, and it is what `each-plan.sh` selects from and what a resuming `each-shard.sh` skips on. Without it every run replans all of `<S>-green..tip`.

What was retired is easy to mistake for the branch itself: the predecessor `rcc` (#2505); the per-run fan-in and the half-hourly sweep (#2578); and the *read*, for a firing only, which now goes to the deciding run first (#2549). So "emergency route" is true of what a firing reads and false of the branch — and three documents said the first and let a reader conclude the second.

Corrected, without behaviour change:

- `.claude/skills/series-loop.md` scopes "emergency route" to the firing in both places, and names CI-side selection as the reader that keeps the branch live.
- `handbook/operations/ci/per-commit/store/README.md` scopes "none of it is load-bearing" to the leg that pays for the push, and says where a lost publish *is* felt — the next run rebuilds the commit.
- `handbook/meta/glossary/README.md` names what the store is for, so the entry no longer reads as a historical note beside "its predecessor `rcc` is retired".
- The workflow map had `rcc-logs.yaml` on a half-hourly cron, wrong since #2578.
- `RCC_RETENTION_DAYS` is 180 in `rcc-lib.sh` and in `rcc-consolidate.yaml`'s input, but three script headers, two leaves and the skill still said 30. **This is the one place I picked a side** — 180 is what the code and the workflow say and NEWS records the increase, so I treated 30 as stale. If the intent was the other way round, the fix belongs in `rcc-lib.sh` instead.

Also on the workflow map, from checking every row against its file: drop `HighPriorityIssues.yml`, which no longer exists, and add `revdep2.yaml`, which does. Note `revdep2` still has no handbook leaf.

## Where it is going

`plan/PLAN-vendoring-simplification.md` settles its question 6 — the store does not earn its keep — and records the cut as **D6**, with a Phase 6 that deletes the branch last.

D6 is not D1 reversed, and the plan says so: D1's defect was two stores reconciled against each other, not the store it picked. It picked records because the reader that mattered had git and no API, and #2549 removed that constraint. So the survivor can be the commit status the leg already writes — which is what selection read *before* D1, by GraphQL in `each-plan.sh` and REST in `each-shard.sh`. The read comes back out of this repository's history rather than being invented.

The plan names all four readers, because three are cheap and one is not: `each-plan.sh` and `each-shard.sh`'s resume check want a state; so does `series-advance.sh`'s `state_of()`, which reads a record directly rather than through `rcc-decided.sh`; and `series-check.sh` wants a *log*, which no status carries — porting it onto the deciding run is the one piece of real work.

The evidence question 6 asked for turned out not to exist. #2549 instruments it, but into a firing's **report**, and a report has no durable home (question 5, still open). Checked 2026-08-09: no firing's read path is recorded anywhere in this repository. So D6's first step becomes three measurements of durable state — dispatch count since #2578, status-vs-record agreement, and what the branch costs to keep. All three need the fork; #2630 takes them.

## The rule that had to widen

#2630's measurement turned up the class D6 most needs absent, present in the fork today: `v1.4-andium-build` still carries a 2026-03-26 `R-CMD-check.yaml` whose release pattern matches the buffer's own name, so pushes to it started the template check and `R-CMD-check-status.yaml` stamped an `rcc` status on a commit no `each-rcc` leg had decided — a status with no record, on the one ref the branch model calls untested.

That is a gap in stage 4, not a one-off. Its identity goal covered `<S>-dev` alone, so `<S>-build` ran whatever tooling it was seeded with — and a workflow fires from the branch it sits on, so the push filter written on seeding day decides what fires today. "Untested" was resting on the ref's name rather than on anything maintaining it.

So the rule widens to every ref of the series. The buffer takes no ports; it takes the sync, appended as one commit when its tooling differs from `main`'s. An append, never a rewrite — `-build`'s force-push stays reserved for mirroring a fold.

Verified in a scratch series rather than asserted:

- the buffer's tooling comes out byte-identical to `main`'s, and a stale workflow `main` no longer has is deleted rather than left behind (the `git rm` before the checkout is what does that);
- the flavored `.github/README.md` survives, as its exclude pathspec intends;
- the sync commit carries no vendor subject, so the consumption anchor still finds the vendor commit beneath it;
- stage 5 replays it onto a ported `-dev` and `--empty=drop` retires it;
- where `main` moved between the two syncs it conflicts on the moved file instead, which is why the header says to resolve toward `main`.

The first real `--apply` still wants supervising, as Phase 1's own row says.

D6's "give the verdict its own `each-rcc` context" wrinkle is #2630's edit, not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DG5RV5fivf1Kd8WwpgATfk
