### PR TITLE
fix(vendoring): Pin the upstream clone's abbreviation, so a vendored tree is reproducible

### DIFF
--- a/configure
+++ b/configure
@@ -116,6 +116,10 @@ if [ "${DUCKDB_R_USE_SYSTEM_LIB}" = "1" ] || [ "${DUCKDB_R_USE_SYSTEM_LIB}" = "t
   # commit hash to 10 chars in the binary (CMake SUBSTRING 0 10), while the
   # vendored pragma_version.cpp sometimes carries 11. Both abbreviate the
   # same SHA, so we compare on the shared 10-char prefix.
+  #
+  # Newly vendored trees carry 10, because the vendor scripts pin core.abbrev
+  # in the upstream clone; the prefix comparison stays for the trees vendored
+  # before that, which a branch keeps until its next vendor commit.
   version_file=duckdb/src/function/table/version/pragma_version.cpp
   if [ -f "${version_file}" ]; then
     vendored_version=$(sed -n 's/^#define DUCKDB_VERSION "\(.*\)"$/\1/p' "${version_file}")

--- a/handbook/architecture/engine/README.md
+++ b/handbook/architecture/engine/README.md
@@ -20,6 +20,16 @@ the source id is what the fast path's commit-match guard checks
 At vendor time `rconfigure.py` writes the version into
 [`R/version.R`](/R/version.R),
 which is what `dbGetInfo()` reports without opening a database.
+The source id is ten characters, and it is ten because the vendor
+scripts pin `core.abbrev` in the upstream clone they work from:
+upstream derives it from `git describe`, whose default abbreviation
+grows with the number of objects in the repository it runs in,
+so without the pin the same upstream commit vendored from two clones
+produced two different trees.
+Ten is DuckDB's own length in the built library,
+which is what the commit-match guard compares against.
+Branches carry eleven-character ids from before the pin;
+they are rewritten by the next vendor commit that touches them.
 The *package* version is a different number, owned by
 [`operations/releases/versioning/`](/handbook/operations/releases/versioning/README.md).
 

--- a/scripts/vendor-one.sh
+++ b/scripts/vendor-one.sh
@@ -88,6 +88,19 @@ elif [ "$upstream_basedir" != "$upstream_dir" ]; then
     "$(git -C "$upstream_basedir" rev-parse --verify HEAD)"
 fi
 
+# Make the vendored tree depend on the upstream commit and nothing else.
+# `DUCKDB_SOURCE_ID` in pragma_version.cpp comes from upstream's
+# `git describe --tags --long`, run inside this clone, and git auto-sizes that
+# abbreviation from the number of objects the repository holds -- so the same
+# commit vendored twice, from clones that have grown apart, writes two different
+# strings and two different trees, and re-vendoring a commit to reproduce a
+# failure does not reproduce the tree. Set on every run, not only on the clone,
+# because the clone may be one someone else made (CI checks upstream out here).
+# Ten is DuckDB's own length: its CMake truncates the id to ten characters in
+# the built library, which is what ./configure's commit-match guard compares
+# against.
+git -C "$upstream_dir" config core.abbrev 10
+
 if [ -n "$(git status --porcelain)" ]; then
   echo "Error: working directory not clean"
   exit 1

--- a/scripts/vendor.sh
+++ b/scripts/vendor.sh
@@ -30,6 +30,16 @@ if [ "$upstream_basedir" != "$upstream_dir" ]; then
   git clone "$upstream_basedir" "$upstream_dir"
 fi
 
+# Make the vendored tree depend on the upstream commit and nothing else.
+# `DUCKDB_SOURCE_ID` in pragma_version.cpp comes from upstream's
+# `git describe --tags --long`, run inside this clone, and git auto-sizes that
+# abbreviation from the number of objects the repository holds -- so the same
+# commit vendored twice, from clones that have grown apart, writes two different
+# strings and two different trees. Ten is DuckDB's own length: its CMake
+# truncates the id to ten characters in the built library, which is what
+# ./configure's commit-match guard compares against.
+git -C "$upstream_dir" config core.abbrev 10
+
 if [ -n "$(git status --porcelain)" ]; then
   echo "Error: working directory not clean"
   exit 1


### PR DESCRIPTION
Closes #2489.

`DUCKDB_SOURCE_ID` in the vendored `pragma_version.cpp` is an abbreviated upstream commit id. Upstream's `package_build.py` derives it from `git describe --tags --long`, run with the working directory inside the clone the vendor scripts hand it, and git auto-sizes that abbreviation from the number of objects the repository holds — so the same upstream commit vendors as `7300522cf0` from one clone and `7300522cf07` from another, and the scripts clone upstream afresh into a clone that grows between runs.

`scripts/vendor.sh` and `scripts/vendor-one.sh` now set `core.abbrev` to `10` in the upstream clone. It is set on every run rather than only where the script creates the clone, because CI checks upstream out at that path itself. Ten is DuckDB's own length — its CMake truncates the id to ten characters in the built library, which is exactly what `configure`'s commit-match guard compares against — so a newly vendored tree and the library it is checked against now spell the commit identically.

The guard keeps comparing on the shared ten-character prefix: branches carry eleven-character ids from before the pin until their next vendor commit rewrites the line. The comment there says so instead of describing the old "sometimes 11" as permanent.

### Verification

Ran the real vendoring step — `scripts/rconfigure.py` with `DUCKDB_PATH` pointing at a `duckdb` checkout of `v1.5.5`, the commit this branch has vendored — in a throwaway worktree, and read the regenerated `pragma_version.cpp`:

- The clone as cloned (`core.abbrev` unset, so `auto`) regenerated `#define DUCKDB_SOURCE_ID "d8cdaa33fd"` — ten characters, against the **eleven** (`d8cdaa33fda`) the same commit's tree carries in this repository. That is the defect, reproduced: one upstream commit, two clones, two different trees.
- `core.abbrev 12` in that clone regenerated `"d8cdaa33fda8"`, and `core.abbrev 10` regenerated `"d8cdaa33fd"` again — so the setting, and nothing else about the clone, decides the length.

The rest of the regenerated tree was byte-identical to the vendored one apart from the `patch/` stack, which `rconfigure.py` does not apply.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULagARsxeoJfMKRx7WwZ3U)_