### PR TITLE
style(clang-format): Never reorder includes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -23,7 +23,12 @@ SpacesInConditionalStatement: false
 AllowShortLambdasOnASingleLine: Inline
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakTemplateDeclarations: Yes
-IncludeBlocks: Regroup
+# Include order is load-bearing in the glue, so the formatter never touches it:
+# `rapi.hpp` has to see `cpp11.hpp` before the R headers, and the `#undef TRUE` /
+# `#undef FALSE` guards around them only work in the order they are written.
+# Sorting or regrouping would reorder those and change what compiles.
+SortIncludes: Never
+IncludeBlocks: Preserve
 Language: Cpp
 AccessModifierOffset: -4
 ---

--- a/handbook/architecture/glue/conventions/README.md
+++ b/handbook/architecture/glue/conventions/README.md
@@ -65,8 +65,23 @@ the pragma is respelled with widened spacing
 which the compiler honours unchanged
 while `R CMD check`'s single-space scan does not report it
 ([`patch/0016-Avoid-mbedtls-diagnostic-pragmas.patch`](/patch/0016-Avoid-mbedtls-diagnostic-pragmas.patch)).
+
+**Layout is the formatter's, include order is not.**
 Formatting runs through the Makefile `format-*` targets,
-driving [`scripts/format.py`](/scripts/format.py).
+driving [`scripts/format.py`](/scripts/format.py),
+and [`.clang-format`](/.clang-format) alone decides the result —
+a bare `clang-format -style=file`, which is what an editor and the
+pull-request formatter
+([`.github/workflows/style/action.yml`](/.github/workflows/style/action.yml))
+run, prints the same tree.
+The one thing it will not rewrite is the order of the `#include`s:
+`SortIncludes: Never` and `IncludeBlocks: Preserve` pin them,
+because in this glue the order compiles or does not.
+`rapi.hpp` has to see `cpp11.hpp` before the R headers,
+and its `#undef TRUE` / `#undef FALSE` guards only work
+where they are written relative to the header that defines them.
+So the includes of a translation unit are the author's to order,
+and a review argues them the way it argues code.
 
 **One header is public.**
 [`inst/include/duckdb_types.hpp`](/inst/include/duckdb_types.hpp)

--- a/scripts/format.py
+++ b/scripts/format.py
@@ -11,7 +11,10 @@ import difflib
 import re
 from python_helpers import open_utf8
 
-cpp_format_command = 'clang-format --sort-includes=0 -style=file'
+# Include order is pinned by `.clang-format` (`SortIncludes: Never`) rather than
+# by a flag here, so that this script and a bare `clang-format` -- editors, the
+# `style` action -- agree on what the formatted tree looks like.
+cpp_format_command = 'clang-format -style=file'
 extensions = ['.cpp', '.c', '.hpp', '.h', '.cc', '.hh', '.test', '.test_slow', '.test_coverage', '.benchmark']
 formatted_directories = ['src']
 ignored_files = []
@@ -239,7 +242,6 @@ def format_file(f, full_path, directory, ext):
     old_lines = old_text.split('\n')
 
     new_text = get_formatted_text(f, full_path, directory, ext)
-    new_text = new_text.replace('ARGS &&...args', 'ARGS &&... args')
     if check_only:
         new_lines = new_text.split('\n')
         old_lines = [x for x in old_lines if '...' not in x]

--- a/src/include/rapi.hpp
+++ b/src/include/rapi.hpp
@@ -300,14 +300,14 @@ void duckdb_r_transform(const duckdb::Vector &src_vec, SEXP dest, duckdb::idx_t 
 SEXP get_attrib(SEXP vec, SEXP name);
 
 template <typename T, typename... ARGS>
-cpp11::external_pointer<T> make_external(const std::string &rclass, ARGS &&... args) {
+cpp11::external_pointer<T> make_external(const std::string &rclass, ARGS &&...args) {
 	auto extptr = cpp11::external_pointer<T>(new T(std::forward<ARGS>(args)...));
 	((cpp11::sexp)extptr).attr("class") = rclass;
 	return extptr;
 }
 
 template <typename T, typename... ARGS>
-cpp11::external_pointer<T> make_external_prot(const std::string &rclass, SEXP prot, ARGS &&... args) {
+cpp11::external_pointer<T> make_external_prot(const std::string &rclass, SEXP prot, ARGS &&...args) {
 	auto extptr = cpp11::external_pointer<T>(new T(std::forward<ARGS>(args)...), true, true, prot);
 	((cpp11::sexp)extptr).attr("class") = rclass;
 	return extptr;


### PR DESCRIPTION
Running `clang-format` over our own C++ was not a safe operation: `.clang-format` set `IncludeBlocks: Regroup` and left `SortIncludes` at the LLVM default, so a bare `clang-format -style=file` rewrote the `#include` order of `src/include/*.hpp`. That is not cosmetic here. `src/include/rapi.hpp` has to see `cpp11.hpp` before the R headers, and its trailing `#undef TRUE` / `#undef FALSE` guards only undo what those headers define because they sit after them. Regrouping moved `convert.hpp` above the `<R...>` block and split that block apart — it changes what compiles, not how it looks. Four of our five headers were rewritten this way.

`scripts/format.py` was already immune, because it passed `--sort-includes=0` on the command line, but nothing else was: an editor, `clangd`, and the pull-request formatter in `.github/workflows/style/action.yml` all invoke plain `clang-format`.

This pins the rule in the config, where every caller sees it, and then runs the formatter.

- `.clang-format`: `SortIncludes: Never` and `IncludeBlocks: Preserve`, with a comment saying why.
- `scripts/format.py`: drop the now-redundant `--sort-includes=0`, so the config is the single source of truth and a regression there fails `make format-check` instead of passing unnoticed.
- `scripts/format.py`: drop the `ARGS &&...args` → `ARGS &&... args` rewrite. It was the last remaining disagreement between the script and a bare `clang-format`, and the check mode already filters lines containing `...`, so it tolerates either spelling.
- `handbook/architecture/glue/conventions/README.md`: a bullet that owns the fact — layout is the formatter's, include order is the author's.

After the config change the only thing formatting our C++ still wants to touch is whitespace inside two parameter packs in `rapi.hpp` (`ARGS &&... args` → `ARGS &&...args`), which is applied in the same commit. Include order across the tree is untouched.

Verified with clang-format 18: `make format-check` passes, and a bare `clang-format -style=file` over `src/*.cpp` and `src/include/*.hpp` produces no diff, so the two entry points now agree. `rapi.hpp` still passes a standalone `g++ -fsyntax-only`. `src/duckdb/` and `inst/include/cpp11/` are excluded from formatting as before, and `.clang-format` is in `.Rbuildignore`, so nothing here reaches the built package.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sq9YGGaSiijaay8BHXaGEm)_