### PR TITLE
docs(plan): Measure D6's three questions, and fold the numbers in

### DIFF
--- a/.claude/skills/series-loop.md
+++ b/.claude/skills/series-loop.md
@@ -139,7 +139,7 @@ list the most recent `each-rcc` runs.
 If that answers, the firing is on the run path for every stage below.
 If it does not — no such access from this session at all —
 the firing falls back to the `rcc2` store,
-which still works, inside its 30-day window,
+which still works, inside its 180-day window,
 but is now an **emergency route** rather than a warm copy:
 `rcc-logs.yaml` is dispatch-only,
 so a firing that needs the store complete has to ask for it
@@ -312,9 +312,15 @@ or the run is there and its results are not
 (a leg that died before it uploaded anything).
 Nothing else in this stage changes; the bytes are the same either way.
 
-**The store is an emergency route, and it is not kept warm.**
+**The store is an emergency route *for a firing*, and it is not kept warm.**
 One writer is still automatic, and it covers almost all of it:
 a leg publishes its own verdict seconds after deciding a commit.
+That publish is not a copy kept for this stage's benefit:
+CI plans and resumes from the store and from nothing else
+(`scripts/rcc-decided.sh`),
+so the branch is load-bearing even in a cycle where no firing opens it,
+and a steady trickle of pushes to `rcc2` is the system working
+rather than a retired branch still ticking.
 Everything else has been retired in the loop's direction of travel —
 the per-run fan-in, which reconciled onto the branch
 whatever a leg could not publish,
@@ -1263,7 +1269,10 @@ is what carries the automatic path into a forward series.
   for a firing that cannot read the runs.
   Neither source may be *required*: a firing that has only one of them
   still finishes, and says in its report which one it had.
-  The fallback is an emergency route and is not kept warm:
+  The fallback is an emergency route *for the firing*, and is not kept warm:
   `rcc-logs.yaml` is dispatched, never scheduled,
   so a firing that needs the copy complete asks for it
   and reads the answer on a later pass — it never blocks on one.
+  On the CI side the store is nobody's fallback:
+  selection reads it and only it,
+  which is why the leg's per-commit publish stays automatic.

--- a/experiments/2026-08-rcc2-read-path/README.md
+++ b/experiments/2026-08-rcc2-read-path/README.md
@@ -1,0 +1,215 @@
+# Whether the verdict store can be retired
+
+*What it measures:* the three things D6 asks for before the `rcc2` store is cut —
+whether the gap it alone covers has ever been felt,
+whether the commit status D6 would read instead agrees with the record it would replace,
+and what keeping the branch costs in the meantime.
+Plus the one thing D6 says to settle with the cut rather than after it:
+whether anything but the `each-rcc` leg writes the `rcc` context.
+
+*When and on what:* 2026-08-09 17:11 UTC, against `krlmlr/duckdb-r`,
+with `rcc2` at cf4802b and the six live series at the refs the run prints.
+`duckdb/duckdb-r` cannot answer any of it:
+both store workflows carry `if: github.repository == 'krlmlr/duckdb-r'`,
+so every run of them there is skipped,
+and the series refs, the `each-rcc` runs and the store live in the fork besides.
+
+*What it supports:* D6 and question 6 of
+[`plan/PLAN-vendoring-simplification.md`](/plan/PLAN-vendoring-simplification.md).
+The store's own page,
+[`operations/ci/per-commit/store/`](/handbook/operations/ci/per-commit/store/README.md),
+describes the branch this weighs but does not lean on these numbers.
+
+Run [`run.sh`](run.sh); it fetches refs and reads the API, and writes nothing.
+The full output of the run described here is
+[`measured-2026-08-09.txt`](measured-2026-08-09.txt).
+
+The counts move between runs, and that is not noise:
+a run was deciding commits while this one was measuring,
+so in-flight totals and `pending` counts differ
+between two passes minutes apart.
+Nothing below turns on those figures to the unit.
+
+## 1. The gap has never been felt — over one day
+
+A `workflow_dispatch` of `rcc-logs.yaml` is a firing saying it needed the store
+and found it incomplete. There have been two, ever, both by `krlmlr`:
+
+```
+  total: 2   since 2026-08-08: 1
+  2026-08-08T09:58:23Z  run 31251750340  by krlmlr  success
+  2026-08-07T13:05:27Z  run 31181036396  by krlmlr  success
+```
+
+Neither is a firing that needed the store.
+Both predate #2578, which merged at 2026-08-08T14:46:49Z,
+and the later one is the verification dispatch that PR's own body names —
+run 31251750340, dispatched *before* changing anything
+to confirm the route the skill was about to depend on.
+So the count since the schedule stopped is **zero**,
+and the schedule itself stopped exactly when it should have:
+of 118 runs, 76 are `schedule` and none since #2578,
+22 are `push` (the workflow exercising itself on a change to its own paths),
+and 2 are the dispatches above.
+
+**The number is right and the window is not.**
+Zero dispatches is what question 6 wanted,
+but it has only been possible to dispatch-and-not for **1.1 days**.
+Question 6 asked for a full cycle, and this is not one.
+This measurement is the one that will change by being re-run,
+which is the argument for re-running it rather than for reading it harder.
+
+## 2. The replacement agrees, everywhere it was asked
+
+Two answers per commit in `<S>-green..<S>-dev`, over all six live series:
+a record via [`scripts/rcc-decided.sh`](/scripts/rcc-decided.sh),
+which is what selection reads today,
+and an `rcc` commit status of `success` or `failure`,
+which is what D6 would read instead.
+`pending` and absent are undecided on both sides.
+
+```
+  main: 0 in flight
+  main-fwd: 409 in flight
+  v1.4-andium: 0 in flight
+  v1.4-andium-fwd: 1 in flight
+  v1.5-variegata: 0 in flight
+  v1.5-variegata-fwd: 10 in flight
+  total: 420 commits
+  status side:     372 none      23 pending      25 success
+  decided by status: 25   by record: 25
+  disagreements:
+    (no lines above means the two answers agree on every commit in flight)
+```
+
+No status without a record, no record without a status,
+and — checked beyond what D6 needs — no commit where the two name a different state.
+
+**On its own this is a thin sample.**
+The range is bounded by `-green`, so 395 of the 420 are simply not built yet;
+25 decided commits is not a go signal.
+So the run asks the same question of the sample the range cannot give:
+the store's 250 newest records, every one of them decided by construction,
+each a chance for a record to exist where a status does not.
+
+```
+  agree: 250   disagree: 0   (of 250)
+```
+
+That is the direction that would break D6 — a record the status read cannot see —
+and it does not happen in 250 consecutive verdicts.
+
+The batched GraphQL query D6 would actually make is in the script,
+recovered from `each-plan.sh`'s pre-D1 form (#2440),
+and it did not run here: the token this session holds serves only a pinned set
+of GraphQL operations. The REST answer above is the same question by a route
+every token serves, at one request per commit instead of one per hundred —
+which is why the pre-D1 planner batched, and why D6's read should too.
+Re-running with an ordinary token exercises the batched path and cross-checks it.
+
+## 3. Keeping it costs 223 MB and about 400 commits a day
+
+```
+  commits: 1563
+  records: 8453
+  logs:    4242
+  total      21447 objects    2651.3 MB  (223.0 MB packed)
+  oldest record: 2026-04-11T11:43:01Z
+  retention window: RCC_RETENTION_DAYS=180 days
+  runs of rcc-consolidate.yaml (nothing is pruned without one):
+    total: 0
+```
+
+`rcc-consolidate.yaml` has **never run** — not once, by anyone, dry or otherwise.
+So nothing has been pruned since the cutover minted the branch on 2026-08-05,
+and the 1562 commits above the root are 4.0 days of verdicts: about 389 a day.
+
+Two things follow that the retention window alone would not tell you.
+
+**A consolidation dispatched today would drop nothing.**
+The oldest surviving record is 120 days old against a 180-day window.
+Retention is not what is deferred; the squash is.
+The whole of what consolidation would buy right now is
+1563 commits collapsing to 2.
+
+**The bill is the copy, not the verdicts.**
+Records are ~2 KB and there are 8453 of them;
+the 223 MB is the 4242 harvested logs,
+which is what the branch exists to make readable without an API.
+
+## What this decides
+
+**Proceed after a cycle of notice**, and start the work that does not depend on it.
+
+Measurement 2 is D6's go/no-go and it says go: the status read agrees with the
+record read on every commit either was asked about, states included, and the
+`rcc` context on every one of those commits was written by the leg.
+Measurement 3 says the standing bill is real, dull and bounded — the reason to
+stop deferring, not a reason to rush.
+Measurement 1 is the only one not yet supporting *now*: the count is zero, but
+one day is not the cycle question 6 asked for, and it is the cheapest of the
+three to re-run.
+
+So: keep the branch and the leg's publish for one full series cycle, re-run this,
+and cut when the dispatch count is still zero. Nothing waits on that —
+porting `series-check.sh` off `git show` is the one piece of real work in D6, it
+is needed under every outcome, and it can land first.
+
+## The wrinkle is not hypothetical
+
+D6 says the `rcc` context is not the leg's alone, and to decide with the cut
+whether the per-commit verdict gets its own. The fork already contains the
+answer.
+
+`R-CMD-check.yaml` runs from the branch it checks, so every series ref carries
+its own copy of the push filter. Today all six `-dev` branches carry `main`'s:
+
+```
+    v1.5-variegata-dev: [main master release next cran-*]
+```
+
+None of those patterns matches a series ref, so the plan's claim holds — nothing
+but the leg writes `rcc` on a `*-dev` branch. That is verified twice over here:
+statically, in the filter on every live series' `-dev`, and empirically, in all
+73 `rcc` status posts across the 420 commits in flight and every post across the
+250 widened commits, each of them `each-rcc / shard N`.
+
+But the claim is a ported commit deep, and it is **already false one ref over**:
+
+```
+    v1.4-andium-build: [main master release next cran-* v*.*-*]
+      FIRES ON ITSELF via 'v*.*-*' -- a second writer of the rcc context
+    on a series ref: 2026-08-06T09:23:58Z  v1.4-andium-build  push  head=6e7dd75ce  failure
+    6e7dd75ce2fe15d3e707814edf0d3db5d26ed4c0
+      rcc statuses: 11, newest failure (rcc)
+      record on rcc2: NO
+      in a <S>-green..<S>-dev range now: no
+```
+
+`v1.4-andium-build`'s copy of the workflow is from 2026-03-26 and still carries
+the `v*.*-*` release-branch pattern, which matches its own name. Four pushes on
+2026-08-06 therefore started the template check on the buffer, and
+`R-CMD-check-status.yaml` stamped `rcc=failure` on `6e7dd75ce` — a
+**status without a record**, exactly the class D6's read would misread, sitting
+in this fork today.
+
+It is harmless for one reason only, and the run checks it rather than assuming
+it: a buffer commit is re-minted when it is consumed onto `-dev`, so its SHA
+never enters selection's range.
+
+```
+    SHAs shared between (<S>-build-base..<S>-build) and (<S>-green..<S>-dev):
+      main: 0 … v1.5-variegata-fwd: 0
+```
+
+That is a property of buffer/dev lineage, not of the context. The `-dev` copies
+are clean because the port stage keeps them level with `main`; the buffer is
+dirty because ports never touch it (F4's stated blind spot). A `-dev` branch
+regaining the glob — a series opened from an old buffer, a forward that replays
+onto a stale seed — puts a whole-branch matrix verdict directly into selection's
+range, where D6 would read it as the commit's own.
+
+So the answer to D6's wrinkle is not "decide it with the cut": give the
+per-commit verdict its own context **before** the status read goes in. It costs
+one line in `each-shard.sh`, and the alternative has already produced the failure
+once.

--- a/experiments/2026-08-rcc2-read-path/measured-2026-08-09.txt
+++ b/experiments/2026-08-rcc2-read-path/measured-2026-08-09.txt
@@ -1,0 +1,91 @@
+measured at: 2026-08-09T17:11:14Z
+repository:  krlmlr/duckdb-r
+remote:      origin -> https://github.com/krlmlr/duckdb-r
+
+=== 1. dispatches of rcc-logs.yaml (the gap being felt) ===
+runs of any event: 118
+  push: 22
+  schedule: 76
+  workflow_dispatch: 2
+every workflow_dispatch run, oldest last:
+  total: 2   since 2026-08-08: 1
+  2026-08-08T09:58:23Z  run 31251750340  by krlmlr  success
+  2026-08-07T13:05:27Z  run 31181036396  by krlmlr  success
+
+=== 2. record vs status over every live series' <S>-green..<S>-dev ===
+  main: 0 in flight
+  main-fwd: 409 in flight
+  v1.4-andium: 0 in flight
+  v1.4-andium-fwd: 1 in flight
+  v1.5-variegata: 0 in flight
+  v1.5-variegata-fwd: 10 in flight
+  total: 420 commits
+  records in the store: 8453
+  status side:     372 none      23 pending      25 success 
+  decided by status: 25   by record: 25
+  disagreements:
+    (no lines above means the two answers agree on every commit in flight)
+  cross-check by the batched GraphQL query D6 would use:
+    unavailable: This GraphQL query is not enabled for this session — only the pinned set of PR-review operations is served. Use REST via `gh api repos/{owner}/{repo}/...` ins
+
+=== 2b. who writes the rcc context on these commits ===
+       73 rcc|github-actions[bot]|each-rcc / shard N
+
+  R-CMD-check.yaml runs from the branch it checks, so each series ref
+  carries its own push filter. A filter matching the branch's own name is
+  the template check firing there, and R-CMD-check-status.yaml writing rcc:
+    main-dev: [main master release next cran-*]
+    main-build: [main master release next cran-*]
+    main-fwd-dev: [main master release next cran-*]
+    main-fwd-build: [main master release next cran-*]
+    v1.4-andium-dev: [main master release next cran-*]
+    v1.4-andium-build: [main master release next cran-* v*.*-*]
+      FIRES ON ITSELF via 'v*.*-*' -- a second writer of the rcc context
+    v1.4-andium-fwd-dev: [main master release next cran-*]
+    v1.4-andium-fwd-build: [main master release next cran-* v*.*-* !*-dev !*-build !*-green !*-base]
+    v1.5-variegata-dev: [main master release next cran-*]
+    v1.5-variegata-build: [main master release next cran-*]
+    v1.5-variegata-fwd-dev: [main master release next cran-*]
+    v1.5-variegata-fwd-build: [main master release next cran-*]
+
+  and what the template check has actually written in this fork:
+    runs of the `rcc` workflow: 29
+    on a series ref: 2026-08-06T16:49:08Z  v1.4-andium-build-base  push  head=6e7dd75ce  failure
+    on a series ref: 2026-08-06T15:18:29Z  v1.4-andium-build-base  push  head=6e7dd75ce  failure
+    on a series ref: 2026-08-06T09:24:01Z  v1.4-andium-build-base  push  head=6e7dd75ce  failure
+    on a series ref: 2026-08-06T09:23:58Z  v1.4-andium-build  push  head=6e7dd75ce  failure
+    6e7dd75ce2fe15d3e707814edf0d3db5d26ed4c0
+      rcc statuses: 11, newest failure (rcc)
+      record on rcc2: NO
+      in a <S>-green..<S>-dev range now: no
+    SHAs shared between (<S>-build-base..<S>-build) and (<S>-green..<S>-dev):
+      main: 0
+      main-fwd: 0
+      v1.4-andium: 0
+      v1.4-andium-fwd: 0
+      v1.5-variegata: 0
+      v1.5-variegata-fwd: 0
+
+=== 2c. widening: the store's 250 newest records, each against its status ===
+  agree: 250   disagree: 0   (of 250)
+  writers seen here:
+    r-universe/krlmlr/duckdb.1.5.dev/deploy|r-universe[bot]|Deploy binaries to R-universe package server
+    rcc|github-actions[bot]|each-rcc / shard N
+
+=== 3. what the store costs to keep ===
+  tip:     cf4802b3564c485e13694018d66f3ba330a9c709  2026-08-09 16:07:31 +0000  each-rcc: b7a89ef50 (run 31312285769)
+  commits: 1563
+  root:    66a4230a01d807fa7fc713c8fb4f8b0cf193da7f  2026-08-05 17:44:51 +0200  Initial
+  records: 8453
+  logs:    4242
+  tree        7184 objects      23.4 MB  (1.2 MB packed)
+  blob       12700 objects    2627.5 MB  (221.5 MB packed)
+  commit      1563 objects       0.4 MB  (0.3 MB packed)
+  total      21447 objects    2651.3 MB  (223.0 MB packed)
+  oldest record: 2026-04-11T11:43:01Z ab70e43df19ef252f2598efb5493607eb2571174
+  newest record: 2026-08-09T16:07:30Z b7a89ef50a753a0e4fd0a1027371497013e9782f
+  retention window: RCC_RETENTION_DAYS=180 days
+  runs of rcc-consolidate.yaml (nothing is pruned without one):
+    total: 0
+
+output kept in /tmp/claude-0/-home-user/59c73ee3-c62a-5328-b2cd-850eb4ec1720/scratchpad/run2

--- a/experiments/2026-08-rcc2-read-path/run.sh
+++ b/experiments/2026-08-rcc2-read-path/run.sh
@@ -1,0 +1,343 @@
+#!/bin/bash
+# Whether the verdict store on `rcc2` can be retired: the three measurements
+# D6 of plan/PLAN-vendoring-simplification.md asks for, plus the writer check
+# its "one wrinkle" clause asks for.
+#
+# Read-only. It fetches refs and reads the REST/GraphQL API; it never pushes,
+# never dispatches a workflow, and writes only under $OUT.
+#
+#   experiments/2026-08-rcc2-read-path/run.sh
+#
+# Run it against the fork. `duckdb/duckdb-r` cannot answer any of this: both
+# store workflows carry `if: github.repository == 'krlmlr/duckdb-r'`, so every
+# run of them there is skipped, and the series refs and the store live in the
+# fork besides.
+#
+# Do not dispatch `rcc-logs.yaml` or `rcc-consolidate.yaml` while measuring.
+# The first is measurement 1's whole signal; the second rewrites the branch
+# measurement 3 is weighing.
+#
+# Environment:
+#   GH_TOKEN / GITHUB_TOKEN - token with contents:read and statuses:read
+#   GITHUB_REPOSITORY       - default: krlmlr/duckdb-r
+#   REMOTE                  - git remote holding the fork's refs (default: origin)
+#   SINCE                   - measurement 1's cutoff (default: 2026-08-08, when
+#                             #2578 made `rcc-logs.yaml` dispatch-only)
+#   WIDEN                   - measurement 2's widening: how many of the store's
+#                             newest records to check for a matching status
+#                             (default 250; 0 disables)
+#   OUT                     - scratch and output directory (default: a mktemp -d)
+#
+# Cost: measurement 3 needs the store's objects, so the `rcc2` fetch moves the
+# whole branch (~220 MB today). Measurement 2 spends one REST call per commit
+# in flight plus one per widened record; the fork's limit is 15000/hour.
+
+set -euo pipefail
+
+REPO="${GITHUB_REPOSITORY:-krlmlr/duckdb-r}"
+REMOTE="${REMOTE:-origin}"
+SINCE="${SINCE:-2026-08-08}"
+WIDEN="${WIDEN:-250}"
+OUT="${OUT:-$(mktemp -d)}"
+TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+: "${TOKEN:?GH_TOKEN or GITHUB_TOKEN is required}"
+
+mkdir -p "${OUT}/statuses" "${OUT}/wide"
+
+api() { # <path-and-query> -> the response body
+  curl -sS --retry 3 \
+    -H "Authorization: Bearer ${TOKEN}" \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "https://api.github.com/$1"
+}
+
+echo "measured at: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "repository:  ${REPO}"
+echo "remote:      ${REMOTE} -> $(git ls-remote --get-url "${REMOTE}")"
+echo
+
+# The store and the series refs, from the fork. `rcc2` is fetched whole because
+# measurement 3 weighs its objects and measurement 2 reads its records.
+git fetch -q "${REMOTE}" "+refs/heads/rcc2:refs/remotes/${REMOTE}/rcc2" \
+  '+refs/heads/*-dev:refs/remotes/'"${REMOTE}"'/*-dev' \
+  '+refs/heads/*-green:refs/remotes/'"${REMOTE}"'/*-green' \
+  '+refs/heads/*-build:refs/remotes/'"${REMOTE}"'/*-build' \
+  '+refs/heads/*-build-base:refs/remotes/'"${REMOTE}"'/*-build-base'
+
+# Live series, discovered the way scripts/series-check.sh discovers them: a
+# `*-build` ref that is not a `*-build-base`, and whose `-dev` and `-green`
+# both exist.
+series=()
+while IFS= read -r b; do
+  s=${b#refs/heads/}; s=${s%-build}
+  case "$s" in *-build-base) continue ;; esac
+  git rev-parse -q --verify "refs/remotes/${REMOTE}/$s-dev" >/dev/null || continue
+  git rev-parse -q --verify "refs/remotes/${REMOTE}/$s-green" >/dev/null || continue
+  series+=("$s")
+done < <(git ls-remote --heads "${REMOTE}" '*-build' | cut -f2)
+
+# ------------------------------------------------------- 1. has it been felt --
+# Every `workflow_dispatch` of `rcc-logs.yaml` is a firing saying it needed the
+# store and found it incomplete. The `push` and `schedule` runs are not that:
+# `push` is the workflow exercising itself on a change to its own paths, and
+# `schedule` stopped with #2578.
+
+echo "=== 1. dispatches of rcc-logs.yaml (the gap being felt) ==="
+api "repos/${REPO}/actions/workflows/rcc-logs.yaml/runs?per_page=100" \
+  | jq -r '"runs of any event: \(.total_count)",
+           (.workflow_runs | group_by(.event)[] | "  \(.[0].event): \(length)")'
+echo "every workflow_dispatch run, oldest last:"
+api "repos/${REPO}/actions/workflows/rcc-logs.yaml/runs?event=workflow_dispatch&per_page=100" \
+  | jq -r --arg since "${SINCE}" '
+      "  total: \(.total_count)   since \($since): \([.workflow_runs[]|select(.created_at >= $since)]|length)",
+      (.workflow_runs[] | "  \(.created_at)  run \(.id)  by \(.triggering_actor.login)  \(.conclusion)")'
+echo
+
+# ----------------------------------------------- 2. would the replacement agree --
+# Two answers per commit in flight:
+#   record  - scripts/rcc-decided.sh, which is what selection reads today;
+#   status  - the `rcc` commit status, which is what D6 would read instead.
+# `pending` and absent are undecided on both sides. A commit decided on one
+# side and not the other is what would break D6's status read.
+
+echo "=== 2. record vs status over every live series' <S>-green..<S>-dev ==="
+: > "${OUT}/inflight"
+for S in "${series[@]}"; do
+  n=$(git rev-list --count "${REMOTE}/$S-green..${REMOTE}/$S-dev")
+  echo "  ${S}: ${n} in flight"
+  git rev-list "${REMOTE}/$S-green..${REMOTE}/$S-dev" | sed "s/^/$S /" >> "${OUT}/inflight"
+done
+awk '{print $2}' "${OUT}/inflight" | LC_ALL=C sort -u > "${OUT}/inflight.shas"
+echo "  total: $(wc -l < "${OUT}/inflight.shas") commits"
+
+GITHUB_REPOSITORY="${REPO}" RCC_READ_DIR="${OUT}/rcc-read" \
+  "$(git rev-parse --show-toplevel)/scripts/rcc-decided.sh" \
+  | LC_ALL=C sort > "${OUT}/decided"
+echo "  records in the store: $(wc -l < "${OUT}/decided")"
+
+# One REST call per commit, against `/statuses` rather than `/status`: it costs
+# the same and returns every post rather than the rolled-up latest, which is
+# what the writer check below needs. D6's own read is the batched GraphQL query
+# below; this is the same answer by a route every token serves.
+fetch_statuses() { # <sha-list-file> <dir>
+  export TOKEN
+  < "$1" xargs -P 8 -I{} sh -c '
+    out="'"$2"'/{}.json"
+    [ -s "$out" ] && exit 0
+    curl -sS --retry 3 -H "Authorization: Bearer ${TOKEN}" \
+      -H "Accept: application/vnd.github+json" \
+      "https://api.github.com/repos/'"${REPO}"'/commits/{}/statuses?per_page=100" > "$out"'
+}
+
+latest_rcc() { # <status-json> -> the newest rcc state, "none" if there is none
+  jq -r 'map(select(.context=="rcc")) | if length==0 then "none" else .[0].state end' "$1"
+}
+
+record_state() { # <sha> -> the record's own state, empty if there is no record
+  git show "${REMOTE}/rcc2:runs2.d/${1:0:2}/$1.ndjson" 2>/dev/null | jq -r '.status.state'
+}
+
+fetch_statuses "${OUT}/inflight.shas" "${OUT}/statuses"
+
+: > "${OUT}/status-state"
+while IFS= read -r sha; do
+  echo "${sha} $(latest_rcc "${OUT}/statuses/${sha}.json")"
+done < "${OUT}/inflight.shas" > "${OUT}/status-state"
+
+awk '$2=="success" || $2=="failure" {print $1}' "${OUT}/status-state" \
+  | LC_ALL=C sort > "${OUT}/status-decided"
+comm -12 "${OUT}/inflight.shas" "${OUT}/decided" > "${OUT}/record-decided"
+
+echo "  status side: $(awk '{print $2}' "${OUT}/status-state" | sort | uniq -c | tr '\n' ' ')"
+echo "  decided by status: $(wc -l < "${OUT}/status-decided")   by record: $(wc -l < "${OUT}/record-decided")"
+echo "  disagreements:"
+comm -23 "${OUT}/status-decided" "${OUT}/record-decided" | while IFS= read -r sha; do
+  echo "    STATUS WITHOUT RECORD  ${sha}  status=$(grep -m1 "^${sha} " "${OUT}/status-state" | cut -d' ' -f2)"
+done
+comm -13 "${OUT}/status-decided" "${OUT}/record-decided" | while IFS= read -r sha; do
+  echo "    RECORD WITHOUT STATUS  ${sha}  record=$(record_state "${sha}")  status=$(grep -m1 "^${sha} " "${OUT}/status-state" | cut -d' ' -f2)"
+done
+while IFS= read -r sha; do
+  r=$(record_state "${sha}"); s=$(grep -m1 "^${sha} " "${OUT}/status-state" | cut -d' ' -f2)
+  [ "$r" = "$s" ] || echo "    STATE MISMATCH  ${sha}  record=${r}  status=${s}"
+done < "${OUT}/record-decided"
+echo "    (no lines above means the two answers agree on every commit in flight)"
+
+# The batched query D6 would actually make, recovered from this repository's own
+# history -- scripts/each-plan.sh read statuses exactly this way before D1
+# (#2440). It costs ~1 request per 100 commits against REST's 1 per commit,
+# which is why the pre-D1 planner batched: a backfill cannot be enumerated over
+# REST at all. Some tokens serve only a pinned set of GraphQL operations; when
+# this one does not, the REST answer above stands on its own and the run says so.
+echo "  cross-check by the batched GraphQL query D6 would use:"
+owner="${REPO%%/*}"; name="${REPO##*/}"
+: > "${OUT}/graphql-state"
+graphql_ok=1
+i=0; q=""
+flush() {
+  [ -z "$q" ] && return 0
+  local body
+  # jq -n --arg does the JSON escaping, so the query carries plain `"`.
+  body=$(jq -n --arg q "query { repository(owner: \"${owner}\", name: \"${name}\") {${q} } }" '{query: $q}' \
+    | curl -sS --retry 3 -X POST -H "Authorization: Bearer ${TOKEN}" \
+        -H "Content-Type: application/json" -d @- https://api.github.com/graphql)
+  if ! jq -e '.data.repository' >/dev/null 2>&1 <<<"${body}"; then
+    graphql_ok=0
+    echo "    unavailable: $(jq -r '.message // (.errors[0].message) // "no data"' <<<"${body}" | head -c 160)"
+    q=""; return 0
+  fi
+  jq -r '.data.repository | to_entries[] | select(.value != null)
+         | "\(.value.oid) \(.value.status.context.state // "NONE" | ascii_downcase)"' \
+    <<<"${body}" >> "${OUT}/graphql-state"
+  q=""
+}
+while IFS= read -r sha; do
+  q+=" c${i}: object(oid: \"${sha}\") { ... on Commit { oid status { context(name: \"rcc\") { state createdAt } } } }"
+  i=$(( i + 1 ))
+  if [ $(( i % 100 )) -eq 0 ]; then flush; [ "${graphql_ok}" -eq 1 ] || break; fi
+done < "${OUT}/inflight.shas"
+[ "${graphql_ok}" -eq 1 ] && flush
+if [ "${graphql_ok}" -eq 1 ]; then
+  LC_ALL=C sort "${OUT}/graphql-state" -o "${OUT}/graphql-state"
+  if diff -q <(LC_ALL=C sort "${OUT}/status-state") "${OUT}/graphql-state" >/dev/null; then
+    echo "    agrees with the REST read on all $(wc -l < "${OUT}/graphql-state") commits"
+  else
+    echo "    DIFFERS from the REST read:"
+    diff <(LC_ALL=C sort "${OUT}/status-state") "${OUT}/graphql-state" | sed 's/^/      /'
+  fi
+fi
+echo
+
+# The wrinkle D6 names: the `rcc` context is not the leg's alone.
+# `R-CMD-check-status.yaml` writes the same context for the ordinary check, and
+# branch protection reads it. `each-shard.sh` describes its posts
+# "each-rcc / shard N"; `R-CMD-check-status.yaml` describes its own with the
+# triggering run's name. So the descriptions say who wrote what, and a series
+# branch that shows anything but the leg is a status D6 would misread.
+echo "=== 2b. who writes the rcc context on these commits ==="
+cat "${OUT}"/statuses/*.json \
+  | jq -r '.[] | "\(.context)|\(.creator.login)|\(.description)"' \
+  | sed 's/shard [0-9]*/shard N/' | sort | uniq -c | sed 's/^/  /'
+echo
+echo "  R-CMD-check.yaml runs from the branch it checks, so each series ref"
+echo "  carries its own push filter. A filter matching the branch's own name is"
+echo "  the template check firing there, and R-CMD-check-status.yaml writing rcc:"
+for S in "${series[@]}"; do
+  for r in "$S-dev" "$S-build"; do
+    pats=$(git show "${REMOTE}/$r:.github/workflows/R-CMD-check.yaml" 2>/dev/null \
+           | sed -n '/^on:/,/^  pull_request:/p' | grep -E "^ +- " | sed "s/^ *- *//; s/['\"]//g")
+    [ -z "${pats}" ] && { echo "    ${r}: <no workflow file>"; continue; }
+    # GitHub applies these in order, a leading `!` excluding what it matches.
+    hit=""
+    while IFS= read -r p; do
+      case "$p" in
+        '!'*) [[ "$r" == ${p#!} ]] && hit="" ;;
+        *)    [[ "$r" == $p ]] && hit="$p" ;;
+      esac
+    done <<< "${pats}"
+    echo "    ${r}: [$(tr '\n' ' ' <<< "${pats}" | sed 's/ $//')]"
+    if [ -n "${hit}" ]; then
+      echo "      FIRES ON ITSELF via '${hit}' -- a second writer of the rcc context"
+    fi
+  done
+done
+echo
+echo "  and what the template check has actually written in this fork:"
+api "repos/${REPO}/actions/workflows/R-CMD-check.yaml/runs?per_page=100" > "${OUT}/rcc-workflow-runs.json"
+jq -r '"    runs of the `rcc` workflow: \(.total_count)",
+       (.workflow_runs[] | select(.head_branch | test("-dev$|-build$|-green$|-base$"))
+        | "    on a series ref: \(.created_at)  \(.head_branch)  \(.event)  head=\(.head_sha[0:9])  \(.conclusion)")' \
+  "${OUT}/rcc-workflow-runs.json"
+
+# Whatever it stamped is a status D6 would read. Whether that matters depends on
+# one thing: can the SHA reach a `<S>-green..<S>-dev` range, which is all
+# selection ever asks about?
+jq -r '.workflow_runs[] | select(.head_branch | test("-dev$|-build$|-green$|-base$")) | .head_sha' \
+  "${OUT}/rcc-workflow-runs.json" | LC_ALL=C sort -u > "${OUT}/template-stamped.shas"
+while IFS= read -r sha; do
+  [ -z "${sha}" ] && continue
+  echo "    ${sha}"
+  api "repos/${REPO}/commits/${sha}/statuses?per_page=100" \
+    | jq -r 'map(select(.context=="rcc"))
+             | "      rcc statuses: \(length), newest \(if length==0 then "none" else "\(.[0].state) (\(.[0].description))" end)"'
+  echo "      record on rcc2: $(git cat-file -e "${REMOTE}/rcc2:runs2.d/${sha:0:2}/${sha}.ndjson" 2>/dev/null && echo yes || echo NO)"
+  inflight=$(grep -c "^${sha}$" "${OUT}/inflight.shas" || true)
+  echo "      in a <S>-green..<S>-dev range now: $([ "${inflight}" -gt 0 ] && echo YES || echo no)"
+  for S in "${series[@]}"; do
+    git merge-base --is-ancestor "${sha}" "${REMOTE}/$S-dev" 2>/dev/null \
+      && echo "      ancestor of ${S}-dev"
+  done
+done < "${OUT}/template-stamped.shas"
+
+# A buffer commit is re-minted when it is consumed onto `-dev`, so its SHA never
+# enters selection's range. That is the bound on the leak above, and it is a
+# property to check rather than assume.
+echo "    SHAs shared between (<S>-build-base..<S>-build) and (<S>-green..<S>-dev):"
+for S in "${series[@]}"; do
+  git rev-parse -q --verify "${REMOTE}/$S-build-base" >/dev/null 2>&1 || continue
+  n=$(comm -12 \
+        <(git rev-list "${REMOTE}/$S-build-base..${REMOTE}/$S-build" 2>/dev/null | LC_ALL=C sort) \
+        <(git rev-list "${REMOTE}/$S-green..${REMOTE}/$S-dev" 2>/dev/null | LC_ALL=C sort) | wc -l)
+  echo "      ${S}: ${n}"
+done
+echo
+
+# The widening. The range above is bounded by `-green`, so most of it is not
+# built yet and only a handful of commits are decided at all -- a thin sample
+# for a go/no-go. The store's newest records are the same question with the
+# sample the range cannot give: every one of them is decided by construction,
+# so each is a chance for a record to exist where a status does not.
+if [ "${WIDEN}" -gt 0 ]; then
+  echo "=== 2c. widening: the store's ${WIDEN} newest records, each against its status ==="
+  git ls-tree -r "${REMOTE}/rcc2" -- runs2.d | awk '$4 ~ /\.ndjson$/ {print $3}' \
+    | git cat-file --batch \
+    | jq -rR 'fromjson? | "\(.status.created_at // .run.created_at // "") \(.commit)"' \
+    | grep -v '^ ' | LC_ALL=C sort > "${OUT}/record-times"
+  tail -n "${WIDEN}" "${OUT}/record-times" | awk '{print $2}' > "${OUT}/wide.shas"
+  fetch_statuses "${OUT}/wide.shas" "${OUT}/wide"
+  agree=0; bad=0
+  while IFS= read -r sha; do
+    s=$(latest_rcc "${OUT}/wide/${sha}.json"); r=$(record_state "${sha}")
+    case "$s" in
+      success|failure)
+        if [ "$s" = "$r" ]; then agree=$(( agree + 1 ))
+        else bad=$(( bad + 1 )); echo "    STATE MISMATCH  ${sha}  record=${r}  status=${s}"; fi ;;
+      *) bad=$(( bad + 1 )); echo "    RECORD WITHOUT DECIDED STATUS  ${sha}  record=${r}  status=${s}" ;;
+    esac
+  done < "${OUT}/wide.shas"
+  echo "  agree: ${agree}   disagree: ${bad}   (of $(wc -l < "${OUT}/wide.shas"))"
+  echo "  writers seen here:"
+  cat "${OUT}"/wide/*.json | jq -r '.[] | "\(.context)|\(.creator.login)|\(.description)"' \
+    | sed 's/shard [0-9]*/shard N/' | sort -u | sed 's/^/    /'
+  echo
+fi
+
+# ------------------------------------------------------ 3. what keeping it costs --
+# Consolidation is manual and RCC_RETENTION_DAYS is 180, so nothing has been
+# pruned unless someone dispatched it -- which is a thing to check, not assume.
+
+echo "=== 3. what the store costs to keep ==="
+tip=$(git rev-parse "${REMOTE}/rcc2")
+echo "  tip:     ${tip}  $(git log -1 --format='%ci  %s' "${tip}")"
+echo "  commits: $(git rev-list --count "${tip}")"
+git rev-list --max-parents=0 "${tip}" | while IFS= read -r r; do
+  echo "  root:    ${r}  $(git log -1 --format='%ci  %s' "${r}")"
+done
+echo "  records: $(git ls-tree -r --name-only "${tip}" -- runs2.d | grep -c '\.ndjson$')"
+echo "  logs:    $(git ls-tree -r --name-only "${tip}" -- logs2.d | grep -c '\.log$')"
+git rev-list --objects "${tip}" | cut -d' ' -f1 \
+  | git cat-file --batch-check='%(objecttype) %(objectsize) %(objectsize:disk)' \
+  | awk '{n[$1]++; s[$1]+=$2; d[$1]+=$3; N++; S+=$2; D+=$3}
+         END {for (t in n) printf "  %-8s %7d objects  %8.1f MB  (%.1f MB packed)\n", t, n[t], s[t]/1048576, d[t]/1048576;
+              printf "  %-8s %7d objects  %8.1f MB  (%.1f MB packed)\n", "total", N, S/1048576, D/1048576}'
+echo "  oldest record: $(head -1 "${OUT}/record-times" 2>/dev/null || echo "run with WIDEN>0")"
+echo "  newest record: $(tail -1 "${OUT}/record-times" 2>/dev/null || echo "run with WIDEN>0")"
+echo "  retention window: RCC_RETENTION_DAYS=$(sed -n 's/^RCC_RETENTION_DAYS="\${RCC_RETENTION_DAYS:-\([0-9]*\)}"/\1/p' "$(git rev-parse --show-toplevel)/scripts/rcc-lib.sh") days"
+echo "  runs of rcc-consolidate.yaml (nothing is pruned without one):"
+api "repos/${REPO}/actions/workflows/rcc-consolidate.yaml/runs?per_page=100" \
+  | jq -r '"    total: \(.total_count)",
+           (.workflow_runs[]? | "    \(.created_at)  \(.event)  by \(.triggering_actor.login)  \(.conclusion)")'
+
+echo
+echo "output kept in ${OUT}"

--- a/experiments/README.md
+++ b/experiments/README.md
@@ -78,6 +78,12 @@ the directory keeps the method so that is possible.
   what the published Windows `libduckdb` exports, and how much of what
   the glue resolves from the engine is in there; supports
   [`build/fast-paths/`](/handbook/build/fast-paths/README.md).
+* [`2026-08-rcc2-read-path/`](2026-08-rcc2-read-path/) —
+  whether the `rcc2` verdict store can be retired: how often its gap has
+  been felt, whether the commit status D6 would read instead agrees with
+  the record it would replace, what the branch costs to keep, and who
+  else writes the `rcc` context; gathered for
+  [`plan/PLAN-vendoring-simplification.md`](/plan/PLAN-vendoring-simplification.md).
 * [`2026-08-temp-storage-spill/`](2026-08-temp-storage-spill/) —
   whether larger-than-memory work actually spills, per connection
   idiom, on duckdb 1.3.2, the current CRAN release, `main`, and the

--- a/handbook/meta/glossary/README.md
+++ b/handbook/meta/glossary/README.md
@@ -53,5 +53,5 @@ one line, so the register stays greppable and diffs per term.
 * **triage verdicts** — the dispositions issue intake assigns, exactly one per open item ([`operations/triage/`](/handbook/operations/triage/README.md)).
 * **vendor commit** — one commit advancing `src/duckdb/` by exactly one upstream commit ([`operations/vendoring/model/`](/handbook/operations/vendoring/model/README.md)).
 * **vendoring** — keeping a dependency's sources inside the depending repository ([`operations/vendoring/model/`](/handbook/operations/vendoring/model/README.md)).
-* **verdict store** / **`rcc2` branch** — the orphan branch holding each commit's build verdict and log, one file per commit ([`operations/ci/per-commit/store/`](/handbook/operations/ci/per-commit/store/README.md)). Its predecessor `rcc` is retired, and kept whole in the archive.
+* **verdict store** / **`rcc2` branch** — the orphan branch holding each commit's build verdict and log, one file per commit, and what per-commit CI selects its work from ([`operations/ci/per-commit/store/`](/handbook/operations/ci/per-commit/store/README.md)). Its predecessor `rcc` is retired, and kept whole in the archive.
 * **WKB** — well-known binary, the geometry interchange across the R boundary ([`usage/types/`](/handbook/usage/types/README.md)).

--- a/handbook/operations/ci/per-commit/selection/README.md
+++ b/handbook/operations/ci/per-commit/selection/README.md
@@ -21,8 +21,10 @@ Branches without a green sibling fall back to first-parent history since `SINCE`
 
 That fallback is the one path that can reach past the store's retention window
 ([`store/`](/handbook/operations/ci/per-commit/store/README.md#retention-is-one-window)):
-`SINCE` defaults to a fixed date months back, while records are dropped after 30
-days, so a commit older than the window reads as undecided and is replanned.
+`SINCE` defaults to a fixed date, while records are dropped after 180 days,
+so a commit older than the window reads as undecided and is replanned —
+and because `SINCE` is fixed and the window is not,
+the gap between them widens with every month that passes.
 A series branch never sees it — `<S>-green` is far newer than the window — and
 the cost where it does bite is a rebuild, never a wrong verdict.
 Narrow `SINCE` on a branch with no green sibling if the rebuild is not wanted.

--- a/handbook/operations/ci/per-commit/store/README.md
+++ b/handbook/operations/ci/per-commit/store/README.md
@@ -81,9 +81,10 @@ and that is what makes the concurrency work without a lock.
 
 ## Retention is one window
 
-The store keeps `RCC_RETENTION_DAYS` (30) of history,
+The store keeps `RCC_RETENTION_DAYS` (180) of history,
 **records and logs alike**,
-and [`rcc-consolidate.sh`](/scripts/rcc-consolidate.sh) enforces it.
+and [`rcc-consolidate.sh`](/scripts/rcc-consolidate.sh) enforces it —
+by hand, so nothing is dropped until an operator dispatches it.
 Logs are still the bulk of what goes — about a megabyte each against ~2 KB for
 a record — but keeping a verdict for a commit decided months ago and long since
 repaired only postpones the same deletion,
@@ -303,10 +304,18 @@ which is what the 256-way fan-out is for.
 A single flat directory of ten thousand records would rewrite the whole tree on
 every push.
 
-And none of it is load-bearing.
+And none of it is load-bearing *for the leg that pays it*.
 Legs still upload their artifacts, which is what a firing reads.
 A failed publish is logged and ignored — it never fails the leg —
 and the verdict is in the artifact and in the job log regardless.
+Where it is felt is the next run:
+selection reads this branch and only this branch
+([`selection/`](/handbook/operations/ci/per-commit/selection/README.md)),
+so a commit whose record never landed reads as undecided
+and is built again.
+Cheap and survivable, then, but not optional —
+the publish is the one write that keeps CI
+from rebuilding what it has already decided.
 
 Two writers have been retired since, in the same direction.
 The per-run fan-in reconciled onto the branch whatever a leg could not publish;
@@ -317,6 +326,17 @@ it is dispatched now, and the one gap it alone covers —
 a run cancelled whole, so that no leg ever published —
 is the reason to dispatch it.
 What is left is the leg's own publish, which is where a verdict comes from.
+
+## Where this is going
+
+**The store is on its way out**, and D6 of
+[`plan/PLAN-vendoring-simplification.md`](/plan/PLAN-vendoring-simplification.md)
+is the cut: selection moves to a batched read of the `rcc` commit status,
+[`series-check.sh`](/scripts/series-check.sh) reads a failure's log from the run
+that decided it rather than from `logs2.d/`,
+and the branch goes with its writers.
+Nothing on this page is deprecated — it is what runs today —
+but a change to any of it is worth weighing against a plan to delete it.
 
 *To deepen: state what the first live cutover, the first live consolidation and
 the first live publish against the real remote changed, and fold the

--- a/handbook/operations/ci/workflows/README.md
+++ b/handbook/operations/ci/workflows/README.md
@@ -20,7 +20,7 @@ which is the part of this a reader can check from the tree.
 | [`R-CMD-check-dev.yaml`](/.github/workflows/R-CMD-check-dev.yaml) | daily cron; push to `cran-*`, tags | the check against r-universe dev builds of each dependency, one job per dependency |
 | [`R-CMD-check-status.yaml`](/.github/workflows/R-CMD-check-status.yaml) | `rcc` runs starting/finishing | mirrors run state onto commit statuses |
 | [`each.yaml`](/.github/workflows/each.yaml) | push to `*-dev` and `each-*`; dispatch | per-commit sharded builds ([`per-commit/`](/handbook/operations/ci/per-commit/README.md)); fork only |
-| [`rcc-logs.yaml`](/.github/workflows/rcc-logs.yaml) | half-hourly cron | harvests run records onto the `rcc2` branch |
+| [`rcc-logs.yaml`](/.github/workflows/rcc-logs.yaml) | dispatch; push when its own files change | backstop harvest onto the `rcc2` branch, for a commit no leg published ([`per-commit/store/`](/handbook/operations/ci/per-commit/store/README.md)) |
 | [`rcc-consolidate.yaml`](/.github/workflows/rcc-consolidate.yaml) | dispatch | rewrites the `rcc2` branch (dry run by default) |
 | [`fledge.yaml`](/.github/workflows/fledge.yaml) | daily cron; dispatch; push only when this file changes | version bump and `NEWS.md` via fledge ([`releases/versioning/`](/handbook/operations/releases/versioning/README.md)) |
 | [`format-suggest.yaml`](/.github/workflows/format-suggest.yaml) | `pull_request_target` | posts formatting suggestions; treats fork code strictly as data |
@@ -28,6 +28,7 @@ which is the part of this a reader can check from the tree.
 | [`pkgdown.yaml`](/.github/workflows/pkgdown.yaml) | push to `docs*`, `cran-*`; dispatch | builds the site (main is covered by `rcc`) |
 | [`rhub.yaml`](/.github/workflows/rhub.yaml) | push to `cran-*`; dispatch | R-hub checks ([`releases/cran/`](/handbook/operations/releases/cran/README.md)) |
 | [`revdep.yaml`](/.github/workflows/revdep.yaml) | push to `revdep*` | one old-vs-new `rcmdcheck` per reverse dependency ([`testing/revdep/`](/handbook/testing/revdep/README.md)) |
+| [`revdep2.yaml`](/.github/workflows/revdep2.yaml) | dispatch | the same comparison sharded across runners, dealt by measured check cost |
 | [`lock.yaml`](/.github/workflows/lock.yaml) | daily cron | locks a thread after a year without activity |
 | [`copilot-setup-steps.yaml`](/.github/workflows/copilot-setup-steps.yaml) | changes to itself | environment bootstrap for coding agents |
 

--- a/plan/PLAN-vendoring-simplification.md
+++ b/plan/PLAN-vendoring-simplification.md
@@ -11,7 +11,10 @@ Phase 1 landed as #87, the README root as #88, Phase 3 as the fork
 move (#2534) — see §9;
 revised after a clean-context review of this document against `origin/main`;
 revised again 2026-08-09 — question 6 is settled, the verdict store is to be
-retired, and §3.3's D6 is the cut).
+retired, and §3.3's D6 is the cut;
+revised the same day with D6's three measurements, which say *proceed after a
+cycle of notice* and move the shared-status wrinkle ahead of the cut
+([`experiments/2026-08-rcc2-read-path/`](/experiments/2026-08-rcc2-read-path/README.md))).
 Inputs: `BRANCHES.md`, `scripts/VENDORING.md`, `scripts/EACH.md`,
 `scripts/VENDORING-LOOP.md` (historical), the four skills in `.claude/skills/`,
 the loop scripts (`series-*.sh`, `each-*`, `rcc-*`, `vendor*`),
@@ -391,47 +394,92 @@ Checked on 2026-08-09: no firing's read path is recorded anywhere in
 this repository — not in `plan/`, `plan/history/`, `experiments/`, or
 the handbook; the only occurrences of the phrase are the instruction in
 `series-loop.md` and the request in this document.
-So D6's first step is not "read the evidence", because there is none to
-read. It is the three measurements below, which are better evidence
+So D6's first step was not "read the evidence", because there was none to
+read. It was the three measurements below, which are better evidence
 anyway: they ask whether the *replacement* works, not whether the
-fallback happened to be used.
+fallback happened to be used. They have been taken.
 
-*The evidence step, concretely.*
+*The evidence step, taken.*
 All three read durable state, all three are re-runnable,
-and all three need access to `krlmlr/duckdb-r` — the fork is where the
+and all three needed access to `krlmlr/duckdb-r` — the fork is where the
 `each-rcc` runs, the series refs and the store itself live, so none of
-them can be taken from this repository:
+them could be taken from this repository.
+Measured there on 2026-08-09, script and full output in
+[`experiments/2026-08-rcc2-read-path/`](/experiments/2026-08-rcc2-read-path/README.md):
 
-1. **Has the store's gap ever been felt?** Count `workflow_dispatch`
-   runs of `rcc-logs.yaml` in the fork since #2578 (2026-08-08).
-   A dispatch is a firing saying it needed the store and found it
-   incomplete; zero across a full cycle is the answer question 6
-   wanted. In `duckdb/duckdb-r` the count is structurally zero —
-   both store workflows carry `if: github.repository ==
-   'krlmlr/duckdb-r'`, so every run here is skipped.
-2. **Would the replacement agree?** For each live series, compare
-   `scripts/rcc-decided.sh` against the `rcc` commit statuses over
-   `<S>-green..tip`. Any commit decided in one and not the other is
-   what would break D6's status read — and finding none is the go
-   signal, since it says the two stores have stayed in step with only
-   one of them being written for.
-3. **What is keeping it costing?** Commits on `rcc2`, its size, and
-   the age of the oldest surviving record — consolidation is manual
-   and the window is 180 days, so this is the standing bill for
-   deferring D6.
+1. **Has the store's gap ever been felt?** **No — over one day.**
+   `rcc-logs.yaml` has two `workflow_dispatch` runs in the fork, ever,
+   both by `krlmlr` and both *before* #2578 merged at
+   2026-08-08T14:46:49Z; the later of the two is the verification
+   dispatch that PR's own body names. Since the schedule stopped the
+   count is zero, and the schedule stopped exactly when it should have
+   (of 118 runs, 76 are `schedule`, none since #2578). But zero has
+   only been possible to observe for **1.1 days**, and question 6
+   asked for a cycle. The number is right and the window is not.
+2. **Would the replacement agree?** **Yes, everywhere it was asked.**
+   Over the 420 commits in flight across all six live series, no
+   status without a record, no record without a status, and no commit
+   where the two name a different state. That range is thin on its own
+   — bounded by `-green`, so only 25 of the 420 are decided at all —
+   so the same question went to the sample the range cannot give: the
+   store's 250 newest records, every one decided by construction, each
+   a chance for a record to exist where a status does not. 250 of 250
+   agree, states included. This is D6's go/no-go and it says go.
+3. **What is keeping it costing?** **223 MB and ~390 commits a day.**
+   `rcc2` holds 1563 commits, 8453 records and 4242 logs, at 223 MB
+   packed (2.65 GB uncompressed) — and the bulk is the logs, records
+   being ~2 KB each. `rcc-consolidate.yaml` has **never run**, so
+   nothing has been pruned since the cutover minted the branch on
+   2026-08-05. Nor would a dispatch help: the oldest surviving record
+   is 120 days old against a 180-day window, so retention is not what
+   is deferred — the squash is, and all it would buy today is 1563
+   commits collapsing to 2.
 
-**One wrinkle to settle before the cut.**
+**The verdict: proceed after a cycle of notice**, and start the work that
+does not depend on the answer.
+Measurement 2 clears the go/no-go, measurement 3 says the standing bill is
+real, dull and bounded — a reason to stop deferring rather than to rush —
+and measurement 1 is the only one not yet supporting *now*.
+It is also the cheapest of the three to re-run.
+So: keep the branch and the leg's publish for one full series cycle,
+re-run the experiment, and cut when the dispatch count is still zero.
+Nothing waits on that — porting `series-check.sh` off `git show` is the one
+piece of real work in D6, it is needed under every outcome, and it can land
+first.
+
+**The wrinkle is not hypothetical, and it goes first.**
 The `rcc` context is not the leg's alone:
 `R-CMD-check-status.yaml` writes the same context for the ordinary check,
 and branch protection reads it.
-Nothing else writes it on a series branch today
-(`R-CMD-check.yaml` does not fire on `*-dev`),
-so selection would be correct as-is — but reading a context that a
-template-owned workflow also writes rebuilds F1's coupling in miniature.
-Giving the per-commit verdict its own context (`each-rcc`) costs one line
-in `each-shard.sh` and ends the question;
-what it costs back is the commit list, where one context is what a reader
-scans. Decide it with D6, not after.
+On a `*-dev` branch that is still fine, and the measurement checked it
+rather than taking this document's word:
+all six `-dev` branches carry `main`'s push filter, which matches no series
+ref, and every one of the 73 `rcc` posts across the commits in flight —
+and every post across the 250 widened commits — reads `each-rcc / shard N`.
+
+But the claim is a ported commit deep, and it is **already false one ref
+over**. `R-CMD-check.yaml` runs from the branch it checks, and
+`v1.4-andium-build` still carries a copy from 2026-03-26 whose `v*.*-*`
+release-branch pattern matches its own name. Four pushes on 2026-08-06
+therefore started the template check on the buffer, and
+`R-CMD-check-status.yaml` stamped `rcc=failure` on `6e7dd75ce` — a status
+with no record, the exact class D6's read would misread, in the fork today.
+It is harmless for one reason, which the measurement confirms rather than
+assumes: a buffer commit is re-minted when it is consumed onto `-dev`
+(0 shared SHAs between `-build-base..-build` and `-green..-dev`, all six
+series), so its SHA never reaches selection.
+
+That is a property of the lineage, not of the context.
+The `-dev` copies are clean because the port stage keeps them level with
+`main`; the buffer is dirty because ports never touch it, which is F4's
+stated blind spot. A `-dev` branch regaining the glob — a series opened from
+an old buffer, a forward replaying onto a stale seed — would put a
+whole-branch matrix verdict straight into selection's range.
+So this is not "decide it with D6": give the per-commit verdict its own
+context (`each-rcc`) **before** the status read goes in. It costs one line
+in `each-shard.sh`, what it costs back is the commit list where one context
+is what a reader scans, and the alternative has already produced the failure
+once.
 
 ### 3.4 Human-facing lag: compare URLs and badges
 
@@ -777,7 +825,7 @@ of the kernel.
 | **3 — landed (#2534)** | replace the standalone repo with a fresh fork (§6), configured with the Pull app so the release-branch mirrors stay current without a job of our own | one-time move; the replaced repository is kept as `krlmlr/duckdb-r-old` |
 | **4** | docs tree (§8): README root landed (#88); next the moves, then node rewrites (including `AGENTS.md`'s and `BRANCHES.md`'s stale rows); `docs-tree` skill | docs only |
 | **5** | kernel extraction + `rigraph` port (config file, generalized subject marker, igraph cost estimator or constant weight) | new repo consumed `@main`; rollback = vendored copy of the kernel |
-| **6** | retire the verdict store (D6), in four steps: take the three measurements (§3.3 — all need the fork); port `series-check.sh` to read the deciding run; move the three state readers to a batched status query; delete the branch and its scripts | each step reverts on its own, and the branch is deleted last — once nothing reads it, deleting it is the cheapest step rather than the risky one |
+| **6** | retire the verdict store (D6), in five steps: ~~take the three measurements~~ (taken 2026-08-09, §3.3 — *proceed after a cycle of notice*); give the per-commit verdict its own `each-rcc` status context, which the measurement moved ahead of the cut; port `series-check.sh` to read the deciding run; re-run measurement 1 and, if the dispatch count is still zero, move the three state readers to a batched status query; delete the branch and its scripts | each step reverts on its own, and the branch is deleted last — once nothing reads it, deleting it is the cheapest step rather than the risky one |
 
 Phase 1a is independently shippable.
 The deletions concentrated in Phase 2, and the larger set is Phase 6's.
@@ -826,3 +874,9 @@ reconciling two stores in between, which is F1 exactly.
    first. The question was right that CI-side selection has to be
    replaced too, and wrong about which read costs — selection becomes
    a status query, while `series-check.sh`'s log read is the work.
+   *Answered on the evidence, 2026-08-09
+   ([`experiments/2026-08-rcc2-read-path/`](/experiments/2026-08-rcc2-read-path/README.md)):
+   a cycle of notice.* The replacement agrees on every commit either
+   store was asked about, so the git-only route can go; but the
+   dispatch count has only been observable for a day, and one day is
+   not the cycle this question asked for.

--- a/plan/PLAN-vendoring-simplification.md
+++ b/plan/PLAN-vendoring-simplification.md
@@ -9,7 +9,9 @@ this file is the proposal, and where the two disagree the leaf is right.
 Status: **in progress** (2026-07-30, branch `claude/vendoring-tooling-design-3swawc`;
 Phase 1 landed as #87, the README root as #88, Phase 3 as the fork
 move (#2534) — see §9;
-revised after a clean-context review of this document against `origin/main`).
+revised after a clean-context review of this document against `origin/main`;
+revised again 2026-08-09 — question 6 is settled, the verdict store is to be
+retired, and §3.3's D6 is the cut).
 Inputs: `BRANCHES.md`, `scripts/VENDORING.md`, `scripts/EACH.md`,
 `scripts/VENDORING-LOOP.md` (historical), the four skills in `.claude/skills/`,
 the loop scripts (`series-*.sh`, `each-*`, `rcc-*`, `vendor*`),
@@ -65,6 +67,11 @@ one layout on a new branch — `runs2.d/<xx>/<sha>.ndjson` and
 `logs2.d/<xx>/<sha>.log` on `rcc2`, written by three producers through one
 publisher, with `rcc` left behind whole. See
 [`operations/ci/per-commit/store/`](/handbook/operations/ci/per-commit/store/README.md).
+The writer count has come down twice more since:
+the per-run fan-in and the 30-minute sweep both went in #2578,
+leaving one automatic writer (the leg's own publish),
+one dispatched (`rcc-logs.yaml`) and one manual (consolidation).
+D6 takes the last of them.
 | Scripts | 26 shell/python executables + 3 data/jq files serve the loop |
 | Skills | 4 (`series-loop`, `series-forward`, `series-rebase`, `series-open`) |
 | Workflows | `each.yaml`, `rcc-logs.yaml`, `rcc-consolidate.yaml` — the legacy dispatch path, which also spanned `cancel-rcc-dispatch.yaml`, is retired (D4). `R-CMD-check.yaml` (whose workflow *name* is `rcc`) and `R-CMD-check-status.yaml` stay: the ordinary push/PR check and the commit status branch protection reads, both core-set from `cynkra/cynkratemplate` |
@@ -289,6 +296,7 @@ as one checklist; this plan is analysis, not a routing node:
 | D3 | State `-build-base`'s contract: maintained and self-guarded by the loop, an input to no decision, consumed by humans (compare URLs and badges, §3.4) | the recurring temptation to treat it as coordination state — or to drop it and lose the only clean "buffered" range |
 | D4 | Retire the legacy dispatch path whole: `vendor-gate.sh`, `each-rcc.sh` + `each.yaml`'s dispatch mode, `cancel-rcc-dispatch.yaml`, ~~and `R-CMD-check-status.yaml`'s rcc role~~ (that last one was wrong — see the status note below). `R-CMD-check.yaml` itself stays — it is also the ordinary push/PR check — it only stops being dispatched per commit | four legacy surfaces that still have to be reasoned about on every change |
 | D5 | State the concurrency design in one place: per-series group + durable idempotent verdicts; **no pending markers, by design** | the recurring "did we lose the running marker" doubt (F3). The pieces exist in `each.yaml` and `EACH.md`; the one-place statement is what is missing |
+| D6 | Retire the verdict store: the three readers of a *state* — `each-plan.sh`, `each-shard.sh`'s resume check, `series-advance.sh`'s frontier walk — read the per-commit **commit status** in one batched query, `series-check.sh` reads a failure's log from the run that decided it, and the `rcc2` branch goes with its writers | the branch itself, `rcc-publish.sh`, `rcc-decided.sh`, `rcc-logs.{sh,yaml}`, `rcc-consolidate.{sh,yaml}`, `rcc-cutover.sh`, `rcc-store-test.sh`, `rcc-lib.sh` entire, the retention window and its two-way rule, and two handbook leaves |
 
 *Status of D4:* landed, minus one item this document had wrong.
 `vendor-gate.sh`, `each-rcc.sh`, `each.yaml`'s dispatch mode and
@@ -325,6 +333,105 @@ after the sweep, a range read is N 2-KB `git show`s,
 which is how the loop reads the range today anyway;
 the single-fetch convenience has no consumer left.
 Order matters only once: sweep, then readers, then the file.
+
+*D6 in full:* **this is not D1 reversed.**
+D1's defect was two stores reconciled against each other,
+not the store it picked;
+it picked records because the reader that mattered — a Claude firing —
+had git and no API.
+#2549 removed that constraint:
+a firing reads the deciding `each-rcc` run first
+and falls back to the branch.
+With the constraint gone, the one surviving store can be the one
+CI already writes for free, and the branch goes with its machinery.
+
+What selection reads instead is the `rcc` commit status the leg
+already POSTs in the same step as the verdict —
+which is what selection read *before* D1:
+`each-plan.sh` scanned statuses by GraphQL and `each-shard.sh`'s resume
+check by REST, so the read is recoverable from this repository's own
+history rather than code to invent.
+The batching question is therefore already answered;
+what has to be re-decided is only the REST resume check,
+which wants the same batched query rather than one call per commit.
+What does not come back is the reconciliation a *second* store needed:
+decided is `success` or `failure`, `pending` or absent is undecided,
+and no `PENDING_TTL_HOURS` returns with it —
+a commit mid-build reads as undecided under the record store too,
+and what prevents double work is the per-branch concurrency group,
+which is F3's finding and D5's statement.
+
+**Four readers, and only one of them is hard.**
+Three want a *state* and nothing else, so they follow selection onto the
+status: `each-plan.sh`, `each-shard.sh`'s resume check, and —
+the one easy to miss, because it is not selection and does not go
+through `rcc-decided.sh` — `series-advance.sh`'s `state_of()`,
+which `git show`s a record to decide what `-green` may pass over.
+Miss it and the ref-mover is the last thing reading a branch
+everything else has stopped writing.
+
+**The blocker is the fourth: logs, not verdicts.**
+`series-check.sh` classifies a failure by what its harvested log
+positively contains, and a status carries no log.
+Its replacement is the run that decided the commit —
+the `each-logs-*` artifact for 14 days, the job log for longer —
+which is the read the series loop already makes at stage 2.
+Porting `series-check.sh` off `git show` is the one piece of real work
+in D6; everything after it is deletion.
+
+**What D6 spends** is the property the branch was built for:
+a reader with git and nothing else.
+After D6 a firing with no API access has nothing to fall back to,
+where today it has a stale-but-readable copy.
+That is a trade to make on evidence rather than on this paragraph.
+#2549 does instrument it — every firing records which path served —
+but into its **report**, and a report has no durable home
+(question 5, still open).
+Checked on 2026-08-09: no firing's read path is recorded anywhere in
+this repository — not in `plan/`, `plan/history/`, `experiments/`, or
+the handbook; the only occurrences of the phrase are the instruction in
+`series-loop.md` and the request in this document.
+So D6's first step is not "read the evidence", because there is none to
+read. It is the three measurements below, which are better evidence
+anyway: they ask whether the *replacement* works, not whether the
+fallback happened to be used.
+
+*The evidence step, concretely.*
+All three read durable state, all three are re-runnable,
+and all three need access to `krlmlr/duckdb-r` — the fork is where the
+`each-rcc` runs, the series refs and the store itself live, so none of
+them can be taken from this repository:
+
+1. **Has the store's gap ever been felt?** Count `workflow_dispatch`
+   runs of `rcc-logs.yaml` in the fork since #2578 (2026-08-08).
+   A dispatch is a firing saying it needed the store and found it
+   incomplete; zero across a full cycle is the answer question 6
+   wanted. In `duckdb/duckdb-r` the count is structurally zero —
+   both store workflows carry `if: github.repository ==
+   'krlmlr/duckdb-r'`, so every run here is skipped.
+2. **Would the replacement agree?** For each live series, compare
+   `scripts/rcc-decided.sh` against the `rcc` commit statuses over
+   `<S>-green..tip`. Any commit decided in one and not the other is
+   what would break D6's status read — and finding none is the go
+   signal, since it says the two stores have stayed in step with only
+   one of them being written for.
+3. **What is keeping it costing?** Commits on `rcc2`, its size, and
+   the age of the oldest surviving record — consolidation is manual
+   and the window is 180 days, so this is the standing bill for
+   deferring D6.
+
+**One wrinkle to settle before the cut.**
+The `rcc` context is not the leg's alone:
+`R-CMD-check-status.yaml` writes the same context for the ordinary check,
+and branch protection reads it.
+Nothing else writes it on a series branch today
+(`R-CMD-check.yaml` does not fire on `*-dev`),
+so selection would be correct as-is — but reading a context that a
+template-owned workflow also writes rebuilds F1's coupling in miniature.
+Giving the per-commit verdict its own context (`each-rcc`) costs one line
+in `each-shard.sh` and ends the question;
+what it costs back is the commit list, where one context is what a reader
+scans. Decide it with D6, not after.
 
 ### 3.4 Human-facing lag: compare URLs and badges
 
@@ -666,13 +773,20 @@ of the kernel.
 | **0 (PR #86, this PR)** | this plan; router in `AGENTS.md`; badge semantics + pointers in `scripts/VENDORING.md` and `scripts/EACH.md` | none — docs only |
 | **1 — landed (#87)** | the port stage: `scripts/series-port.sh` plus the amended `series-loop` / `series-forward` / `series-rebase` skills | first real `--apply` still runs supervised |
 | **1a (follow-up)** | resolve the subject-vs-path contradiction (§4), in order: harden `vendor-one.sh` and `vendor.sh`'s subject scans to bounded-and-loud; relax `classify()` to subject-decided; rewrite the landed rationale in `series-port.sh`'s header and `series-loop.md` stage 4; stage 1 invokes `main`'s `vendor-one.sh` against the buffer worktree | wider than first scoped — two scanners, one classifier, two rationale blocks, one skill rule; each independently shippable |
-| **2** | single verdict store (D1: selection and resume by record; backstop stops writing, its schedule dispatches idle undecided work); one sweep, then drop the aggregate outright (D2); the fan-in stays (per-commit logs, §3.2) | verdicts are already dual-written today; rollback = read statuses again |
+| **2 — landed, and further than written** | single verdict store (D1: selection and resume by record; backstop stops writing, its schedule dispatches idle undecided work); one sweep, then drop the aggregate outright (D2); ~~the fan-in stays (per-commit logs, §3.2)~~ — it did not: the fan-in and the backstop's schedule both went in #2578, leaving the leg's own publish as the store's one automatic writer | verdicts are already dual-written today; rollback = read statuses again |
 | **3 — landed (#2534)** | replace the standalone repo with a fresh fork (§6), configured with the Pull app so the release-branch mirrors stay current without a job of our own | one-time move; the replaced repository is kept as `krlmlr/duckdb-r-old` |
 | **4** | docs tree (§8): README root landed (#88); next the moves, then node rewrites (including `AGENTS.md`'s and `BRANCHES.md`'s stale rows); `docs-tree` skill | docs only |
 | **5** | kernel extraction + `rigraph` port (config file, generalized subject marker, igraph cost estimator or constant weight) | new repo consumed `@main`; rollback = vendored copy of the kernel |
+| **6** | retire the verdict store (D6), in four steps: take the three measurements (§3.3 — all need the fork); port `series-check.sh` to read the deciding run; move the three state readers to a batched status query; delete the branch and its scripts | each step reverts on its own, and the branch is deleted last — once nothing reads it, deleting it is the cheapest step rather than the risky one |
 
-Phases 1a and 2 are independently shippable; the deletions concentrate in
-Phase 2.
+Phase 1a is independently shippable.
+The deletions concentrated in Phase 2, and the larger set is Phase 6's.
+That selection moves twice — onto records in D1, onto statuses in D6 —
+is worth stating rather than glossing:
+the first move is what makes the second one small,
+because it left one store to replace instead of two to reconcile.
+Doing them in the other order would have meant
+reconciling two stores in between, which is F1 exactly.
 
 ## 10. Open questions
 
@@ -681,9 +795,13 @@ Phase 2.
    dropping them automatically) or squash into one port commit per
    firing (fewer CI verdicts, but squashing breaks the patch-id match
    and with it the automatic drop)? Leaning individual.
-2. **Record-store scale.** One commit per record keeps `rcc` growing
-   (~1 commit/record; consolidation squashes). Is the current
-   consolidation cadence enough once statuses stop being a second copy?
+2. ~~**Record-store scale.**~~ *Absorbed by D6:* a store that is going
+   away does not need a cadence. One commit per record keeps `rcc2`
+   growing, consolidation is manual, and the retention window is 180
+   days — so nothing is dropped until an operator dispatches it, and
+   the branch grows by one small commit per verdict in the meantime.
+   That is the standing cost of keeping it, and it is bounded, dull,
+   and about to be moot.
 3. ~~**Fork migration depth (§6).**~~ *Settled by the move:* `rcc2`
    came across whole, and everything else — the retired `rcc`, the
    snapshot branches, the ref litter, the finished topic branches —
@@ -695,12 +813,16 @@ Phase 2.
 5. **Review artifacts.** Should routine-generated review digests
    (like `main-dev-review.md`) land under `plan/` by convention,
    or in PR comments only?
-6. **Does the store still earn its keep?** It exists because an agent
-   firing could not read CI logs; that is no longer true where the
-   firing has Actions access, so `series-loop.md` now reads the run
-   and falls back to `rcc2`. Every firing records which path served.
-   If the fallback goes unused across a full cycle, the question is
-   what the store is still *for* — CI-side selection reads it too
-   (D1), so retiring it means replacing that read as well, and the
-   answer may be "keep it, cheaply" rather than "delete it".
-   Decide on the evidence, not on this paragraph.
+6. ~~**Does the store still earn its keep?**~~ *Settled: it does not,
+   and §3.3's D6 is the cut.* The question asked to be decided on
+   evidence: the store exists because a firing could not read CI
+   logs, which stopped being true when `series-loop.md` began reading
+   the deciding run and falling back to `rcc2` (#2549), and every
+   firing since records which path served it. What settled it is the
+   goal that evidence was serving — the infrastructure around the
+   branch is to go, and the store is most of it. So the evidence
+   becomes D6's first step rather than its gate: it says whether the
+   git-only route can be dropped now or wants a cycle of notice
+   first. The question was right that CI-side selection has to be
+   replaced too, and wrong about which read costs — selection becomes
+   a status query, while `series-check.sh`'s log read is the work.

--- a/scripts/rcc-consolidate.sh
+++ b/scripts/rcc-consolidate.sh
@@ -44,7 +44,7 @@
 #
 # Environment variables:
 #   OUT_DIR             - the `rcc2` worktree to consolidate (default: runs)
-#   RCC_RETENTION_DAYS  - keep records and logs at most this old (default: 30);
+#   RCC_RETENTION_DAYS  - keep records and logs at most this old (default: 180);
 #                         0 keeps everything, and then only the squash happens
 #   APPLY               - if non-empty, commit and force-push; otherwise report
 #                         what would change and leave the branch alone

--- a/scripts/rcc-cutover.sh
+++ b/scripts/rcc-cutover.sh
@@ -56,7 +56,7 @@
 #                         report only, never written
 #   BRANCH              - the branch to create (default: rcc2)
 #   REMOTE              - remote to push to (default: origin)
-#   RCC_RETENTION_DAYS  - keep records and logs at most this old (default: 30)
+#   RCC_RETENTION_DAYS  - keep records and logs at most this old (default: 180)
 #   APPLY               - if non-empty, commit and push; otherwise report what
 #                         would happen and leave everything alone
 #   FORCE               - if non-empty, push even when BRANCH already exists on

--- a/scripts/rcc-lib.sh
+++ b/scripts/rcc-lib.sh
@@ -27,7 +27,7 @@
 #
 # ## Retention
 #
-# The store keeps `RCC_RETENTION_DAYS` (default 30) of history, records and logs
+# The store keeps `RCC_RETENTION_DAYS` (default 180) of history, records and logs
 # alike, and `rcc-consolidate.sh` enforces it. That is one window rather than
 # two, and it is load-bearing in both directions: a producer must not look
 # further back than the window, or it re-derives every tick what consolidation

--- a/scripts/series-advance.sh
+++ b/scripts/series-advance.sh
@@ -347,7 +347,7 @@ if git rev-parse -q --verify "$remote/$S-fwd-build" >/dev/null &&
   exit 0
 fi
 # Pending work does not hold the buffer (.claude/skills/series-loop.md stage 5):
-# each.yaml plans every commit in green..tip that has no status, so a longer tip
+# each.yaml plans every commit in green..tip that has no record, so a longer tip
 # is more work planned in the same pass, not work deferred. A known failure does
 # hold it: stage 2 will fold a fix into that commit and replay everything above,
 # so anything appended now is minted only to be re-minted. The stage-3 walk above


### PR DESCRIPTION
**Depends on #2625**, which is where D6 exists. The first commit here is a verbatim squash of that branch so there is something to fold numbers into; drop it once #2625 merges — it rebases away by patch-id rather than needing a resolution. Draft until then. Only the second commit is this PR's own work.

D6 asks three things before the `rcc2` verdict store is cut, and #2625 could not take any of them from this repository: both store workflows carry `if: github.repository == 'krlmlr/duckdb-r'`, so every run of them here is skipped, and the series refs, the `each-rcc` runs and the store live in the fork besides. Taken there on 2026-08-09. The script and its full output land in `experiments/2026-08-rcc2-read-path/`; it fetches refs and reads the API, and writes nothing. Neither `rcc-logs.yaml` nor `rcc-consolidate.yaml` was dispatched while measuring — the first is measurement 1's whole signal and the second rewrites the branch measurement 3 weighs.

## 1. The gap has never been felt — over one day

`rcc-logs.yaml` has two `workflow_dispatch` runs in the fork, ever, both by `krlmlr`, and both *before* #2578 merged at 2026-08-08T14:46:49Z. The later of the two is the verification dispatch #2578's own body names, run 31251750340, dispatched before changing anything to confirm the route the skill was about to depend on. So the count since the schedule stopped is zero — and the schedule stopped exactly when it should have: of 118 runs, 76 are `schedule` and none since #2578.

The number is right and the window is not. Zero is what question 6 wanted, but it has only been possible to observe for **1.1 days**, and the question asked for a full cycle.

## 2. The replacement agrees, everywhere it was asked

Two answers per commit in `<S>-green..<S>-dev` over all six live series: a record via `scripts/rcc-decided.sh`, and an `rcc` status of `success`/`failure`. Over 420 commits in flight — no status without a record, no record without a status, and no commit where the two name a different state.

On its own that is thin: the range is bounded by `-green`, so 395 of the 420 are simply not built yet and only 25 are decided at all. So the run asks the same question of the sample the range cannot give — the store's 250 newest records, every one decided by construction, each a chance for a record to exist where a status does not. 250 of 250 agree, states included. That is the direction that would break D6, and it does not happen in 250 consecutive verdicts.

The batched GraphQL query D6 would actually make is in the script, recovered from `each-plan.sh`'s pre-D1 form (#2440). It did not run: the token this session holds serves only a pinned set of GraphQL operations, so the comparison went over REST at one request per commit instead of one per hundred. Same answer, and re-running with an ordinary token exercises the batched path.

## 3. Keeping it costs 223 MB and about 390 commits a day

1563 commits, 8453 records, 4242 logs; 223 MB packed, 2.65 GB uncompressed, and the bulk of that is logs — a record is ~2 KB.

`rcc-consolidate.yaml` has **never run**, so nothing has been pruned since the cutover minted the branch on 2026-08-05, and the 1562 commits above the root are 4.0 days of verdicts. Nor would dispatching it help: the oldest surviving record is 120 days old against a 180-day window, so retention is not what is being deferred — the squash is, and all it would buy today is 1563 commits collapsing to 2.

## What it decides

**Proceed after a cycle of notice**, and start the work that does not depend on the answer. Measurement 2 clears the go/no-go; measurement 3 says the standing bill is real, dull and bounded, which is a reason to stop deferring rather than to rush; measurement 1 is the only one not yet supporting *now*, and is the cheapest to re-run. So: keep the branch and the leg's publish for one full series cycle, re-run, and cut when the count is still zero. Nothing waits on that — porting `series-check.sh` off `git show` is the one piece of real work in D6, is needed under every outcome, and can land first. Phase 6 grows the re-run as its gate.

## The wrinkle is not hypothetical, and it moves ahead of the cut

D6 says the `rcc` context is not the leg's alone and to decide with the cut whether the per-commit verdict gets its own. The fork already contains the answer, so this is one thing the measurement changed rather than confirmed.

The claim holds for `*-dev`, and is checked rather than taken on trust: all six `-dev` branches carry `main`'s push filter, which matches no series ref, and every one of the 73 `rcc` posts across the commits in flight — plus every post across the 250 widened commits — reads `each-rcc / shard N`.

But `R-CMD-check.yaml` runs from the branch it checks, and `v1.4-andium-build` still carries a copy from 2026-03-26 whose `v*.*-*` release-branch pattern matches its own name. Four pushes on 2026-08-06 therefore started the template check on the buffer, and `R-CMD-check-status.yaml` stamped `rcc=failure` on `6e7dd75ce` — a status with no record, the exact class D6's read would misread, sitting in the fork today.

It reaches nothing for one reason, which the run confirms rather than assumes: a buffer commit is re-minted when it is consumed onto `-dev`, so its SHA never enters selection's range (0 shared SHAs between `-build-base..-build` and `-green..-dev`, all six series). That is a property of the lineage, not of the context. The `-dev` copies are clean because the port stage keeps them level with `main`; the buffer is dirty because ports never touch it, which is F4's stated blind spot. A `-dev` branch regaining the glob — a series opened from an old buffer, a forward replaying onto a stale seed — would put a whole-branch matrix verdict straight into selection's range.

So: give the per-commit verdict its own `each-rcc` context **before** the status read goes in. One line in `each-shard.sh`, and the alternative has already produced the failure once.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XKYwx9LB1tpMrpK6SPLMT1)_