### PR TITLE
fix(vendoring): Say when the glue check could not run, instead of blaming the glue

### DIFF
--- a/handbook/operations/vendoring/troubleshooting/README.md
+++ b/handbook/operations/vendoring/troubleshooting/README.md
@@ -34,6 +34,14 @@ The failure classes, and what each needs:
 * **The glue gate stops `vendor-one.sh`** —
   the fresh headers broke the glue;
   fix the glue and fold it into that vendor commit.
+  The gate names the files it could not compile,
+  and only that banner (`GLUE BROKEN`, exit 3) implicates the commit at HEAD.
+* **The glue gate could not run** (`GLUE CHECK COULD NOT RUN`, exit 6) —
+  the compile flags come from `R CMD SHLIB -n`,
+  which needs the `src/Makevars.rstrtmgr` only `./configure` writes,
+  so this says `./configure` failed and nothing was compiled.
+  It is a local setup problem: run `./configure` and read its output.
+  The vendor commit is not implicated, and amending it fixes nothing.
 * **A patch stopped applying** — if it reverses cleanly the run
   retires it and continues; if it neither applies nor reverses the run
   stops, and the patch needs a hand rebase against the regenerated tree

--- a/scripts/vendor-one.sh
+++ b/scripts/vendor-one.sh
@@ -109,11 +109,20 @@ glue_compile_flags() {
     sed -E 's/^ *(ccache )?g\+\+ //; s/ -c cpp11\.cpp -o cpp11\.o *$//'
 }
 
+# The glue files that failed to compile, one per line. Written only by the run
+# that got as far as compiling, and read only after that run reported 1 -- so
+# the list a banner prints is always the list this check produced, never one an
+# earlier run in the same container left behind.
+glue_failures=/tmp/vendor-one-glue-failures.txt
+
+# 0 the glue compiles, 1 some file does not, 2 the check could not run. The
+# three are distinct because the caller acts differently on each: only 1 says
+# anything about the commit at HEAD.
 glue_compiles() {
   local flags
   flags=$(glue_compile_flags)
   if [ -z "$flags" ]; then
-    echo "Error: could not derive glue compile flags (R CMD SHLIB -n)"
+    echo "Error: could not derive glue compile flags (R CMD SHLIB -n)" >&2
     return 2
   fi
   # `eval` because R quotes its include path (-I"/usr/share/R/include"); plain
@@ -121,7 +130,7 @@ glue_compiles() {
   # and every glue file looks broken.
   (cd src && ls *.cpp | FLAGS="$flags" xargs -P 4 -I{} \
     sh -c 'eval "g++ $FLAGS -fsyntax-only \"\$1\"" 2>/dev/null || echo "$1"' sh {}) | sort |
-    tee /tmp/vendor-one-glue-failures.txt |
+    tee "$glue_failures" |
     { ! grep -q .; }
 }
 
@@ -318,14 +327,32 @@ while [ $commits_vendored -lt $num_commits ]; do
 
   echo "Successfully vendored commit $commits_vendored"
 
-  if [ "$check_glue" = true ] && ! glue_compiles; then
-    echo ""
-    echo "=== GLUE BROKEN by $(git rev-parse --short HEAD) (upstream ${commit}) ==="
-    echo "Files: $(tr '\n' ' ' < /tmp/vendor-one-glue-failures.txt)"
-    echo "The breaking vendor commit is at HEAD and the upstream clone is kept."
-    echo "Fix the glue, run clang-format, amend into HEAD appending an"
-    echo "'R-side fix' section to the message, then rerun this script."
-    exit 3
+  if [ "$check_glue" = true ]; then
+    # Not `! glue_compiles`, which would collapse "the check could not run" into
+    # "the glue is broken" and send the operator to fix code that compiles.
+    glue_status=0
+    glue_compiles || glue_status=$?
+    if [ "$glue_status" = 2 ]; then
+      echo ""
+      echo "=== GLUE CHECK COULD NOT RUN at $(git rev-parse --short HEAD) (upstream ${commit}) ==="
+      echo "Deriving the compile flags needs src/Makevars.rstrtmgr, which only"
+      echo "./configure writes; reaching this means ./configure failed. Nothing"
+      echo "was compiled, so this says nothing about the glue or about the commit"
+      echo "at HEAD -- do not amend it."
+      echo "Run ./configure and read its output, then rerun this script;"
+      echo "--no-check-glue skips the check altogether."
+      # Its own code, below the ones already spoken for: 3 is broken glue, 4 a
+      # broken patch, 5 the wrong upstream line.
+      exit 6
+    elif [ "$glue_status" != 0 ]; then
+      echo ""
+      echo "=== GLUE BROKEN by $(git rev-parse --short HEAD) (upstream ${commit}) ==="
+      echo "Files: $(tr '\n' ' ' < "$glue_failures")"
+      echo "The breaking vendor commit is at HEAD and the upstream clone is kept."
+      echo "Fix the glue, run clang-format, amend into HEAD appending an"
+      echo "'R-side fix' section to the message, then rerun this script."
+      exit 3
+    fi
   fi
 
   if [ -n "${is_tag}" ]; then


### PR DESCRIPTION
Closes #2513.

`glue_compiles()` in `scripts/vendor-one.sh` already distinguishes three outcomes — `0` the glue compiles, `1` some file does not, `2` the compile flags could not be derived at all — but the caller tested it with `if ... ! glue_compiles`, which collapses every non-zero status into one branch. A `./configure` that failed therefore printed

```
=== GLUE BROKEN by abc1234 (upstream def5678) ===
Files:
```

with an empty file list (or, worse, one a previous run in the same container left in `/tmp`), and told the operator to fix code that compiles fine and amend a vendor commit that is correct.

The caller now branches on the status:

- **`2` → `GLUE CHECK COULD NOT RUN`, exit 6.** Deriving the flags needs `src/Makevars.rstrtmgr`, which only `./configure` writes and which the check runs `./configure` for when it is missing — so status 2 means `./configure` failed. Nothing was compiled, so the banner says explicitly that this implicates neither the glue nor the commit at HEAD, points at `./configure`, and mentions `--no-check-glue`. No file list is printed, because the run produced none. The code is 6 because 3, 4 and 5 are already spoken for (broken glue, broken patch, wrong upstream line).
- **`1` → `GLUE BROKEN`, exit 3**, unchanged, now reached only with a non-empty failure list.

The failure-list path moves behind a `glue_failures` variable and is read only on the branch that wrote it, and the "could not derive" message goes to stderr with the rest of the diagnostics.

`handbook/operations/vendoring/troubleshooting/README.md` gains the new failure class next to the existing glue one, and says which banner implicates the commit at HEAD.

Checked with `bash -n`, and the handbook link-integrity sweep from the `docs-consistency` skill passes.