### PR TITLE
docs(testing): Give the two undocumented testthat helpers a header

### DIFF
--- a/handbook/testing/suite/README.md
+++ b/handbook/testing/suite/README.md
@@ -36,8 +36,7 @@ and `_snaps/`
 **The helpers.**
 Every `helper-*.R` is sourced before the first test,
 and that set is the list.
-Each should open with a header saying why it exists;
-`helper-DBItest.R` and `helper-skip.R` do not yet.
+Each opens with a header saying why it exists.
 Three constraints are not obvious from reading one:
 `helper-DBItest.R`'s `make_context()` call must stay in the helper,
 any expectation whose output can carry the package name goes

--- a/tests/testthat/helper-DBItest.R
+++ b/tests/testthat/helper-DBItest.R
@@ -1,3 +1,14 @@
+# The context the DBI conformance suite runs against: a driver, and the tweaks
+# that say how DuckDB answers wherever the standard leaves a choice.
+# `test-DBItest.R` runs the suite; everything it needs to know about this
+# backend is here, so a suite failure is read as either a tweak that misstates
+# the backend or a genuine deviation from DBI.
+#
+# The driver is on disk rather than in memory, so the suite exercises the file
+# backend; the finalizer removes that file once the database reference is
+# collected. It is created here because the context is, and the context is
+# created here because it must be -- see below.
+
 drv <- duckdb(tempfile(fileext = ".duckdb"))
 reg.finalizer(drv@database_ref, function(x) {
   unlink(drv@dbdir, force = TRUE)

--- a/tests/testthat/helper-skip.R
+++ b/tests/testthat/helper-skip.R
@@ -1,3 +1,20 @@
+# The skip conditions this suite shares, each named for what it skips on.
+#
+# A test that cannot run everywhere is skipped on a property of what it is
+# running against -- a development snapshot of the engine, a renamed flavor,
+# CRAN, a build with icu linked in -- and the same property is asked about from
+# several test files. The reasoning for each lives here, so a call site is one
+# line that says which condition it is subject to and nothing more.
+#
+# A condition that a test could assert on instead is not one of these: where
+# DuckDB publishes no extension binaries the suite asserts the download error
+# rather than skipping, so the day the gap closes it is the assertion that
+# fails (handbook/testing/suite/README.md).
+
+# Skip where the vendored engine is a development snapshot rather than a
+# release. `get_duckdb_version()` reports a bare three-component version only at
+# a tag; anything else is a snapshot between releases, which has no published
+# extension binaries and no released libduckdb to match.
 # https://github.com/r-lib/testthat/issues/2236
 skip_on_dev_version <- function() {
   version <- get_duckdb_version()


### PR DESCRIPTION
Closes #2502.

Every `helper-*.R` is sourced before the first test, and `handbook/testing/suite/README.md` asks each to open with a header saying why it exists — naming `helper-DBItest.R` and `helper-skip.R` as the two that did not. `helper-DBItest.R` opened on a driver being constructed; `helper-skip.R` opened on a bare issue link above its first function.

- **`helper-DBItest.R`** now says what it is — the context the DBI conformance suite runs against, driver and tweaks — how `test-DBItest.R` relates to it, and how a suite failure is read against it (a tweak that misstates the backend, or a genuine deviation). It also says why the driver is on disk rather than in memory. The existing note that the `make_context()` call must stay in the helper is untouched and is what the header's last line points at.
- **`helper-skip.R`** now says what its conditions have in common: each is named for a property of what the tests are running against, so a call site stays one line while the reasoning stays in the helper. It also says what does *not* belong there — a gap a test could assert on is asserted rather than skipped, which is the suite's existing rule for unpublished extension platforms. `skip_on_dev_version()` gains a sentence; the bare link above it said nothing about what the skip is for.

The handbook sentence that named the two as outstanding now states the rule without the exception. `helper-arrow.R`, `helper-snapshot.R` and `helper-storage.R` already opened with one and are unchanged.

Nothing executable changed; both files still parse, and `air` leaves them as they are.

One thing noticed while writing the `skip_on_dev_version()` sentence, left alone as out of scope: its regex is `^[0-9]+[.][0-9]+[.][0-9]$` — the last component has no `+`, so a patch release in double digits (`1.5.10`) would be classified as a development version and skipped. Worth a separate look.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULagARsxeoJfMKRx7WwZ3U)_