### PR TITLE
feat(patch): Keep `D_ASSERT`'s operand named in a release build

### DIFF
--- a/experiments/2026-08-09-d-assert-operand/README.md
+++ b/experiments/2026-08-09-d-assert-operand/README.md
@@ -1,0 +1,89 @@
+# What a release-build `D_ASSERT` could say about its operand
+
+*What it measures:* whether `D_ASSERT` can be made to keep its condition
+named in a release build — so a binding or helper that exists only for an
+assert is still "used" — what that costs, and what it would retire.
+
+*When and on what:* 2026-08-09, against the engine vendored that day,
+on Linux x86_64 with GCC 13.3 and Clang 18.1, R 4.5.3.
+Two runs: [`forms.cpp`](forms.cpp) over four spellings of the macro
+([`forms.out`](forms.out)), and the whole tree compiled with the winning
+one and the two patches it would replace reverted
+([`tree.out`](tree.out), via
+[`scripts/warnings.sh`](/scripts/warnings.sh)).
+
+*What it supports:* why
+[`patch/0036`](/patch/0036-Mark-two-assert-only-bindings-used.patch) and
+[`patch/0037`](/patch/0037-Compile-an-assert-only-helper-only-when-asserts-are-on.patch)
+fix their two sites locally instead of fixing the class at the macro,
+and what an upstream proposal would have to carry
+([`build/warnings/`](/handbook/build/warnings/README.md)).
+
+## Why the question comes up
+
+Outside a debug build `D_ASSERT` **is** `assert`, and with `NDEBUG` the C
+standard requires `assert(x)` to expand to `((void)0)`.
+The operand is discarded without being parsed,
+so nothing in it is used — or even type-checked.
+A binding that appears only inside a `D_ASSERT` is therefore genuinely
+unused in a release build, which is what `-Wunused-variable` reports and
+what those two patches answer, one site at a time.
+
+A macro that named the operand without evaluating it would answer the
+whole class at once, including the sites a future vendor bump brings in.
+
+## The spelling matters more than it looks
+
+Four candidates, in `forms.cpp`, against four shapes: a binding used only
+by an assert, a static function called only from one, a bit-field
+condition, and a condition with no conversion to `bool`.
+
+* `((void)(sizeof(condition), 0))` is the most faithful to `((void)0)` —
+  the expansion's *value* is literally `0` — and it fails twice.
+  GCC reports **every** expansion under `-Wall`
+  ("left operand of comma operator has no effect", `-Wunused-value`),
+  which floods the build the macro exists to keep clean;
+  and `sizeof` applied directly to a bit-field is ill-formed, so
+  `D_ASSERT(bits.flag)` stops compiling on both compilers.
+* `((void)sizeof((condition) ? 1 : 0))` is quiet on both.
+  The `? 1 : 0` is load-bearing twice over: it makes a bit-field operand
+  an rvalue, and it keeps the comma out of the expansion.
+* `((void)sizeof((condition) ? 1 : 0), (void)0)` buys back the literal
+  `(void)0` ending — casting the left operand to void is what silences
+  GCC — and behaves identically to the previous one in every case here.
+  The faithfulness is free but also worth nothing measurable.
+
+**The winning form checks more than it silences.** It requires the
+condition to be contextually convertible to `bool`, so a nonsensical
+assert becomes an error in release too — matching what a debug build
+already enforces. Today `D_ASSERT(some_struct)` compiles in release and
+breaks only under `-DDEBUG`.
+
+**It does not cover assert-only *functions* on Clang.** A static function
+referenced only from an unevaluated operand draws
+`-Wunneeded-internal-declaration` ("is not needed and will not be
+emitted"), which Clang's `-Wall` enables. GCC is quiet. So `0037`'s
+`#ifdef` would survive the macro; only `0036` is retired.
+
+## Whole-tree: it compiles, and it finds three dead asserts
+
+All 341 vendored translation units compile with the macro in place —
+every `D_ASSERT` in the engine does type-check as a condition, which is
+the question that decides whether the macro is available at all.
+
+It is not free, though. Three assert operands that were never parsed turn
+out to be vacuous, all of them `>= 0` on an unsigned value:
+
+* `lru_cache.hpp:151` — `current_total_weight -= …;` immediately followed
+  by `D_ASSERT(current_total_weight >= 0);`. The assert is plainly there
+  to catch the subtraction underflowing, and on an unsigned type it can
+  never fire. This one is a real broken invariant check, not a tidiness
+  finding.
+* `iterator.hpp:74` and `:108` — `size() >= 0` and `count >= 0`,
+  harmlessly always true.
+
+So adopting the macro trades two patches for one patch plus three sites,
+and the fix for a vacuous assert is to correct or delete it, which is
+upstream's call. That is the argument for proposing the macro to
+`duckdb/duckdb` rather than carrying it here: its value is engine-wide,
+and so is the cleanup it demands.

--- a/experiments/2026-08-09-d-assert-operand/forms.cpp
+++ b/experiments/2026-08-09-d-assert-operand/forms.cpp
@@ -1,0 +1,59 @@
+#include <cassert>
+#include <cstddef>
+
+#if FORM == 0
+#define D_ASSERT(condition) assert(condition) // the status quo: ((void)0) under NDEBUG
+#elif FORM == 1
+#define D_ASSERT(condition) ((void)sizeof((condition) ? 1 : 0))
+#elif FORM == 2
+#define D_ASSERT(condition) ((void)(sizeof(condition), 0))
+#elif FORM == 3
+#define D_ASSERT(condition) ((void)sizeof((condition) ? 1 : 0), (void)0)
+#endif
+
+struct Vec {
+	int size() const {
+		return 2;
+	}
+};
+static Vec GetEntries() {
+	return Vec();
+}
+
+// (a) a binding used only by an assert
+static int UnusedBinding() {
+	auto &&entries = GetEntries();
+	D_ASSERT(entries.size() <= 2);
+	return 1;
+}
+
+// (b) a static function called only from an assert
+static bool IsOk(int x) {
+	return x > 0;
+}
+static int UnusedFunction() {
+	D_ASSERT(IsOk(1));
+	return 2;
+}
+
+// (c) a bit-field as the condition
+struct Bits {
+	unsigned flag : 1;
+};
+static int BitField(Bits b) {
+	D_ASSERT(b.flag);
+	return 3;
+}
+
+// (d) a condition with no conversion to bool -- a typo an assert should catch
+struct NotBool {
+	int a;
+};
+static int NonBoolean(NotBool n) {
+	D_ASSERT(n);
+	return 4;
+}
+
+int main() {
+	return UnusedBinding() + UnusedFunction() + BitField(Bits {1}) + NonBoolean(NotBool {1});
+}

--- a/experiments/2026-08-09-d-assert-operand/forms.out
+++ b/experiments/2026-08-09-d-assert-operand/forms.out
@@ -1,0 +1,23 @@
+$ for f in 0 1 2 3; do for cc in g++ clang++; do
+    $cc -std=gnu++17 -DNDEBUG -DFORM=$f -O2 -Wall -Wextra -fsyntax-only forms.cpp; done; done
+
+FORM=0  g++      warning: unused variable 'entries' [-Wunused-variable]
+FORM=0  clang++  warning: unused variable 'entries' [-Wunused-variable]
+FORM=0  clang++  warning: unused function 'IsOk' [-Wunused-function]
+
+FORM=1  g++      error: could not convert 'n' from 'NotBool' to 'bool'
+FORM=1  clang++  error: value of type 'NotBool' is not contextually convertible to 'bool'
+
+FORM=2  g++      warning: left operand of comma operator has no effect [-Wunused-value]  (x4)
+FORM=2  g++      error: invalid application of 'sizeof' to a bit-field
+FORM=2  clang++  error: invalid application of 'sizeof' to bit-field
+
+FORM=3  g++      error: could not convert 'n' from 'NotBool' to 'bool'
+FORM=3  clang++  error: value of type 'NotBool' is not contextually convertible to 'bool'
+
+# With the deliberately non-boolean case (d) removed, at -O0, warning counts:
+FORM=0  g++ 2   clang++ 3
+FORM=1  g++ 0   clang++ 1   # clang: -Wunneeded-internal-declaration on IsOk
+FORM=3  g++ 0   clang++ 1   # identical to FORM=1
+
+# -Wunneeded-internal-declaration is enabled by clang's -Wall, not only -Wextra.

--- a/experiments/2026-08-09-d-assert-operand/tree.out
+++ b/experiments/2026-08-09-d-assert-operand/tree.out
@@ -1,0 +1,17 @@
+$ scripts/warnings.sh all      # D_ASSERT = ((void)sizeof((condition) ? 1 : 0)),
+                               # patches 0036 and 0037 reverted
+
+== glue: 15 translation units
+-- 464 warnings in files another scope owns:
+       13  cpp11
+      451  vendored
+-- glue: clean
+== vendored: 341 translation units
+-- vendored warnings (3):
+   duckdb/src/include/duckdb/common/lru_cache.hpp:151:47: warning: comparison of unsigned expression in '>= 0' is always true [-Wtype-limits]
+   duckdb/src/include/duckdb/execution/index/art/iterator.hpp:108:32: warning: comparison of unsigned expression in '>= 0' is always true [-Wtype-limits]
+   duckdb/src/include/duckdb/execution/index/art/iterator.hpp:74:41: warning: comparison of unsigned expression in '>= 0' is always true [-Wtype-limits]
+-- vendored: not clean.
+
+# No errors: all 341 translation units compiled. The three warnings are new --
+# they are in assert operands the status quo never parses.

--- a/patch/0039-Keep-D_ASSERT-s-operand-named-in-a-release-build.patch
+++ b/patch/0039-Keep-D_ASSERT-s-operand-named-in-a-release-build.patch
@@ -1,0 +1,41 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kirill =?UTF-8?q?M=C3=BCller?= <kirill@cynkra.com>
+Date: Sun, 9 Aug 2026 12:00:00 +0200
+Subject: [PATCH] Keep D_ASSERT's operand named in a release build
+
+assert() discards its operand unparsed under NDEBUG, so a binding or
+helper that exists only for an assert is unused in a release build, and
+a condition that is not even a condition compiles. sizeof is
+unevaluated: naming the operand inside it costs nothing at run time,
+keeps the names used, and type-checks the condition -- which makes
+release agree with debug, where D_ASSERT already requires a bool.
+
+experiments/2026-08-09-d-assert-operand/ has the alternatives and why
+this spelling won.
+---
+  src/duckdb/src/include/duckdb/common/assert.hpp | 10 +++++++++-
+  1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/src/duckdb/src/include/duckdb/common/assert.hpp b/src/duckdb/src/include/duckdb/common/assert.hpp
+index 4bf4b90..dd94e2b 100644
+--- a/src/duckdb/src/include/duckdb/common/assert.hpp
++++ b/src/duckdb/src/include/duckdb/common/assert.hpp
+@@ -24,7 +24,15 @@
+ //! On most builds, NDEBUG is defined, turning the assert call into a NO-OP
+ //! Only the 'else' condition is supposed to check the assertions
+ #include <assert.h>
+-#define D_ASSERT assert
++//! assert() discards its operand unparsed under NDEBUG, so a binding or helper
++//! that exists only for an assert is unused in a release build, and a condition
++//! that is not even a condition compiles. Name the operand without evaluating
++//! it: sizeof is unevaluated, so this costs nothing at run time, while the
++//! names inside stay used and the condition stays type-checked.
++//! The `? 1 : 0` is load-bearing twice -- it makes a bit-field operand an
++//! rvalue, which sizeof cannot take directly, and it keeps a comma operator out
++//! of the expansion, which GCC reports under -Wall.
++#define D_ASSERT(condition) ((void)sizeof((condition) ? 1 : 0))
+ namespace duckdb {
+ DUCKDB_API void DuckDBAssertInternal(bool condition, const char *condition_name, const char *file, int linenr);
+ }
+-- 
+2.43.0

--- a/patch/0040-Fix-three-asserts-that-can-never-fire.patch
+++ b/patch/0040-Fix-three-asserts-that-can-never-fire.patch
@@ -1,0 +1,53 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kirill =?UTF-8?q?M=C3=BCller?= <kirill@cynkra.com>
+Date: Sun, 9 Aug 2026 12:00:00 +0200
+Subject: [PATCH] Fix three asserts that can never fire
+
+All three compare an unsigned value >= 0, which 0039 is what makes
+visible -- the operand was never parsed before. Two are harmlessly
+always true. The third is not: SharedLruCache::DeleteImpl() subtracts
+and then asserts the result did not go below zero, which an idx_t
+cannot do; assert what it meant, before the subtraction.
+---
+  src/duckdb/src/include/duckdb/common/lru_cache.hpp             | 2 +-
+  src/duckdb/src/include/duckdb/execution/index/art/iterator.hpp | 4 ++--
+  2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/duckdb/src/include/duckdb/common/lru_cache.hpp b/src/duckdb/src/include/duckdb/common/lru_cache.hpp
+index 5b29982..9e2c368 100644
+--- a/src/duckdb/src/include/duckdb/common/lru_cache.hpp
++++ b/src/duckdb/src/include/duckdb/common/lru_cache.hpp
+@@ -147,8 +147,8 @@ private:
+ 	using EntryMap = unordered_map<Key, Entry, KeyHash, KeyEqual>;
+ 
+ 	void DeleteImpl(typename EntryMap::iterator iter) {
++		D_ASSERT(current_total_weight >= iter->second.payload_weight);
+ 		current_total_weight -= iter->second.payload_weight;
+-		D_ASSERT(current_total_weight >= 0);
+ 		lru_list.erase(iter->second.lru_iterator);
+ 		entry_map.erase(iter);
+ 	}
+diff --git a/src/duckdb/src/include/duckdb/execution/index/art/iterator.hpp b/src/duckdb/src/include/duckdb/execution/index/art/iterator.hpp
+index 46a933e..90a8d31 100644
+--- a/src/duckdb/src/include/duckdb/execution/index/art/iterator.hpp
++++ b/src/duckdb/src/include/duckdb/execution/index/art/iterator.hpp
+@@ -71,7 +71,7 @@ struct RowIdSetOutput {
+ 	}
+ 
+ 	bool IsFull() const {
+-		D_ASSERT(row_ids.size() >= 0 && row_ids.size() <= capacity);
++		D_ASSERT(row_ids.size() <= capacity);
+ 		return row_ids.size() >= capacity;
+ 	}
+ 	void SetKey(const IteratorKey &, const idx_t) {
+@@ -105,7 +105,7 @@ struct KeyRowIdOutput {
+ 		arena.Reset();
+ 	}
+ 	bool IsFull() const {
+-		D_ASSERT(count >= 0 && count <= capacity);
++		D_ASSERT(count <= capacity);
+ 		return count >= capacity;
+ 	}
+ 	void SetKey(const IteratorKey &current_key, const idx_t column_key_len) {
+-- 
+2.43.0

--- a/src/duckdb/src/include/duckdb/common/assert.hpp
+++ b/src/duckdb/src/include/duckdb/common/assert.hpp
@@ -24,7 +24,15 @@
 //! On most builds, NDEBUG is defined, turning the assert call into a NO-OP
 //! Only the 'else' condition is supposed to check the assertions
 #include <assert.h>
-#define D_ASSERT assert
+//! assert() discards its operand unparsed under NDEBUG, so a binding or helper
+//! that exists only for an assert is unused in a release build, and a condition
+//! that is not even a condition compiles. Name the operand without evaluating
+//! it: sizeof is unevaluated, so this costs nothing at run time, while the
+//! names inside stay used and the condition stays type-checked.
+//! The `? 1 : 0` is load-bearing twice -- it makes a bit-field operand an
+//! rvalue, which sizeof cannot take directly, and it keeps a comma operator out
+//! of the expansion, which GCC reports under -Wall.
+#define D_ASSERT(condition) ((void)sizeof((condition) ? 1 : 0))
 namespace duckdb {
 DUCKDB_API void DuckDBAssertInternal(bool condition, const char *condition_name, const char *file, int linenr);
 }

--- a/src/duckdb/src/include/duckdb/common/lru_cache.hpp
+++ b/src/duckdb/src/include/duckdb/common/lru_cache.hpp
@@ -147,8 +147,8 @@ private:
 	using EntryMap = unordered_map<Key, Entry, KeyHash, KeyEqual>;
 
 	void DeleteImpl(typename EntryMap::iterator iter) {
+		D_ASSERT(current_total_weight >= iter->second.payload_weight);
 		current_total_weight -= iter->second.payload_weight;
-		D_ASSERT(current_total_weight >= 0);
 		lru_list.erase(iter->second.lru_iterator);
 		entry_map.erase(iter);
 	}

--- a/src/duckdb/src/include/duckdb/execution/index/art/iterator.hpp
+++ b/src/duckdb/src/include/duckdb/execution/index/art/iterator.hpp
@@ -71,7 +71,7 @@ struct RowIdSetOutput {
 	}
 
 	bool IsFull() const {
-		D_ASSERT(row_ids.size() >= 0 && row_ids.size() <= capacity);
+		D_ASSERT(row_ids.size() <= capacity);
 		return row_ids.size() >= capacity;
 	}
 	void SetKey(const IteratorKey &, const idx_t) {
@@ -105,7 +105,7 @@ struct KeyRowIdOutput {
 		arena.Reset();
 	}
 	bool IsFull() const {
-		D_ASSERT(count >= 0 && count <= capacity);
+		D_ASSERT(count <= capacity);
 		return count >= capacity;
 	}
 	void SetKey(const IteratorKey &current_key, const idx_t column_key_len) {


### PR DESCRIPTION
**Not for merge — a proposal, recorded so it can be judged, and closed immediately.** Its value is engine-wide rather than this repository's, so if it goes anywhere it goes to `duckdb/duckdb`.

It came out of the question on #2617: why doesn't `D_ASSERT` already mark its operand used?

## The answer, and what a macro could do about it

Outside a debug build `D_ASSERT` **is** `assert`, and with `NDEBUG` the C standard requires `assert(x)` to expand to `((void)0)`. The operand is discarded without being parsed — so nothing in it is used, and a condition that is not even a condition compiles. That is the whole class `0036` and `0037` answer one site at a time, and the class grows with every vendor bump.

`0039` names the operand inside `sizeof`, which is unevaluated: nothing runs, the names stay used, and the condition is type-checked — so release agrees with debug, where `D_ASSERT` already requires a `bool`.

## The spelling is most of the work

Four candidates measured against four shapes — a binding used only by an assert, a static function called only from one, a bit-field condition, and a condition with no conversion to `bool`:

- `((void)(sizeof(condition), 0))` is the most faithful to `((void)0)` — the expansion's *value* is literally `0` — and it fails twice. GCC reports **every** expansion under `-Wall` (`-Wunused-value`, "left operand of comma operator has no effect"), flooding the build the macro exists to keep clean; and `sizeof` applied directly to a bit-field is ill-formed, so `D_ASSERT(bits.flag)` stops compiling on both compilers.
- `((void)sizeof((condition) ? 1 : 0))` is quiet on both. The `? 1 : 0` is load-bearing twice: it makes a bit-field operand an rvalue, and it keeps the comma out of the expansion.
- `((void)sizeof((condition) ? 1 : 0), (void)0)` buys back the literal `(void)0` ending — casting the left operand to void is what silences GCC — and behaves identically in every case tested. Free, and worth nothing measurable.

**It does not cover assert-only *functions* on Clang.** A static function referenced only from an unevaluated operand draws `-Wunneeded-internal-declaration` ("is not needed and will not be emitted"), which Clang's `-Wall` enables; GCC is quiet. So `0037`'s `#ifdef` survives the macro — only `0036` is retired by it.

## What the visibility costs

All 341 vendored translation units compile with the macro in place: every `D_ASSERT` in the engine does type-check as a condition, which is the question that decides whether this is available at all.

Three assert operands that were never parsed turn out to be vacuous, all `>= 0` on an unsigned value, and `0040` fixes them. Two are harmlessly always true. **The third is a broken invariant check:** `SharedLruCache::DeleteImpl()` subtracts a weight and then asserts the result did not go below zero, which an `idx_t` cannot do — the assert is plainly there to catch that subtraction underflowing and never could. It now asserts what it meant, before the subtraction.

So adopting the macro trades two patches for one patch plus three sites, and correcting a vacuous assert is upstream's call. That is the argument for sending this to `duckdb/duckdb` rather than carrying it here.

## Numbering

`0039` and `0040` assume #2617's `0035`–`0038` have landed. Since this is closed on arrival, that never has to be reconciled.

`experiments/2026-08-09-d-assert-operand/` holds the probe, both runs' recorded output, and the reasoning — that part is worth keeping whatever happens to the patches, and can be split into a PR of its own on request.

---
_Generated by [Claude Code](https://claude.ai/code/session_0148iKGyG7gmmQsdaDckmA3x)_