### PR TITLE
docs: Convert the stray Rd spellings in roxygen to Markdown

### DIFF
--- a/R/Driver.R
+++ b/R/Driver.R
@@ -119,7 +119,7 @@ driver_registry <- new.env(parent = emptyenv())
 #' DuckDB's prebuilt extensions for Linux are compiled with the GNU C++ standard library (`libstdc++`).
 #' Loading one into a `duckdb` package that was itself built with a *different* C++ standard library --
 #' most commonly `libc++` (clang's `-stdlib=libc++`) --
-#' is an ABI mismatch that crashes R (\url{https://github.com/duckdb/duckdb-r/issues/1107}).
+#' is an ABI mismatch that crashes R (<https://github.com/duckdb/duckdb-r/issues/1107>).
 #' Almost all Linux builds (CRAN binaries and most source installs) use `libstdc++` and are unaffected;
 #' macOS and Windows are unaffected.
 #'

--- a/R/backend-dbplyr__duckdb_connection.R
+++ b/R/backend-dbplyr__duckdb_connection.R
@@ -34,14 +34,14 @@
 NULL
 
 # Declare which version of dbplyr API is being called.
-# @param con A \code{\link{dbConnect}} object, as returned by \code{dbConnect()}
+# @param con A [dbConnect()] object, as returned by `dbConnect()`
 # @name dbplyr_edition
 dbplyr_edition.duckdb_connection <- function(con) {
   2L
 }
 
 # Description of the database connection
-# @param con A \code{\link{dbConnect}} object, as returned by \code{dbConnect()}
+# @param con A [dbConnect()] object, as returned by `dbConnect()`
 # @name db_connection_describe
 # @return
 # String consisting of DuckDB version, user login name, operating system, R version and the name of database
@@ -143,7 +143,7 @@ duckdb_n_distinct <- function(..., na.rm = FALSE) {
 }
 
 # Customized translation functions for DuckDB SQL
-# @param con A \code{\link{dbConnect}} object, as returned by \code{dbConnect()}
+# @param con A [dbConnect()] object, as returned by `dbConnect()`
 # @name sql_translation
 sql_translation.duckdb_connection <- function(con) {
   sql_variant <- pkg_method("sql_variant", "dbplyr")
@@ -606,7 +606,7 @@ sql_translation.duckdb_connection <- function(con) {
 
 
 # Customized translation for comparing to objects in DuckDB SQL
-# @param con A \code{\link{dbConnect}} object, as returned by \code{dbConnect()}
+# @param con A [dbConnect()] object, as returned by `dbConnect()`
 # @param x First object to be compared
 # @param y Second object to be compared
 # @name sql_expr_matches
@@ -617,7 +617,7 @@ sql_expr_matches.duckdb_connection <- function(con, x, y) {
 }
 
 # Customized escape translation for date objects
-# @param con A \code{\link{dbConnect}} object, as returned by \code{dbConnect()}
+# @param con A [dbConnect()] object, as returned by `dbConnect()`
 # @param x Date object to be escaped
 # @name sql_escape_date
 sql_escape_date.duckdb_connection <- function(con, x) {
@@ -627,7 +627,7 @@ sql_escape_date.duckdb_connection <- function(con, x) {
 }
 
 # Customized escape translation for datetime objects
-# @param con A \code{\link{dbConnect}} object, as returned by \code{dbConnect()}
+# @param con A [dbConnect()] object, as returned by `dbConnect()`
 # @param x Datetime object to be escaped
 # @name sql_escape_datetime
 sql_escape_datetime.duckdb_connection <- function(con, x) {
@@ -636,7 +636,7 @@ sql_escape_datetime.duckdb_connection <- function(con, x) {
 }
 
 # Customized handling for tbl() to allow the use of replacement scans
-# @param src .con A \code{\link{dbConnect}} object, as returned by \code{dbConnect()}
+# @param src .con A [dbConnect()] object, as returned by `dbConnect()`
 # @param from Table or parquet/csv -files to be registered
 # @param cache Enable object cache for parquet files
 tbl.duckdb_connection <- function(src, from, ..., cache = FALSE) {

--- a/R/csv.R
+++ b/R/csv.R
@@ -18,7 +18,7 @@
 #' @param col.names Override the detected or generated column names
 #' @param col.types Character vector of column types in the same order as col.names,
 #' or a named character vector where names are column names and types pairs.
-#' Valid types are \href{https://duckdb.org/docs/sql/data_types/overview.html}{DuckDB data types}, e.g. VARCHAR, DOUBLE, DATE, BIGINT, BOOLEAN, etc.
+#' Valid types are [DuckDB data types](https://duckdb.org/docs/sql/data_types/overview.html), e.g. VARCHAR, DOUBLE, DATE, BIGINT, BOOLEAN, etc.
 #' @param lower.case.names Transform column names to lower case
 #' @param sep Alias for delim for compatibility
 #' @param transaction Should a transaction be used for the entire operation

--- a/handbook/architecture/r-layer/style/README.md
+++ b/handbook/architecture/r-layer/style/README.md
@@ -78,11 +78,14 @@ is snake_case whatever the generic above it is called.
 
 **Reference pages are markdown roxygen.**
 `Roxygen: list(markdown = TRUE)` is set in
-[`DESCRIPTION`](/DESCRIPTION), so a cross-reference is `[dbConnect()]`
-and code is backticked;
-a few pages still carry the older `\code{\link{}}` spelling
-([#2616](https://github.com/duckdb/duckdb-r/issues/2616)),
-and converting one is an ordinary edit.
+[`DESCRIPTION`](/DESCRIPTION), so a cross-reference is `[dbConnect()]`,
+code is backticked, a bare URL goes in angle brackets,
+and a phrase linked to one is an ordinary markdown link.
+What markdown does not express stays Rd, and that is not a leftover:
+`\describe{}` / `\item{}` for a definition list — roxygen renders a
+markdown one literally, so there is nothing to convert to —
+and `\sQuote{}`, `\pkg{}`, `\dontrun{}`, which markdown has no spelling
+for at all.
 Each `@param` is a sentence — capitalised, ending in a full stop.
 
 ## Where this package deviates
@@ -111,11 +114,9 @@ Each `@param` is a sentence — capitalised, ending in a full stop.
   functions the package uses, swapped for the real ones at load
   when rlang is installed.
 
-*To deepen: state the rules once the three sweeps that make the code
+*To deepen: state the rules once the two sweeps that make the code
 match them have run — `air.toml`
-([#2614](https://github.com/duckdb/duckdb-r/issues/2614)),
-the error-raising spelling
-([#2615](https://github.com/duckdb/duckdb-r/issues/2615)),
-and the roxygen conversion
-([#2616](https://github.com/duckdb/duckdb-r/issues/2616)) —
+([#2614](https://github.com/duckdb/duckdb-r/issues/2614))
+and the error-raising spelling
+([#2615](https://github.com/duckdb/duckdb-r/issues/2615)) —
 and add the rules a review has enforced twice since.*


### PR DESCRIPTION
Closes #2616.

`Roxygen: list(markdown = TRUE)` has been set for a long time, but a few blocks still carried the older Rd spelling. All of them, and nothing else:

- `R/Driver.R` — one `\url{}` → angle brackets
- `R/csv.R` — one `\href{}{}` → a markdown link
- `R/backend-dbplyr__duckdb_connection.R` — seven `\code{\link{dbConnect}} … \code{dbConnect()}` pairs → `[dbConnect()] … `` `dbConnect()` ``. These sit in the commented-out documentation of the dbplyr S3 methods, so they generate nothing today, but they are the spelling anyone re-enabling a block would copy.

Regenerated `man/` with roxygen2 8.1.0.9000 (the version `DESCRIPTION` pins): every `.Rd` file and `NAMESPACE` come out **byte-identical**, which is what a pure spelling change should do.

### What stays Rd, and why the style page now says so

The remaining Rd macros in `R/` are not stragglers, so the style page records them instead of leaving the next reader to wonder:

- `\describe{}` / `\item{}` in `R/storage.R` — roxygen2 does **not** support markdown definition lists. Checked against 8.1.0.9000 in a scratch package: `Term` / `:   Definition` passes through into the `.Rd` verbatim, so converting would break the rendered page.
- `\sQuote{}` (four section references in `R/Driver.R`), `\pkg{}` (one in `R/dbConnect__duckdb_driver.R`), `\dontrun{}` (one `@examples` in `R/test-fixtures.R`) — markdown has no spelling for any of these.

The style page's deepen line drops the roxygen sweep and now names the two that remain.

### Noticed, not fixed

The same page's formatting paragraph still says "Nothing runs air over this repository today… this one carries only `.clang-format`" and defers to #2614. That issue is closed, `air.toml` is in the tree, and `main`'s tip is `chore: Format with air`, so the paragraph is stale — but it is a different sweep's prose and rewriting it belongs with whoever owns the formatting policy.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULagARsxeoJfMKRx7WwZ3U)_