### PR TITLE
feat(relational): Remove `allow_materialization` from `rel_to_altrep()`

### DIFF
--- a/R/relational.R
+++ b/R/relational.R
@@ -618,6 +618,8 @@ rel_set_alias <- function(rel, alias) {
 
 #' Transforms a relation object to a lazy data frame using altrep
 #' @param rel the DuckDB relation object
+#' @param ... reserved for future extensions, must be empty
+#' @param n_rows,n_cells the materialization budget, in rows and in cells
 #' @return a data frame
 #' @noRd
 #' @examples
@@ -626,17 +628,12 @@ rel_set_alias <- function(rel, alias) {
 #' print(rel_to_altrep(rel))
 rel_to_altrep <- function(
   rel,
-  allow_materialization = TRUE,
+  ...,
   n_rows = Inf,
-  n_cells = Inf,
-  ...
+  n_cells = Inf
 ) {
-  # FIXME: Move dots after `rel` for duckplyr >= 1.1.0
   if (...length() > 0) {
     stop("... must be empty")
-  }
-  if (!isTRUE(allow_materialization)) {
-    n_cells <- 0
   }
   rethrow_rapi_rel_to_altrep(rel, n_rows = n_rows, n_cells = n_cells)
 }

--- a/handbook/architecture/r-layer/conventions/README.md
+++ b/handbook/architecture/r-layer/conventions/README.md
@@ -42,5 +42,4 @@ The guard that scans for offenders is
 
 *To deepen: state the S4 class inventory and the deferred S3
 registration for Suggests packages; drain
-[#98](https://github.com/duckdb/duckdb-r/issues/98),
-[#1052](https://github.com/duckdb/duckdb-r/issues/1052).*
+[#98](https://github.com/duckdb/duckdb-r/issues/98).*

--- a/handbook/usage/relational/README.md
+++ b/handbook/usage/relational/README.md
@@ -77,14 +77,17 @@ execute to a destination instead.
 The API grew to serve duckplyr — `NEWS.md` records rounds of "internal
 changes to support the duckplyr package" — and being internal does not
 make it free to change:
-`rel_to_altrep()` still carries
-`# FIXME: Move dots after `rel` for duckplyr >= 1.1.0`,
-a signature held in place by a downstream version.
+`rel_to_altrep()` kept an `allow_materialization` argument that duckplyr
+had stopped passing in 1.1.0,
+and only once no duckplyr in the field still named it was it removed and
+`...` moved directly after `rel`,
+so that a budget is spelled out in full or refused
+rather than matched positionally
+([#1052](https://github.com/duckdb/duckdb-r/issues/1052)).
 So a change here is negotiated with duckplyr rather than merely reviewed,
 and duckplyr is the reverse dependency a behaviour change is checked
 against first
 ([`testing/revdep/`](/handbook/testing/revdep/README.md)).
 
 *To deepen: state which verbs duckplyr actually calls, so a change can be
-scoped against real use rather than the whole surface;
-drain the `rel_to_altrep()` signature FIXME when duckplyr's floor allows.*
+scoped against real use rather than the whole surface.*

--- a/tests/testthat/_snaps/relational.md
+++ b/tests/testthat/_snaps/relational.md
@@ -367,15 +367,6 @@
 ---
 
     Code
-      nrow(forbid)
-    Condition
-      Error:
-      ! Materialization is disabled, use `collect()` or `as_tibble()` to materialize.
-      i Context: GetQueryResult
-
----
-
-    Code
       nrow(four_rows)
     Condition
       Error:

--- a/tests/testthat/test-relational.R
+++ b/tests/testthat/test-relational.R
@@ -193,6 +193,18 @@ test_that("expr_operator validates ... parameter", {
   )
 })
 
+test_that("rel_to_altrep validates ... parameter", {
+  rel <- rel_from_df(con, data.frame(a = 1))
+  expect_error(
+    rel_to_altrep(rel, allow_materialization = FALSE),
+    "... must be empty"
+  )
+  expect_error(
+    rel_to_altrep(rel, 5),
+    "... must be empty"
+  )
+})
+
 
 # TODO should maybe be a different file, test_enum_strings.R
 
@@ -1508,12 +1520,7 @@ test_that("prudence", {
     )
   )
 
-  forbid <- rel_to_altrep(rel2, allow_materialization = FALSE)
-  expect_snapshot(error = TRUE, {
-    nrow(forbid)
-  })
-
-  forbid_nrow <- rel_to_altrep(rel2, n_cells = 0)
+  forbid <- rel_to_altrep(rel2, n_cells = 0)
   expect_snapshot(error = TRUE, {
     nrow(forbid)
   })


### PR DESCRIPTION
Closes #1052.

`rel_to_altrep()` carried `allow_materialization = TRUE` only as a compatibility shim: it did nothing but set `n_cells <- 0` when `FALSE`, which callers can and do say directly. duckplyr passed it in 1.0.0, dropped it in 1.1.0, and no released version since names it — so the shim has no callers left.

Removing it also drains the FIXME that the same downstream floor was holding in place — "Move dots after `rel` for duckplyr >= 1.1.0". The signature is now `rel_to_altrep(rel, ..., n_rows = Inf, n_cells = Inf)`: a materialization budget has to be named, and anything else — including an old positional second argument, or a stale `allow_materialization =` — lands in the dots and errors instead of being silently reinterpreted as `n_rows`.

Checked against duckplyr, both directions:

- duckplyr's full suite (main, 59f047b) against this branch and against duckdb `main` produces identical results — same 1341 passes, same 1225 skips, and the same two pre-existing `test-fallback.R` snapshot failures, which are dplyr message-formatting drift unrelated to this change.
- Released duckplyr 1.2.1 from CRAN, loaded against this build, still gets the prudence budgets it asks for: lavish materializes, stingy and `prudence = c(rows = 5)` refuse, `collect()` and a budget large enough both succeed.
- duckdb's own suite passes in full.

Tests: the `prudence` test lost its duplicated `allow_materialization = FALSE` case — the block below it built `forbid_nrow <- rel_to_altrep(rel2, n_cells = 0)` and then asserted on `forbid` again, so the `n_cells = 0` relation was never actually exercised; it is now. A new test pins that both a stray `allow_materialization =` and a positional second argument are rejected.

Handbook: `usage/relational/` states the resolved coupling instead of the FIXME and drops it from its deepen line, and `architecture/r-layer/conventions/` drops #1052 from its drain list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DcZXkXhcC8mp1T2JTLtPXQ