### PR TITLE
docs(spatial): Measure the geometry surface end to end, and plan the write side

### DIFF
--- a/experiments/2026-08-09-spatial-interop/README.md
+++ b/experiments/2026-08-09-spatial-interop/README.md
@@ -1,0 +1,116 @@
+# DuckDB ↔ R-spatial interop
+
+*What it measures:* which route carries a geometry across the R boundary
+and what arrives on the other side —
+37 rows in all: 10 asking whether a spatial name is core in 1.5,
+8 reading a `GEOMETRY` column into R,
+19 writing an R geometry into one —
+plus what each route does to the CRS.
+
+*When and on what:* 2026-08-09, duckdb 1.5.5.9013
+(DuckDB 1.5.5, vendored build, `spatial` loaded from the extension store),
+sf 1.1-2, wk 0.9.5, geoarrow 0.4.3, arrow 25.0.0, nanoarrow 0.9.0,
+Linux.
+The geometries are the first three counties of `sf`'s `nc.shp`
+(`MULTIPOLYGON`, EPSG:4267).
+
+*What it supports:*
+[`usage/types/`](/handbook/usage/types/README.md), and
+[`plan/PLAN-spatial-interop.md`](/plan/PLAN-spatial-interop.md),
+which proposes what to do about the write side.
+
+Run [`probe.R`](probe.R); the recorded run is [`probe.md`](probe.md),
+rendered with `reprex::reprex(si = TRUE)`.
+
+## What the run compresses to
+
+**The engine moved under this issue.**
+`GEOMETRY` is a core type in DuckDB 1.5, not an extension alias,
+and so are `ST_AsWKB()`, `ST_GeomFromWKB()`, `ST_AsText()`,
+`ST_SetCRS()`, and the `VARCHAR` → `GEOMETRY` cast that reads WKT.
+The `spatial` extension is still what supplies the geometry *functions* —
+`ST_Read()`, `ST_Point()`, `ST_Area()`, `ST_Transform()`,
+even `ST_GeomFromText()` —
+and, less obviously, the CRS provider:
+naming a CRS in DDL (`GEOMETRY('EPSG:4326')`) fails with
+"unrecognized coordinate system" until `spatial` is loaded,
+while `ST_SetCRS()` takes the same string without it.
+
+**Reading works, in three shapes, and the CRS survives all of them.**
+`geometry = "blob"` yields raw WKB, `geometry = "wk"` yields `wk_wkb`
+carrying the column's CRS identifier as an attribute,
+and `dbGetQueryArrow()` yields a `geoarrow.wkb` field whose extension
+metadata carries the CRS as PROJJSON —
+DuckDB 1.5 registers that Arrow extension type in both directions,
+which is what
+[duckdb_spatial#153](https://github.com/duckdb/duckdb_spatial/issues/153)
+was waiting for.
+`sf::st_as_sfc()` reconstructs the source CRS from either representation.
+
+**Two read-side gaps are in sf, not here.**
+`sf::st_read(con, <table>)` still warns
+"Could not find a simple features geometry column" and returns a
+`data.frame`: it recognizes neither a `GEOMETRY` column nor the
+`wk_wkb` vector this package hands it.
+The `st_read(con, query = )` workaround from the issue thread still
+works, and still loses the CRS —
+`ST_AsWKB()` returns a `BLOB`, and a `BLOB` has no CRS to carry.
+
+**The write side is where the story is.**
+No route from an `sf` or `sfc` object reaches a `GEOMETRY` column,
+and the failures are worse than a refusal:
+
+* An `sf` object handed to `dbWriteTable()` or `sf::st_write()`
+  fails with "Failed to parse geometry: Unknown geometry type at
+  offset 0" — sf's own `dbDataType()` method declares the column
+  `geometry` and writes EWKB hex into it, which DuckDB now tries to
+  parse as WKT.
+  The 2024 report's "Unknown type: '0106…'" has become a parse error;
+  it is still a failure.
+* A bare `sfc` column is not refused at all.
+  A `POINT` column writes **silently** as `DOUBLE[]` —
+  the type detector walks into the `sfg` list and finds numbers —
+  so the geometry is gone and nothing says so.
+  `LINESTRING` and `MULTIPOLYGON` reach the transform and abort with
+  `Invalid Error: std::exception`, naming neither column nor type.
+  `duckdb_register()` is the same both ways: it types an `sf` object's
+  column as `DOUBLE[2][][][]` and fails on fetch.
+* A `wk_wkb` column writes as `BLOB`, dropping its class and CRS
+  without a warning.
+* `BLOB` → `GEOMETRY` has no cast, so `field.types = c(geom =
+  "GEOMETRY")` over WKB fails, and so does `dbAppendTable()` of WKB
+  into an existing `GEOMETRY` column.
+
+**Three routes do work today,** none of them obvious:
+
+* **WKT, in one step.**
+  `dbWriteTable(con, tbl, df, field.types = c(geom = "GEOMETRY"))`
+  with a `character` column of `st_as_text()` output lands a
+  `GEOMETRY` column, because the `VARCHAR` cast parses WKT —
+  and `field.types = c(geom = "GEOMETRY('EPSG:4267')")` lands the CRS
+  with it, once `spatial` is loaded.
+  `dbAppendTable()` of WKT works for the same reason.
+  This is shorter than the `ALTER TABLE … USING ST_GeomFromWKB()`
+  route the handbook has been giving, which needs two statements and
+  drops the CRS: `SET DATA TYPE GEOMETRY` names the bare type, so a
+  CRS applied in the `USING` clause has nowhere to live.
+  A projection — `SELECT ST_SetCRS(geom, 'EPSG:4267')` — keeps it.
+* **WKB through a parameter.** `ST_GeomFromWKB(?)` bound to a raw
+  vector yields `GEOMETRY`, which is the per-query form of the same
+  thing.
+* **Arrow, which is the only route that carries geometry and CRS
+  together.**
+  A `wk_wkb` column becomes a `geoarrow.wkb` field with PROJJSON
+  metadata, and DuckDB reads it as `GEOMETRY('EPSG:4267')`;
+  the round trip back to `sf` is geometry-equal and CRS-equal to the
+  original.
+  It is also the narrowest path in the record:
+  `duckdb_register_arrow()` accepts an `arrow` object but not a
+  `nanoarrow` array stream (that one aborts with `std::exception`),
+  and `arrow`'s own conversions do not preserve the extension type —
+  `as_arrow_table()` turns a `wk_wkb` column into a plain `BLOB` and an
+  `sf` object into `geoarrow.multipolygon`, an encoding DuckDB does not
+  register, which arrives as `STRUCT(x DOUBLE, y DOUBLE)[][][]`.
+  Only `arrow::as_record_batch_reader()` wrapped around a
+  `nanoarrow` stream keeps `geoarrow.wkb` intact,
+  and only with the geoarrow package loaded to register it.

--- a/experiments/2026-08-09-spatial-interop/probe.R
+++ b/experiments/2026-08-09-spatial-interop/probe.R
@@ -1,0 +1,456 @@
+# DuckDB <-> R-spatial interop: which route carries a geometry, and what
+# arrives. One row per route, both directions, plus the CRS detail the
+# summary rows cannot hold.
+# The recorded run is probe.md, rendered with reprex::reprex(si = TRUE).
+library(duckdb)
+library(sf)
+library(geoarrow) # registers the geoarrow.wkb nanoarrow extension
+options(width = 200)
+options(nanoarrow.warn_unregistered_extension = FALSE)
+# Name the extension store explicitly, so the location reminder stays out
+# of the record.
+options(duckdb.home = "~/.duckdb")
+
+# One line of outcome, so a route fits on a row. DuckDB wraps every R-side
+# failure in one "Invalid Error:", which says nothing; the rest is verbatim.
+outcome <- function(expr) {
+  tryCatch(
+    expr,
+    error = function(e) {
+      msg <- gsub("\n.*", "", conditionMessage(e))
+      paste("ERROR:", sub("^Invalid Error: ", "", msg))
+    }
+  )
+}
+routes <- function(...) {
+  rows <- list(...)
+  data.frame(
+    route = vapply(rows, `[[`, character(1), 1L),
+    outcome = vapply(rows, `[[`, character(1), 2L)
+  )
+}
+
+con <- dbConnect(duckdb(), geometry = "wk")
+invisible(dbExecute(con, "INSTALL spatial"))
+invisible(dbExecute(con, "LOAD spatial"))
+
+nc <- read_sf(system.file("shape/nc.shp", package = "sf"))[
+  1:3,
+  c("NAME", "geometry")
+]
+nc_wkb <- st_as_binary(st_geometry(nc)) # list of raw
+nc_wk <- wk::as_wkb(st_geometry(nc)) # wk_wkb, carries the CRS
+nc_wkt <- st_as_text(st_geometry(nc)) # character
+
+# Which ST_ functions are core in 1.5, and which still need the extension.
+core <- dbConnect(duckdb(allow_extensions = FALSE))
+is_core <- function(sql) {
+  tryCatch(
+    {
+      dbGetQuery(core, sql)
+      "core"
+    },
+    error = function(e) {
+      msg <- conditionMessage(e)
+      absent <- grepl("not in the catalog|does not exist", msg) ||
+        grepl("unrecognized coordinate system", msg)
+      if (absent) "spatial extension" else "core"
+    }
+  )
+}
+print(
+  routes(
+    c(
+      "GEOMETRY type, 'POINT (1 2)'::GEOMETRY",
+      is_core("SELECT 'POINT (1 2)'::GEOMETRY")
+    ),
+    c(
+      "ST_AsWKB / ST_GeomFromWKB",
+      is_core("SELECT ST_GeomFromWKB(ST_AsWKB('POINT (1 2)'::GEOMETRY))")
+    ),
+    c("ST_AsText", is_core("SELECT ST_AsText('POINT (1 2)'::GEOMETRY)")),
+    c(
+      "ST_SetCRS",
+      is_core("SELECT ST_SetCRS('POINT (1 2)'::GEOMETRY, 'EPSG:4326')")
+    ),
+    c(
+      "GEOMETRY('EPSG:4326') in DDL",
+      is_core("CREATE TABLE ddl (g GEOMETRY('EPSG:4326'))")
+    ),
+    c("ST_GeomFromText", is_core("SELECT ST_GeomFromText('POINT (1 2)')")),
+    c("ST_Point", is_core("SELECT ST_Point(1, 2)")),
+    c(
+      "ST_Area",
+      is_core("SELECT ST_Area('POLYGON ((0 0, 1 0, 1 1, 0 0))'::GEOMETRY)")
+    ),
+    c("ST_Read", is_core("SELECT 1 FROM ST_Read('nonexistent.shp')")),
+    c(
+      "ST_Transform",
+      is_core(
+        "SELECT ST_Transform('POINT (1 2)'::GEOMETRY, 'EPSG:4326', 'EPSG:3857')"
+      )
+    )
+  ),
+  right = FALSE
+)
+dbDisconnect(core, shutdown = TRUE)
+
+# --- Reading: a GEOMETRY column on its way to R -----------------------
+
+shp <- system.file("shape/nc.shp", package = "sf")
+read_query <- paste0("SELECT NAME, geom FROM ST_Read('", shp, "') LIMIT 3")
+
+# wk_crs() reads the CRS wherever the representation keeps it: an
+# attribute on wk_wkb, the Arrow schema on geoarrow_vctr.
+describe <- function(x) {
+  crs <- tryCatch(wk::wk_crs(x), error = function(e) NULL)
+  paste0(
+    paste(class(x), collapse = "/"),
+    if (is.list(x) && length(x) && is.raw(x[[1]])) " of raw" else "",
+    ", crs ",
+    if (is.null(crs) || is.na(crs)[1]) {
+      "absent"
+    } else if (startsWith(crs, "{")) {
+      "PROJJSON"
+    } else {
+      crs
+    }
+  )
+}
+
+print(
+  routes(
+    c(
+      "dbGetQuery(), geometry = \"blob\" (default)",
+      outcome({
+        con_b <- dbConnect(duckdb())
+        on.exit(dbDisconnect(con_b, shutdown = TRUE))
+        invisible(dbExecute(con_b, "LOAD spatial"))
+        describe(dbGetQuery(con_b, read_query)$geom)
+      })
+    ),
+    c(
+      "dbGetQuery(), geometry = \"wk\"",
+      outcome(describe(dbGetQuery(con, read_query)$geom))
+    ),
+    c(
+      "dbGetQuery() + ST_AsWKB()",
+      outcome({
+        q <- paste0(
+          "SELECT ST_AsWKB(geom) AS geom FROM ST_Read('",
+          shp,
+          "') LIMIT 3"
+        )
+        describe(dbGetQuery(con, q)$geom)
+      })
+    ),
+    c(
+      "dbGetQueryArrow() schema",
+      outcome({
+        s <- nanoarrow::as_nanoarrow_array_stream(dbGetQueryArrow(
+          con,
+          read_query
+        ))
+        m <- s$get_schema()$children$geom$metadata
+        paste0(
+          m[["ARROW:extension:name"]],
+          ", crs ",
+          if (is.null(m[["ARROW:extension:metadata"]])) "absent" else "present"
+        )
+      })
+    ),
+    c(
+      "dbGetQueryArrow() -> data.frame (geoarrow loaded)",
+      outcome({
+        s <- nanoarrow::as_nanoarrow_array_stream(dbGetQueryArrow(
+          con,
+          read_query
+        ))
+        describe(as.data.frame(s)$geom)
+      })
+    ),
+    c(
+      "sf::st_read(con, <table>)",
+      outcome({
+        invisible(dbExecute(con, paste0("CREATE TABLE nc AS ", read_query)))
+        x <- withCallingHandlers(
+          st_read(con, "nc", quiet = TRUE),
+          warning = function(w) {
+            message("warning: ", conditionMessage(w))
+            invokeRestart("muffleWarning")
+          }
+        )
+        paste(class(x), collapse = "/")
+      })
+    ),
+    c(
+      "sf::st_read(con, query = ST_AsWKB(...))",
+      outcome({
+        q <- "SELECT NAME, ST_AsWKB(geom) AS geometry FROM nc"
+        x <- st_read(con, query = q, geometry_column = "geometry", quiet = TRUE)
+        paste0(paste(class(x), collapse = "/"), ", crs ", st_crs(x)$input)
+      })
+    ),
+    c(
+      "duckplyr's rel_from_df(), wk_wkb column",
+      outcome({
+        d <- data.frame(NAME = nc$NAME)
+        d$geom <- nc_wk
+        class(duckdb:::rel_from_df(con, d))
+      })
+    )
+  ),
+  right = FALSE
+)
+
+# --- Writing: an R geometry on its way into a GEOMETRY column ---------
+
+typeof_col <- function(table, col = "geom") {
+  dbGetQuery(
+    con,
+    paste0("SELECT typeof(", col, ") AS t FROM ", table, " LIMIT 1")
+  )$t
+}
+with_col <- function(x) {
+  d <- data.frame(NAME = nc$NAME)
+  d$geom <- x
+  d
+}
+
+print(
+  routes(
+    c(
+      "dbWriteTable(), sf object",
+      outcome({
+        dbWriteTable(con, "w_sf", nc, overwrite = TRUE)
+        typeof_col("w_sf", "geometry")
+      })
+    ),
+    c(
+      "dbWriteTable(), data.frame with sfc (MULTIPOLYGON)",
+      outcome({
+        dbWriteTable(con, "w_sfc", as.data.frame(nc), overwrite = TRUE)
+        typeof_col("w_sfc", "geometry")
+      })
+    ),
+    c(
+      "dbWriteTable(), data.frame with sfc (POINT)",
+      outcome({
+        dbWriteTable(
+          con,
+          "w_pt",
+          with_col(st_sfc(st_point(c(1, 2)))[c(1, 1, 1)]),
+          overwrite = TRUE
+        )
+        typeof_col("w_pt")
+      })
+    ),
+    c(
+      "duckdb_register(), sf object, typed",
+      outcome({
+        duckdb_register(con, "w_reg", nc)
+        typeof_col("w_reg", "geometry")
+      })
+    ),
+    c(
+      "duckdb_register(), sf object, fetched",
+      outcome({
+        class(dbGetQuery(con, "SELECT geometry FROM w_reg")$geometry)
+      })
+    ),
+    c(
+      "dbWriteTable(), wk_wkb column",
+      outcome({
+        dbWriteTable(con, "w_wk", with_col(nc_wk), overwrite = TRUE)
+        typeof_col("w_wk")
+      })
+    ),
+    c(
+      "dbWriteTable(), list of raw (WKB)",
+      outcome({
+        dbWriteTable(con, "w_raw", with_col(nc_wkb), overwrite = TRUE)
+        typeof_col("w_raw")
+      })
+    ),
+    c(
+      "dbWriteTable(), WKB + field.types = GEOMETRY",
+      outcome({
+        dbWriteTable(
+          con,
+          "w_ft",
+          with_col(nc_wkb),
+          field.types = c(geom = "GEOMETRY"),
+          overwrite = TRUE
+        )
+        typeof_col("w_ft")
+      })
+    ),
+    c(
+      "dbWriteTable(), WKT + field.types = GEOMETRY",
+      outcome({
+        dbWriteTable(
+          con,
+          "w_wkt",
+          with_col(nc_wkt),
+          field.types = c(geom = "GEOMETRY"),
+          overwrite = TRUE
+        )
+        typeof_col("w_wkt")
+      })
+    ),
+    c(
+      "dbWriteTable(), WKT + field.types = GEOMETRY('EPSG:4267')",
+      outcome({
+        dbWriteTable(
+          con,
+          "w_crs",
+          with_col(nc_wkt),
+          field.types = c(geom = "GEOMETRY('EPSG:4267')"),
+          overwrite = TRUE
+        )
+        typeof_col("w_crs")
+      })
+    ),
+    c(
+      "dbWriteTable() + ALTER ... USING ST_GeomFromWKB()",
+      outcome({
+        dbWriteTable(con, "w_alter", with_col(nc_wkb), overwrite = TRUE)
+        dbExecute(
+          con,
+          "ALTER TABLE w_alter ALTER COLUMN geom SET DATA TYPE GEOMETRY USING ST_GeomFromWKB(geom)"
+        )
+        typeof_col("w_alter")
+      })
+    ),
+    c(
+      "dbAppendTable(), WKB into a GEOMETRY column",
+      outcome({
+        dbAppendTable(con, "w_alter", with_col(nc_wkb))
+        "appended"
+      })
+    ),
+    c(
+      "dbAppendTable(), WKT into a GEOMETRY column",
+      outcome({
+        dbAppendTable(con, "w_alter", with_col(nc_wkt))
+        "appended"
+      })
+    ),
+    c(
+      "dbBind(), WKB into ST_GeomFromWKB(?)",
+      outcome({
+        r <- dbGetQuery(
+          con,
+          "SELECT typeof(ST_GeomFromWKB(?)) AS t",
+          params = list(nc_wkb[1])
+        )
+        r$t
+      })
+    ),
+    c(
+      "sf::st_write(nc, dsn = con)",
+      outcome({
+        st_write(nc, dsn = con, layer = "w_stw")
+        typeof_col("w_stw", "geometry")
+      })
+    ),
+    c(
+      "duckdb_register_arrow(), arrow table from sf",
+      outcome({
+        duckdb_register_arrow(con, "w_at_sf", arrow::as_arrow_table(nc))
+        typeof_col("w_at_sf", "geometry")
+      })
+    ),
+    c(
+      "duckdb_register_arrow(), arrow table from wk_wkb",
+      outcome({
+        duckdb_register_arrow(
+          con,
+          "w_at_wk",
+          arrow::as_arrow_table(with_col(nc_wk))
+        )
+        typeof_col("w_at_wk")
+      })
+    ),
+    c(
+      "duckdb_register_arrow(), nanoarrow stream",
+      outcome({
+        duckdb_register_arrow(
+          con,
+          "w_na",
+          nanoarrow::as_nanoarrow_array_stream(with_col(nc_wk))
+        )
+        typeof_col("w_na")
+      })
+    ),
+    c(
+      "duckdb_register_arrow(), reader over a nanoarrow stream",
+      outcome({
+        rbr <- arrow::as_record_batch_reader(
+          nanoarrow::as_nanoarrow_array_stream(with_col(nc_wk))
+        )
+        duckdb_register_arrow(con, "w_rbr", rbr)
+        substr(typeof_col("w_rbr"), 1, 40)
+      })
+    )
+  ),
+  right = FALSE
+)
+
+# --- The CRS, end to end ---------------------------------------------
+
+# Reading: both representations reach sf with the source's CRS, though
+# only wk keeps the identifier the column was declared with.
+c(
+  wk = isTRUE(
+    st_crs(st_as_sfc(dbGetQuery(con, read_query)$geom)) == st_crs(nc)
+  ),
+  geoarrow = isTRUE(
+    st_crs(st_as_sfc(
+      as.data.frame(
+        nanoarrow::as_nanoarrow_array_stream(dbGetQueryArrow(con, read_query))
+      )$geom
+    )) ==
+      st_crs(nc)
+  )
+)
+
+# The route that keeps it: geoarrow.wkb in, GEOMETRY(<PROJJSON>) out.
+# A reader is consumed once, so this needs a fresh one.
+duckdb_register_arrow(
+  con,
+  "w_rbr2",
+  arrow::as_record_batch_reader(nanoarrow::as_nanoarrow_array_stream(with_col(
+    nc_wk
+  )))
+)
+invisible(dbExecute(con, "CREATE TABLE roundtrip AS SELECT * FROM w_rbr2"))
+back <- dbGetQuery(con, "SELECT geom FROM roundtrip")$geom
+sfc <- st_as_sfc(back)
+c(
+  rows = length(sfc),
+  crs_equal = isTRUE(st_crs(sfc) == st_crs(nc)),
+  geometry_equal = all(st_equals(sfc, st_geometry(nc), sparse = FALSE)[cbind(
+    1:3,
+    1:3
+  )])
+)
+
+# The route that drops it: SET DATA TYPE GEOMETRY names the bare type,
+# so a CRS applied in the USING clause has nowhere to live.
+invisible(dbExecute(
+  con,
+  "ALTER TABLE w_alter ALTER COLUMN geom SET DATA TYPE GEOMETRY
+     USING ST_SetCRS(geom, 'EPSG:4267')"
+))
+attr(dbGetQuery(con, "SELECT geom FROM w_alter")$geom, "crs")
+
+# The route that keeps it without naming the CRS in DDL: a projection.
+invisible(dbExecute(
+  con,
+  "CREATE TABLE w_setcrs AS
+     SELECT NAME, ST_SetCRS(geom, 'EPSG:4267') AS geom FROM w_alter"
+))
+attr(dbGetQuery(con, "SELECT geom FROM w_setcrs")$geom, "crs")
+
+dbDisconnect(con, shutdown = TRUE)

--- a/experiments/2026-08-09-spatial-interop/probe.md
+++ b/experiments/2026-08-09-spatial-interop/probe.md
@@ -1,0 +1,588 @@
+``` r
+# DuckDB <-> R-spatial interop: which route carries a geometry, and what
+# arrives. One row per route, both directions, plus the CRS detail the
+# summary rows cannot hold.
+# The recorded run is probe.md, rendered with reprex::reprex(si = TRUE).
+library(duckdb)
+#> Loading required package: DBI
+library(sf)
+#> Linking to GEOS 3.12.1, GDAL 3.8.4, PROJ 9.4.0; sf_use_s2() is TRUE
+library(geoarrow) # registers the geoarrow.wkb nanoarrow extension
+options(width = 200)
+options(nanoarrow.warn_unregistered_extension = FALSE)
+# Name the extension store explicitly, so the location reminder stays out
+# of the record.
+options(duckdb.home = "~/.duckdb")
+
+# One line of outcome, so a route fits on a row. DuckDB wraps every R-side
+# failure in one "Invalid Error:", which says nothing; the rest is verbatim.
+outcome <- function(expr) {
+  tryCatch(
+    expr,
+    error = function(e) {
+      msg <- gsub("\n.*", "", conditionMessage(e))
+      paste("ERROR:", sub("^Invalid Error: ", "", msg))
+    }
+  )
+}
+routes <- function(...) {
+  rows <- list(...)
+  data.frame(
+    route = vapply(rows, `[[`, character(1), 1L),
+    outcome = vapply(rows, `[[`, character(1), 2L)
+  )
+}
+
+con <- dbConnect(duckdb(), geometry = "wk")
+invisible(dbExecute(con, "INSTALL spatial"))
+invisible(dbExecute(con, "LOAD spatial"))
+
+nc <- read_sf(system.file("shape/nc.shp", package = "sf"))[
+  1:3,
+  c("NAME", "geometry")
+]
+nc_wkb <- st_as_binary(st_geometry(nc)) # list of raw
+nc_wk <- wk::as_wkb(st_geometry(nc)) # wk_wkb, carries the CRS
+nc_wkt <- st_as_text(st_geometry(nc)) # character
+
+# Which ST_ functions are core in 1.5, and which still need the extension.
+core <- dbConnect(duckdb(allow_extensions = FALSE))
+is_core <- function(sql) {
+  tryCatch(
+    {
+      dbGetQuery(core, sql)
+      "core"
+    },
+    error = function(e) {
+      msg <- conditionMessage(e)
+      absent <- grepl("not in the catalog|does not exist", msg) ||
+        grepl("unrecognized coordinate system", msg)
+      if (absent) "spatial extension" else "core"
+    }
+  )
+}
+print(
+  routes(
+    c(
+      "GEOMETRY type, 'POINT (1 2)'::GEOMETRY",
+      is_core("SELECT 'POINT (1 2)'::GEOMETRY")
+    ),
+    c(
+      "ST_AsWKB / ST_GeomFromWKB",
+      is_core("SELECT ST_GeomFromWKB(ST_AsWKB('POINT (1 2)'::GEOMETRY))")
+    ),
+    c("ST_AsText", is_core("SELECT ST_AsText('POINT (1 2)'::GEOMETRY)")),
+    c(
+      "ST_SetCRS",
+      is_core("SELECT ST_SetCRS('POINT (1 2)'::GEOMETRY, 'EPSG:4326')")
+    ),
+    c(
+      "GEOMETRY('EPSG:4326') in DDL",
+      is_core("CREATE TABLE ddl (g GEOMETRY('EPSG:4326'))")
+    ),
+    c("ST_GeomFromText", is_core("SELECT ST_GeomFromText('POINT (1 2)')")),
+    c("ST_Point", is_core("SELECT ST_Point(1, 2)")),
+    c(
+      "ST_Area",
+      is_core("SELECT ST_Area('POLYGON ((0 0, 1 0, 1 1, 0 0))'::GEOMETRY)")
+    ),
+    c("ST_Read", is_core("SELECT 1 FROM ST_Read('nonexistent.shp')")),
+    c(
+      "ST_Transform",
+      is_core(
+        "SELECT ST_Transform('POINT (1 2)'::GEOMETRY, 'EPSG:4326', 'EPSG:3857')"
+      )
+    )
+  ),
+  right = FALSE
+)
+#>    route                                  outcome          
+#> 1  GEOMETRY type, 'POINT (1 2)'::GEOMETRY core             
+#> 2  ST_AsWKB / ST_GeomFromWKB              core             
+#> 3  ST_AsText                              core             
+#> 4  ST_SetCRS                              core             
+#> 5  GEOMETRY('EPSG:4326') in DDL           spatial extension
+#> 6  ST_GeomFromText                        spatial extension
+#> 7  ST_Point                               spatial extension
+#> 8  ST_Area                                spatial extension
+#> 9  ST_Read                                spatial extension
+#> 10 ST_Transform                           spatial extension
+dbDisconnect(core, shutdown = TRUE)
+
+# --- Reading: a GEOMETRY column on its way to R -----------------------
+
+shp <- system.file("shape/nc.shp", package = "sf")
+read_query <- paste0("SELECT NAME, geom FROM ST_Read('", shp, "') LIMIT 3")
+
+# wk_crs() reads the CRS wherever the representation keeps it: an
+# attribute on wk_wkb, the Arrow schema on geoarrow_vctr.
+describe <- function(x) {
+  crs <- tryCatch(wk::wk_crs(x), error = function(e) NULL)
+  paste0(
+    paste(class(x), collapse = "/"),
+    if (is.list(x) && length(x) && is.raw(x[[1]])) " of raw" else "",
+    ", crs ",
+    if (is.null(crs) || is.na(crs)[1]) {
+      "absent"
+    } else if (startsWith(crs, "{")) {
+      "PROJJSON"
+    } else {
+      crs
+    }
+  )
+}
+
+print(
+  routes(
+    c(
+      "dbGetQuery(), geometry = \"blob\" (default)",
+      outcome({
+        con_b <- dbConnect(duckdb())
+        on.exit(dbDisconnect(con_b, shutdown = TRUE))
+        invisible(dbExecute(con_b, "LOAD spatial"))
+        describe(dbGetQuery(con_b, read_query)$geom)
+      })
+    ),
+    c(
+      "dbGetQuery(), geometry = \"wk\"",
+      outcome(describe(dbGetQuery(con, read_query)$geom))
+    ),
+    c(
+      "dbGetQuery() + ST_AsWKB()",
+      outcome({
+        q <- paste0(
+          "SELECT ST_AsWKB(geom) AS geom FROM ST_Read('",
+          shp,
+          "') LIMIT 3"
+        )
+        describe(dbGetQuery(con, q)$geom)
+      })
+    ),
+    c(
+      "dbGetQueryArrow() schema",
+      outcome({
+        s <- nanoarrow::as_nanoarrow_array_stream(dbGetQueryArrow(
+          con,
+          read_query
+        ))
+        m <- s$get_schema()$children$geom$metadata
+        paste0(
+          m[["ARROW:extension:name"]],
+          ", crs ",
+          if (is.null(m[["ARROW:extension:metadata"]])) "absent" else "present"
+        )
+      })
+    ),
+    c(
+      "dbGetQueryArrow() -> data.frame (geoarrow loaded)",
+      outcome({
+        s <- nanoarrow::as_nanoarrow_array_stream(dbGetQueryArrow(
+          con,
+          read_query
+        ))
+        describe(as.data.frame(s)$geom)
+      })
+    ),
+    c(
+      "sf::st_read(con, <table>)",
+      outcome({
+        invisible(dbExecute(con, paste0("CREATE TABLE nc AS ", read_query)))
+        x <- withCallingHandlers(
+          st_read(con, "nc", quiet = TRUE),
+          warning = function(w) {
+            message("warning: ", conditionMessage(w))
+            invokeRestart("muffleWarning")
+          }
+        )
+        paste(class(x), collapse = "/")
+      })
+    ),
+    c(
+      "sf::st_read(con, query = ST_AsWKB(...))",
+      outcome({
+        q <- "SELECT NAME, ST_AsWKB(geom) AS geometry FROM nc"
+        x <- st_read(con, query = q, geometry_column = "geometry", quiet = TRUE)
+        paste0(paste(class(x), collapse = "/"), ", crs ", st_crs(x)$input)
+      })
+    ),
+    c(
+      "duckplyr's rel_from_df(), wk_wkb column",
+      outcome({
+        d <- data.frame(NAME = nc$NAME)
+        d$geom <- nc_wk
+        class(duckdb:::rel_from_df(con, d))
+      })
+    )
+  ),
+  right = FALSE
+)
+#> warning: Could not find a simple features geometry column. Will return a `data.frame`.
+#>   route                                             outcome                                          
+#> 1 dbGetQuery(), geometry = "blob" (default)         list of raw, crs absent                          
+#> 2 dbGetQuery(), geometry = "wk"                     wk_wkb/wk_vctr, crs EPSG:4267                    
+#> 3 dbGetQuery() + ST_AsWKB()                         list of raw, crs absent                          
+#> 4 dbGetQueryArrow() schema                          geoarrow.wkb, crs present                        
+#> 5 dbGetQueryArrow() -> data.frame (geoarrow loaded) geoarrow_vctr/nanoarrow_vctr, crs PROJJSON       
+#> 6 sf::st_read(con, <table>)                         data.frame                                       
+#> 7 sf::st_read(con, query = ST_AsWKB(...))           sf/data.frame, crs NA                            
+#> 8 duckplyr's rel_from_df(), wk_wkb column           ERROR: Can't convert column `geom` to relational.
+
+# --- Writing: an R geometry on its way into a GEOMETRY column ---------
+
+typeof_col <- function(table, col = "geom") {
+  dbGetQuery(
+    con,
+    paste0("SELECT typeof(", col, ") AS t FROM ", table, " LIMIT 1")
+  )$t
+}
+with_col <- function(x) {
+  d <- data.frame(NAME = nc$NAME)
+  d$geom <- x
+  d
+}
+
+print(
+  routes(
+    c(
+      "dbWriteTable(), sf object",
+      outcome({
+        dbWriteTable(con, "w_sf", nc, overwrite = TRUE)
+        typeof_col("w_sf", "geometry")
+      })
+    ),
+    c(
+      "dbWriteTable(), data.frame with sfc (MULTIPOLYGON)",
+      outcome({
+        dbWriteTable(con, "w_sfc", as.data.frame(nc), overwrite = TRUE)
+        typeof_col("w_sfc", "geometry")
+      })
+    ),
+    c(
+      "dbWriteTable(), data.frame with sfc (POINT)",
+      outcome({
+        dbWriteTable(
+          con,
+          "w_pt",
+          with_col(st_sfc(st_point(c(1, 2)))[c(1, 1, 1)]),
+          overwrite = TRUE
+        )
+        typeof_col("w_pt")
+      })
+    ),
+    c(
+      "duckdb_register(), sf object, typed",
+      outcome({
+        duckdb_register(con, "w_reg", nc)
+        typeof_col("w_reg", "geometry")
+      })
+    ),
+    c(
+      "duckdb_register(), sf object, fetched",
+      outcome({
+        class(dbGetQuery(con, "SELECT geometry FROM w_reg")$geometry)
+      })
+    ),
+    c(
+      "dbWriteTable(), wk_wkb column",
+      outcome({
+        dbWriteTable(con, "w_wk", with_col(nc_wk), overwrite = TRUE)
+        typeof_col("w_wk")
+      })
+    ),
+    c(
+      "dbWriteTable(), list of raw (WKB)",
+      outcome({
+        dbWriteTable(con, "w_raw", with_col(nc_wkb), overwrite = TRUE)
+        typeof_col("w_raw")
+      })
+    ),
+    c(
+      "dbWriteTable(), WKB + field.types = GEOMETRY",
+      outcome({
+        dbWriteTable(
+          con,
+          "w_ft",
+          with_col(nc_wkb),
+          field.types = c(geom = "GEOMETRY"),
+          overwrite = TRUE
+        )
+        typeof_col("w_ft")
+      })
+    ),
+    c(
+      "dbWriteTable(), WKT + field.types = GEOMETRY",
+      outcome({
+        dbWriteTable(
+          con,
+          "w_wkt",
+          with_col(nc_wkt),
+          field.types = c(geom = "GEOMETRY"),
+          overwrite = TRUE
+        )
+        typeof_col("w_wkt")
+      })
+    ),
+    c(
+      "dbWriteTable(), WKT + field.types = GEOMETRY('EPSG:4267')",
+      outcome({
+        dbWriteTable(
+          con,
+          "w_crs",
+          with_col(nc_wkt),
+          field.types = c(geom = "GEOMETRY('EPSG:4267')"),
+          overwrite = TRUE
+        )
+        typeof_col("w_crs")
+      })
+    ),
+    c(
+      "dbWriteTable() + ALTER ... USING ST_GeomFromWKB()",
+      outcome({
+        dbWriteTable(con, "w_alter", with_col(nc_wkb), overwrite = TRUE)
+        dbExecute(
+          con,
+          "ALTER TABLE w_alter ALTER COLUMN geom SET DATA TYPE GEOMETRY USING ST_GeomFromWKB(geom)"
+        )
+        typeof_col("w_alter")
+      })
+    ),
+    c(
+      "dbAppendTable(), WKB into a GEOMETRY column",
+      outcome({
+        dbAppendTable(con, "w_alter", with_col(nc_wkb))
+        "appended"
+      })
+    ),
+    c(
+      "dbAppendTable(), WKT into a GEOMETRY column",
+      outcome({
+        dbAppendTable(con, "w_alter", with_col(nc_wkt))
+        "appended"
+      })
+    ),
+    c(
+      "dbBind(), WKB into ST_GeomFromWKB(?)",
+      outcome({
+        r <- dbGetQuery(
+          con,
+          "SELECT typeof(ST_GeomFromWKB(?)) AS t",
+          params = list(nc_wkb[1])
+        )
+        r$t
+      })
+    ),
+    c(
+      "sf::st_write(nc, dsn = con)",
+      outcome({
+        st_write(nc, dsn = con, layer = "w_stw")
+        typeof_col("w_stw", "geometry")
+      })
+    ),
+    c(
+      "duckdb_register_arrow(), arrow table from sf",
+      outcome({
+        duckdb_register_arrow(con, "w_at_sf", arrow::as_arrow_table(nc))
+        typeof_col("w_at_sf", "geometry")
+      })
+    ),
+    c(
+      "duckdb_register_arrow(), arrow table from wk_wkb",
+      outcome({
+        duckdb_register_arrow(
+          con,
+          "w_at_wk",
+          arrow::as_arrow_table(with_col(nc_wk))
+        )
+        typeof_col("w_at_wk")
+      })
+    ),
+    c(
+      "duckdb_register_arrow(), nanoarrow stream",
+      outcome({
+        duckdb_register_arrow(
+          con,
+          "w_na",
+          nanoarrow::as_nanoarrow_array_stream(with_col(nc_wk))
+        )
+        typeof_col("w_na")
+      })
+    ),
+    c(
+      "duckdb_register_arrow(), reader over a nanoarrow stream",
+      outcome({
+        rbr <- arrow::as_record_batch_reader(
+          nanoarrow::as_nanoarrow_array_stream(with_col(nc_wk))
+        )
+        duckdb_register_arrow(con, "w_rbr", rbr)
+        substr(typeof_col("w_rbr"), 1, 40)
+      })
+    )
+  ),
+  right = FALSE
+)
+#> Note: method with signature 'DBIObject#sf' chosen for function 'dbDataType',
+#>  target signature 'duckdb_connection#sf'.
+#>  "duckdb_connection#ANY" would also be valid
+#>    route                                                     outcome                                                                                                     
+#> 1  dbWriteTable(), sf object                                 ERROR: Invalid Input Error: Failed to parse geometry: Unknown geometry type at offset 0                     
+#> 2  dbWriteTable(), data.frame with sfc (MULTIPOLYGON)        ERROR: Invalid Error: std::exception                                                                        
+#> 3  dbWriteTable(), data.frame with sfc (POINT)               DOUBLE[]                                                                                                    
+#> 4  duckdb_register(), sf object, typed                       DOUBLE[2][][][]                                                                                             
+#> 5  duckdb_register(), sf object, fetched                     ERROR: Invalid Error: std::exception                                                                        
+#> 6  dbWriteTable(), wk_wkb column                             BLOB                                                                                                        
+#> 7  dbWriteTable(), list of raw (WKB)                         BLOB                                                                                                        
+#> 8  dbWriteTable(), WKB + field.types = GEOMETRY              ERROR: Conversion Error: Unimplemented type for cast (BLOB -> GEOMETRY) when casting from source column geom
+#> 9  dbWriteTable(), WKT + field.types = GEOMETRY              GEOMETRY                                                                                                    
+#> 10 dbWriteTable(), WKT + field.types = GEOMETRY('EPSG:4267') GEOMETRY('EPSG:4267')                                                                                       
+#> 11 dbWriteTable() + ALTER ... USING ST_GeomFromWKB()         GEOMETRY                                                                                                    
+#> 12 dbAppendTable(), WKB into a GEOMETRY column               ERROR: Conversion Error: Unimplemented type for cast (BLOB -> GEOMETRY) when casting from source column geom
+#> 13 dbAppendTable(), WKT into a GEOMETRY column               appended                                                                                                    
+#> 14 dbBind(), WKB into ST_GeomFromWKB(?)                      GEOMETRY                                                                                                    
+#> 15 sf::st_write(nc, dsn = con)                               ERROR: Invalid Input Error: Failed to parse geometry: Unknown geometry type at offset 0                     
+#> 16 duckdb_register_arrow(), arrow table from sf              STRUCT(x DOUBLE, y DOUBLE)[][][]                                                                            
+#> 17 duckdb_register_arrow(), arrow table from wk_wkb          BLOB                                                                                                        
+#> 18 duckdb_register_arrow(), nanoarrow stream                 ERROR: std::exception                                                                                       
+#> 19 duckdb_register_arrow(), reader over a nanoarrow stream   GEOMETRY('EPSG:4267')
+
+# --- The CRS, end to end ---------------------------------------------
+
+# Reading: both representations reach sf with the source's CRS, though
+# only wk keeps the identifier the column was declared with.
+c(
+  wk = isTRUE(
+    st_crs(st_as_sfc(dbGetQuery(con, read_query)$geom)) == st_crs(nc)
+  ),
+  geoarrow = isTRUE(
+    st_crs(st_as_sfc(
+      as.data.frame(
+        nanoarrow::as_nanoarrow_array_stream(dbGetQueryArrow(con, read_query))
+      )$geom
+    )) ==
+      st_crs(nc)
+  )
+)
+#>       wk geoarrow 
+#>     TRUE     TRUE
+
+# The route that keeps it: geoarrow.wkb in, GEOMETRY(<PROJJSON>) out.
+# A reader is consumed once, so this needs a fresh one.
+duckdb_register_arrow(
+  con,
+  "w_rbr2",
+  arrow::as_record_batch_reader(nanoarrow::as_nanoarrow_array_stream(with_col(
+    nc_wk
+  )))
+)
+invisible(dbExecute(con, "CREATE TABLE roundtrip AS SELECT * FROM w_rbr2"))
+back <- dbGetQuery(con, "SELECT geom FROM roundtrip")$geom
+sfc <- st_as_sfc(back)
+c(
+  rows = length(sfc),
+  crs_equal = isTRUE(st_crs(sfc) == st_crs(nc)),
+  geometry_equal = all(st_equals(sfc, st_geometry(nc), sparse = FALSE)[cbind(
+    1:3,
+    1:3
+  )])
+)
+#>           rows      crs_equal geometry_equal 
+#>              3              1              1
+
+# The route that drops it: SET DATA TYPE GEOMETRY names the bare type,
+# so a CRS applied in the USING clause has nowhere to live.
+invisible(dbExecute(
+  con,
+  "ALTER TABLE w_alter ALTER COLUMN geom SET DATA TYPE GEOMETRY
+     USING ST_SetCRS(geom, 'EPSG:4267')"
+))
+attr(dbGetQuery(con, "SELECT geom FROM w_alter")$geom, "crs")
+#> NULL
+
+# The route that keeps it without naming the CRS in DDL: a projection.
+invisible(dbExecute(
+  con,
+  "CREATE TABLE w_setcrs AS
+     SELECT NAME, ST_SetCRS(geom, 'EPSG:4267') AS geom FROM w_alter"
+))
+attr(dbGetQuery(con, "SELECT geom FROM w_setcrs")$geom, "crs")
+#> [1] "EPSG:4267"
+
+dbDisconnect(con, shutdown = TRUE)
+```
+
+<details style="margin-bottom:10px;">
+
+<summary>
+
+Session info
+</summary>
+
+``` r
+sessioninfo::session_info()
+#> ─ Session info ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+#>  setting  value
+#>  version  R version 4.5.3 (2026-03-11)
+#>  os       Ubuntu 24.04.4 LTS
+#>  system   x86_64, linux-gnu
+#>  ui       X11
+#>  language (EN)
+#>  collate  C.UTF-8
+#>  ctype    C.UTF-8
+#>  tz       Etc/UTC
+#>  date     2026-08-09
+#>  pandoc   3.9.0.2 @ /usr/local/bin/ (via rmarkdown)
+#>  quarto   1.9.38 @ /usr/local/bin/quarto
+#> 
+#> ─ Packages ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+#>  package     * version    date (UTC) lib source
+#>  arrow         25.0.0     2026-07-16 [1] RSPM
+#>  assertthat    0.2.1      2019-03-21 [1] RSPM
+#>  bit           4.6.0      2025-03-06 [1] RSPM
+#>  bit64         4.8.2      2026-05-19 [1] RSPM
+#>  class         7.3-23     2025-01-01 [2] CRAN (R 4.5.3)
+#>  classInt      0.4-11     2025-01-08 [1] RSPM
+#>  cli           3.6.6      2026-04-09 [1] RSPM
+#>  DBI         * 1.3.0      2026-02-25 [1] RSPM
+#>  digest        0.6.39     2025-11-19 [1] RSPM
+#>  duckdb      * 1.5.5.9013 2026-08-09 [1] local
+#>  e1071         1.7-17     2025-12-18 [1] RSPM
+#>  evaluate      1.0.5      2025-08-27 [1] RSPM
+#>  fastmap       1.2.0      2024-05-15 [1] RSPM
+#>  fs            2.1.0      2026-04-18 [1] RSPM
+#>  geoarrow    * 0.4.3      2026-06-04 [1] RSPM
+#>  glue          1.8.1      2026-04-17 [1] RSPM
+#>  htmltools     0.5.9      2025-12-04 [1] RSPM
+#>  KernSmooth    2.23-26    2025-01-01 [2] CRAN (R 4.5.3)
+#>  knitr         1.51       2025-12-20 [1] RSPM
+#>  lifecycle     1.0.5      2026-01-08 [1] RSPM
+#>  magrittr      2.0.5      2026-04-04 [1] RSPM
+#>  nanoarrow     0.9.0      2026-08-04 [1] RSPM
+#>  otel          0.2.0      2025-08-29 [1] RSPM
+#>  pillar        1.11.1     2025-09-17 [1] RSPM
+#>  pkgconfig     2.0.3      2019-09-22 [1] RSPM
+#>  proxy         0.4-29     2025-12-29 [1] RSPM
+#>  purrr         1.2.2      2026-04-10 [1] RSPM
+#>  R6            2.6.1      2025-02-15 [1] RSPM
+#>  Rcpp          1.1.2      2026-07-05 [1] RSPM
+#>  reprex        2.1.1      2024-07-06 [1] RSPM
+#>  rlang         1.3.0      2026-07-05 [1] RSPM
+#>  rmarkdown     2.31       2026-03-26 [1] RSPM
+#>  s2            1.1.11     2026-06-01 [1] RSPM
+#>  sessioninfo   1.2.4      2026-06-04 [1] RSPM
+#>  sf          * 1.1-2      2026-07-23 [1] RSPM
+#>  tibble        3.3.1      2026-01-11 [1] RSPM
+#>  tidyselect    1.2.1      2024-03-11 [1] RSPM
+#>  units         1.0-1      2026-03-11 [1] RSPM
+#>  vctrs         0.7.3      2026-04-11 [1] RSPM
+#>  withr         3.0.3      2026-06-19 [1] RSPM
+#>  wk            0.9.5      2025-12-18 [1] RSPM
+#>  xfun          0.60       2026-07-09 [1] RSPM
+#>  yaml          2.3.12     2025-12-10 [1] RSPM
+#> 
+#>  [1] /root/R/x86_64-pc-linux-gnu-library/4.5
+#>  [2] /opt/R/4.5.3/lib/R/library
+#>  * ── Packages attached to the search path.
+#> 
+#> ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+```
+
+</details>

--- a/experiments/README.md
+++ b/experiments/README.md
@@ -74,6 +74,11 @@ the directory keeps the method so that is possible.
   series' `-dev`, what kind, and how much of the raw difference is not a
   fix at all; supports
   [`operations/vendoring/series-loop/`](/handbook/operations/vendoring/series-loop/README.md).
+* [`2026-08-09-spatial-interop/`](2026-08-09-spatial-interop/) —
+  which route carries a geometry across the R boundary, in each
+  direction, what arrives, and what each does to the CRS; supports
+  [`usage/types/`](/handbook/usage/types/README.md) and
+  [`plan/PLAN-spatial-interop.md`](/plan/PLAN-spatial-interop.md).
 * [`2026-08-09-windows-fast-path/`](2026-08-09-windows-fast-path/) —
   what the published Windows `libduckdb` exports, and how much of what
   the glue resolves from the engine is in there; supports

--- a/handbook/usage/types/README.md
+++ b/handbook/usage/types/README.md
@@ -27,17 +27,44 @@ and [`src/transform.cpp`](/src/transform.cpp) (the way back).
   [`R/dbConnect__duckdb_driver.R`](/R/dbConnect__duckdb_driver.R),
   returns raw vectors; `"wk"` returns `wk_wkb`, which
   `sf::st_as_sfc()` converts onward.
-  There is no automatic conversion on the *write* side,
-  and an `sf` object handed to `dbWriteTable()` fails rather than
-  finding one ([#1670](https://github.com/duckdb/duckdb-r/issues/1670)).
-  The route is WKB in a `BLOB` column —
-  `sf::st_as_binary()` produces the raw vectors, and a list of them
-  writes as `BLOB` — with `ST_GeomFromWKB()` reading it back,
-  either per query or once, through
-  `ALTER TABLE … ALTER COLUMN … SET DATA TYPE GEOMETRY USING`.
+  `GEOMETRY` is a core DuckDB type since 1.5,
+  so reading one needs no extension —
+  but the geometry *functions* are still `spatial`'s, and so is the CRS
+  provider that resolves a name like `EPSG:4326`
+  ([`extensions/`](/handbook/usage/extensions/README.md)).
+  The column's CRS reaches R either way:
+  as an attribute on `wk_wkb`, and as PROJJSON in the metadata of the
+  `geoarrow.wkb` field an Arrow result carries — the engine registers
+  that Arrow extension type in both directions.
+* **Writing a geometry means writing WKT, not WKB.**
+  A `character` column of `sf::st_as_text()` output with
+  `field.types = c(geom = "GEOMETRY")` lands a `GEOMETRY` column in one
+  statement, because the `VARCHAR` cast parses WKT;
+  spell the CRS into the type — `"GEOMETRY('EPSG:4267')"` — to keep it,
+  which needs `spatial` loaded.
+  WKB has no such cast:
+  `BLOB` → `GEOMETRY` is unimplemented, so the same call over
+  `sf::st_as_binary()` output fails, and `ST_GeomFromWKB()` has to do
+  the conversion — per query, bound to `?`, or once through
+  `ALTER TABLE … ALTER COLUMN … SET DATA TYPE GEOMETRY USING`,
+  which drops the CRS because it names the bare type.
+* **An `sf` or `sfc` column is not written, and may not say so.**
+  A whole `sf` object handed to `dbWriteTable()` fails inside sf's own
+  `dbDataType()` method, which writes EWKB hex into a column DuckDB
+  parses as WKT
+  ([#1670](https://github.com/duckdb/duckdb-r/issues/1670));
+  a bare `sfc` column is worse — a `POINT` column writes *silently* as
+  `DOUBLE[]`, and other geometry types abort with a message naming
+  neither column nor type.
+  Convert to text or to WKB first, and take one of the routes above;
+  a `wk_wkb` column is no shortcut — it writes as `BLOB` like any
+  other list of raw vectors, dropping its class and its CRS.
   The duckspatial and duckdbfs packages wrap this.
-  Native `sf` support is roadmapped in
-  [#117](https://github.com/duckdb/duckdb-r/issues/117).
+  What the whole surface does, route by route, is
+  [`experiments/2026-08-09-spatial-interop/`](/experiments/2026-08-09-spatial-interop/README.md);
+  what to do about the write side is
+  [`plan/PLAN-spatial-interop.md`](/plan/PLAN-spatial-interop.md)
+  ([#117](https://github.com/duckdb/duckdb-r/issues/117)).
 * **An untyped `NULL` comes back as `NA_integer_`,**
   matching the engine's own `SELECT NULL`;
   mapping it to logical `NA` instead was declined

--- a/plan/PLAN-spatial-interop.md
+++ b/plan/PLAN-spatial-interop.md
@@ -1,0 +1,188 @@
+# Plan: geometry on the write side, and the sf seam
+
+*This is a plan — work proposed, not a description of the system.
+[`usage/types/`](/handbook/usage/types/README.md) owns what geometry
+does today, and where the two disagree, the leaf is right.
+The measurements it argues from are
+[`experiments/2026-08-09-spatial-interop/`](/experiments/2026-08-09-spatial-interop/README.md),
+run on 2026-08-09 against duckdb 1.5.5.9013.
+It closes out [#117](https://github.com/duckdb/duckdb-r/issues/117),
+open since 2024 and stated against an engine that has since changed
+underneath it.*
+
+## What is already done
+
+The issue was filed when spatial's geometry was an extension type that
+could not customize its Arrow output.
+Both halves of that have gone away.
+`GEOMETRY` is a core DuckDB type as of 1.5, and this package converts it:
+`geometry = "blob"` returns raw WKB, `geometry = "wk"` returns `wk_wkb`
+carrying the column's CRS
+([#2278](https://github.com/duckdb/duckdb-r/issues/2278),
+[#2279](https://github.com/duckdb/duckdb-r/pull/2279)).
+The engine registers a `geoarrow.wkb` Arrow extension type in both
+directions, so `dbGetQueryArrow()` hands out a field the geoarrow
+package decodes, CRS included —
+which is what
+[duckdb_spatial#153](https://github.com/duckdb/duckdb_spatial/issues/153)
+blocked on.
+
+So the read side is finished, and #117's remaining scope is the write
+side and the sf seam.
+
+## What is not, and what it costs today
+
+The experiment's write matrix has nineteen rows and three successes,
+none of them reachable from an `sf` object.
+Three problems, in the order a user meets them.
+
+**An `sfc` column is not refused.**
+A `POINT` column writes silently as `DOUBLE[]`:
+`DetectRType()` walks into the `sfg` list, finds numbers, and types the
+column as a list of doubles.
+The geometry is gone and nothing says so — the worst outcome in the
+matrix, because it is the only one that does not fail.
+`LINESTRING` and `MULTIPOLYGON` fail instead, with
+`Invalid Error: std::exception`, naming neither the column nor the
+type.
+`duckdb_register()` behaves the same way.
+Compare `rel_from_df()`, which says
+"Can't convert column `geom` to relational."
+
+**A whole `sf` object fails in sf's code, not ours.**
+sf registers a `dbDataType()` method that declares the column
+`geometry` and writes EWKB hex text into it;
+DuckDB 1.5 has a `VARCHAR` → `GEOMETRY` cast that parses *WKT*, so the
+hex arrives as "Failed to parse geometry: Unknown geometry type at
+offset 0".
+`sf::st_write(dsn = con)` fails identically.
+
+**The route that does work is not the one anyone guesses.**
+WKT text plus `field.types = c(geom = "GEOMETRY")` lands a `GEOMETRY`
+column in one statement, and `field.types = c(geom =
+"GEOMETRY('EPSG:4267')")` lands the CRS with it.
+WKB does not: `BLOB` → `GEOMETRY` has no cast, so the same call over
+`st_as_binary()` output fails, and so does `dbAppendTable()` of WKB
+into an existing `GEOMETRY` column.
+The Arrow route carries geometry *and* CRS —
+a `geoarrow.wkb` field is read as `GEOMETRY('<PROJJSON>')` and the
+round trip back to `sf` is geometry-equal and CRS-equal —
+but only through `arrow::as_record_batch_reader()` wrapped around a
+`nanoarrow` stream, with geoarrow loaded;
+`duckdb_register_arrow()` rejects a bare `nanoarrow` stream with
+`std::exception`, and `arrow`'s own conversions lose the extension
+type.
+
+## What to do
+
+Four steps, in dependency order.
+The first two are worth doing whatever happens to the rest.
+
+### 1. Stop the silent loss, and say what failed
+
+A geometry column that cannot be written should say so, in R, naming
+the column and the class — never become `DOUBLE[]`, and never surface
+as `std::exception`.
+
+Two changes in the glue, both small:
+
+* `DetectRType()` ([`src/types.cpp`](/src/types.cpp)) should recognize
+  `sfc` before it descends into the list, the way it already recognizes
+  `blob` and `data.frame`, and yield a refusal carrying the class name.
+* The `std::exception` path is the more general defect: a non-DuckDB
+  exception escaping the register/write path is rendered with no
+  content at all.
+  Whatever the geometry decision is, that message should name the
+  column.
+
+This is a bug fix, not a feature, and it is what makes the rest
+diagnosable.
+
+### 2. Give the leaf the shorter route
+
+[`usage/types/`](/handbook/usage/types/README.md) currently documents
+the `ALTER TABLE … ALTER COLUMN … SET DATA TYPE GEOMETRY USING
+ST_GeomFromWKB()` route.
+It works, but it takes two statements and drops the CRS —
+`SET DATA TYPE GEOMETRY` names the bare type, so a CRS applied in the
+`USING` clause has nowhere to live.
+The one-statement WKT route belongs there instead, with the CRS form
+beside it and the note that naming a CRS in DDL needs `spatial`
+loaded while `ST_SetCRS()` does not.
+
+### 3. Write `wk_wkb` as `GEOMETRY`, not `BLOB`
+
+The narrow, honest version of native support:
+teach the write path that a `wk_wkb` column is a geometry.
+
+`wk` is already a `Suggests` and already the read side's non-default
+representation, so this closes the loop without a new dependency and
+without sf.
+The column's `crs` attribute is the CRS to declare.
+`dbDataType()` gains a `wk_wkb` method returning `"GEOMETRY"`, or
+`"GEOMETRY('<crs>')"` where the attribute is set and resolvable;
+the register path types the column the same way.
+
+The open question is how the bytes get there, and the experiment
+answers it in the negative for the obvious candidate:
+there is no `BLOB` → `GEOMETRY` cast to lean on, so the write cannot
+simply hand WKB to a declared `GEOMETRY` column.
+Either the glue converts through `ST_GeomFromWKB()` in the projection
+it already builds over the registered view — which needs no engine
+change and works today — or the cast is asked for upstream, which is
+the cleaner shape and makes `dbAppendTable()` of WKB work as a
+side effect.
+Ask upstream; use the projection meanwhile.
+
+### 4. Decide what `sf` support means, then ask for it where it belongs
+
+With step 3 in place, an `sf` object is one `wk::as_wkb()` away from
+writing, and the remaining question is whether this package should
+take that step for the user.
+
+Two costs argue for *not* adding an `sf` method here.
+sf is a heavy dependency, even suggested, and this package already
+declines to carry attribute classes across the boundary in general
+([#590](https://github.com/duckdb/duckdb-r/issues/590)) —
+`units` columns lose their class in exactly the same way, and geometry
+being special would be a rule with one member.
+The seam that already exists is `wk`, which is what sf itself uses to
+talk to other formats.
+
+So the proposal is: support `wk_wkb` here, and let sf be sf's:
+
+* `sf::st_read(con, <table>)` should recognize a `GEOMETRY` column, or
+  the `wk_wkb` vector this package hands it.
+  Today it warns and returns a `data.frame`, which is the single most
+  visible thing in the issue thread and is fixable only in sf.
+* `sf::dbDataType()` declaring `geometry` and writing EWKB hex is what
+  makes `dbWriteTable(con, tbl, <sf>)` fail against DuckDB.
+  Once a `GEOMETRY` column accepts WKB, that method has a working
+  target; until then, the R-side error should at least say what to do
+  (`wk::as_wkb()`, or `st_as_text()` with `field.types`).
+
+Both belong in an issue against r-spatial/sf, with this experiment as
+the evidence, rather than in a workaround here.
+
+### Not proposed
+
+* **A `geometry = "sf"` connection option.**
+  The read side already reaches `sf` in one call
+  (`sf::st_as_sfc()` over `wk_wkb`), CRS included,
+  so the option would buy a dependency and save nothing.
+* **Fixing `arrow`'s conversions.**
+  That `arrow::as_arrow_table()` drops `geoarrow.wkb` is worth
+  reporting, but the Arrow route is not the one most users take, and
+  the nanoarrow stream it needs is one `duckdb_register_arrow()`
+  argument away — see below.
+* **Anything that requires the `spatial` extension to be present.**
+  Everything above works with core `GEOMETRY`; extensions stay
+  opt-in
+  ([`usage/extensions/`](/handbook/usage/extensions/README.md)).
+
+### Adjacent, and cheap
+
+`duckdb_register_arrow()` accepting a `nanoarrow` array stream
+directly would remove the `arrow` round trip from the one write route
+that carries a CRS, and would fix an `std::exception` on the way.
+It is independent of everything above and not gated on any of it.

--- a/plan/README.md
+++ b/plan/README.md
@@ -27,6 +27,7 @@ when the two disagree, the handbook leaf is right.
 | Implementing `dbSendQueryArrow()` and the DBI Arrow API | [`PLAN-dbSendQueryArrow.md`](PLAN-dbSendQueryArrow.md) |
 | A producer thread for streaming results: overlapping engine production with R-side conversion, and spillable materialized results | [`PLAN-streaming-thread.md`](PLAN-streaming-thread.md) |
 | Making Ctrl+C reach a DuckDB call blocked in a network wait, and why the obvious escalation is refused | [`PLAN-query-cancellation.md`](PLAN-query-cancellation.md) |
+| Geometry on the write side: stopping the silent `sfc` loss, writing `wk_wkb` as `GEOMETRY`, and which half of #117 belongs to sf | [`PLAN-spatial-interop.md`](PLAN-spatial-interop.md) |
 
 ## `done/` — plans that came true
 


### PR DESCRIPTION
Reviews the current state of #117, which was filed in 2024 against an engine that has changed underneath it, and lands the evidence and a plan.

## What changed underneath the issue

`GEOMETRY` is a core DuckDB type as of 1.5, not a spatial-extension alias, and the engine registers a `geoarrow.wkb` Arrow extension type in **both** directions — which is exactly what duckdb/duckdb_spatial#153 was blocking on when the issue was written. This package already converts the type on read (#2278, #2279). So the read side of #117 is finished, and the remaining scope is the write side and the sf seam.

## The experiment

`experiments/2026-08-09-spatial-interop/` — 37 rows against duckdb 1.5.5.9013 (vendored build, `spatial` loaded), sf 1.1-2, wk 0.9.5, geoarrow 0.4.3, arrow 25.0.0: which spatial names are core in 1.5, eight ways of reading a `GEOMETRY` column into R, nineteen ways of writing one, plus what each route does to the CRS. `probe.R` is the script, `probe.md` the recorded run.

Reading works in three shapes and the CRS survives all of them — `wk_wkb` carries it as an attribute, an Arrow result carries it as PROJJSON, and `sf::st_as_sfc()` reconstructs the source CRS from either. The two remaining read-side gaps are in sf: `st_read(con, <table>)` still warns "Could not find a simple features geometry column", and the `query =` workaround from the issue thread still drops the CRS.

The write matrix has nineteen rows and three successes, none of them reachable from an `sf` object:

- A `POINT` `sfc` column writes **silently** as `DOUBLE[]` — the type detector walks into the `sfg` list and finds numbers. `LINESTRING` and `MULTIPOLYGON` abort with `Invalid Error: std::exception`, naming neither column nor type. `duckdb_register()` does the same.
- A whole `sf` object fails inside sf's own `dbDataType()` method, which writes EWKB hex into a column DuckDB now parses as WKT. The 2024 report's `Unknown type: '0106…'` has become a parse error; it is still a failure.
- WKT plus `field.types = c(geom = "GEOMETRY")` lands a `GEOMETRY` column in one statement, and `"GEOMETRY('EPSG:4267')"` lands the CRS with it. That is shorter than the `ALTER TABLE … USING ST_GeomFromWKB()` route the handbook has been giving, which needs two statements and drops the CRS.
- WKB cannot take that route: `BLOB` → `GEOMETRY` is unimplemented, so `field.types` over `st_as_binary()` output fails, and so does `dbAppendTable()` of WKB into an existing `GEOMETRY` column.
- The Arrow route is the only one carrying geometry *and* CRS — round-trip geometry-equal and CRS-equal — but only through `arrow::as_record_batch_reader()` over a `nanoarrow` stream; `duckdb_register_arrow()` rejects a bare nanoarrow stream with `std::exception`, and `arrow`'s own conversions lose the extension type.

## The plan

`plan/PLAN-spatial-interop.md` proposes four steps in dependency order: refuse an `sfc` column instead of losing it (and fix the contentless `std::exception`), give the leaf the shorter write route, write `wk_wkb` as `GEOMETRY` rather than `BLOB`, and take the two sf-side halves to r-spatial/sf with this experiment as evidence rather than working around them here. It declines a `geometry = "sf"` option and anything requiring the spatial extension to be present, and notes one cheap independent fix: `duckdb_register_arrow()` accepting a nanoarrow array stream.

## Also

`handbook/usage/types/README.md` is updated to what the run found — the geometry bullet became three, and the write route it documented is replaced by the shorter one. Index rows added in `experiments/README.md` and `plan/README.md`.

Docs and evidence only; no package code changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TGzoEgfuEmXLYokHESxMsH)_