### PR TITLE
fix(scripts): Let `BASE_SCAN_DEPTH` raise the base scan in all four scanners

### DIFF
--- a/scripts/series-advance.sh
+++ b/scripts/series-advance.sh
@@ -100,6 +100,12 @@ state_of() {
   echo "$rec" | sed -nr 's/.*"status":[^}]*"state": *"([a-z]+)".*/\1/p' | head -n 1
 }
 
+# How deep the base scan looks, and the one knob that raises it. The same
+# default, and the same variable, as scripts/vendor.sh and scripts/vendor-one.sh
+# read: a branch deep enough to need the bound raised needs it raised for every
+# script that scans, so one export unblocks the run rather than half of it.
+base_scan_depth="${BASE_SCAN_DEPTH:-20}"
+
 # The upstream SHA a ref has vendored. The pathspec narrows the walk, the
 # subject decides: commits that touch src/duckdb without vendoring are ordinary
 # (the patch stack is applied to the vendored tree in place), so look past them
@@ -110,13 +116,13 @@ state_of() {
 # and the reason is on stderr for a human to act on.
 vendored_sha() {
   local subjects sha n
-  subjects=$(git log -n 20 --format=%s "$1" -- src/duckdb || true)
+  subjects=$(git log -n "$base_scan_depth" --format=%s "$1" -- src/duckdb || true)
   sha=$(sed -nr 's/^.*duckdb.duckdb@([0-9a-f]+)( .*)?$/\1/p' <<<"$subjects" | head -n 1)
   if [ -z "$sha" ]; then
     n=$(grep -c . <<<"$subjects" || true)
-    if [ "$n" -ge 20 ]; then
-      echo "vendored_sha: 20 src/duckdb commits on $1, none of them vendoring;" >&2
-      echo "  if that is genuine, raise the bound in this helper" >&2
+    if [ "$n" -ge "$base_scan_depth" ]; then
+      echo "vendored_sha: $base_scan_depth src/duckdb commits on $1, none of them vendoring;" >&2
+      echo "  if that is genuine, raise BASE_SCAN_DEPTH" >&2
     else
       echo "vendored_sha: no vendor commit among $n src/duckdb commits on $1" >&2
     fi

--- a/scripts/series-check.sh
+++ b/scripts/series-check.sh
@@ -64,17 +64,21 @@ git fetch -q "$remote"
 
 rcc_tip() { git rev-parse -q --verify "refs/remotes/$remote/$rcc" 2>/dev/null; }
 
+# How deep the base scan looks; see scripts/series-advance.sh for why the four
+# scanning scripts share the variable and the default.
+base_scan_depth="${BASE_SCAN_DEPTH:-20}"
+
 # See scripts/series-advance.sh: the pathspec narrows the walk, the subject
 # decides, and an empty answer explains itself on stderr.
 vendored_sha() {
   local subjects sha n
-  subjects=$(git log -n 20 --format=%s "$1" -- src/duckdb || true)
+  subjects=$(git log -n "$base_scan_depth" --format=%s "$1" -- src/duckdb || true)
   sha=$(sed -nr 's/^.*duckdb.duckdb@([0-9a-f]+)( .*)?$/\1/p' <<<"$subjects" | head -n 1)
   if [ -z "$sha" ]; then
     n=$(grep -c . <<<"$subjects" || true)
-    if [ "$n" -ge 20 ]; then
-      echo "vendored_sha: 20 src/duckdb commits on $1, none of them vendoring;" >&2
-      echo "  if that is genuine, raise the bound in this helper" >&2
+    if [ "$n" -ge "$base_scan_depth" ]; then
+      echo "vendored_sha: $base_scan_depth src/duckdb commits on $1, none of them vendoring;" >&2
+      echo "  if that is genuine, raise BASE_SCAN_DEPTH" >&2
     else
       echo "vendored_sha: no vendor commit among $n src/duckdb commits on $1" >&2
     fi


### PR DESCRIPTION
Closes #2512.

The base scan — how far back a script looks for the last vendoring commit under `src/duckdb/` — is bounded at twenty commits in four scripts. `vendor.sh` and `vendor-one.sh` read `BASE_SCAN_DEPTH`; `series-advance.sh` and `series-check.sh` hard-coded `20` in both the `git log -n` and the `[ "$n" -ge 20 ]` that decides how the refusal reads.

A branch that stacks more than twenty non-vendoring commits under `src/duckdb/` therefore needed the bound raised twice: once by exporting the variable, and once by editing the two series scripts — which is the situation the variable exists to avoid. `scripts/vendor-one.sh` even carries the comment "Matches the bound in `vendored_sha()` (`scripts/series-advance.sh`)" directly above the line reading the variable that script did not read.

Both series scripts now derive the bound from `BASE_SCAN_DEPTH` with the same default of `20`, and their refusal names the variable instead of telling the operator to raise a literal in the helper. The sentence in `scripts/VENDORING.md` — "Twenty commits, the same bound `vendored_sha()` uses in `series-advance.sh`; `BASE_SCAN_DEPTH` raises it." — is true as written for the first time, so it needs no edit.

`scripts/series-advance-test.sh` passes unchanged (47 passed, 0 failed), which exercises `vendored_sha()` against the synthetic remote it builds.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULagARsxeoJfMKRx7WwZ3U)_