### PR TITLE
fix(glue): Drop the semicolon after two namespace closings

### DIFF
--- a/src/include/signal.hpp
+++ b/src/include/signal.hpp
@@ -52,4 +52,4 @@ private:
 	static void signal_handler(int signum);
 };
 
-}; // namespace duckdb
+} // namespace duckdb

--- a/src/signal.cpp
+++ b/src/signal.cpp
@@ -85,4 +85,4 @@ void ScopedInterruptHandler::signal_handler(int signum) {
 	}
 }
 
-}; // namespace duckdb
+} // namespace duckdb


### PR DESCRIPTION
A follow-up to #2610, same topic — two more `-Wextra-semi` sites, both `}; // namespace duckdb`, in `src/signal.cpp` and `src/include/signal.hpp`. The `;` declares nothing, and C++98 did not allow it at all.

**Why #2610 missed them, which is the interesting part.** GCC only reports a stray `;` at namespace scope from version 15; 13 and 14 both say nothing. The runners carry GCC 15.2 while Ubuntu 24.04 stops at 14 — so the gate in #2620 found these on CI while a local run under either available compiler stayed clean. That is the gate doing its job on its first real outing, on the very PR that introduces it.

Verified with clang across all 15 glue translation units: these two, and nothing else of the kind. Clang names exactly what GCC 15 named, which makes it a usable second opinion when the compiler CI uses cannot be installed locally — #2620 now says so, and adds `DUCKDB_R_WARNINGS_CXX` for the case where it can.

#2620 stays red until this lands; it is what its remaining failure is.