### PR TITLE
refactor: Raise every error through `abort()`, so it points at the caller

### DIFF
--- a/R/Driver.R
+++ b/R/Driver.R
@@ -4,9 +4,12 @@
 
 DBDIR_MEMORY <- ":memory:"
 
-check_flag <- function(x) {
+# `call` names the frame the flag was passed in, not this check: rlang's
+# `abort()` would otherwise report `check_flag()` to someone who called
+# `dbConnect()`. The base fallback ignores it and suppresses the call entirely.
+check_flag <- function(x, call = parent.frame()) {
   if (is.null(x) || length(x) != 1 || is.na(x) || !is.logical(x)) {
-    stop("flags need to be scalar logicals")
+    abort("flags need to be scalar logicals", call = call)
   }
 }
 
@@ -15,9 +18,9 @@ extptr_str <- function(e, n = 5) {
   substr(x, nchar(x) - n + 1, nchar(x))
 }
 
-drv_to_string <- function(drv) {
+drv_to_string <- function(drv, call = parent.frame()) {
   if (!is(drv, "duckdb_driver")) {
-    stop("pass a duckdb_driver object")
+    abort("pass a duckdb_driver object", call = call)
   }
   sprintf(
     "<duckdb_driver dbdir='%s' read_only=%s bigint=%s>",
@@ -151,7 +154,7 @@ duckdb <- function(
 ) {
   check_flag(read_only)
   if (...length() > 0) {
-    stop("... must be empty")
+    abort("... must be empty")
   }
   if (
     !is.null(shared_home) &&
@@ -159,10 +162,10 @@ duckdb <- function(
         length(shared_home) == 1L &&
         !is.na(shared_home))
   ) {
-    stop("`shared_home` must be TRUE, FALSE, or NULL.", call. = FALSE)
+    abort("`shared_home` must be TRUE, FALSE, or NULL.")
   }
   if (!is.null(home) && !is.null(shared_home)) {
-    stop("Pass either `home` or `shared_home`, not both.", call. = FALSE)
+    abort("Pass either `home` or `shared_home`, not both.")
   }
 
   convert_opts <- duckdb_convert_opts(bigint = bigint)
@@ -316,7 +319,7 @@ duckdb <- function(
 #' @export
 duckdb_shutdown <- function(drv) {
   if (!is(drv, "duckdb_driver")) {
-    stop("pass a duckdb_driver object")
+    abort("pass a duckdb_driver object")
   }
   if (!dbIsValid(drv)) {
     warning("invalid driver object, already closed?")

--- a/R/Result.R
+++ b/R/Result.R
@@ -152,7 +152,7 @@ is_wholenumber <- function(x, tol = .Machine$double.eps^0.5) {
 #' @export
 duckdb_fetch_arrow <- function(res, chunk_size = 1000000) {
   if (chunk_size <= 0) {
-    stop("Chunk Size must be higher than 0")
+    abort("Chunk Size must be higher than 0")
   }
   rethrow_rapi_execute_arrow(res@query_result, chunk_size)
 }
@@ -163,7 +163,7 @@ duckdb_fetch_arrow <- function(res, chunk_size = 1000000) {
 #' @export
 duckdb_fetch_record_batch <- function(res, chunk_size = 1000000) {
   if (chunk_size <= 0) {
-    stop("Chunk Size must be higher than 0")
+    abort("Chunk Size must be higher than 0")
   }
   rethrow_rapi_record_batch(res@query_result, chunk_size)
 }

--- a/R/Viewer.R
+++ b/R/Viewer.R
@@ -107,12 +107,12 @@ rs_preview <- function(
 ) {
   # Error if both table and view are passed
   if (!is.null(table) && !is.null(view)) {
-    stop("`table` and `view` can not both be used", call. = FALSE)
+    abort("`table` and `view` can not both be used")
   }
 
   # Error if neither table and view are passed
   if (is.null(table) && is.null(view)) {
-    stop("`table` and `view` can not both be `NULL`", call. = FALSE)
+    abort("`table` and `view` can not both be `NULL`")
   }
 
   name <- if (!is.null(table)) {

--- a/R/backend-dbplyr__duckdb_connection.R
+++ b/R/backend-dbplyr__duckdb_connection.R
@@ -75,9 +75,8 @@ duckdb_grepl <- function(
 ) {
   # https://duckdb.org/docs/sql/functions/patternmatching
   if (any(c(perl, fixed, useBytes))) {
-    stop(
-      "Parameters `perl`, `fixed` and `useBytes` in grepl are not currently supported in DuckDB backend",
-      call. = FALSE
+    abort(
+      "Parameters `perl`, `fixed` and `useBytes` in grepl are not currently supported in DuckDB backend"
     )
   }
 
@@ -97,14 +96,21 @@ duckdb_grepl <- function(
 # year, month or day, so send the integer it names. Anything that is not a
 # double -- a column reference, a SQL fragment, an integer already -- passes
 # through untouched, so a column keeps whatever type the table gave it.
-duckdb_integerish <- function(x, arg = deparse(substitute(x))) {
+# `call` names the translation the argument was written in, not this check:
+# rlang's `abort()` would otherwise report `duckdb_integerish()` for a
+# `date_build()` the caller wrote.
+duckdb_integerish <- function(
+  x,
+  arg = deparse(substitute(x)),
+  call = parent.frame()
+) {
   if (!is.double(x)) {
     return(x)
   }
 
   int <- suppressWarnings(as.integer(x))
   if (!identical(as.double(int), as.double(x))) {
-    stop("`", arg, "` must be a whole number.", call. = FALSE)
+    abort(paste0("`", arg, "` must be a whole number."), call = call)
   }
 
   int
@@ -118,7 +124,7 @@ duckdb_n_distinct <- function(..., na.rm = FALSE) {
   check_dots_unnamed <- pkg_method("check_dots_unnamed", "rlang")
 
   if (missing(...)) {
-    stop("`...` is absent, but must be supplied.")
+    abort("`...` is absent, but must be supplied.")
   }
   check_dots_unnamed()
 
@@ -283,9 +289,8 @@ sql_translation.duckdb_connection <- function(con) {
         with_year = identical(type, "year.quarter")
       ) {
         if (fiscal_start != 1) {
-          stop(
-            "`fiscal_start` is not yet supported in DuckDB translation. Must be 1.",
-            call. = FALSE
+          abort(
+            "`fiscal_start` is not yet supported in DuckDB translation. Must be 1."
           )
         }
         if (is.logical(type)) {
@@ -321,7 +326,7 @@ sql_translation.duckdb_connection <- function(con) {
               ))
             )
           },
-          stop(paste("Unsupported type", type), call. = FALSE)
+          abort(paste("Unsupported type", type))
         )
       },
       qday = function(x) {
@@ -347,7 +352,7 @@ sql_translation.duckdb_connection <- function(con) {
         } else if (label && abbr) {
           sql_expr(STRFTIME(!!x, "%a"))
         } else {
-          stop("Unrecognized arguments to `wday`", call. = FALSE)
+          abort("Unrecognized arguments to `wday`")
         }
       },
       yday = function(x) sql_expr(EXTRACT(DOY %FROM% !!x)),
@@ -431,12 +436,12 @@ sql_translation.duckdb_connection <- function(con) {
       date_count_between = function(start, end, precision, ..., n = 1L) {
         rlang::check_dots_empty()
         if (precision != "day") {
-          stop(
+          abort(
             'The only supported value for `precision` on SQL backends is "day"'
           )
         }
         if (n != 1) {
-          stop('The only supported value for `n` on SQL backends is "1"')
+          abort('The only supported value for `n` on SQL backends is "1"')
         }
 
         build_sql("DATEDIFF('day', ", !!start, ", ", !!end, ")")
@@ -546,9 +551,8 @@ sql_translation.duckdb_connection <- function(con) {
             !!pad
           ))
         } else {
-          stop(
-            'Argument \'side\' should be "left", "right" or "both"',
-            call. = FALSE
+          abort(
+            'Argument \'side\' should be "left", "right" or "both"'
           )
         }
       }
@@ -662,15 +666,14 @@ tbl.duckdb_connection <- function(src, from, ..., cache = FALSE) {
 #' @rdname backend-duckdb
 tbl_file <- function(src = NULL, path, ..., cache = FALSE) {
   if (...length() > 0) {
-    stop("... must be empty.", call. = FALSE)
+    abort("... must be empty.")
   }
   if (grepl("'", path)) {
-    stop(
+    abort(paste0(
       "File '",
       path,
-      "' contains a single quote, this is not supported",
-      call. = FALSE
-    )
+      "' contains a single quote, this is not supported"
+    ))
   }
   if (is.null(src)) {
     src <- default_conn()

--- a/R/check_unsupported_arg.R
+++ b/R/check_unsupported_arg.R
@@ -6,7 +6,7 @@
 #
 # This is a base-only variant. The wording follows dbplyr's, so a message from
 # this backend reads like the one the same argument produces on any other, but
-# it is raised with `stop()` rather than `cli::cli_abort()` -- the cli
+# it is raised with `abort()` rather than `cli::cli_abort()` -- the cli
 # formatting is all this package would gain from the dependency.
 
 # `x` is accepted when it is missing, when it is `NULL` and `allow_null` is
@@ -18,7 +18,8 @@ check_unsupported_arg <- function(
   x,
   allowed = NULL,
   allow_null = FALSE,
-  arg = deparse(substitute(x))
+  arg = deparse(substitute(x)),
+  call = parent.frame()
 ) {
   if (missing(x)) {
     return(invisible())
@@ -49,7 +50,7 @@ check_unsupported_arg <- function(
     )
   }
 
-  stop(msg, call. = FALSE)
+  abort(msg, call = call)
 }
 
 # Renders a value the way it would be written in R -- strings quoted, numbers

--- a/R/convert.R
+++ b/R/convert.R
@@ -5,33 +5,37 @@ duckdb_convert_opts <- function(
   bigint = "numeric",
   array = "none",
   geometry = "blob",
-  map = "data.frame"
+  map = "data.frame",
+  call = parent.frame()
 ) {
   tz_out_convert <- match.arg(tz_out_convert)
   timezone_out <- check_tz(timezone_out)
 
   if (bigint == "integer64") {
     if (!is_installed("bit64")) {
-      stop("bit64 package is required for integer64 support")
+      abort("bit64 package is required for integer64 support", call = call)
     }
   } else if (bigint != "numeric") {
-    stop(paste0("Unsupported bigint configuration: ", bigint))
+    abort(paste0("Unsupported bigint configuration: ", bigint), call = call)
   }
 
   if (geometry == "wk") {
     if (!is_installed("wk")) {
-      stop("wk package is required for geometry = \"wk\" support")
+      abort("wk package is required for geometry = \"wk\" support", call = call)
     }
   } else if (geometry != "blob") {
-    stop(paste0("Unsupported geometry configuration: ", geometry))
+    abort(paste0("Unsupported geometry configuration: ", geometry), call = call)
   }
 
   if (map == "list_of") {
     if (!is_installed("vctrs")) {
-      stop("vctrs package is required for map = \"list_of\" support")
+      abort(
+        "vctrs package is required for map = \"list_of\" support",
+        call = call
+      )
     }
   } else if (map != "data.frame") {
-    stop(paste0("Unsupported map configuration: ", map))
+    abort(paste0("Unsupported map configuration: ", map), call = call)
   }
 
   duckdb_convert_opts_impl(

--- a/R/csv.R
+++ b/R/csv.R
@@ -78,7 +78,7 @@ duckdb_read_csv <- function(
     warning("Arguments passed to ... are currently not used")
   }
   if (length(na.strings) > 1) {
-    stop("na.strings must be of length 1")
+    abort("na.strings must be of length 1")
   }
   if (!missing(sep)) {
     delim <- sep
@@ -97,17 +97,19 @@ duckdb_read_csv <- function(
   if (length(files) > 1) {
     nn <- sapply(headers, ncol)
     if (!all(nn == nn[1])) {
-      stop("Files have different numbers of columns")
+      abort("Files have different numbers of columns")
     }
     nms <- sapply(headers, names)
     if (!all(nms == nms[, 1])) {
-      stop("Files have different variable names or order")
+      abort("Files have different variable names or order")
     }
     if (is.null(col.types)) {
       types <- sapply(headers, function(df) {
         sapply(df, dbDataType, dbObj = conn)
       })
-      if (!all(types == types[, 1])) stop("Files have different variable types")
+      if (!all(types == types[, 1])) {
+        abort("Files have different variable types")
+      }
     }
   }
 
@@ -180,26 +182,26 @@ set_csv_fields <- function(found, col.names, col.types) {
 
   if (!is.null(col.types)) {
     if (length(col.types) != ncol(found)) {
-      stop(
+      abort(paste0(
         "You supplied ",
         length(col.types),
         " values to `col.names`, but file has ",
         ncol(found),
         " columns."
-      )
+      ))
     }
 
     if (!is.null(names(col.types))) {
       return(col.types)
     } else {
       if (length(col.types) != ncol(found)) {
-        stop(
+        abort(paste0(
           "You supplied ",
           length(col.types),
           " values to `col.types`, but file has ",
           ncol(found),
           " columns."
-        )
+        ))
       }
       fields <- col.types
       names(fields) <- col.names

--- a/R/dbAppendTable__duckdb_connection.R
+++ b/R/dbAppendTable__duckdb_connection.R
@@ -9,17 +9,17 @@ dbAppendTable__duckdb_connection <- function(
   row.names = NULL
 ) {
   if (!is.null(row.names)) {
-    stop("Can't pass `row.names` to `dbAppendTable()`")
+    abort("Can't pass `row.names` to `dbAppendTable()`")
   }
 
   target_names <- dbListFields(conn, name)
 
   if (!all(names(value) %in% target_names)) {
-    stop(
+    abort(paste0(
       "Column `",
       setdiff(names(value), target_names)[[1]],
       "` does not exist in target table."
-    )
+    ))
   }
 
   if (nrow(value)) {

--- a/R/dbBind__duckdb_result.R
+++ b/R/dbBind__duckdb_result.R
@@ -3,14 +3,14 @@
 #' @usage NULL
 dbBind__duckdb_result <- function(res, params, ...) {
   if (!res@env$open) {
-    stop("result has already been cleared")
+    abort("result has already been cleared")
   }
   res@env$rows_fetched <- 0
   res@env$resultset <- data.frame()
 
   params <- as.list(params)
   if (!is.null(names(params))) {
-    stop("`params` must not be named")
+    abort("`params` must not be named")
   }
 
   params <- encode_values(params)

--- a/R/dbBind__duckdb_result_arrow.R
+++ b/R/dbBind__duckdb_result_arrow.R
@@ -3,7 +3,7 @@
 #' @usage NULL
 dbBind__duckdb_result_arrow <- function(res, params, ...) {
   if (!res@env$open) {
-    stop("result has already been cleared")
+    abort("result has already been cleared")
   }
   res@env$completed <- FALSE
   res@env$arrow_schema <- NULL
@@ -12,7 +12,7 @@ dbBind__duckdb_result_arrow <- function(res, params, ...) {
 
   params <- as.list(params)
   if (!is.null(names(params))) {
-    stop("`params` must not be named")
+    abort("`params` must not be named")
   }
 
   params <- encode_values(params)

--- a/R/dbColumnInfo__duckdb_result.R
+++ b/R/dbColumnInfo__duckdb_result.R
@@ -3,7 +3,7 @@
 #' @usage NULL
 dbColumnInfo__duckdb_result <- function(res, ...) {
   if (!res@env$open) {
-    stop("result has already been cleared")
+    abort("result has already been cleared")
   }
   return(data.frame(
     name = res@stmt_lst$names,

--- a/R/dbColumnInfo__duckdb_result_arrow.R
+++ b/R/dbColumnInfo__duckdb_result_arrow.R
@@ -3,7 +3,7 @@
 #' @usage NULL
 dbColumnInfo__duckdb_result_arrow <- function(res, ...) {
   if (!res@env$open) {
-    stop("result has already been cleared")
+    abort("result has already been cleared")
   }
   data.frame(
     name = res@stmt_lst$names,

--- a/R/dbDataType__duckdb_driver.R
+++ b/R/dbDataType__duckdb_driver.R
@@ -3,7 +3,7 @@
 dbDataType__duckdb_driver <- function(dbObj, obj, ...) {
   # FIXME: Use RApiTypes::DetectRType()
   if (is.null(obj)) {
-    stop("NULL parameter")
+    abort("NULL parameter")
   }
   if (is.data.frame(obj)) {
     return(vapply(

--- a/R/dbExistsTable__duckdb_connection_ANY.R
+++ b/R/dbExistsTable__duckdb_connection_ANY.R
@@ -3,10 +3,10 @@
 #' @usage NULL
 dbExistsTable__duckdb_connection_ANY <- function(conn, name, ...) {
   if (!dbIsValid(conn)) {
-    stop("Invalid connection")
+    abort("Invalid connection")
   }
   if (length(name) != 1) {
-    stop("Can only have a single name argument")
+    abort("Can only have a single name argument")
   }
   exists <- FALSE
   tryCatch(

--- a/R/dbFetchArrow__duckdb_result_arrow.R
+++ b/R/dbFetchArrow__duckdb_result_arrow.R
@@ -5,7 +5,7 @@
 #' @usage NULL
 dbFetchArrow__duckdb_result_arrow <- function(res, ..., chunk_size = 1000000) {
   if (!res@env$open) {
-    stop("result has already been cleared")
+    abort("result has already been cleared")
   }
   require_nanoarrow("dbFetchArrow()")
 
@@ -13,7 +13,7 @@ dbFetchArrow__duckdb_result_arrow <- function(res, ..., chunk_size = 1000000) {
     if (isTRUE(res@env$completed)) {
       return(empty_arrow_stream(res))
     }
-    stop("Need to call `dbBind()` before `dbFetchArrow()`")
+    abort("Need to call `dbBind()` before `dbFetchArrow()`")
   }
 
   pending <- res@env$pending_query_results
@@ -67,7 +67,7 @@ dbFetchArrowChunk__duckdb_result_arrow <- function(
   chunk_size = 1000000
 ) {
   if (!res@env$open) {
-    stop("result has already been cleared")
+    abort("result has already been cleared")
   }
   require_nanoarrow("dbFetchArrowChunk()")
 
@@ -75,7 +75,7 @@ dbFetchArrowChunk__duckdb_result_arrow <- function(
     if (isTRUE(res@env$completed)) {
       return(empty_arrow_chunk(res))
     }
-    stop("Need to call `dbBind()` before `dbFetchArrowChunk()`")
+    abort("Need to call `dbBind()` before `dbFetchArrowChunk()`")
   }
 
   repeat {
@@ -120,12 +120,11 @@ setMethod(
 
 require_nanoarrow <- function(what) {
   if (!requireNamespace("nanoarrow", quietly = TRUE)) {
-    stop(
+    abort(
       sprintf(
         "%s requires the `nanoarrow` package. Install it with `install.packages(\"nanoarrow\")`.",
         what
-      ),
-      call. = FALSE
+      )
     )
   }
 }

--- a/R/dbFetch__duckdb_result.R
+++ b/R/dbFetch__duckdb_result.R
@@ -4,18 +4,18 @@
 #' @usage NULL
 dbFetch__duckdb_result <- function(res, n = -1, ...) {
   if (!res@env$open) {
-    stop("result set was closed")
+    abort("result set was closed")
   }
 
   if (res@arrow) {
     if (n != -1) {
-      stop("Cannot dbFetch() an Arrow result unless n = -1")
+      abort("Cannot dbFetch() an Arrow result unless n = -1")
     }
     return(as.data.frame(duckdb_fetch_arrow(res)))
   }
 
   if (is.null(res@env$resultset)) {
-    stop("Need to call `dbBind()` before `dbFetch()`")
+    abort("Need to call `dbBind()` before `dbFetch()`")
   }
   if (res@stmt_lst$type == "EXPLAIN") {
     df <- res@env$resultset
@@ -24,16 +24,16 @@ dbFetch__duckdb_result <- function(res, n = -1, ...) {
     return(df)
   }
   if (length(n) != 1) {
-    stop("need exactly one value in n")
+    abort("need exactly one value in n")
   }
   if (is.infinite(n) || is.na(n)) {
     n <- -1
   }
   if (n < -1) {
-    stop("cannot fetch negative n other than -1")
+    abort("cannot fetch negative n other than -1")
   }
   if (!is_wholenumber(n)) {
-    stop("n needs to be not a whole number")
+    abort("n needs to be not a whole number")
   }
   if (
     res@stmt_lst$type != "SELECT" &&

--- a/R/dbGetRowCount__duckdb_result.R
+++ b/R/dbGetRowCount__duckdb_result.R
@@ -3,7 +3,7 @@
 #' @usage NULL
 dbGetRowCount__duckdb_result <- function(res, ...) {
   if (!res@env$open) {
-    stop("result has already been cleared")
+    abort("result has already been cleared")
   }
   return(res@env$rows_fetched)
 }

--- a/R/dbGetRowCount__duckdb_result_arrow.R
+++ b/R/dbGetRowCount__duckdb_result_arrow.R
@@ -3,7 +3,7 @@
 #' @usage NULL
 dbGetRowCount__duckdb_result_arrow <- function(res, ...) {
   if (!res@env$open) {
-    stop("result has already been cleared")
+    abort("result has already been cleared")
   }
   0
 }

--- a/R/dbGetRowsAffected__duckdb_result.R
+++ b/R/dbGetRowsAffected__duckdb_result.R
@@ -3,7 +3,7 @@
 #' @usage NULL
 dbGetRowsAffected__duckdb_result <- function(res, ...) {
   if (!res@env$open) {
-    stop("result has already been cleared")
+    abort("result has already been cleared")
   }
   if (is.null(res@env$resultset)) {
     return(NA_integer_)

--- a/R/dbGetRowsAffected__duckdb_result_arrow.R
+++ b/R/dbGetRowsAffected__duckdb_result_arrow.R
@@ -3,7 +3,7 @@
 #' @usage NULL
 dbGetRowsAffected__duckdb_result_arrow <- function(res, ...) {
   if (!res@env$open) {
-    stop("result has already been cleared")
+    abort("result has already been cleared")
   }
   NA_integer_
 }

--- a/R/dbGetStatement__duckdb_result.R
+++ b/R/dbGetStatement__duckdb_result.R
@@ -3,7 +3,7 @@
 #' @usage NULL
 dbGetStatement__duckdb_result <- function(res, ...) {
   if (!res@env$open) {
-    stop("result has already been cleared")
+    abort("result has already been cleared")
   }
   return(res@stmt_lst$str)
 }

--- a/R/dbGetStatement__duckdb_result_arrow.R
+++ b/R/dbGetStatement__duckdb_result_arrow.R
@@ -3,7 +3,7 @@
 #' @usage NULL
 dbGetStatement__duckdb_result_arrow <- function(res, ...) {
   if (!res@env$open) {
-    stop("result has already been cleared")
+    abort("result has already been cleared")
   }
   res@stmt_lst$str
 }

--- a/R/dbHasCompleted__duckdb_result.R
+++ b/R/dbHasCompleted__duckdb_result.R
@@ -3,7 +3,7 @@
 #' @usage NULL
 dbHasCompleted__duckdb_result <- function(res, ...) {
   if (!res@env$open) {
-    stop("result has already been cleared")
+    abort("result has already been cleared")
   }
 
   if (is.null(res@env$resultset)) {

--- a/R/dbHasCompleted__duckdb_result_arrow.R
+++ b/R/dbHasCompleted__duckdb_result_arrow.R
@@ -3,7 +3,7 @@
 #' @usage NULL
 dbHasCompleted__duckdb_result_arrow <- function(res, ...) {
   if (!res@env$open) {
-    stop("result has already been cleared")
+    abort("result has already been cleared")
   }
   isTRUE(res@env$completed)
 }

--- a/R/dbQuoteIdentifier__duckdb_connection.R
+++ b/R/dbQuoteIdentifier__duckdb_connection.R
@@ -7,7 +7,7 @@ dbQuoteIdentifier__duckdb_connection <- function(conn, x, ...) {
   }
 
   if (any(is.na(x))) {
-    stop("Cannot pass NA to dbQuoteIdentifier()")
+    abort("Cannot pass NA to dbQuoteIdentifier()")
   }
 
   x <- enc2utf8(x)

--- a/R/dbQuoteLiteral__duckdb_connection.R
+++ b/R/dbQuoteLiteral__duckdb_connection.R
@@ -65,7 +65,7 @@ dbQuoteLiteral__duckdb_connection <- function(conn, x, ...) {
         } else if (is.raw(x)) {
           paste0("'", paste0("\\x", format(x), collapse = ""), "'")
         } else {
-          stop("Lists must contain raw vectors or NULL", call. = FALSE)
+          abort("Lists must contain raw vectors or NULL")
         }
       },
       character(1)

--- a/R/dbWriteTable__duckdb_connection_character_data.frame.R
+++ b/R/dbWriteTable__duckdb_connection_character_data.frame.R
@@ -25,7 +25,7 @@ dbWriteTable__duckdb_connection_character_data.frame <- function(
   # TODO: start a transaction if one is not already running
 
   if (overwrite && append) {
-    stop("Setting both overwrite and append makes no sense")
+    abort("Setting both overwrite and append makes no sense")
   }
 
   if (!is.null(field.types)) {
@@ -34,18 +34,18 @@ dbWriteTable__duckdb_connection_character_data.frame <- function(
         !is.null(names(field.types)) &&
         !anyDuplicated(names(field.types)))
     ) {
-      stop(
+      abort(
         "`field.types` must be a named character vector with unique names, or NULL"
       )
     }
   }
   if (append && !is.null(field.types)) {
-    stop("Cannot specify `field.types` with `append = TRUE`")
+    abort("Cannot specify `field.types` with `append = TRUE`")
   }
 
   value <- as.data.frame(value)
   if (!is.data.frame(value)) {
-    stop("need a data frame as parameter")
+    abort("need a data frame as parameter")
   }
 
   # use Kirill's magic, convert rownames to additional column
@@ -56,12 +56,12 @@ dbWriteTable__duckdb_connection_character_data.frame <- function(
       dbRemoveTable(conn, name)
     }
     if (!overwrite && !append) {
-      stop(
+      abort(paste0(
         "Table ",
         name,
         " already exists. Set `overwrite = TRUE` if you want to remove the existing table. ",
         "Set `append = TRUE` if you would like to add the new data to the existing table."
-      )
+      ))
     }
   }
   table_name <- dbQuoteIdentifier(conn, name)

--- a/R/relational.R
+++ b/R/relational.R
@@ -20,7 +20,7 @@ expr_reference <- function(
   alias = NULL
 ) {
   if (...length() > 0) {
-    stop("... must be empty")
+    abort("... must be empty")
   }
 
   if (inherits(table, "duckdb_relation")) {
@@ -51,7 +51,7 @@ expr_constant <- function(
   convert_opts = NULL
 ) {
   if (...length() > 0) {
-    stop("... must be empty")
+    abort("... must be empty")
   }
 
   if (is.null(alias)) {
@@ -83,7 +83,7 @@ expr_operator <- function(
   alias = NULL
 ) {
   if (...length() > 0) {
-    stop("... must be empty")
+    abort("... must be empty")
   }
 
   if (is.null(alias)) {
@@ -107,7 +107,7 @@ expr_comparison <- function(
   alias = NULL
 ) {
   if (...length() > 0) {
-    stop("... must be empty")
+    abort("... must be empty")
   }
 
   if (is.null(alias)) {
@@ -133,7 +133,7 @@ expr_function <- function(
   alias = NULL
 ) {
   if (...length() > 0) {
-    stop("... must be empty")
+    abort("... must be empty")
   }
 
   if (is.null(alias)) {
@@ -189,7 +189,7 @@ rel_from_df <- function(
   strict = NULL
 ) {
   if (...length() > 0) {
-    stop("... must be empty")
+    abort("... must be empty")
   }
 
   # FIXME: Enable warning
@@ -221,7 +221,7 @@ as.data.frame.duckdb_relation <- function(
 ) {
   # nolint: object_name_linter
   if (!missing(row.names) || !missing(optional)) {
-    stop("row.names and optional parameters not supported")
+    abort("row.names and optional parameters not supported")
   }
   rethrow_rapi_rel_to_df(x)
 }
@@ -307,7 +307,7 @@ rel_order <- function(rel, orders, ascending = NULL, nulls_first = NULL) {
   }
 
   if (length(orders) != length(ascending)) {
-    stop("length of ascending must equal length of orders")
+    abort("length of ascending must equal length of orders")
   }
 
   if (is.null(nulls_first)) {
@@ -315,7 +315,7 @@ rel_order <- function(rel, orders, ascending = NULL, nulls_first = NULL) {
   }
 
   if (length(orders) != length(nulls_first)) {
-    stop("length of nulls_first must equal length of orders")
+    abort("length of nulls_first must equal length of orders")
   }
 
   return(rethrow_rapi_rel_order(rel, orders, ascending, nulls_first))
@@ -363,13 +363,13 @@ expr_window <- function(
     ascending <- rep(TRUE, length(order_bys))
   }
   if (length(order_bys) != length(ascending)) {
-    stop("length of ascending must equal length of order_bys")
+    abort("length of ascending must equal length of order_bys")
   }
   if (is.null(nulls_first)) {
     nulls_first <- rep(FALSE, length(order_bys))
   }
   if (length(order_bys) != length(nulls_first)) {
-    stop("length of nulls_first must equal length of order_bys")
+    abort("length of nulls_first must equal length of order_bys")
   }
 
   expr_window_(
@@ -633,7 +633,7 @@ rel_to_altrep <- function(
 ) {
   # FIXME: Move dots after `rel` for duckplyr >= 1.1.0
   if (...length() > 0) {
-    stop("... must be empty")
+    abort("... must be empty")
   }
   if (!isTRUE(allow_materialization)) {
     n_cells <- 0
@@ -719,7 +719,7 @@ rel_to_sql <- function(rel) {
 #' as.data.frame(rel2)
 rel_from_sql <- function(con, sql, env = parent.frame()) {
   if (!is.environment(env)) {
-    stop("`env` must be an environment.", call. = FALSE)
+    abort("`env` must be an environment.")
   }
   rethrow_rapi_rel_from_sql(con@conn_ref, sql, env)
 }

--- a/R/rlang.R
+++ b/R/rlang.R
@@ -17,6 +17,23 @@ is_interactive <- function() {
   interactive()
 }
 
+# `rlang::abort()`. How this package raises every error it raises itself.
+#
+# The base fallback passes `call. = FALSE`, so the message stands on its own
+# instead of being prefixed with the internal call that noticed the problem --
+# `check_flag()` or a method's `.local()` says nothing to the person who called
+# `dbConnect()`. rlang's own `abort()` does better than suppressing it: it
+# names the calling function, which is what the `rethrow_` wrappers already
+# give C++ errors.
+#
+# A message vector is joined with newlines here; the bulleted layout rlang gives
+# it is not available without the dependency. The rlang-only arguments are
+# accepted and ignored, so a call site can pass `call` without asking which
+# implementation it is talking to.
+abort <- function(message = NULL, ..., class = NULL, call = NULL) {
+  stop(paste(message, collapse = "\n"), call. = FALSE)
+}
+
 # `rlang::check_dots_empty0()`.
 check_dots_empty0 <- function(...) {
   if (...length() > 0L) {

--- a/R/s3_register.R
+++ b/R/s3_register.R
@@ -65,13 +65,12 @@ s3_register <- function(generic, class, method = NULL) {
 # get parent pkg function and method
 pkg_method <- function(fun, pkg) {
   if (!requireNamespace(pkg, quietly = TRUE)) {
-    stop(
+    abort(paste0(
       fun,
       " requires the ",
       pkg,
-      " package, please install it first and try again",
-      call. = FALSE
-    )
+      " package, please install it first and try again"
+    ))
   }
   fun_name <- utils::getFromNamespace(fun, pkg)
   return(fun_name)

--- a/R/storage-home.R
+++ b/R/storage-home.R
@@ -81,15 +81,14 @@ resolve_storage_home <- function(home = NULL, shared_home = NULL) {
       # location, abort -- reusing the storage-location message as the error
       # text so the user sees exactly how to choose. Only an explicit "no"
       # proceeds with a temporary directory.
-      stop(
+      abort(
         paste(
           storage_location_message(
             list(root = session_home(), source = "session"),
             interactive = TRUE
           ),
           collapse = "\n"
-        ),
-        call. = FALSE
+        )
       )
     }
     if (isTRUE(answer)) {
@@ -157,9 +156,8 @@ describe_storage_home <- function() {
 
 check_home_arg <- function(home) {
   if (!is_nonempty_string(home)) {
-    stop(
-      "`home` must be a single non-empty string (a directory path), or NULL.",
-      call. = FALSE
+    abort(
+      "`home` must be a single non-empty string (a directory path), or NULL."
     )
   }
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -22,6 +22,7 @@
 
   if (requireNamespace("rlang", quietly = TRUE)) {
     is_interactive <<- rlang::is_interactive
+    abort <<- rlang::abort
     rapi_error <<- rapi_error_rlang
     check_dots_empty0 <<- rlang::check_dots_empty0
     inform <<- rlang::inform

--- a/handbook/architecture/r-layer/style/README.md
+++ b/handbook/architecture/r-layer/style/README.md
@@ -40,7 +40,7 @@ and leaves the lines it did not come for alone.
 The guide's [error chapter](https://style.tidyverse.org/errors.html)
 assumes `cli::cli_abort()`, which this package cannot call
 ([below](#where-this-package-deviates));
-its wording rules survive the downgrade to `stop()` intact,
+its wording rules survive the downgrade intact,
 and they are what a review checks.
 A problem statement first, in sentence case, ending in a full stop;
 **must** where the expectation can be stated
@@ -48,11 +48,16 @@ A problem statement first, in sentence case, ending in a full stop;
 and **can't** where it cannot;
 the offending argument in backticks,
 and what the caller actually passed rather than only what was wanted.
-It is raised with `call. = FALSE`, and through rlang where that is
-installed, as the `rethrow_` wrappers do — so the message points at the
-user's call and not at the internal check that noticed
-([#2615](https://github.com/duckdb/duckdb-r/issues/2615),
-which both spellings in the tree are still being converted to).
+It is raised with `abort()` and never with `stop()`:
+[`R/rlang.R`](/R/rlang.R)'s fallback passes `call. = FALSE`, and
+`.onLoad()` swaps in `rlang::abort()` where rlang is installed, which
+names the calling function instead — the treatment the `rethrow_`
+wrappers already give errors coming out of C++.
+Either way the message points at the user's call rather than at the
+internal check that noticed.
+The three `stop()` calls left in `R/` are the base fallbacks themselves —
+`abort()`, `check_dots_empty0()`, `rapi_error()` — each the base half of
+a pair whose other half is rlang's.
 
 **`...` goes after the required arguments**
 ([design guide](https://design.tidyverse.org/dots-after-required.html)),
@@ -108,15 +113,17 @@ Each `@param` is a sentence — capitalised, ending in a full stop.
   and a new function has nothing before it that is not required.
 * **cli and rlang are not dependencies.**
   Both are `Suggests`, so the guide's `cli_abort()` examples
-  become `stop()` here, and its bulleted structure and inline markup
-  are not available — the wording rules above are all a message has.
+  become `abort()` here, and its bulleted structure and inline markup
+  are not available on the base path — a message vector is joined with
+  newlines there, so the wording rules above are all it has.
   [`R/rlang.R`](/R/rlang.R) holds base fallbacks for the few rlang
   functions the package uses, swapped for the real ones at load
   when rlang is installed.
 
-*To deepen: state the rules once the two sweeps that make the code
-match them have run — `air.toml`
-([#2614](https://github.com/duckdb/duckdb-r/issues/2614))
-and the error-raising spelling
-([#2615](https://github.com/duckdb/duckdb-r/issues/2615)) —
-and add the rules a review has enforced twice since.*
+*To deepen: state the rules once the `air.toml` sweep that makes the
+code match them has run
+([#2614](https://github.com/duckdb/duckdb-r/issues/2614)),
+and add the rules a review has enforced twice since.
+`warning()` is the other half of this page's message rules and is not
+stated at all: nothing says whether it takes the same treatment
+`abort()` just did.*

--- a/tests/testthat/_snaps/backend-dbplyr__duckdb_connection.md
+++ b/tests/testthat/_snaps/backend-dbplyr__duckdb_connection.md
@@ -415,42 +415,42 @@
     Code
       translate(grepl("dummy", txt, perl = TRUE))
     Condition
-      Error:
+      Error in `grepl()`:
       ! Parameters `perl`, `fixed` and `useBytes` in grepl are not currently supported in DuckDB backend
     Code
       translate(quarter(x, type = "other"))
     Condition
-      Error:
+      Error in `quarter()`:
       ! Unsupported type other
     Code
       translate(quarter(x, fiscal_start = 2))
     Condition
-      Error:
+      Error in `quarter()`:
       ! `fiscal_start` is not yet supported in DuckDB translation. Must be 1.
     Code
       translate(str_pad(x, width = 10, side = "other"))
     Condition
-      Error:
+      Error in `str_pad()`:
       ! Argument 'side' should be "left", "right" or "both"
     Code
       translate(date_build(2000L, invalid = "previous"))
     Condition
-      Error:
+      Error in `date_build()`:
       ! Argument `invalid` isn't supported on database backends.
     Code
       translate(date_build(2000.5))
     Condition
-      Error:
+      Error in `date_build()`:
       ! `year` must be a whole number.
     Code
       translate(difftime(x, y, units = "secs"))
     Condition
-      Error:
+      Error in `difftime()`:
       ! `units = "secs"` isn't supported on database backends.
       It must be "days" instead.
     Code
       translate(difftime(x, y, tz = "UTC"))
     Condition
-      Error:
+      Error in `difftime()`:
       ! Argument `tz` isn't supported on database backends.
 

--- a/tests/testthat/_snaps/storage-home.md
+++ b/tests/testthat/_snaps/storage-home.md
@@ -64,7 +64,7 @@
     Code
       resolve_storage_home()
     Condition
-      Error:
+      Error in `resolve_storage_home()`:
       ! duckdb keeps downloaded extensions and secrets in a temporary directory:
       /tmp/Rtmpxx/duckdb
       This is removed when the R session ends.


### PR DESCRIPTION
Closes #2615.

Rebased onto `main` now that #2635 (#2616) has merged; the folded commit dropped out and the style-page conflict resolved itself. This PR is one commit.

### The problem

`stop()` without `call. = FALSE` prefixes the message with the frame that raised it, which is the internal check that noticed rather than anything the caller wrote — `Error in check_flag(read_only):` for a bad flag passed to `dbConnect()`, `Error in .local(...):` for anything raised inside an S4 method. The tree carried both spellings, `stop()` and `stop(call. = FALSE)`, and neither is what the style page asks for.

### The change

`R/rlang.R` gains an `abort()` beside the other rlang fallbacks: base `stop(call. = FALSE)`, swapped for `rlang::abort()` in `.onLoad()` when rlang is installed, which names the calling function instead of suppressing it — the treatment the `rethrow_` wrappers already give errors coming out of C++. All 88 `stop()` calls in `R/` go through it.

Two things the sweep could not do mechanically:

- **Seven call sites relied on `stop()` concatenating its arguments**, which `abort()` does not do — `rlang::abort()`'s `...` is condition data, and the fallback ignores it. Those are `paste0()` now (`R/csv.R`, `R/dbAppendTable__…`, `R/dbWriteTable__…`, `R/s3_register.R`, two in the dbplyr backend). An R-level pass over the parsed sources confirms every `abort()` call now takes exactly one unnamed argument and no `call.`.
- **Five internal checks take a `call` defaulting to `parent.frame()`** and pass it on: `check_flag()`, `drv_to_string()`, `duckdb_convert_opts()`, `check_unsupported_arg()`, `duckdb_integerish()`. Without it rlang names the check itself — which is the thing this change exists to stop reporting. The `date_build(2000.5)` snapshot is the visible proof: it went `Error:` → `` Error in `duckdb_integerish()`: `` → `` Error in `date_build()`: `` as the argument was threaded.

The three `stop()` calls left in `R/` are the base fallbacks themselves — `abort()`, `check_dots_empty0()`, `rapi_error()` — each the base half of a pair whose other half is rlang's. The style page says so, and its deepen line drops this sweep.

`warning()` is deliberately untouched: the issue is about `stop()`, and whether warnings take the same treatment is now a question the style page's deepen line asks.

### Snapshots

Two files move, both in the intended direction, with rlang installed:

- `backend-dbplyr__duckdb_connection.md` — eight recorded translation errors go from a bare `Error:` to naming the function the caller wrote: `grepl()`, `quarter()` ×2, `str_pad()`, `date_build()` ×2, `difftime()` ×2.
- `storage-home.md` — one goes to `` Error in `resolve_storage_home()`: ``.

Nothing else in the suite changed. Re-verified after the rebase: `testthat::test_local()` is green (0 failures) against a fresh `R CMD INSTALL`ed build, so the four `callr` subprocess tests run too, and `air format .` leaves the result alone.