### PR TITLE
perf(vendoring): Keep git's stat cache valid across a regeneration of the vendored tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,10 @@ $RECYCLE.BIN/
 /src/*.dll
 /scripts/__pycache__
 /duckdb
+# Where scripts/rconfigure.py keeps the tree it is replacing while it
+# regenerates src/duckdb/; removed at the end of every run, so it exists only
+# while one is in flight.
+/src/.duckdb-previous
 /src/Makevars.duckdb
 /src/Makevars.rstrtmgr
 /src/Makevars.system-lib

--- a/scripts/rconfigure.py
+++ b/scripts/rconfigure.py
@@ -130,6 +130,64 @@ copy_logos()
 
 target_dir = os.path.join(os.getcwd(), 'src', 'duckdb')
 
+# Where the tree this run replaces is kept while the new one is generated.
+#
+# The regeneration itself is unavoidable, but rewriting a file is not free after
+# the write: it invalidates git's stat cache entry for it, so every later git
+# command over the tree re-hashes all ~3550 files. `git status` measured 1.06 s
+# right after every file was touched against 0.017 s with the index still valid,
+# and a vendor run pays that twice per candidate -- once for the "more than one
+# changed file" test that decides whether the candidate is worth a commit, and
+# once for `git add` -- whether or not the candidate is kept.
+#
+# So the old tree is moved aside rather than deleted, and every regenerated file
+# that turns out to be byte-identical to its predecessor is replaced by that
+# predecessor: `os.replace` puts the original inode back, with the size, mtime
+# and ctime the index recorded, and the stat cache entry is valid again. The
+# tree left behind is byte-for-byte what a regeneration from scratch produces,
+# because that is what it was compared against; only the inodes below the
+# unchanged majority are older than the run.
+previous_dir = os.path.join(os.getcwd(), 'src', '.duckdb-previous')
+
+
+def files_equal(a, b):
+    """Do these two paths hold the same bytes? A missing `b` is not equal."""
+    if not os.path.isfile(b):
+        return False
+    if os.path.getsize(a) != os.path.getsize(b):
+        return False
+    with open(a, 'rb') as fa, open(b, 'rb') as fb:
+        return fa.read() == fb.read()
+
+
+def restore_unchanged(previous, target):
+    """Put back the inode of every regenerated file that did not change.
+
+    Returns (restored, rewritten).
+    """
+    restored = rewritten = 0
+    for root, dirs, files in os.walk(target):
+        rel = os.path.relpath(root, target)
+        previous_root = previous if rel == os.curdir else os.path.join(previous, rel)
+        for name in files:
+            current = os.path.join(root, name)
+            before = os.path.join(previous_root, name)
+            if files_equal(current, before):
+                os.replace(before, current)
+                restored += 1
+            else:
+                rewritten += 1
+    return restored, rewritten
+
+
+# A run that died between the move and the regeneration leaves the tree here and
+# nothing at target_dir; put it back rather than dropping it on the floor.
+if os.path.isdir(previous_dir) and not os.path.isdir(target_dir):
+    os.rename(previous_dir, target_dir)
+shutil.rmtree(previous_dir, ignore_errors=True)
+if os.path.isdir(target_dir):
+    os.rename(target_dir, previous_dir)
+
 linenr = bool(os.getenv("DUCKDB_R_LINENR", ""))
 
 (source_list, include_list, original_sources) = package_build.build_package(target_dir, extensions, linenr)
@@ -144,7 +202,8 @@ linenr = bool(os.getenv("DUCKDB_R_LINENR", ""))
 source_list = [x for x in source_list if 'third_party/jemalloc' not in x.replace('\\', '/')]
 
 # Walk target_dir, find all source and include files, and terminate with newline,
-# if not already present
+# if not already present. Before the restore below, so what it compares against
+# is the final content of each file.
 for root, dirs, files in os.walk(target_dir):
     for file in files:
         if file.endswith('.cpp') or file.endswith('.hpp') or file.endswith('.c') or file.endswith('.h') or file.endswith('.cc'):
@@ -154,6 +213,10 @@ for root, dirs, files in os.walk(target_dir):
                 if len(lines) > 0 and lines[-1][-1] != '\n':
                     with open (filename, "a") as fw:
                         fw.write("\n")
+
+restored, rewritten = restore_unchanged(previous_dir, target_dir)
+shutil.rmtree(previous_dir, ignore_errors=True)
+print("Vendored tree: {} files changed, {} unchanged".format(rewritten, restored))
 
 script_path = os.path.dirname(os.path.abspath(__file__)).replace('\\', '/')
 

--- a/scripts/vendor-one.sh
+++ b/scripts/vendor-one.sh
@@ -209,8 +209,12 @@ while [ $commits_vendored -lt $num_commits ]; do
       exit 1
     }
 
-    rm -rf ${vendor_dir}
-
+    # The tree is not deleted here: rconfigure.py moves it aside itself and puts
+    # back the inode of every regenerated file that did not change, so a file
+    # whose content is the same keeps its stat cache entry and every later git
+    # command over ~3550 files stays cheap -- which this loop pays twice per
+    # candidate, kept or skipped. Files upstream dropped still go: they are in
+    # the tree that was moved aside, and never come back from it.
     echo "R: configure"
     DUCKDB_PATH="$upstream_dir" python3 scripts/rconfigure.py || {
       echo "Error: Failed to configure"

--- a/scripts/vendor.sh
+++ b/scripts/vendor.sh
@@ -64,8 +64,11 @@ is_tag=
 for commit in $original; do
   echo "Importing commit $commit"
 
-  rm -rf ${vendor_dir}
-
+  # The tree is not deleted here: rconfigure.py moves it aside itself and puts
+  # back the inode of every regenerated file that did not change, so a file
+  # whose content is the same keeps its stat cache entry and every later git
+  # command over ~3550 files stays cheap. Files upstream dropped still go -- they
+  # are in the tree that was moved aside, and never come back from it.
   echo "R: configure"
   DUCKDB_PATH="$upstream_dir" python3 scripts/rconfigure.py
 


### PR DESCRIPTION
Closes #2490.

Every vendor run regenerated all ~3550 files under `src/duckdb/`, including the ones whose content did not change. Upstream's packaging already declines to copy a file whose content is identical (`amalgamation.copy_if_different`), but `vendor.sh` and `vendor-one.sh` ran `rm -rf src/duckdb` first, so there was never anything to compare against and every file was written.

The cost is not the writes. Rewriting a file invalidates git's stat cache entry for it, so every later git command over the tree has to re-hash the whole thing — and a vendor run does that twice per candidate: once for the "more than one changed file" test that decides whether the candidate is worth a commit, and once for `git add`. Candidates that are skipped pay the same price as candidates that are vendored.

### What changed

`rconfigure.py` moves the tree aside (`src/.duckdb-previous`) instead of having it deleted, regenerates as before, and then puts back the inode of every regenerated file that turns out byte-identical to its predecessor. `os.replace` restores the size, mtime and ctime the index recorded, so the stat cache entry is valid again.

Files upstream dropped still go: they stay in the tree that was moved aside, which is removed at the end of the run. That is what the callers' `rm -rf` used to guarantee, so it is gone from both of them — the lifecycle now belongs to the script that regenerates. A run that dies between the move and the regeneration leaves the tree at `.duckdb-previous` with nothing at `src/duckdb`; the next run puts it back rather than dropping it.

The tree left behind is byte-for-byte what a regeneration from scratch produces, because that is exactly what each file was compared against.

### Measured

Against a `duckdb` checkout of the vendored commit (`v1.5.5`), regenerating over a clean tree, 4 vCPU container, 3552 files, three rounds of each:

- first `git status` over the vendored tree afterwards: **0.113–0.117 s → 0.014–0.021 s**, which is the untouched-tree floor (0.015 s measured on a tree nothing had written to)
- the regeneration itself: 0.69–1.31 s before, 0.72–1.01 s after — unchanged within the noise
- `src/duckdb/` (all 3552 files), `src/Makevars`, `src/Makevars.win`, `src/include/sources.mk` and `R/version.R`: **byte-identical** to the old flow's output, compared by digest

Also checked directly: files planted under `src/duckdb/` that the regeneration does not produce are removed, along with the directories that held them, and the recovery path leaves no `.duckdb-previous` behind.

The container this was measured on has a much faster disk than the one in the issue (which measured 1.06 s against 0.017 s), so the absolute saving there should be larger; the ratio is the same mechanism either way.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULagARsxeoJfMKRx7WwZ3U)_