### PR TITLE
feat(types)!: Send `POSIXct` as `TIMESTAMPTZ` by default, with `dbConnect(posixct = )` to choose

### DIFF
--- a/R/convert.R
+++ b/R/convert.R
@@ -6,7 +6,7 @@ duckdb_convert_opts <- function(
   array = "none",
   geometry = "blob",
   map = "data.frame",
-  posixct = "timestamp"
+  posixct = "timestamptz"
 ) {
   tz_out_convert <- match.arg(tz_out_convert)
   timezone_out <- check_tz(timezone_out)

--- a/R/convert.R
+++ b/R/convert.R
@@ -5,7 +5,8 @@ duckdb_convert_opts <- function(
   bigint = "numeric",
   array = "none",
   geometry = "blob",
-  map = "data.frame"
+  map = "data.frame",
+  posixct = "timestamp"
 ) {
   tz_out_convert <- match.arg(tz_out_convert)
   timezone_out <- check_tz(timezone_out)
@@ -34,6 +35,10 @@ duckdb_convert_opts <- function(
     stop(paste0("Unsupported map configuration: ", map))
   }
 
+  if (!posixct %in% c("timestamp", "timestamptz")) {
+    stop(paste0("Unsupported posixct configuration: ", posixct))
+  }
+
   duckdb_convert_opts_impl(
     timezone_out = timezone_out,
     tz_out_convert = tz_out_convert,
@@ -41,6 +46,7 @@ duckdb_convert_opts <- function(
     array = array,
     geometry = geometry,
     map = map,
+    posixct = posixct,
     arrow = FALSE,
     streaming = FALSE,
     experimental = FALSE,
@@ -57,6 +63,7 @@ duckdb_convert_opts_impl <- function(
   array = NULL,
   geometry = NULL,
   map = NULL,
+  posixct = NULL,
   arrow = NULL,
   streaming = NULL,
   experimental = NULL,
@@ -79,6 +86,9 @@ duckdb_convert_opts_impl <- function(
   }
   if (!is.null(map)) {
     x$map <- map
+  }
+  if (!is.null(posixct)) {
+    x$posixct <- posixct
   }
   if (!is.null(arrow)) {
     x$arrow <- arrow

--- a/R/dbConnect__duckdb_driver.R
+++ b/R/dbConnect__duckdb_driver.R
@@ -44,18 +44,21 @@
 #'   to round-trip through [dbWriteTable()] / [dbCreateTable()] without specifying `field.types`,
 #'   and lets scans accept named-list cells as MAP entries.
 #' @param posixct The DuckDB type `POSIXct` columns are sent as.
-#'   There are two options: `"timestamp"` and `"timestamptz"`.
-#'   If `"timestamp"` is selected (the default), a `POSIXct` column becomes a
-#'   `TIMESTAMP` column holding the UTC rendering of each instant, and its
-#'   time zone is lost.
-#'   If `"timestamptz"` is selected, it becomes a `TIMESTAMPTZ` column holding
-#'   the instant itself, which is what a `POSIXct` value means
-#'   ([#184](https://github.com/duckdb/duckdb-r/issues/184)).
+#'   There are two options: `"timestamptz"` and `"timestamp"`.
+#'   If `"timestamptz"` is selected (the default), a `POSIXct` column becomes a
+#'   `TIMESTAMPTZ` column holding the instant itself, which is what a `POSIXct`
+#'   value means ([#184](https://github.com/duckdb/duckdb-r/issues/184)).
 #'   Reading such a column back labels it with the session `TimeZone`,
 #'   not with the zone it was written from.
+#'   If `"timestamp"` is selected, it becomes a `TIMESTAMP` column holding the
+#'   UTC rendering of each instant, and its time zone is lost.
+#'   This is the mapping earlier versions used, and the way back to it.
 #'   The setting reaches [dbWriteTable()], [dbAppendTable()],
 #'   [duckdb_register()], bound parameters, [dbDataType()] and
 #'   [dbQuoteLiteral()].
+#'   It does not reach a data frame picked up by name under
+#'   `duckdb(environment_scan = TRUE)`, nor the relational API behind
+#'   \pkg{duckplyr}, which both stay on `TIMESTAMP`.
 #'
 #' @return `dbConnect()` returns an object of class [duckdb_connection-class].
 #'
@@ -93,7 +96,7 @@ dbConnect__duckdb_driver <- function(
   array = "none",
   geometry = "blob",
   map = "data.frame",
-  posixct = "timestamp"
+  posixct = "timestamptz"
 ) {
   check_flag(debug)
   timezone_out <- check_tz(timezone_out)

--- a/R/dbConnect__duckdb_driver.R
+++ b/R/dbConnect__duckdb_driver.R
@@ -43,6 +43,19 @@
 #'   `data.frame(key = <K>, value = <V>)` that records the SQL key/value types. This enables MAP columns
 #'   to round-trip through [dbWriteTable()] / [dbCreateTable()] without specifying `field.types`,
 #'   and lets scans accept named-list cells as MAP entries.
+#' @param posixct The DuckDB type `POSIXct` columns are sent as.
+#'   There are two options: `"timestamp"` and `"timestamptz"`.
+#'   If `"timestamp"` is selected (the default), a `POSIXct` column becomes a
+#'   `TIMESTAMP` column holding the UTC rendering of each instant, and its
+#'   time zone is lost.
+#'   If `"timestamptz"` is selected, it becomes a `TIMESTAMPTZ` column holding
+#'   the instant itself, which is what a `POSIXct` value means
+#'   ([#184](https://github.com/duckdb/duckdb-r/issues/184)).
+#'   Reading such a column back labels it with the session `TimeZone`,
+#'   not with the zone it was written from.
+#'   The setting reaches [dbWriteTable()], [dbAppendTable()],
+#'   [duckdb_register()], bound parameters, [dbDataType()] and
+#'   [dbQuoteLiteral()].
 #'
 #' @return `dbConnect()` returns an object of class [duckdb_connection-class].
 #'
@@ -79,7 +92,8 @@ dbConnect__duckdb_driver <- function(
   bigint = "numeric",
   array = "none",
   geometry = "blob",
-  map = "data.frame"
+  map = "data.frame",
+  posixct = "timestamp"
 ) {
   check_flag(debug)
   timezone_out <- check_tz(timezone_out)
@@ -105,7 +119,8 @@ dbConnect__duckdb_driver <- function(
     bigint = bigint,
     array = array,
     geometry = geometry,
-    map = map
+    map = map,
+    posixct = posixct
   )
 
   config <- utils::modifyList(drv@config, config)

--- a/R/dbDataType__duckdb_connection.R
+++ b/R/dbDataType__duckdb_connection.R
@@ -2,7 +2,7 @@
 #' @inheritParams DBI::dbDataType
 #' @usage NULL
 dbDataType__duckdb_connection <- function(dbObj, obj, ...) {
-  dbDataType(dbObj@driver, obj, ...)
+  duckdb_data_type(dbObj, obj)
 }
 
 #' @rdname duckdb_connection-class

--- a/R/dbDataType__duckdb_driver.R
+++ b/R/dbDataType__duckdb_driver.R
@@ -1,7 +1,14 @@
 #' @rdname duckdb_driver-class
 #' @usage NULL
 dbDataType__duckdb_driver <- function(dbObj, obj, ...) {
-  # FIXME: Use RApiTypes::DetectRType()
+  duckdb_data_type(dbObj, obj)
+}
+
+# Shared by the driver and the connection method. Both classes carry
+# `convert_opts`; reading it here is what lets `dbConnect(posixct = )` reach
+# `dbDataType()` on the connection.
+# FIXME: Use RApiTypes::DetectRType()
+duckdb_data_type <- function(dbObj, obj) {
   if (is.null(obj)) {
     stop("NULL parameter")
   }
@@ -28,7 +35,11 @@ dbDataType__duckdb_driver <- function(dbObj, obj, ...) {
   } else if (is.numeric(obj)) {
     "DOUBLE"
   } else if (inherits(obj, "POSIXt")) {
-    "TIMESTAMP"
+    if (identical(dbObj@convert_opts$posixct, "timestamptz")) {
+      "TIMESTAMPTZ"
+    } else {
+      "TIMESTAMP"
+    }
   } else if (
     inherits(obj, "blob") ||
       (is.list(obj) &&

--- a/R/dbQuoteLiteral__duckdb_connection.R
+++ b/R/dbQuoteLiteral__duckdb_connection.R
@@ -21,6 +21,17 @@ dbQuoteLiteral__duckdb_connection <- function(conn, x, ...) {
       return(SQL(character()))
     }
 
+    # A `TIMESTAMPTZ` literal without an offset is read in the session zone,
+    # so spell the offset out; that much parses without the icu extension.
+    if (identical(conn@convert_opts$posixct, "timestamptz")) {
+      out <- dbQuoteString(
+        conn,
+        strftime(as.POSIXct(x), "%Y-%m-%d %H:%M:%S+00:00", tz = "UTC")
+      )
+
+      return(SQL(paste0(out, "::timestamptz")))
+    }
+
     out <- dbQuoteString(
       conn,
       strftime(as.POSIXct(x), "%Y-%m-%d %H:%M:%S", tz = "UTC")

--- a/R/relational.R
+++ b/R/relational.R
@@ -64,6 +64,10 @@ expr_constant <- function(
     } else {
       convert_opts <- con@convert_opts
     }
+    # `TIMESTAMP` for the same reason `rel_from_df()` pins it: a constant
+    # lands in a relation, and the relational path returns the zone it was
+    # given rather than the session's.
+    convert_opts$posixct <- "timestamp"
   }
 
   rethrow_rapi_expr_constant(val, alias, convert_opts)
@@ -195,6 +199,11 @@ rel_from_df <- function(
   # FIXME: Enable warning
   if (is.null(convert_opts)) {
     convert_opts <- con@convert_opts
+    # A relation promises the data frame back unchanged, which a TIMESTAMPTZ
+    # column cannot: it comes back labeled with the session zone. Measured in
+    # experiments/2026-08-09-rel-from-df-posixct/README.md; a caller who wants
+    # the connection's setting here passes `convert_opts` themselves.
+    convert_opts$posixct <- "timestamp"
   }
   if (!is.null(experimental)) {
     convert_opts$experimental <- experimental

--- a/experiments/2026-08-09-rel-from-df-posixct/README.md
+++ b/experiments/2026-08-09-rel-from-df-posixct/README.md
@@ -5,7 +5,8 @@
 which columns the strict check accepts, and whether what it accepts
 comes back with the same `tzone` — for the shipped policy and the three
 alternatives to it, across column label × `timezone_out` ×
-session `TimeZone`, 36 cells each.
+session `TimeZone`, 36 cells each;
+and, separately, which session zone a user gets without setting one.
 
 *When and on what:* 2026-08-09, duckdb 1.5.5.9013
 (DuckDB 1.5.5, fast-path build against the release `libduckdb`,
@@ -17,8 +18,9 @@ R 4.5.3, Linux, machine zone `Etc/UTC`.
 and [`usage/timestamps/`](/handbook/usage/timestamps/README.md).
 
 Run [`run.sh`](run.sh) with `DUCKDB_R_USE_SYSTEM_LIB=1` on a clean
-tree; one policy's run is [`grid.R`](grid.R), the policies other than
-the shipped one are the patches under [`patches/`](patches/),
+tree; one policy's run is [`grid.R`](grid.R), the default-zone probe is
+[`default-zone.R`](default-zone.R), the policies other than the shipped
+one are the patches under [`patches/`](patches/),
 and the recorded run is [`grid.md`](grid.md).
 
 **Why the check is in question.**
@@ -72,13 +74,17 @@ quietly.
 
 `session-tz` is the principled fix and the surprising loser. It never
 relabels — by construction, since it accepts exactly the columns whose
-label already matches the session's — but that accept-set depends on
-how the binary was built. This build's session zone is `Etc/UTC`, so a
-column labeled `"UTC"`, which is what `timezone_out`'s own default
-produces, is refused: the two strings name one zone and the check
-compares strings. A build with no icu reports `"UTC"` and accepts it.
-Making duckplyr's fast path appear and disappear with the presence of
-an extension costs more than the 6 refusals it buys back.
+label already matches the session's — but which columns those are is
+decided by the machine the code runs on. An icu-linked build echoes the
+machine's `TZ` as the session zone verbatim, so a column labeled
+`"UTC"`, which is what `timezone_out`'s own default produces, is
+accepted where `TZ=UTC` and refused where `TZ=Etc/UTC` or
+`TZ=Europe/Zurich`: the check compares strings, and two of those name
+the same zone. A build with no icu reports `"UTC"` whatever the machine
+says. So duckplyr's fast path would work in a `TZ=UTC` container and
+fall back on the laptop that pushed to it, which is worse than the 6
+refusals it buys back — and worse than a difference a build flag would
+at least make visible.
 
 `relaxed` is worst: 30 of 36 cells silently relabeled.
 
@@ -90,6 +96,13 @@ result — the label is per session in DuckDB's model
 ([`plan/history/2026-05-timestamptz-icu.md`](/plan/history/2026-05-timestamptz-icu.md)) —
 or duckplyr deciding a session-zone label is one it can live with
 ([#2574](https://github.com/duckdb/duckdb-r/issues/2574)).
+
+**Why the machine zone is not a grid dimension.**
+Every cell sets the session zone explicitly, so the machine's `TZ`
+cannot reach the measurement. It decides only which row a user lands in
+by default, and that is what the default-zone probe records: five
+machine zones, five session zones, echoed verbatim. `Etc/UTC` in the
+run above is this container's `TZ`, not a DuckDB default.
 
 **What this run does not cover.**
 A build without icu, where `SET TimeZone` fails for every value and the

--- a/experiments/2026-08-09-rel-from-df-posixct/README.md
+++ b/experiments/2026-08-09-rel-from-df-posixct/README.md
@@ -1,0 +1,99 @@
+# What `posixct` would cost the relational path
+
+*What it measures:* what `rel_from_df()` and `rel_to_altrep()` do to a
+`POSIXct` column now that `posixct` defaults to `"timestamptz"` —
+which columns the strict check accepts, and whether what it accepts
+comes back with the same `tzone` — for the shipped policy and the three
+alternatives to it, across column label × `timezone_out` ×
+session `TimeZone`, 36 cells each.
+
+*When and on what:* 2026-08-09, duckdb 1.5.5.9013
+(DuckDB 1.5.5, fast-path build against the release `libduckdb`,
+so icu is linked in and the session `TimeZone` exists from startup),
+R 4.5.3, Linux, machine zone `Etc/UTC`.
+
+*What it supports:*
+[`usage/relational/`](/handbook/usage/relational/README.md)
+and [`usage/timestamps/`](/handbook/usage/timestamps/README.md).
+
+Run [`run.sh`](run.sh) with `DUCKDB_R_USE_SYSTEM_LIB=1` on a clean
+tree; one policy's run is [`grid.R`](grid.R), the policies other than
+the shipped one are the patches under [`patches/`](patches/),
+and the recorded run is [`grid.md`](grid.md).
+
+**Why the check is in question.**
+`rel_from_df()` refuses a `POSIXct` column whose `tzone` is not
+`timezone_out`, so that a relation duckplyr builds from a data frame
+returns that data frame and not a relabeled copy of it.
+A `TIMESTAMPTZ` column is labeled with the session `TimeZone` instead,
+so following the new default would leave the check comparing against a
+zone the column no longer comes back in: the guard still fires, just
+not on what it guards.
+
+**The policies.**
+
+* `baseline` — the tree before `posixct` existed, `origin/main`.
+* `timestamp-rel` — what ships: the relational path pins
+  `posixct = "timestamp"` and the check is left alone.
+* `follow` — take the connection's setting, check unchanged.
+* `session-tz` — follow, and compare against the session `TimeZone`,
+  the zone the column will actually come back in.
+* `relaxed` — follow, and accept every `POSIXct`, on the grounds that
+  the instant survives whatever labels it.
+
+**The verdicts.**
+A cell is `ok` when the column is accepted and comes back with the same
+`tzone`, `refused` when the check rejects it — duckplyr falls back to
+dplyr, which is slower and correct — and `relabeled` when it is
+accepted and comes back with a different `tzone`, which is a wrong
+answer nothing reports. No cell moved an instant.
+
+| policy | ok | refused | relabeled |
+|---|---|---|---|
+| `baseline` | 9 | 24 | 3 |
+| `timestamp-rel` | 9 | 24 | 3 |
+| `follow` | 2 | 24 | 10 |
+| `session-tz` | 6 | 30 | 0 |
+| `relaxed` | 6 | 0 | 30 |
+
+**What the numbers say.**
+
+`timestamp-rel` reproduces `baseline` cell for cell, which is the point
+of shipping it: the relational path is the one place a `POSIXct` still
+crosses as `TIMESTAMP`, so duckplyr sees no change at all. Its three
+relabeled cells are the `tzone = ""` column coming back with no `tzone`
+attribute, which is older than this question and pinned as expected in
+[`tests/testthat/test-timezone.R`](/tests/testthat/test-timezone.R).
+
+`follow` is the one to avoid. Taking the setting while keeping the old
+check turns 7 of the baseline's refusals into silent relabels, from 3
+to 10, and drops `ok` from 9 to 2. Every cell it loses, it loses
+quietly.
+
+`session-tz` is the principled fix and the surprising loser. It never
+relabels — by construction, since it accepts exactly the columns whose
+label already matches the session's — but that accept-set depends on
+how the binary was built. This build's session zone is `Etc/UTC`, so a
+column labeled `"UTC"`, which is what `timezone_out`'s own default
+produces, is refused: the two strings name one zone and the check
+compares strings. A build with no icu reports `"UTC"` and accepts it.
+Making duckplyr's fast path appear and disappear with the presence of
+an extension costs more than the 6 refusals it buys back.
+
+`relaxed` is worst: 30 of 36 cells silently relabeled.
+
+So the relational path keeps `TIMESTAMP`
+([`R/relational.R`](/R/relational.R)), and the setting reaches it only
+when a caller passes `convert_opts` themselves.
+What would let it follow the default is a per-column zone on the
+result — the label is per session in DuckDB's model
+([`plan/history/2026-05-timestamptz-icu.md`](/plan/history/2026-05-timestamptz-icu.md)) —
+or duckplyr deciding a session-zone label is one it can live with
+([#2574](https://github.com/duckdb/duckdb-r/issues/2574)).
+
+**What this run does not cover.**
+A build without icu, where `SET TimeZone` fails for every value and the
+session zone reads `"UTC"`: on the fast path icu is linked in and its
+absence cannot be produced. The grid reaches that zone by setting it
+(`session = UTC`), which is the same label, so only the inability to
+change it is missing.

--- a/experiments/2026-08-09-rel-from-df-posixct/README.md
+++ b/experiments/2026-08-09-rel-from-df-posixct/README.md
@@ -143,21 +143,52 @@ where the shipped tree leaves it unlabeled. Matching what plain
 `TIMESTAMP` already does — no label at all when `timezone_out` is
 empty — would settle those.
 
-**What neither run covers, and what asks it.**
-Whether the connect-time `SET` can be issued safely on a build without
-icu. The guard is to ask `duckdb_extensions()` first and skip when icu
-is not loaded, since `SET TimeZone` is an icu setting and asking for it
-otherwise attempts an autoload; on the fast path icu is linked in, so
-the skip branch cannot be reached from either run above.
-[`no-icu.R`](no-icu.R) is the probe for it, and needs a build the fast
-path cannot give it: the vendored engine compiled from source, which
-links `parquet` and `core_functions` and nothing else
-([`usage/extensions/`](/handbook/usage/extensions/README.md)).
-Its run is not recorded here yet.
+## The build with no icu in it
 
-**What this run does not cover.**
-A build without icu, where `SET TimeZone` fails for every value and the
-session zone reads `"UTC"`: on the fast path icu is linked in and its
-absence cannot be produced. The grid reaches that zone by setting it
-(`session = UTC`), which is the same label, so only the inability to
-change it is missing.
+Neither run above can reach a session without icu: the fast path links
+a release `libduckdb`, which has it. [`run-no-icu.sh`](run-no-icu.sh)
+builds the vendored engine from source instead — `parquet` and
+`core_functions` and nothing else
+([`usage/extensions/`](/handbook/usage/extensions/README.md)) — and runs
+[`no-icu.R`](no-icu.R) against it, recorded in
+[`no-icu.md`](no-icu.md).
+
+**Without icu the writing default has no machine to follow.**
+`dbWriteTable()` still writes `TIMESTAMP WITH TIME ZONE`, the instant
+still round-trips, and the label is `"UTC"` under `TZ=UTC` and under
+`TZ=Europe/Zurich` alike — `GetClientProperties()` falls back to a
+hardcoded `"UTC"` when the setting does not exist. So the machine
+dependence measured above is not a property of the change; it is a
+property of having icu.
+
+**Asking about the zone in SQL is not free, and not safe.**
+`current_setting('TimeZone')` and `SET TimeZone` both reach for icu.
+With no icu installed, both raise an Extension Autoloading Error rather
+than blocking — `autoinstall_known_extensions` is `false`, so autoload
+loads a local extension but never downloads one, and the failure costs
+0.2s, not a network timeout. `duckdb_extensions()` is the safe way to
+ask: it reported icu without loading it in every cell.
+
+**The label is order-dependent within one session.**
+Where icu is installed but not loaded — which is what running
+`INSTALL icu` once leaves behind — a `TIMESTAMPTZ` column is labeled
+`"UTC"` until something touches the setting, and the machine's zone
+afterwards. On `TZ=Europe/Zurich`, `current_setting('TimeZone')`
+autoloads icu in 0.05s, and the same query that returned `"UTC"` before
+it returns `"Europe/Zurich"` after. Nothing announces the switch, and
+the toucher need not be the caller's own code.
+
+That last one is what decides the pin. Guarding it on "icu is already
+loaded" is *necessary* — an unguarded `SET` at connect raises on a
+build without icu — but it is also *ineffective exactly where the
+machine dependence lives*, because in the installed-but-not-loaded
+state the guard skips and the first later touch of the setting brings
+the machine's zone back. A pin that closed that hole would have to
+`LOAD icu` at connect for everyone who has it cached, which is a much
+larger change than a default.
+
+**What none of these runs covers.**
+Windows, where icu cannot be installed at all on the arm64 build
+([`usage/extensions/`](/handbook/usage/extensions/README.md)), and any
+platform where the extension exists but the machine zone is one R does
+not know.

--- a/experiments/2026-08-09-rel-from-df-posixct/README.md
+++ b/experiments/2026-08-09-rel-from-df-posixct/README.md
@@ -22,6 +22,9 @@ tree; one policy's run is [`grid.R`](grid.R), the default-zone probe is
 [`default-zone.R`](default-zone.R), the policies other than the shipped
 one are the patches under [`patches/`](patches/),
 and the recorded run is [`grid.md`](grid.md).
+[`run-defaults.sh`](run-defaults.sh) asks the second question below over
+[`defaults-grid.R`](defaults-grid.R), recorded in
+[`defaults.md`](defaults.md).
 
 **Why the check is in question.**
 `rel_from_df()` refuses a `POSIXct` column whose `tzone` is not
@@ -103,6 +106,49 @@ cannot reach the measurement. It decides only which row a user lands in
 by default, and that is what the default-zone probe records: five
 machine zones, five session zones, echoed verbatim. `Etc/UTC` in the
 run above is this container's `TZ`, not a DuckDB default.
+
+## What the defaults do
+
+The grid above sets the session zone in every cell. Setting nothing is
+the commoner case, and it asks a different question: is the answer the
+same on every machine? [`defaults.md`](defaults.md) runs column label ×
+`timezone_out` against three machine zones, for the shipped tree and
+for `pin-session` — a patch that issues `SET TimeZone = timezone_out`
+at connect when icu is already loaded.
+
+**The shipped default DBI round trip follows the machine.**
+`dbWriteTable()` then `dbReadTable()` of a column labeled `"UTC"`
+returns `"UTC"` where `TZ=UTC`, `"Etc/UTC"` where `TZ=Etc/UTC`, and
+`"Europe/Zurich"` where `TZ=Europe/Zurich`. The instant is right in all
+three; the label is the machine's. Under `TZ=UTC` three of the twelve
+cells round-trip unchanged, under either other zone none of them do.
+This is the writing direction inheriting what
+[#2401](https://github.com/duckdb/duckdb-r/pull/2401) established for
+reading, and it is why a package whose tests compare timestamps can
+pass in a `TZ=UTC` runner and fail on a contributor's laptop.
+
+**Pinning the session zone removes the machine from the answer.**
+Under `pin-session`, `dbi_back` is `timezone_out` in all nine
+non-empty-`timezone_out` cells of every machine zone, and the
+`"UTC"`/`"UTC"` cell round-trips unchanged everywhere. Only
+`timezone_out = ""` still varies, which is what it asks for. The same
+pin makes the relational check correct again — the round-trip label
+becomes `timezone_out`, which is the zone the check already compares
+against — so `rel_from_df()` could follow the default with no new
+relabeling, rather than pinning `TIMESTAMP`.
+
+Two cells get worse under the patch as written: `timezone_out = ""`
+with an unlabeled column comes back labeled with the machine's zone
+where the shipped tree leaves it unlabeled. Matching what plain
+`TIMESTAMP` already does — no label at all when `timezone_out` is
+empty — would settle those.
+
+**What neither run covers.**
+Whether the connect-time `SET` can be issued safely on a build without
+icu. The guard is to ask `duckdb_extensions()` first and skip when icu
+is not loaded, since `SET TimeZone` is an icu setting and asking for it
+otherwise attempts an autoload; on the fast path icu is linked in, so
+the skip branch is never exercised here.
 
 **What this run does not cover.**
 A build without icu, where `SET TimeZone` fails for every value and the

--- a/experiments/2026-08-09-rel-from-df-posixct/README.md
+++ b/experiments/2026-08-09-rel-from-df-posixct/README.md
@@ -143,12 +143,17 @@ where the shipped tree leaves it unlabeled. Matching what plain
 `TIMESTAMP` already does — no label at all when `timezone_out` is
 empty — would settle those.
 
-**What neither run covers.**
+**What neither run covers, and what asks it.**
 Whether the connect-time `SET` can be issued safely on a build without
 icu. The guard is to ask `duckdb_extensions()` first and skip when icu
 is not loaded, since `SET TimeZone` is an icu setting and asking for it
 otherwise attempts an autoload; on the fast path icu is linked in, so
-the skip branch is never exercised here.
+the skip branch cannot be reached from either run above.
+[`no-icu.R`](no-icu.R) is the probe for it, and needs a build the fast
+path cannot give it: the vendored engine compiled from source, which
+links `parquet` and `core_functions` and nothing else
+([`usage/extensions/`](/handbook/usage/extensions/README.md)).
+Its run is not recorded here yet.
 
 **What this run does not cover.**
 A build without icu, where `SET TimeZone` fails for every value and the

--- a/experiments/2026-08-09-rel-from-df-posixct/default-zone.R
+++ b/experiments/2026-08-09-rel-from-df-posixct/default-zone.R
@@ -1,0 +1,22 @@
+# What the session TimeZone is when nobody sets it.
+#
+# The grid sets it in every cell, so this is the missing half: which of those
+# rows a user lands in by default. ICU reads the zone once when it loads, so
+# each machine zone needs its own process; run.sh supplies TZ.
+suppressMessages(library(duckdb))
+
+con <- suppressMessages(dbConnect(duckdb()))
+session <- dbGetQuery(con, "SELECT current_setting('TimeZone') AS tz")$tz
+res <- dbGetQuery(
+  con,
+  "SELECT TIMESTAMP '2024-01-10 13:03:12' AS ts,
+          TIMESTAMPTZ '2024-01-10 13:03:12-08:00' AS tstz"
+)
+cat(sprintf(
+  "TZ=%-18s session %-18s ts label %-8s tstz label %s\n",
+  Sys.getenv("TZ"),
+  session,
+  attr(res$ts, "tzone"),
+  attr(res$tstz, "tzone")
+))
+dbDisconnect(con, shutdown = TRUE)

--- a/experiments/2026-08-09-rel-from-df-posixct/defaults-grid.R
+++ b/experiments/2026-08-09-rel-from-df-posixct/defaults-grid.R
@@ -1,0 +1,94 @@
+# The same round trips, but with nobody calling `SET TimeZone`.
+#
+# grid.R sets the session zone in every cell, which is what a caller who
+# knows about it would do. This is the other half: what the defaults do, and
+# whether the answer moves with the machine's TZ. run.sh supplies TZ and
+# POLICY; icu reads the zone once when it loads, so each TZ needs a process.
+suppressMessages(library(duckdb))
+options(width = 200)
+
+rel_from_df <- duckdb:::rel_from_df
+rel_to_altrep <- duckdb:::rel_to_altrep
+
+policy <- Sys.getenv("POLICY", "shipped")
+INSTANT <- 1745781814.84963
+
+make_col <- function(label) {
+  switch(
+    label,
+    absent = structure(INSTANT, class = c("POSIXct", "POSIXt")),
+    empty = structure(INSTANT, class = c("POSIXct", "POSIXt"), tzone = ""),
+    structure(INSTANT, class = c("POSIXct", "POSIXt"), tzone = label)
+  )
+}
+
+label_of <- function(x) {
+  z <- attr(x, "tzone")
+  if (is.null(z)) {
+    "<absent>"
+  } else if (!nzchar(z)) {
+    "<empty>"
+  } else {
+    z
+  }
+}
+
+verdict_of <- function(out, df) {
+  if (inherits(out, "error")) {
+    return(c("refused", NA_character_))
+  }
+  same_label <- identical(attr(out$a, "tzone"), attr(df$a, "tzone"))
+  same_instant <- isTRUE(all.equal(as.numeric(out$a), INSTANT))
+  v <- if (!same_instant) {
+    "wrong-instant"
+  } else if (same_label) {
+    "ok"
+  } else {
+    "relabeled"
+  }
+  c(v, label_of(out$a))
+}
+
+cell <- function(col, tz_out) {
+  df <- data.frame(a = make_col(col))
+  con <- suppressMessages(dbConnect(duckdb(), timezone_out = tz_out))
+  on.exit(dbDisconnect(con, shutdown = TRUE))
+
+  session <- dbGetQuery(con, "SELECT current_setting('TimeZone') AS tz")$tz
+  rel <- verdict_of(
+    tryCatch(rel_to_altrep(rel_from_df(con, df)), error = function(e) e),
+    df
+  )
+  dbi <- verdict_of(
+    tryCatch(
+      {
+        dbWriteTable(con, "t", df)
+        dbReadTable(con, "t")
+      },
+      error = function(e) e
+    ),
+    df
+  )
+
+  data.frame(
+    policy = policy,
+    TZ = Sys.getenv("TZ"),
+    col = label_of(df$a),
+    tz_out = if (nzchar(tz_out)) tz_out else "<empty>",
+    session = session,
+    rel = rel[[1]],
+    rel_back = rel[[2]],
+    dbi = dbi[[1]],
+    dbi_back = dbi[[2]]
+  )
+}
+
+grid <- expand.grid(
+  col = c("UTC", "empty", "absent", "America/New_York"),
+  tz_out = c("UTC", "", "America/New_York"),
+  stringsAsFactors = FALSE
+)
+
+out <- do.call(rbind, Map(cell, grid$col, grid$tz_out))
+rownames(out) <- NULL
+print(out, right = FALSE)

--- a/experiments/2026-08-09-rel-from-df-posixct/defaults.md
+++ b/experiments/2026-08-09-rel-from-df-posixct/defaults.md
@@ -1,0 +1,93 @@
+# What the defaults do, per machine zone
+
+Recorded by `run-defaults.sh`; `README.md` says what the columns
+mean. `rel` is `rel_from_df()` then `rel_to_altrep()`; `dbi` is
+`dbWriteTable()` then `dbReadTable()`. Nothing calls `SET TimeZone`.
+
+## shipped
+
+```
+   policy  TZ  col              tz_out           session rel       rel_back         dbi       dbi_back
+1  shipped UTC UTC              UTC              UTC     ok        UTC              ok        UTC     
+2  shipped UTC <empty>          UTC              UTC     refused   <NA>             relabeled UTC     
+3  shipped UTC <absent>         UTC              UTC     refused   <NA>             relabeled UTC     
+4  shipped UTC America/New_York UTC              UTC     refused   <NA>             relabeled UTC     
+5  shipped UTC UTC              <empty>          UTC     refused   <NA>             ok        UTC     
+6  shipped UTC <empty>          <empty>          UTC     relabeled <absent>         relabeled UTC     
+7  shipped UTC <absent>         <empty>          UTC     ok        <absent>         relabeled UTC     
+8  shipped UTC America/New_York <empty>          UTC     refused   <NA>             relabeled UTC     
+9  shipped UTC UTC              America/New_York UTC     refused   <NA>             ok        UTC     
+10 shipped UTC <empty>          America/New_York UTC     refused   <NA>             relabeled UTC     
+11 shipped UTC <absent>         America/New_York UTC     refused   <NA>             relabeled UTC     
+12 shipped UTC America/New_York America/New_York UTC     ok        America/New_York relabeled UTC     
+   policy  TZ      col              tz_out           session rel       rel_back         dbi       dbi_back
+1  shipped Etc/UTC UTC              UTC              Etc/UTC ok        UTC              relabeled Etc/UTC 
+2  shipped Etc/UTC <empty>          UTC              Etc/UTC refused   <NA>             relabeled Etc/UTC 
+3  shipped Etc/UTC <absent>         UTC              Etc/UTC refused   <NA>             relabeled Etc/UTC 
+4  shipped Etc/UTC America/New_York UTC              Etc/UTC refused   <NA>             relabeled Etc/UTC 
+5  shipped Etc/UTC UTC              <empty>          Etc/UTC refused   <NA>             relabeled Etc/UTC 
+6  shipped Etc/UTC <empty>          <empty>          Etc/UTC relabeled <absent>         relabeled Etc/UTC 
+7  shipped Etc/UTC <absent>         <empty>          Etc/UTC ok        <absent>         relabeled Etc/UTC 
+8  shipped Etc/UTC America/New_York <empty>          Etc/UTC refused   <NA>             relabeled Etc/UTC 
+9  shipped Etc/UTC UTC              America/New_York Etc/UTC refused   <NA>             relabeled Etc/UTC 
+10 shipped Etc/UTC <empty>          America/New_York Etc/UTC refused   <NA>             relabeled Etc/UTC 
+11 shipped Etc/UTC <absent>         America/New_York Etc/UTC refused   <NA>             relabeled Etc/UTC 
+12 shipped Etc/UTC America/New_York America/New_York Etc/UTC ok        America/New_York relabeled Etc/UTC 
+   policy  TZ            col              tz_out           session       rel       rel_back         dbi       dbi_back     
+1  shipped Europe/Zurich UTC              UTC              Europe/Zurich ok        UTC              relabeled Europe/Zurich
+2  shipped Europe/Zurich <empty>          UTC              Europe/Zurich refused   <NA>             relabeled Europe/Zurich
+3  shipped Europe/Zurich <absent>         UTC              Europe/Zurich refused   <NA>             relabeled Europe/Zurich
+4  shipped Europe/Zurich America/New_York UTC              Europe/Zurich refused   <NA>             relabeled Europe/Zurich
+5  shipped Europe/Zurich UTC              <empty>          Europe/Zurich refused   <NA>             relabeled Europe/Zurich
+6  shipped Europe/Zurich <empty>          <empty>          Europe/Zurich relabeled <absent>         relabeled Europe/Zurich
+7  shipped Europe/Zurich <absent>         <empty>          Europe/Zurich ok        <absent>         relabeled Europe/Zurich
+8  shipped Europe/Zurich America/New_York <empty>          Europe/Zurich refused   <NA>             relabeled Europe/Zurich
+9  shipped Europe/Zurich UTC              America/New_York Europe/Zurich refused   <NA>             relabeled Europe/Zurich
+10 shipped Europe/Zurich <empty>          America/New_York Europe/Zurich refused   <NA>             relabeled Europe/Zurich
+11 shipped Europe/Zurich <absent>         America/New_York Europe/Zurich refused   <NA>             relabeled Europe/Zurich
+12 shipped Europe/Zurich America/New_York America/New_York Europe/Zurich ok        America/New_York relabeled Europe/Zurich
+```
+
+## pin-session
+
+```
+   policy      TZ  col              tz_out           session          rel       rel_back         dbi       dbi_back        
+1  pin-session UTC UTC              UTC              UTC              ok        UTC              ok        UTC             
+2  pin-session UTC <empty>          UTC              UTC              refused   <NA>             relabeled UTC             
+3  pin-session UTC <absent>         UTC              UTC              refused   <NA>             relabeled UTC             
+4  pin-session UTC America/New_York UTC              UTC              refused   <NA>             relabeled UTC             
+5  pin-session UTC UTC              <empty>          UTC              refused   <NA>             ok        UTC             
+6  pin-session UTC <empty>          <empty>          UTC              relabeled UTC              relabeled UTC             
+7  pin-session UTC <absent>         <empty>          UTC              relabeled UTC              relabeled UTC             
+8  pin-session UTC America/New_York <empty>          UTC              refused   <NA>             relabeled UTC             
+9  pin-session UTC UTC              America/New_York America/New_York refused   <NA>             relabeled America/New_York
+10 pin-session UTC <empty>          America/New_York America/New_York refused   <NA>             relabeled America/New_York
+11 pin-session UTC <absent>         America/New_York America/New_York refused   <NA>             relabeled America/New_York
+12 pin-session UTC America/New_York America/New_York America/New_York ok        America/New_York ok        America/New_York
+   policy      TZ      col              tz_out           session          rel       rel_back         dbi       dbi_back        
+1  pin-session Etc/UTC UTC              UTC              UTC              ok        UTC              ok        UTC             
+2  pin-session Etc/UTC <empty>          UTC              UTC              refused   <NA>             relabeled UTC             
+3  pin-session Etc/UTC <absent>         UTC              UTC              refused   <NA>             relabeled UTC             
+4  pin-session Etc/UTC America/New_York UTC              UTC              refused   <NA>             relabeled UTC             
+5  pin-session Etc/UTC UTC              <empty>          Etc/UTC          refused   <NA>             relabeled Etc/UTC         
+6  pin-session Etc/UTC <empty>          <empty>          Etc/UTC          relabeled Etc/UTC          relabeled Etc/UTC         
+7  pin-session Etc/UTC <absent>         <empty>          Etc/UTC          relabeled Etc/UTC          relabeled Etc/UTC         
+8  pin-session Etc/UTC America/New_York <empty>          Etc/UTC          refused   <NA>             relabeled Etc/UTC         
+9  pin-session Etc/UTC UTC              America/New_York America/New_York refused   <NA>             relabeled America/New_York
+10 pin-session Etc/UTC <empty>          America/New_York America/New_York refused   <NA>             relabeled America/New_York
+11 pin-session Etc/UTC <absent>         America/New_York America/New_York refused   <NA>             relabeled America/New_York
+12 pin-session Etc/UTC America/New_York America/New_York America/New_York ok        America/New_York ok        America/New_York
+   policy      TZ            col              tz_out           session          rel       rel_back         dbi       dbi_back        
+1  pin-session Europe/Zurich UTC              UTC              UTC              ok        UTC              ok        UTC             
+2  pin-session Europe/Zurich <empty>          UTC              UTC              refused   <NA>             relabeled UTC             
+3  pin-session Europe/Zurich <absent>         UTC              UTC              refused   <NA>             relabeled UTC             
+4  pin-session Europe/Zurich America/New_York UTC              UTC              refused   <NA>             relabeled UTC             
+5  pin-session Europe/Zurich UTC              <empty>          Europe/Zurich    refused   <NA>             relabeled Europe/Zurich   
+6  pin-session Europe/Zurich <empty>          <empty>          Europe/Zurich    relabeled Europe/Zurich    relabeled Europe/Zurich   
+7  pin-session Europe/Zurich <absent>         <empty>          Europe/Zurich    relabeled Europe/Zurich    relabeled Europe/Zurich   
+8  pin-session Europe/Zurich America/New_York <empty>          Europe/Zurich    refused   <NA>             relabeled Europe/Zurich   
+9  pin-session Europe/Zurich UTC              America/New_York America/New_York refused   <NA>             relabeled America/New_York
+10 pin-session Europe/Zurich <empty>          America/New_York America/New_York refused   <NA>             relabeled America/New_York
+11 pin-session Europe/Zurich <absent>         America/New_York America/New_York refused   <NA>             relabeled America/New_York
+12 pin-session Europe/Zurich America/New_York America/New_York America/New_York ok        America/New_York ok        America/New_York
+```

--- a/experiments/2026-08-09-rel-from-df-posixct/grid.R
+++ b/experiments/2026-08-09-rel-from-df-posixct/grid.R
@@ -1,0 +1,103 @@
+# One policy's worth of the rel_from_df() POSIXct grid.
+#
+# For every (column tzone x timezone_out x session TimeZone) cell, hand the
+# column to rel_from_df() and read it back with rel_to_altrep(), and record
+# which of four things happened:
+#
+#   ok            accepted, and the data frame comes back unchanged
+#   relabeled     accepted, same instant, different `tzone` -- the silent one
+#   refused       the strict check rejected the column
+#   wrong-instant accepted and the value moved (nothing should produce this)
+#
+# POLICY names the build; run.sh sets it. See README.md.
+suppressMessages(library(duckdb))
+options(width = 200)
+
+rel_from_df <- duckdb:::rel_from_df
+rel_to_altrep <- duckdb:::rel_to_altrep
+
+policy <- Sys.getenv("POLICY", "shipped")
+
+# One instant, four ways of labeling it in R. "absent" is what `Sys.time()`
+# returns; "empty" is what `as.POSIXct()` leaves behind. Both mean "local".
+INSTANT <- 1745781814.84963
+
+make_col <- function(label) {
+  switch(
+    label,
+    absent = structure(INSTANT, class = c("POSIXct", "POSIXt")),
+    empty = structure(INSTANT, class = c("POSIXct", "POSIXt"), tzone = ""),
+    structure(INSTANT, class = c("POSIXct", "POSIXt"), tzone = label)
+  )
+}
+
+label_of <- function(x) {
+  z <- attr(x, "tzone")
+  if (is.null(z)) {
+    "<absent>"
+  } else if (!nzchar(z)) {
+    "<empty>"
+  } else {
+    z
+  }
+}
+
+cell <- function(col, tz_out, session) {
+  df <- data.frame(a = make_col(col))
+  # The storage-location notice is an `inform()`, not an option
+  con <- suppressMessages(dbConnect(duckdb(), timezone_out = tz_out))
+  on.exit(dbDisconnect(con, shutdown = TRUE))
+  dbExecute(con, paste0("SET TimeZone = '", session, "'"))
+
+  out <- tryCatch(rel_to_altrep(rel_from_df(con, df)), error = function(e) e)
+
+  if (inherits(out, "error")) {
+    verdict <- "refused"
+    back <- NA_character_
+  } else {
+    back <- label_of(out$a)
+    same_label <- identical(attr(out$a, "tzone"), attr(df$a, "tzone"))
+    same_instant <- isTRUE(all.equal(as.numeric(out$a), INSTANT))
+    verdict <- if (!same_instant) {
+      "wrong-instant"
+    } else if (same_label) {
+      "ok"
+    } else {
+      "relabeled"
+    }
+  }
+
+  data.frame(
+    policy = policy,
+    col = label_of(df$a),
+    tz_out = if (nzchar(tz_out)) tz_out else "<empty>",
+    session = session,
+    verdict = verdict,
+    back = back
+  )
+}
+
+grid <- expand.grid(
+  col = c("UTC", "empty", "absent", "America/New_York"),
+  tz_out = c("UTC", "", "America/New_York"),
+  session = c("UTC", "Etc/UTC", "America/New_York"),
+  stringsAsFactors = FALSE
+)
+
+out <- do.call(rbind, Map(cell, grid$col, grid$tz_out, grid$session))
+rownames(out) <- NULL
+
+cat(
+  "policy",
+  policy,
+  "| duckdb",
+  as.character(packageVersion("duckdb")),
+  "| DuckDB",
+  duckdb:::get_duckdb_version(),
+  "| local zone",
+  Sys.timezone(),
+  "\n\n"
+)
+print(out, right = FALSE)
+cat("\ntally:\n")
+print(table(out$verdict))

--- a/experiments/2026-08-09-rel-from-df-posixct/grid.md
+++ b/experiments/2026-08-09-rel-from-df-posixct/grid.md
@@ -2,6 +2,19 @@
 
 Recorded by `run.sh`; what each column means is in `README.md`.
 
+## default session zone
+
+Which grid row a user lands in without `SET TimeZone`, per machine
+zone. One process each: icu reads the zone once, when it loads.
+
+```
+TZ=UTC                session UTC                ts label UTC      tstz label UTC
+TZ=Etc/UTC            session Etc/UTC            ts label UTC      tstz label Etc/UTC
+TZ=Europe/Zurich      session Europe/Zurich      ts label UTC      tstz label Europe/Zurich
+TZ=America/New_York   session America/New_York   ts label UTC      tstz label America/New_York
+TZ=Asia/Tokyo         session Asia/Tokyo         ts label UTC      tstz label Asia/Tokyo
+```
+
 ## baseline
 
 ```

--- a/experiments/2026-08-09-rel-from-df-posixct/grid.md
+++ b/experiments/2026-08-09-rel-from-df-posixct/grid.md
@@ -1,0 +1,248 @@
+# `rel_from_df()` POSIXct grid
+
+Recorded by `run.sh`; what each column means is in `README.md`.
+
+## baseline
+
+```
+policy baseline | duckdb 1.5.5.9013 | DuckDB 1.5.5 | local zone Etc/UTC 
+
+   policy   col              tz_out           session          verdict   back            
+1  baseline UTC              UTC              UTC              ok        UTC             
+2  baseline <empty>          UTC              UTC              refused   <NA>            
+3  baseline <absent>         UTC              UTC              refused   <NA>            
+4  baseline America/New_York UTC              UTC              refused   <NA>            
+5  baseline UTC              <empty>          UTC              refused   <NA>            
+6  baseline <empty>          <empty>          UTC              relabeled <absent>        
+7  baseline <absent>         <empty>          UTC              ok        <absent>        
+8  baseline America/New_York <empty>          UTC              refused   <NA>            
+9  baseline UTC              America/New_York UTC              refused   <NA>            
+10 baseline <empty>          America/New_York UTC              refused   <NA>            
+11 baseline <absent>         America/New_York UTC              refused   <NA>            
+12 baseline America/New_York America/New_York UTC              ok        America/New_York
+13 baseline UTC              UTC              Etc/UTC          ok        UTC             
+14 baseline <empty>          UTC              Etc/UTC          refused   <NA>            
+15 baseline <absent>         UTC              Etc/UTC          refused   <NA>            
+16 baseline America/New_York UTC              Etc/UTC          refused   <NA>            
+17 baseline UTC              <empty>          Etc/UTC          refused   <NA>            
+18 baseline <empty>          <empty>          Etc/UTC          relabeled <absent>        
+19 baseline <absent>         <empty>          Etc/UTC          ok        <absent>        
+20 baseline America/New_York <empty>          Etc/UTC          refused   <NA>            
+21 baseline UTC              America/New_York Etc/UTC          refused   <NA>            
+22 baseline <empty>          America/New_York Etc/UTC          refused   <NA>            
+23 baseline <absent>         America/New_York Etc/UTC          refused   <NA>            
+24 baseline America/New_York America/New_York Etc/UTC          ok        America/New_York
+25 baseline UTC              UTC              America/New_York ok        UTC             
+26 baseline <empty>          UTC              America/New_York refused   <NA>            
+27 baseline <absent>         UTC              America/New_York refused   <NA>            
+28 baseline America/New_York UTC              America/New_York refused   <NA>            
+29 baseline UTC              <empty>          America/New_York refused   <NA>            
+30 baseline <empty>          <empty>          America/New_York relabeled <absent>        
+31 baseline <absent>         <empty>          America/New_York ok        <absent>        
+32 baseline America/New_York <empty>          America/New_York refused   <NA>            
+33 baseline UTC              America/New_York America/New_York refused   <NA>            
+34 baseline <empty>          America/New_York America/New_York refused   <NA>            
+35 baseline <absent>         America/New_York America/New_York refused   <NA>            
+36 baseline America/New_York America/New_York America/New_York ok        America/New_York
+
+tally:
+
+       ok   refused relabeled 
+        9        24         3 
+```
+
+## timestamp-rel
+
+```
+policy timestamp-rel | duckdb 1.5.5.9013 | DuckDB 1.5.5 | local zone Etc/UTC 
+
+   policy        col              tz_out           session          verdict   back            
+1  timestamp-rel UTC              UTC              UTC              ok        UTC             
+2  timestamp-rel <empty>          UTC              UTC              refused   <NA>            
+3  timestamp-rel <absent>         UTC              UTC              refused   <NA>            
+4  timestamp-rel America/New_York UTC              UTC              refused   <NA>            
+5  timestamp-rel UTC              <empty>          UTC              refused   <NA>            
+6  timestamp-rel <empty>          <empty>          UTC              relabeled <absent>        
+7  timestamp-rel <absent>         <empty>          UTC              ok        <absent>        
+8  timestamp-rel America/New_York <empty>          UTC              refused   <NA>            
+9  timestamp-rel UTC              America/New_York UTC              refused   <NA>            
+10 timestamp-rel <empty>          America/New_York UTC              refused   <NA>            
+11 timestamp-rel <absent>         America/New_York UTC              refused   <NA>            
+12 timestamp-rel America/New_York America/New_York UTC              ok        America/New_York
+13 timestamp-rel UTC              UTC              Etc/UTC          ok        UTC             
+14 timestamp-rel <empty>          UTC              Etc/UTC          refused   <NA>            
+15 timestamp-rel <absent>         UTC              Etc/UTC          refused   <NA>            
+16 timestamp-rel America/New_York UTC              Etc/UTC          refused   <NA>            
+17 timestamp-rel UTC              <empty>          Etc/UTC          refused   <NA>            
+18 timestamp-rel <empty>          <empty>          Etc/UTC          relabeled <absent>        
+19 timestamp-rel <absent>         <empty>          Etc/UTC          ok        <absent>        
+20 timestamp-rel America/New_York <empty>          Etc/UTC          refused   <NA>            
+21 timestamp-rel UTC              America/New_York Etc/UTC          refused   <NA>            
+22 timestamp-rel <empty>          America/New_York Etc/UTC          refused   <NA>            
+23 timestamp-rel <absent>         America/New_York Etc/UTC          refused   <NA>            
+24 timestamp-rel America/New_York America/New_York Etc/UTC          ok        America/New_York
+25 timestamp-rel UTC              UTC              America/New_York ok        UTC             
+26 timestamp-rel <empty>          UTC              America/New_York refused   <NA>            
+27 timestamp-rel <absent>         UTC              America/New_York refused   <NA>            
+28 timestamp-rel America/New_York UTC              America/New_York refused   <NA>            
+29 timestamp-rel UTC              <empty>          America/New_York refused   <NA>            
+30 timestamp-rel <empty>          <empty>          America/New_York relabeled <absent>        
+31 timestamp-rel <absent>         <empty>          America/New_York ok        <absent>        
+32 timestamp-rel America/New_York <empty>          America/New_York refused   <NA>            
+33 timestamp-rel UTC              America/New_York America/New_York refused   <NA>            
+34 timestamp-rel <empty>          America/New_York America/New_York refused   <NA>            
+35 timestamp-rel <absent>         America/New_York America/New_York refused   <NA>            
+36 timestamp-rel America/New_York America/New_York America/New_York ok        America/New_York
+
+tally:
+
+       ok   refused relabeled 
+        9        24         3 
+```
+
+## follow
+
+```
+policy follow | duckdb 1.5.5.9013 | DuckDB 1.5.5 | local zone Etc/UTC 
+
+   policy col              tz_out           session          verdict   back            
+1  follow UTC              UTC              UTC              ok        UTC             
+2  follow <empty>          UTC              UTC              refused   <NA>            
+3  follow <absent>         UTC              UTC              refused   <NA>            
+4  follow America/New_York UTC              UTC              refused   <NA>            
+5  follow UTC              <empty>          UTC              refused   <NA>            
+6  follow <empty>          <empty>          UTC              relabeled UTC             
+7  follow <absent>         <empty>          UTC              relabeled UTC             
+8  follow America/New_York <empty>          UTC              refused   <NA>            
+9  follow UTC              America/New_York UTC              refused   <NA>            
+10 follow <empty>          America/New_York UTC              refused   <NA>            
+11 follow <absent>         America/New_York UTC              refused   <NA>            
+12 follow America/New_York America/New_York UTC              relabeled UTC             
+13 follow UTC              UTC              Etc/UTC          relabeled Etc/UTC         
+14 follow <empty>          UTC              Etc/UTC          refused   <NA>            
+15 follow <absent>         UTC              Etc/UTC          refused   <NA>            
+16 follow America/New_York UTC              Etc/UTC          refused   <NA>            
+17 follow UTC              <empty>          Etc/UTC          refused   <NA>            
+18 follow <empty>          <empty>          Etc/UTC          relabeled Etc/UTC         
+19 follow <absent>         <empty>          Etc/UTC          relabeled Etc/UTC         
+20 follow America/New_York <empty>          Etc/UTC          refused   <NA>            
+21 follow UTC              America/New_York Etc/UTC          refused   <NA>            
+22 follow <empty>          America/New_York Etc/UTC          refused   <NA>            
+23 follow <absent>         America/New_York Etc/UTC          refused   <NA>            
+24 follow America/New_York America/New_York Etc/UTC          relabeled Etc/UTC         
+25 follow UTC              UTC              America/New_York relabeled America/New_York
+26 follow <empty>          UTC              America/New_York refused   <NA>            
+27 follow <absent>         UTC              America/New_York refused   <NA>            
+28 follow America/New_York UTC              America/New_York refused   <NA>            
+29 follow UTC              <empty>          America/New_York refused   <NA>            
+30 follow <empty>          <empty>          America/New_York relabeled America/New_York
+31 follow <absent>         <empty>          America/New_York relabeled America/New_York
+32 follow America/New_York <empty>          America/New_York refused   <NA>            
+33 follow UTC              America/New_York America/New_York refused   <NA>            
+34 follow <empty>          America/New_York America/New_York refused   <NA>            
+35 follow <absent>         America/New_York America/New_York refused   <NA>            
+36 follow America/New_York America/New_York America/New_York ok        America/New_York
+
+tally:
+
+       ok   refused relabeled 
+        2        24        10 
+```
+
+## session-tz
+
+```
+policy session-tz | duckdb 1.5.5.9013 | DuckDB 1.5.5 | local zone Etc/UTC 
+
+   policy     col              tz_out           session          verdict back            
+1  session-tz UTC              UTC              UTC              ok      UTC             
+2  session-tz <empty>          UTC              UTC              refused <NA>            
+3  session-tz <absent>         UTC              UTC              refused <NA>            
+4  session-tz America/New_York UTC              UTC              refused <NA>            
+5  session-tz UTC              <empty>          UTC              ok      UTC             
+6  session-tz <empty>          <empty>          UTC              refused <NA>            
+7  session-tz <absent>         <empty>          UTC              refused <NA>            
+8  session-tz America/New_York <empty>          UTC              refused <NA>            
+9  session-tz UTC              America/New_York UTC              ok      UTC             
+10 session-tz <empty>          America/New_York UTC              refused <NA>            
+11 session-tz <absent>         America/New_York UTC              refused <NA>            
+12 session-tz America/New_York America/New_York UTC              refused <NA>            
+13 session-tz UTC              UTC              Etc/UTC          refused <NA>            
+14 session-tz <empty>          UTC              Etc/UTC          refused <NA>            
+15 session-tz <absent>         UTC              Etc/UTC          refused <NA>            
+16 session-tz America/New_York UTC              Etc/UTC          refused <NA>            
+17 session-tz UTC              <empty>          Etc/UTC          refused <NA>            
+18 session-tz <empty>          <empty>          Etc/UTC          refused <NA>            
+19 session-tz <absent>         <empty>          Etc/UTC          refused <NA>            
+20 session-tz America/New_York <empty>          Etc/UTC          refused <NA>            
+21 session-tz UTC              America/New_York Etc/UTC          refused <NA>            
+22 session-tz <empty>          America/New_York Etc/UTC          refused <NA>            
+23 session-tz <absent>         America/New_York Etc/UTC          refused <NA>            
+24 session-tz America/New_York America/New_York Etc/UTC          refused <NA>            
+25 session-tz UTC              UTC              America/New_York refused <NA>            
+26 session-tz <empty>          UTC              America/New_York refused <NA>            
+27 session-tz <absent>         UTC              America/New_York refused <NA>            
+28 session-tz America/New_York UTC              America/New_York ok      America/New_York
+29 session-tz UTC              <empty>          America/New_York refused <NA>            
+30 session-tz <empty>          <empty>          America/New_York refused <NA>            
+31 session-tz <absent>         <empty>          America/New_York refused <NA>            
+32 session-tz America/New_York <empty>          America/New_York ok      America/New_York
+33 session-tz UTC              America/New_York America/New_York refused <NA>            
+34 session-tz <empty>          America/New_York America/New_York refused <NA>            
+35 session-tz <absent>         America/New_York America/New_York refused <NA>            
+36 session-tz America/New_York America/New_York America/New_York ok      America/New_York
+
+tally:
+
+     ok refused 
+      6      30 
+```
+
+## relaxed
+
+```
+policy relaxed | duckdb 1.5.5.9013 | DuckDB 1.5.5 | local zone Etc/UTC 
+
+   policy  col              tz_out           session          verdict   back            
+1  relaxed UTC              UTC              UTC              ok        UTC             
+2  relaxed <empty>          UTC              UTC              relabeled UTC             
+3  relaxed <absent>         UTC              UTC              relabeled UTC             
+4  relaxed America/New_York UTC              UTC              relabeled UTC             
+5  relaxed UTC              <empty>          UTC              ok        UTC             
+6  relaxed <empty>          <empty>          UTC              relabeled UTC             
+7  relaxed <absent>         <empty>          UTC              relabeled UTC             
+8  relaxed America/New_York <empty>          UTC              relabeled UTC             
+9  relaxed UTC              America/New_York UTC              ok        UTC             
+10 relaxed <empty>          America/New_York UTC              relabeled UTC             
+11 relaxed <absent>         America/New_York UTC              relabeled UTC             
+12 relaxed America/New_York America/New_York UTC              relabeled UTC             
+13 relaxed UTC              UTC              Etc/UTC          relabeled Etc/UTC         
+14 relaxed <empty>          UTC              Etc/UTC          relabeled Etc/UTC         
+15 relaxed <absent>         UTC              Etc/UTC          relabeled Etc/UTC         
+16 relaxed America/New_York UTC              Etc/UTC          relabeled Etc/UTC         
+17 relaxed UTC              <empty>          Etc/UTC          relabeled Etc/UTC         
+18 relaxed <empty>          <empty>          Etc/UTC          relabeled Etc/UTC         
+19 relaxed <absent>         <empty>          Etc/UTC          relabeled Etc/UTC         
+20 relaxed America/New_York <empty>          Etc/UTC          relabeled Etc/UTC         
+21 relaxed UTC              America/New_York Etc/UTC          relabeled Etc/UTC         
+22 relaxed <empty>          America/New_York Etc/UTC          relabeled Etc/UTC         
+23 relaxed <absent>         America/New_York Etc/UTC          relabeled Etc/UTC         
+24 relaxed America/New_York America/New_York Etc/UTC          relabeled Etc/UTC         
+25 relaxed UTC              UTC              America/New_York relabeled America/New_York
+26 relaxed <empty>          UTC              America/New_York relabeled America/New_York
+27 relaxed <absent>         UTC              America/New_York relabeled America/New_York
+28 relaxed America/New_York UTC              America/New_York ok        America/New_York
+29 relaxed UTC              <empty>          America/New_York relabeled America/New_York
+30 relaxed <empty>          <empty>          America/New_York relabeled America/New_York
+31 relaxed <absent>         <empty>          America/New_York relabeled America/New_York
+32 relaxed America/New_York <empty>          America/New_York ok        America/New_York
+33 relaxed UTC              America/New_York America/New_York relabeled America/New_York
+34 relaxed <empty>          America/New_York America/New_York relabeled America/New_York
+35 relaxed <absent>         America/New_York America/New_York relabeled America/New_York
+36 relaxed America/New_York America/New_York America/New_York ok        America/New_York
+
+tally:
+
+       ok relabeled 
+        6        30 
+```

--- a/experiments/2026-08-09-rel-from-df-posixct/no-icu.R
+++ b/experiments/2026-08-09-rel-from-df-posixct/no-icu.R
@@ -2,131 +2,124 @@
 #
 # Answers what neither grid could, because a fast-path build links icu
 # statically and its absence cannot be produced there:
-#   1. what the session zone reads when the setting does not exist
-#   2. whether `duckdb_extensions()` is safe to ask (the pin's guard)
-#   3. whether `SET TimeZone` reaches for icu, and what that costs
-#   4. whether the default write/read round trip still follows the machine
+#   1. which ways of asking about the session zone are safe without icu
+#   2. what the zone reads when the setting does not exist
+#   3. whether the default write/read round trip still follows the machine
+#   4. what `SET TimeZone` costs when it has to reach for the extension
 #
-# Run against a source build installed in its own library; run.sh in the
-# no-icu worktree supplies TZ.
+# Needs the vendored engine compiled from source -- it links `parquet` and
+# `core_functions` and nothing else -- installed in its own library:
+#
+#   git worktree add --detach ../duckdb-r-noicu HEAD
+#   (cd ../duckdb-r-noicu && MAKEFLAGS=-j4 NOT_CRAN=true \
+#      R CMD INSTALL . --library=$HOME/R-noicu --no-byte-compile)
+#   R_LIBS=$HOME/R-noicu TZ=UTC Rscript experiments/.../no-icu.R
 suppressMessages(library(duckdb))
 
-TZ <- Sys.getenv("TZ")
 INSTANT <- as.POSIXct(1745781814.84963, origin = "1970-01-01", tz = "UTC")
 
 say <- function(...) cat(sprintf(...), "\n", sep = "")
 
-# An empty extension directory is a machine that has never downloaded icu,
-# whatever this one's ~/.duckdb holds.
-empty_store <- tempfile("ext-store-")
-dir.create(empty_store)
+# `try_sql()` reports what a statement did rather than letting it stop the
+# script: on this build some of them raise an autoloading error, which is
+# itself one of the answers.
+try_sql <- function(con, sql, exec = FALSE) {
+  t <- system.time(
+    out <- tryCatch(
+      if (exec) dbExecute(con, sql) else dbGetQuery(con, sql),
+      error = function(e) e
+    )
+  )[["elapsed"]]
+  if (inherits(out, "error")) {
+    sprintf("%s (%.2fs)", sub("\n.*", "", conditionMessage(out)), t)
+  } else if (exec) {
+    sprintf("ok (%.2fs)", t)
+  } else {
+    sprintf("%s (%.2fs)", as.character(out[[1]]), t)
+  }
+}
 
-fresh <- function(...) {
-  suppressMessages(dbConnect(
-    duckdb(config = list(extension_directory = empty_store)),
-    ...
-  ))
+report <- function(label, con) {
+  say("-- %s --", label)
+
+  # 1. duckdb_extensions() is a catalog function, not a setting lookup.
+  ext <- dbGetQuery(
+    con,
+    "SELECT loaded, installed, install_mode
+       FROM duckdb_extensions() WHERE extension_name = 'icu'"
+  )
+  say(
+    "duckdb_extensions(): loaded=%s installed=%s install_mode=%s",
+    ext$loaded,
+    ext$installed,
+    ext$install_mode
+  )
+
+  # 2. The label on a TIMESTAMPTZ column is the session zone as the glue sees
+  # it, through GetClientProperties(); asking in SQL is the other way, and the
+  # two do not agree, because asking in SQL can load the extension that
+  # supplies the setting.
+  label <- function() {
+    attr(
+      dbGetQuery(con, "SELECT TIMESTAMPTZ '2024-01-10 13:03:12-08:00' AS a")$a,
+      "tzone"
+    )
+  }
+  say("tzone label before anything asks for the setting: %s", label())
+  say(
+    "current_setting('TimeZone'): %s",
+    try_sql(con, "SELECT current_setting('TimeZone')")
+  )
+  say("tzone label after: %s", label())
+
+  # 3. Does the default round trip still follow the machine?
+  df <- data.frame(a = INSTANT)
+  dbWriteTable(con, "t", df, overwrite = TRUE)
+  back <- dbReadTable(con, "t")$a
+  say("dbWriteTable type: %s", dbGetQuery(con, "DESCRIBE t")$column_type)
+  say(
+    "round trip: label %s, instant %s",
+    attr(back, "tzone"),
+    if (isTRUE(all.equal(as.numeric(back), as.numeric(INSTANT)))) {
+      "preserved"
+    } else {
+      "MOVED"
+    }
+  )
+
+  # 4. What a connect-time pin would be issuing.
+  say(
+    "SET TimeZone = 'UTC': %s",
+    try_sql(con, "SET TimeZone = 'UTC'", exec = TRUE)
+  )
+  say(
+    "icu loaded after: %s",
+    dbGetQuery(
+      con,
+      "SELECT loaded FROM duckdb_extensions() WHERE extension_name = 'icu'"
+    )$loaded
+  )
 }
 
 say(
-  "== TZ=%s, duckdb %s, DuckDB %s ==",
-  TZ,
+  "== TZ=%s, duckdb %s, DuckDB %s, source build ==",
+  Sys.getenv("TZ"),
   packageVersion("duckdb"),
   duckdb:::get_duckdb_version()
 )
 
-con <- fresh()
-
-# 2. Is duckdb_extensions() safe to ask? Nothing should be loaded by asking.
-ext <- dbGetQuery(
-  con,
-  "SELECT extension_name, loaded, installed, install_mode
-     FROM duckdb_extensions() WHERE extension_name = 'icu'"
-)
-say(
-  "icu row: loaded=%s installed=%s install_mode=%s",
-  ext$loaded,
-  ext$installed,
-  ext$install_mode
-)
-
-# 1. What does the session zone read with no icu?
-say(
-  "session zone: %s",
-  dbGetQuery(con, "SELECT current_setting('TimeZone') AS tz")$tz
-)
-
-# 4. Does the default round trip still follow the machine?
-df <- data.frame(a = INSTANT)
-dbWriteTable(con, "t", df)
-back <- dbReadTable(con, "t")$a
-say(
-  "dbWriteTable type: %s",
-  dbGetQuery(con, "DESCRIBE t")$column_type
-)
-say(
-  "round trip: label %s, instant %s",
-  attr(back, "tzone"),
-  if (isTRUE(all.equal(as.numeric(back), as.numeric(INSTANT)))) {
-    "preserved"
-  } else {
-    "MOVED"
-  }
-)
-
-# 3. What does asking for the setting cost? Time it: a network reach shows up.
-elapsed <- system.time(
-  err <- tryCatch(dbExecute(con, "SET TimeZone = 'UTC'"), error = function(e) e)
-)[["elapsed"]]
-say(
-  "SET TimeZone = 'UTC': %s (%.2fs)",
-  if (inherits(err, "error")) {
-    paste0("error: ", sub("\n.*", "", conditionMessage(err)))
-  } else {
-    "ok"
-  },
-  elapsed
-)
-say(
-  "session zone after: %s",
-  dbGetQuery(con, "SELECT current_setting('TimeZone') AS tz")$tz
-)
-
+# A machine that has never downloaded icu, whatever this one's store holds.
+empty_store <- tempfile("ext-store-")
+dir.create(empty_store)
+con <- suppressMessages(dbConnect(
+  duckdb(config = list(extension_directory = empty_store))
+))
+report("empty extension store", con)
 dbDisconnect(con, shutdown = TRUE)
 
-# The same question on a machine that has downloaded icu before: the default
-# store. If `SET TimeZone` autoloads from there, a connect-time pin would
-# silently load an extension for everyone who has one cached, which is what
-# the guard exists to avoid.
-say("-- default extension store (icu may be cached) --")
+# And a machine that has: the default store, where icu may be cached. If
+# asking loads it, a connect-time pin would load an extension for everyone
+# who has one, which is what a guard would exist to avoid.
 con2 <- suppressMessages(dbConnect(duckdb()))
-say(
-  "icu before: loaded=%s",
-  dbGetQuery(
-    con2,
-    "SELECT loaded FROM duckdb_extensions() WHERE extension_name = 'icu'"
-  )$loaded
-)
-elapsed2 <- system.time(
-  err2 <- tryCatch(
-    dbExecute(con2, "SET TimeZone = 'UTC'"),
-    error = function(e) e
-  )
-)[["elapsed"]]
-say(
-  "SET TimeZone = 'UTC': %s (%.2fs)",
-  if (inherits(err2, "error")) {
-    paste0("error: ", sub("\n.*", "", conditionMessage(err2)))
-  } else {
-    "ok"
-  },
-  elapsed2
-)
-say(
-  "icu after: loaded=%s",
-  dbGetQuery(
-    con2,
-    "SELECT loaded FROM duckdb_extensions() WHERE extension_name = 'icu'"
-  )$loaded
-)
+report("default extension store", con2)
 dbDisconnect(con2, shutdown = TRUE)

--- a/experiments/2026-08-09-rel-from-df-posixct/no-icu.R
+++ b/experiments/2026-08-09-rel-from-df-posixct/no-icu.R
@@ -1,0 +1,132 @@
+# The branch the fast path cannot reach: a build with no icu in it.
+#
+# Answers what neither grid could, because a fast-path build links icu
+# statically and its absence cannot be produced there:
+#   1. what the session zone reads when the setting does not exist
+#   2. whether `duckdb_extensions()` is safe to ask (the pin's guard)
+#   3. whether `SET TimeZone` reaches for icu, and what that costs
+#   4. whether the default write/read round trip still follows the machine
+#
+# Run against a source build installed in its own library; run.sh in the
+# no-icu worktree supplies TZ.
+suppressMessages(library(duckdb))
+
+TZ <- Sys.getenv("TZ")
+INSTANT <- as.POSIXct(1745781814.84963, origin = "1970-01-01", tz = "UTC")
+
+say <- function(...) cat(sprintf(...), "\n", sep = "")
+
+# An empty extension directory is a machine that has never downloaded icu,
+# whatever this one's ~/.duckdb holds.
+empty_store <- tempfile("ext-store-")
+dir.create(empty_store)
+
+fresh <- function(...) {
+  suppressMessages(dbConnect(
+    duckdb(config = list(extension_directory = empty_store)),
+    ...
+  ))
+}
+
+say(
+  "== TZ=%s, duckdb %s, DuckDB %s ==",
+  TZ,
+  packageVersion("duckdb"),
+  duckdb:::get_duckdb_version()
+)
+
+con <- fresh()
+
+# 2. Is duckdb_extensions() safe to ask? Nothing should be loaded by asking.
+ext <- dbGetQuery(
+  con,
+  "SELECT extension_name, loaded, installed, install_mode
+     FROM duckdb_extensions() WHERE extension_name = 'icu'"
+)
+say(
+  "icu row: loaded=%s installed=%s install_mode=%s",
+  ext$loaded,
+  ext$installed,
+  ext$install_mode
+)
+
+# 1. What does the session zone read with no icu?
+say(
+  "session zone: %s",
+  dbGetQuery(con, "SELECT current_setting('TimeZone') AS tz")$tz
+)
+
+# 4. Does the default round trip still follow the machine?
+df <- data.frame(a = INSTANT)
+dbWriteTable(con, "t", df)
+back <- dbReadTable(con, "t")$a
+say(
+  "dbWriteTable type: %s",
+  dbGetQuery(con, "DESCRIBE t")$column_type
+)
+say(
+  "round trip: label %s, instant %s",
+  attr(back, "tzone"),
+  if (isTRUE(all.equal(as.numeric(back), as.numeric(INSTANT)))) {
+    "preserved"
+  } else {
+    "MOVED"
+  }
+)
+
+# 3. What does asking for the setting cost? Time it: a network reach shows up.
+elapsed <- system.time(
+  err <- tryCatch(dbExecute(con, "SET TimeZone = 'UTC'"), error = function(e) e)
+)[["elapsed"]]
+say(
+  "SET TimeZone = 'UTC': %s (%.2fs)",
+  if (inherits(err, "error")) {
+    paste0("error: ", sub("\n.*", "", conditionMessage(err)))
+  } else {
+    "ok"
+  },
+  elapsed
+)
+say(
+  "session zone after: %s",
+  dbGetQuery(con, "SELECT current_setting('TimeZone') AS tz")$tz
+)
+
+dbDisconnect(con, shutdown = TRUE)
+
+# The same question on a machine that has downloaded icu before: the default
+# store. If `SET TimeZone` autoloads from there, a connect-time pin would
+# silently load an extension for everyone who has one cached, which is what
+# the guard exists to avoid.
+say("-- default extension store (icu may be cached) --")
+con2 <- suppressMessages(dbConnect(duckdb()))
+say(
+  "icu before: loaded=%s",
+  dbGetQuery(
+    con2,
+    "SELECT loaded FROM duckdb_extensions() WHERE extension_name = 'icu'"
+  )$loaded
+)
+elapsed2 <- system.time(
+  err2 <- tryCatch(
+    dbExecute(con2, "SET TimeZone = 'UTC'"),
+    error = function(e) e
+  )
+)[["elapsed"]]
+say(
+  "SET TimeZone = 'UTC': %s (%.2fs)",
+  if (inherits(err2, "error")) {
+    paste0("error: ", sub("\n.*", "", conditionMessage(err2)))
+  } else {
+    "ok"
+  },
+  elapsed2
+)
+say(
+  "icu after: loaded=%s",
+  dbGetQuery(
+    con2,
+    "SELECT loaded FROM duckdb_extensions() WHERE extension_name = 'icu'"
+  )$loaded
+)
+dbDisconnect(con2, shutdown = TRUE)

--- a/experiments/2026-08-09-rel-from-df-posixct/no-icu.md
+++ b/experiments/2026-08-09-rel-from-df-posixct/no-icu.md
@@ -1,0 +1,46 @@
+# Timestamps on a build with no icu
+
+Recorded by `run-no-icu.sh`; `README.md` says what it asks.
+
+```
+== TZ=UTC, duckdb 1.5.5.9013, DuckDB 1.5.5, source build ==
+-- empty extension store --
+duckdb_extensions(): loaded=FALSE installed=FALSE install_mode=NOT_INSTALLED
+tzone label before anything asks for the setting: UTC
+current_setting('TimeZone'): Extension Autoloading Error: An error occurred while trying to automatically install the required extension 'icu': (0.16s)
+tzone label after: UTC
+dbWriteTable type: TIMESTAMP WITH TIME ZONE
+round trip: label UTC, instant preserved
+SET TimeZone = 'UTC': Invalid Error: Extension Autoloading Error: An error occurred while trying to automatically install the required extension 'icu': (0.02s)
+icu loaded after: FALSE
+-- default extension store --
+duckdb_extensions(): loaded=FALSE installed=TRUE install_mode=REPOSITORY
+tzone label before anything asks for the setting: UTC
+current_setting('TimeZone'): UTC (0.05s)
+tzone label after: UTC
+dbWriteTable type: TIMESTAMP WITH TIME ZONE
+round trip: label UTC, instant preserved
+SET TimeZone = 'UTC': ok (0.00s)
+icu loaded after: TRUE
+
+== TZ=Europe/Zurich, duckdb 1.5.5.9013, DuckDB 1.5.5, source build ==
+-- empty extension store --
+duckdb_extensions(): loaded=FALSE installed=FALSE install_mode=NOT_INSTALLED
+tzone label before anything asks for the setting: UTC
+current_setting('TimeZone'): Extension Autoloading Error: An error occurred while trying to automatically install the required extension 'icu': (0.18s)
+tzone label after: UTC
+dbWriteTable type: TIMESTAMP WITH TIME ZONE
+round trip: label UTC, instant preserved
+SET TimeZone = 'UTC': Invalid Error: Extension Autoloading Error: An error occurred while trying to automatically install the required extension 'icu': (0.02s)
+icu loaded after: FALSE
+-- default extension store --
+duckdb_extensions(): loaded=FALSE installed=TRUE install_mode=REPOSITORY
+tzone label before anything asks for the setting: UTC
+current_setting('TimeZone'): Europe/Zurich (0.05s)
+tzone label after: Europe/Zurich
+dbWriteTable type: TIMESTAMP WITH TIME ZONE
+round trip: label Europe/Zurich, instant preserved
+SET TimeZone = 'UTC': ok (0.00s)
+icu loaded after: TRUE
+
+```

--- a/experiments/2026-08-09-rel-from-df-posixct/patches/follow.patch
+++ b/experiments/2026-08-09-rel-from-df-posixct/patches/follow.patch
@@ -1,0 +1,29 @@
+diff --git a/R/relational.R b/R/relational.R
+index e6af84c..f81f2af 100644
+--- a/R/relational.R
++++ b/R/relational.R
+@@ -64,10 +64,7 @@ expr_constant <- function(
+     } else {
+       convert_opts <- con@convert_opts
+     }
+-    # `TIMESTAMP` for the same reason `rel_from_df()` pins it: a constant
+-    # lands in a relation, and the relational path returns the zone it was
+-    # given rather than the session's.
+-    convert_opts$posixct <- "timestamp"
++    # EXPERIMENT follow: take `posixct` as the connection gives it.
+   }
+ 
+   rethrow_rapi_expr_constant(val, alias, convert_opts)
+@@ -199,11 +196,7 @@ rel_from_df <- function(
+   # FIXME: Enable warning
+   if (is.null(convert_opts)) {
+     convert_opts <- con@convert_opts
+-    # A relation promises the data frame back unchanged, which a TIMESTAMPTZ
+-    # column cannot: it comes back labeled with the session zone. Measured in
+-    # experiments/2026-08-09-rel-from-df-posixct/README.md; a caller who wants
+-    # the connection's setting here passes `convert_opts` themselves.
+-    convert_opts$posixct <- "timestamp"
++    # EXPERIMENT follow: take `posixct` as the connection gives it.
+   }
+   if (!is.null(experimental)) {
+     convert_opts$experimental <- experimental

--- a/experiments/2026-08-09-rel-from-df-posixct/patches/pin-session.patch
+++ b/experiments/2026-08-09-rel-from-df-posixct/patches/pin-session.patch
@@ -1,0 +1,76 @@
+diff --git a/R/dbConnect__duckdb_driver.R b/R/dbConnect__duckdb_driver.R
+index 2d88830..6d4a9d7 100644
+--- a/R/dbConnect__duckdb_driver.R
++++ b/R/dbConnect__duckdb_driver.R
+@@ -137,6 +137,11 @@ dbConnect__duckdb_driver <- function(
+   conn <- duckdb_connection(drv, debug = debug, convert_opts = convert_opts)
+   on.exit(dbDisconnect(conn))
+ 
++  # EXPERIMENT pin-session: make the session zone `timezone_out`, so a
++  # TIMESTAMPTZ column comes back with the label the connection promises
++  # instead of the one the machine happens to carry.
++  duckdb_pin_session_timezone(conn, timezone_out)
++
+   reg.finalizer(conn@conn_ref, onexit = TRUE, rapi_disconnect)
+   on.exit(NULL)
+ 
+@@ -148,3 +153,30 @@ dbConnect__duckdb_driver <- function(
+ #' @rdname duckdb
+ #' @export
+ setMethod("dbConnect", "duckdb_driver", dbConnect__duckdb_driver)
++
++# The TimeZone setting lives in icu, and asking for it when icu is absent
++# would try to autoload it. Where icu is not loaded the session zone already
++# reads "UTC", which is what `timezone_out` defaults to, so the only case
++# that needs the SET is the one where asking is free.
++duckdb_pin_session_timezone <- function(conn, timezone_out) {
++  loaded <- dbGetQuery(
++    conn,
++    "SELECT loaded FROM duckdb_extensions() WHERE extension_name = 'icu'"
++  )
++  if (nrow(loaded) == 0 || !isTRUE(loaded$loaded[[1]])) {
++    return(invisible(FALSE))
++  }
++
++  zone <- if (nzchar(timezone_out)) timezone_out else Sys.timezone()
++  if (is.na(zone) || !nzchar(zone)) {
++    return(invisible(FALSE))
++  }
++
++  tryCatch(
++    {
++      dbExecute(conn, paste0("SET TimeZone = ", dbQuoteString(conn, zone)))
++      invisible(TRUE)
++    },
++    error = function(e) invisible(FALSE)
++  )
++}
+diff --git a/R/relational.R b/R/relational.R
+index 67b59b8..56bebb7 100644
+--- a/R/relational.R
++++ b/R/relational.R
+@@ -64,10 +64,7 @@ expr_constant <- function(
+     } else {
+       convert_opts <- con@convert_opts
+     }
+-    # `TIMESTAMP` for the same reason `rel_from_df()` pins it: a constant
+-    # lands in a relation, and the relational path returns the zone it was
+-    # given rather than the session's.
+-    convert_opts$posixct <- "timestamp"
++    # EXPERIMENT follow: take `posixct` as the connection gives it.
+   }
+ 
+   rethrow_rapi_expr_constant(val, alias, convert_opts)
+@@ -199,11 +196,7 @@ rel_from_df <- function(
+   # FIXME: Enable warning
+   if (is.null(convert_opts)) {
+     convert_opts <- con@convert_opts
+-    # A relation promises the data frame back unchanged, which a TIMESTAMPTZ
+-    # column cannot: it comes back labeled with the session zone. Measured in
+-    # experiments/2026-08-09-rel-from-df-posixct/README.md; a caller who wants
+-    # the connection's setting here passes `convert_opts` themselves.
+-    convert_opts$posixct <- "timestamp"
++    # EXPERIMENT follow: take `posixct` as the connection gives it.
+   }
+   if (!is.null(experimental)) {
+     convert_opts$experimental <- experimental

--- a/experiments/2026-08-09-rel-from-df-posixct/patches/relaxed.patch
+++ b/experiments/2026-08-09-rel-from-df-posixct/patches/relaxed.patch
@@ -1,0 +1,53 @@
+diff --git a/R/relational.R b/R/relational.R
+index e6af84c..f81f2af 100644
+--- a/R/relational.R
++++ b/R/relational.R
+@@ -64,10 +64,7 @@ expr_constant <- function(
+     } else {
+       convert_opts <- con@convert_opts
+     }
+-    # `TIMESTAMP` for the same reason `rel_from_df()` pins it: a constant
+-    # lands in a relation, and the relational path returns the zone it was
+-    # given rather than the session's.
+-    convert_opts$posixct <- "timestamp"
++    # EXPERIMENT follow: take `posixct` as the connection gives it.
+   }
+ 
+   rethrow_rapi_expr_constant(val, alias, convert_opts)
+@@ -199,11 +196,7 @@ rel_from_df <- function(
+   # FIXME: Enable warning
+   if (is.null(convert_opts)) {
+     convert_opts <- con@convert_opts
+-    # A relation promises the data frame back unchanged, which a TIMESTAMPTZ
+-    # column cannot: it comes back labeled with the session zone. Measured in
+-    # experiments/2026-08-09-rel-from-df-posixct/README.md; a caller who wants
+-    # the connection's setting here passes `convert_opts` themselves.
+-    convert_opts$posixct <- "timestamp"
++    # EXPERIMENT follow: take `posixct` as the connection gives it.
+   }
+   if (!is.null(experimental)) {
+     convert_opts$experimental <- experimental
+diff --git a/src/relational.cpp b/src/relational.cpp
+index 7c28151..9716ba0 100644
+--- a/src/relational.cpp
++++ b/src/relational.cpp
+@@ -96,15 +96,10 @@ bool check_has_valid_class(SEXP col, const std::string &col_name, const std::str
+ 		if (class1 == "hms" && class2 == "difftime") {
+ 			valid = true;
+ 		} else if (class1 == "POSIXct" && class2 == "POSIXt") {
+-			SEXP tzone_attr = Rf_getAttrib(col, RStrings::get().tzone_sym);
+-			if (tzone_attr == R_NilValue) {
+-				if (tzone == "") {
+-					valid = true;
+-				}
+-			} else if (Rf_isString(tzone_attr) && LENGTH(tzone_attr) == 1 &&
+-			           cpp11::as_cpp<string>(tzone_attr) == tzone) {
+-				valid = true;
+-			}
++			// EXPERIMENT relaxed: a TIMESTAMPTZ column carries the instant
++			// whatever labels it in R, so accept every POSIXct.
++			(void)tzone;
++			valid = true;
+ 		}
+ 	}
+ 

--- a/experiments/2026-08-09-rel-from-df-posixct/patches/session-tz.patch
+++ b/experiments/2026-08-09-rel-from-df-posixct/patches/session-tz.patch
@@ -1,0 +1,54 @@
+diff --git a/R/relational.R b/R/relational.R
+index e6af84c..f81f2af 100644
+--- a/R/relational.R
++++ b/R/relational.R
+@@ -64,10 +64,7 @@ expr_constant <- function(
+     } else {
+       convert_opts <- con@convert_opts
+     }
+-    # `TIMESTAMP` for the same reason `rel_from_df()` pins it: a constant
+-    # lands in a relation, and the relational path returns the zone it was
+-    # given rather than the session's.
+-    convert_opts$posixct <- "timestamp"
++    # EXPERIMENT follow: take `posixct` as the connection gives it.
+   }
+ 
+   rethrow_rapi_expr_constant(val, alias, convert_opts)
+@@ -199,11 +196,7 @@ rel_from_df <- function(
+   # FIXME: Enable warning
+   if (is.null(convert_opts)) {
+     convert_opts <- con@convert_opts
+-    # A relation promises the data frame back unchanged, which a TIMESTAMPTZ
+-    # column cannot: it comes back labeled with the session zone. Measured in
+-    # experiments/2026-08-09-rel-from-df-posixct/README.md; a caller who wants
+-    # the connection's setting here passes `convert_opts` themselves.
+-    convert_opts$posixct <- "timestamp"
++    # EXPERIMENT follow: take `posixct` as the connection gives it.
+   }
+   if (!is.null(experimental)) {
+     convert_opts$experimental <- experimental
+diff --git a/src/relational.cpp b/src/relational.cpp
+index 7c28151..1e35d4e 100644
+--- a/src/relational.cpp
++++ b/src/relational.cpp
+@@ -296,12 +296,19 @@ void check_column_validity(SEXP col, const std::string &col_name, ConvertOpts::S
+ 	// Check each column
+ 	strings df_names = df.names();
+ 
++	// EXPERIMENT session-tz: the zone a column comes back labeled with is the
++	// session's, not `timezone_out`, so compare against that instead.
++	string round_trip_tz = convert_opts.timezone_out;
++	if (convert_opts.posixct == ConvertOpts::PosixctType::TIMESTAMPTZ) {
++		round_trip_tz = con->conn->context->GetClientProperties().time_zone;
++	}
++
+ 	for (int i = 0; i < df.ncol(); i++) {
+ 		SEXP col = df[i];
+ 		std::string col_name = static_cast<std::string>(df_names[i]);
+ 
+ 		// Run all column checks at once
+-		check_column_validity(col, col_name, convert_opts.strict_relational, convert_opts.timezone_out);
++		check_column_validity(col, col_name, convert_opts.strict_relational, round_trip_tz);
+ 	}
+ 
+ 	named_parameter_map_t other_params;

--- a/experiments/2026-08-09-rel-from-df-posixct/run-defaults.sh
+++ b/experiments/2026-08-09-rel-from-df-posixct/run-defaults.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+# Run defaults-grid.R for the shipped tree and for pin-session, over three
+# machine zones, into defaults.md.
+#
+# Separate from run.sh because it asks a different question: run.sh sets the
+# session zone in every cell and compares check policies; this one sets
+# nothing and asks whether the answer moves with the machine.
+#
+# Usage: DUCKDB_R_USE_SYSTEM_LIB=1 experiments/2026-08-09-rel-from-df-posixct/run-defaults.sh
+#
+# Needs a clean tree: pin-session.patch is a context diff against the
+# committed files, reverted with `git apply -R`.
+
+set -eu
+
+here=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+root=$(git rev-parse --show-toplevel)
+out=$here/defaults.md
+patch=$here/patches/pin-session.patch
+
+run() {
+  policy=$1
+  printf 'running %s\n' "$policy" >&2
+  (cd "$root" && R CMD INSTALL . --no-byte-compile >/dev/null 2>&1)
+  {
+    printf '\n## %s\n\n' "$policy"
+    printf '```\n'
+    for tz in UTC Etc/UTC Europe/Zurich; do
+      TZ=$tz POLICY="$policy" Rscript "$here/defaults-grid.R" 2>&1 |
+        grep -v '^Loading required'
+    done
+    printf '```\n'
+  } >>"$out"
+}
+
+{
+  printf '# What the defaults do, per machine zone\n\n'
+  printf 'Recorded by `run-defaults.sh`; `README.md` says what the columns\n'
+  printf 'mean. `rel` is `rel_from_df()` then `rel_to_altrep()`; `dbi` is\n'
+  printf '`dbWriteTable()` then `dbReadTable()`. Nothing calls `SET TimeZone`.\n'
+} >"$out"
+
+run shipped
+
+git -C "$root" apply "$patch"
+# shellcheck disable=SC2064
+trap "git -C '$root' apply -R '$patch'" EXIT INT TERM
+run pin-session
+git -C "$root" apply -R "$patch"
+trap - EXIT INT TERM
+
+printf 'rebuilding the shipped tree\n' >&2
+(cd "$root" && R CMD INSTALL . --no-byte-compile >/dev/null 2>&1)

--- a/experiments/2026-08-09-rel-from-df-posixct/run-no-icu.sh
+++ b/experiments/2026-08-09-rel-from-df-posixct/run-no-icu.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+# Build the vendored engine from source in a throwaway worktree and run
+# no-icu.R against it, into no-icu.md.
+#
+# The fast path links a release `libduckdb`, which has icu in it, so icu's
+# absence cannot be produced there. A source build links `parquet` and
+# `core_functions` and nothing else. It installs into its own library so the
+# fast-path build stays where it is.
+#
+# Usage: experiments/2026-08-09-rel-from-df-posixct/run-no-icu.sh
+#
+# Takes as long as a full engine build -- tens of minutes cold. Reuses the
+# worktree and the library if they are already there.
+
+set -eu
+
+here=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+root=$(git rev-parse --show-toplevel)
+tree=${NOICU_TREE:-$root/../duckdb-r-noicu}
+lib=${NOICU_LIB:-$HOME/R-noicu}
+out=$here/no-icu.md
+
+if [ ! -d "$tree" ]; then
+  git -C "$root" worktree add --detach "$tree" HEAD
+fi
+mkdir -p "$lib"
+
+printf 'building from source in %s\n' "$tree" >&2
+(
+  cd "$tree" &&
+    env -u DUCKDB_R_USE_SYSTEM_LIB MAKEFLAGS="${MAKEFLAGS:--j4}" NOT_CRAN=true \
+      R CMD INSTALL . --library="$lib" --no-byte-compile >/dev/null 2>&1
+)
+
+{
+  printf '# Timestamps on a build with no icu\n\n'
+  printf 'Recorded by `run-no-icu.sh`; `README.md` says what it asks.\n\n'
+  printf '```\n'
+  for tz in UTC Europe/Zurich; do
+    R_LIBS="$lib" TZ=$tz Rscript "$here/no-icu.R" 2>&1 |
+      grep -vE '^(Loading required|ℹ|duckdb is storing|This persists)'
+    printf '\n'
+  done
+  printf '```\n'
+} >"$out"
+
+printf 'wrote %s\n' "$out" >&2

--- a/experiments/2026-08-09-rel-from-df-posixct/run.sh
+++ b/experiments/2026-08-09-rel-from-df-posixct/run.sh
@@ -34,6 +34,14 @@ build_and_run() {
 {
   printf '# `rel_from_df()` POSIXct grid\n\n'
   printf 'Recorded by `run.sh`; what each column means is in `README.md`.\n'
+  printf '\n## default session zone\n\n'
+  printf 'Which grid row a user lands in without `SET TimeZone`, per machine\n'
+  printf 'zone. One process each: icu reads the zone once, when it loads.\n\n'
+  printf '```\n'
+  for tz in UTC Etc/UTC Europe/Zurich America/New_York Asia/Tokyo; do
+    TZ=$tz Rscript "$here/default-zone.R" 2>&1
+  done
+  printf '```\n'
 } >"$out"
 
 # The baseline is the tree without `posixct` at all: the row every other

--- a/experiments/2026-08-09-rel-from-df-posixct/run.sh
+++ b/experiments/2026-08-09-rel-from-df-posixct/run.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+# Run grid.R once per policy, rebuilding the glue in between, into grid.md.
+#
+# The shipped tree is the `timestamp-rel` policy; the other three are the
+# patches under patches/, applied with `git apply` and reverted after the run,
+# so the working tree is where it started whether or not a build fails. The
+# shipped tree is rebuilt at the end, because the last build installed was a
+# patched one.
+#
+# Usage: DUCKDB_R_USE_SYSTEM_LIB=1 experiments/2026-08-09-rel-from-df-posixct/run.sh
+#
+# Needs a clean tree: the `baseline` policy checks R/ and src/ out at
+# BASELINE_REV (default origin/main) and back, and the patches are context
+# diffs against the committed files, reverted with `git apply -R`.
+
+set -eu
+
+here=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+root=$(git rev-parse --show-toplevel)
+out=$here/grid.md
+
+build_and_run() {
+  policy=$1
+  printf 'running %s\n' "$policy" >&2
+  (cd "$root" && R CMD INSTALL . --no-byte-compile >/dev/null 2>&1)
+  {
+    printf '\n## %s\n\n' "$policy"
+    printf '```\n'
+    POLICY="$policy" Rscript "$here/grid.R" 2>&1
+    printf '```\n'
+  } >>"$out"
+}
+
+{
+  printf '# `rel_from_df()` POSIXct grid\n\n'
+  printf 'Recorded by `run.sh`; what each column means is in `README.md`.\n'
+} >"$out"
+
+# The baseline is the tree without `posixct` at all: the row every other
+# policy is compared against, measured rather than remembered.
+git -C "$root" checkout -q "${BASELINE_REV:-origin/main}" -- R src
+trap 'git -C "$root" checkout -q HEAD -- R src' EXIT INT TERM
+build_and_run baseline
+git -C "$root" checkout -q HEAD -- R src
+trap - EXIT INT TERM
+
+build_and_run timestamp-rel
+
+for policy in follow session-tz relaxed; do
+  patch=$here/patches/$policy.patch
+  git -C "$root" apply "$patch"
+  # shellcheck disable=SC2064
+  trap "git -C '$root' apply -R '$patch'" EXIT INT TERM
+  build_and_run "$policy"
+  git -C "$root" apply -R "$patch"
+  trap - EXIT INT TERM
+done
+
+printf 'rebuilding the shipped tree\n' >&2
+(cd "$root" && R CMD INSTALL . --no-byte-compile >/dev/null 2>&1)

--- a/experiments/README.md
+++ b/experiments/README.md
@@ -69,6 +69,12 @@ the directory keeps the method so that is possible.
   fires, and what a warning raised from one can do to the load it
   interrupts; supports
   [`usage/integrations/`](/handbook/usage/integrations/README.md).
+* [`2026-08-09-rel-from-df-posixct/`](2026-08-09-rel-from-df-posixct/) —
+  which `POSIXct` columns `rel_from_df()` accepts once `posixct`
+  defaults to `TIMESTAMPTZ`, and whether what it accepts comes back
+  with the same `tzone`, for the shipped policy and the three
+  alternatives to it; supports
+  [`usage/relational/`](/handbook/usage/relational/README.md).
 * [`2026-08-09-series-carry-scope/`](2026-08-09-series-carry-scope/) —
   how many of a buffer's vendor commits have a fix waiting on the base
   series' `-dev`, what kind, and how much of the raw difference is not a

--- a/handbook/usage/relational/README.md
+++ b/handbook/usage/relational/README.md
@@ -42,6 +42,25 @@ duckplyr surfaces these refusals as errors on an explicit
 What a value becomes once it has crossed is
 [`types/`](/handbook/usage/types/README.md)'s.
 
+**A `POSIXct` lifts as `TIMESTAMP` here, and only here.**
+Everything else that hands R values to the engine follows
+`dbConnect(posixct = )`, whose default sends the instant as
+`TIMESTAMPTZ` ([`timestamps/`](/handbook/usage/timestamps/README.md));
+`rel_from_df()` pins the older mapping instead
+([`R/relational.R`](/R/relational.R)),
+because a `TIMESTAMPTZ` column comes back labeled with the session
+`TimeZone` and a relation has to return the data frame it was given.
+The three ways of letting it follow the default all cost more than
+they pay — the strict check then guards a zone the column will not
+come back in, comparing against the session's refuses `"UTC"` on any
+build whose session zone spells that `"Etc/UTC"`, and dropping the
+check relabels 30 of 36 measured cells silently
+([`experiments/2026-08-09-rel-from-df-posixct/`](/experiments/2026-08-09-rel-from-df-posixct/README.md)).
+Passing `convert_opts` explicitly is the way in for a caller who wants
+`TIMESTAMPTZ` anyway, and a per-column zone on a result — which DuckDB
+does not have — is what would settle it
+([#2574](https://github.com/duckdb/duckdb-r/issues/2574)).
+
 **Untyped `NULL` constants.**
 `expr_constant(NA)` builds an untyped `NULL`
 ([#143](https://github.com/duckdb/duckdb-r/pull/143)),

--- a/handbook/usage/timestamps/README.md
+++ b/handbook/usage/timestamps/README.md
@@ -1,7 +1,8 @@
 # Timestamps and time zones
 
-How a timestamp crosses to R:
-which zone labels it, when an instant can change,
+How a timestamp crosses between R and the engine:
+which zone labels it on the way out, which DuckDB type carries it on the
+way in, when an instant can change,
 and what the session `TimeZone` setting is.
 The behaviour is pinned by
 [`tests/testthat/test-timezone.R`](/tests/testthat/test-timezone.R)
@@ -46,10 +47,29 @@ the wider type mapping is
   as the display zone for `"with"`,
   as the target zone for `"force"` —
   both spelled `timezone_out = ""`.
-* **Going the other way, in a dbplyr pipeline, the zone is dbplyr's
-  to apply — and it applies one only when the value is escaped.**
-  `!!` sends the instant as a UTC-naive literal;
-  an inline `as.POSIXct("…")` is translated and casts the string as written.
+* **Which DuckDB type a `POSIXct` becomes is `posixct`'s to choose.**
+  The default `"timestamp"` sends the UTC rendering of each instant
+  into a `TIMESTAMP` column and drops the R-side zone;
+  `dbConnect(posixct = "timestamptz")` sends the instant itself,
+  which is what a `POSIXct` value means, into a `TIMESTAMPTZ` column
+  ([#184](https://github.com/duckdb/duckdb-r/issues/184)).
+  The setting reaches every path that hands R values to the engine —
+  `dbWriteTable()`, `dbAppendTable()`, `duckdb_register()`,
+  `rel_from_df()`, bound parameters, `dbDataType()` and
+  `dbQuoteLiteral()` — nested columns included.
+* **A zone survives the round trip only through `TIMESTAMPTZ`,
+  and only the session's.**
+  Write under `posixct = "timestamptz"` with the session `TimeZone`
+  set to the column's zone, and the data frame comes back identical;
+  set to any other zone, the instant still comes back exact
+  and the label is the session's.
+  The default mapping has no zone to read back at all,
+  because the column it writes carries none.
+* **In a dbplyr pipeline, `posixct` reaches only the escaped value.**
+  `!!` escapes R-side through `dbQuoteLiteral()`, so the literal is
+  typed the way the setting says;
+  an inline `as.POSIXct("…")` is translated instead
+  and casts the string as written, out of the setting's reach.
   The mechanics and the workaround are
   [`integrations/`](/handbook/usage/integrations/README.md)'s
   ([#1064](https://github.com/duckdb/duckdb-r/issues/1064)).
@@ -60,6 +80,7 @@ the wider type mapping is
   [`plan/history/2026-05-timestamptz-icu.md`](/plan/history/2026-05-timestamptz-icu.md),
   carries that scenario and the rest of the history.
 
-*To deepen: state the writing direction —
-what `dbWriteTable()` and `duckdb_register()` pick for a `POSIXct`,
-and the round-trip that loses the input zone.*
+*To deepen: extend
+[`experiments/2026-08-08-timezone-grid/`](/experiments/2026-08-08-timezone-grid/README.md)
+over the writing direction, so `posixct` is measured
+rather than argued.*

--- a/handbook/usage/timestamps/README.md
+++ b/handbook/usage/timestamps/README.md
@@ -38,6 +38,12 @@ the wider type mapping is
   a binary that does (the DuckDB CLI, a fast-path build against a
   release `libduckdb`) has the setting from startup,
   defaulting to the machine's zone.
+  It takes that zone as the machine spells it,
+  so a `TIMESTAMPTZ` label is `TZ` verbatim —
+  `"UTC"` and `"Etc/UTC"` are one zone under two labels,
+  and no value of `timezone_out` aligns with the session zone
+  on every machine, because the session zone is not a constant
+  ([`experiments/2026-08-09-rel-from-df-posixct/`](/experiments/2026-08-09-rel-from-df-posixct/README.md)).
 * **`tz_out_convert = "force"` is the one instant-changing path.**
   It relabels every datetime column in `timezone_out`,
   preserving the UTC-rendered wall clock;

--- a/handbook/usage/timestamps/README.md
+++ b/handbook/usage/timestamps/README.md
@@ -32,6 +32,15 @@ the wider type mapping is
 * **The session `TimeZone` is the icu extension's setting.**
   `SET TimeZone` needs icu for any value, `'UTC'` included;
   where icu never loaded, results quietly fall back to a `UTC` label.
+  Where icu is *installed but not loaded* — what running `INSTALL icu`
+  once leaves behind — the fallback holds only until something touches
+  the setting: `SET TimeZone` and `current_setting('TimeZone')` both
+  autoload icu, and from then on the label is the machine's zone,
+  so the same query can return a differently labeled column later in
+  one session, with nothing announcing the switch
+  ([`experiments/2026-08-09-rel-from-df-posixct/`](/experiments/2026-08-09-rel-from-df-posixct/README.md)).
+  Asking `duckdb_extensions()` loads nothing, and is how to tell
+  which state a session is in.
   This package autoloads an *installed* icu but downloads nothing
   by itself ([`extensions/`](/handbook/usage/extensions/README.md)),
   and does not link icu statically —

--- a/handbook/usage/timestamps/README.md
+++ b/handbook/usage/timestamps/README.md
@@ -47,23 +47,34 @@ the wider type mapping is
   as the display zone for `"with"`,
   as the target zone for `"force"` —
   both spelled `timezone_out = ""`.
-* **Which DuckDB type a `POSIXct` becomes is `posixct`'s to choose.**
-  The default `"timestamp"` sends the UTC rendering of each instant
-  into a `TIMESTAMP` column and drops the R-side zone;
-  `dbConnect(posixct = "timestamptz")` sends the instant itself,
-  which is what a `POSIXct` value means, into a `TIMESTAMPTZ` column
+* **A `POSIXct` crosses as `TIMESTAMPTZ`, the instant it names.**
+  That is what the R value means, and
+  `dbConnect(posixct = "timestamp")` is the way back to the older
+  mapping, which sent the UTC rendering into a naive `TIMESTAMP`
+  column and dropped the R-side zone
   ([#184](https://github.com/duckdb/duckdb-r/issues/184)).
-  The setting reaches every path that hands R values to the engine —
-  `dbWriteTable()`, `dbAppendTable()`, `duckdb_register()`,
-  `rel_from_df()`, bound parameters, `dbDataType()` and
+  The setting reaches `dbWriteTable()`, `dbAppendTable()`,
+  `duckdb_register()`, bound parameters, `dbDataType()` and
   `dbQuoteLiteral()` — nested columns included.
+* **Two paths stay on `TIMESTAMP` whatever the setting says.**
+  A data frame picked up by name under
+  `duckdb(environment_scan = TRUE)` scans with the table function's
+  own defaults, because the replacement scan has the database and
+  not the connection whose options these are.
+  `rel_from_df()` declines the setting rather than misses it:
+  a relation promises the data frame back unchanged, which a
+  `TIMESTAMPTZ` column cannot keep, and what each candidate policy
+  costs is measured in
+  [`experiments/2026-08-09-rel-from-df-posixct/`](/experiments/2026-08-09-rel-from-df-posixct/README.md).
+  A caller who wants the setting there passes `convert_opts` —
+  the rest is [`relational/`](/handbook/usage/relational/README.md)'s.
 * **A zone survives the round trip only through `TIMESTAMPTZ`,
   and only the session's.**
-  Write under `posixct = "timestamptz"` with the session `TimeZone`
-  set to the column's zone, and the data frame comes back identical;
-  set to any other zone, the instant still comes back exact
-  and the label is the session's.
-  The default mapping has no zone to read back at all,
+  Set the session `TimeZone` to the column's zone and the data frame
+  comes back identical;
+  set it to any other zone and the instant still comes back exact,
+  labeled with the session's.
+  `posixct = "timestamp"` has no zone to read back at all,
   because the column it writes carries none.
 * **In a dbplyr pipeline, `posixct` reaches only the escaped value.**
   `!!` escapes R-side through `dbQuoteLiteral()`, so the literal is
@@ -82,5 +93,5 @@ the wider type mapping is
 
 *To deepen: extend
 [`experiments/2026-08-08-timezone-grid/`](/experiments/2026-08-08-timezone-grid/README.md)
-over the writing direction, so `posixct` is measured
-rather than argued.*
+over the writing direction, so the paths `posixct` does reach
+are measured across their settings too.*

--- a/handbook/usage/types/README.md
+++ b/handbook/usage/types/README.md
@@ -69,7 +69,8 @@ and [`src/transform.cpp`](/src/transform.cpp) (the way back).
 * **Timestamps** come back as `POSIXct`;
   which zone labels them — `timezone_out` for plain `TIMESTAMP`,
   the session `TimeZone` for `TIMESTAMPTZ` —
-  and when an instant can change is
+  when an instant can change, and which of the two types a `POSIXct`
+  becomes on the way in, is
   [`timestamps/`](/handbook/usage/timestamps/README.md)'s.
 * **Not every column lifts into the relational path** (duckplyr's):
   `rel_from_df()` refuses rather than converts —

--- a/man/duckdb.Rd
+++ b/man/duckdb.Rd
@@ -39,7 +39,8 @@ duckdb_adbc()
   bigint = "numeric",
   array = "none",
   geometry = "blob",
-  map = "data.frame"
+  map = "data.frame",
+  posixct = "timestamp"
 )
 
 \S4method{dbDisconnect}{duckdb_connection}(conn, ..., shutdown = TRUE)
@@ -157,6 +158,20 @@ If \code{"list_of"} is selected, \code{MAP} columns are returned as a \code{\lin
 \verb{data.frame(key = <K>, value = <V>)} that records the SQL key/value types. This enables MAP columns
 to round-trip through \code{\link[DBI:dbWriteTable]{dbWriteTable()}} / \code{\link[DBI:dbCreateTable]{dbCreateTable()}} without specifying \code{field.types},
 and lets scans accept named-list cells as MAP entries.}
+
+\item{posixct}{The DuckDB type \code{POSIXct} columns are sent as.
+There are two options: \code{"timestamp"} and \code{"timestamptz"}.
+If \code{"timestamp"} is selected (the default), a \code{POSIXct} column becomes a
+\code{TIMESTAMP} column holding the UTC rendering of each instant, and its
+time zone is lost.
+If \code{"timestamptz"} is selected, it becomes a \code{TIMESTAMPTZ} column holding
+the instant itself, which is what a \code{POSIXct} value means
+(\href{https://github.com/duckdb/duckdb-r/issues/184}{#184}).
+Reading such a column back labels it with the session \code{TimeZone},
+not with the zone it was written from.
+The setting reaches \code{\link[DBI:dbWriteTable]{dbWriteTable()}}, \code{\link[DBI:dbAppendTable]{dbAppendTable()}},
+\code{\link[=duckdb_register]{duckdb_register()}}, bound parameters, \code{\link[DBI:dbDataType]{dbDataType()}} and
+\code{\link[DBI:dbQuoteLiteral]{dbQuoteLiteral()}}.}
 
 \item{conn}{A \code{duckdb_connection} object}
 

--- a/man/duckdb.Rd
+++ b/man/duckdb.Rd
@@ -40,7 +40,7 @@ duckdb_adbc()
   array = "none",
   geometry = "blob",
   map = "data.frame",
-  posixct = "timestamp"
+  posixct = "timestamptz"
 )
 
 \S4method{dbDisconnect}{duckdb_connection}(conn, ..., shutdown = TRUE)
@@ -160,18 +160,21 @@ to round-trip through \code{\link[DBI:dbWriteTable]{dbWriteTable()}} / \code{\li
 and lets scans accept named-list cells as MAP entries.}
 
 \item{posixct}{The DuckDB type \code{POSIXct} columns are sent as.
-There are two options: \code{"timestamp"} and \code{"timestamptz"}.
-If \code{"timestamp"} is selected (the default), a \code{POSIXct} column becomes a
-\code{TIMESTAMP} column holding the UTC rendering of each instant, and its
-time zone is lost.
-If \code{"timestamptz"} is selected, it becomes a \code{TIMESTAMPTZ} column holding
-the instant itself, which is what a \code{POSIXct} value means
-(\href{https://github.com/duckdb/duckdb-r/issues/184}{#184}).
+There are two options: \code{"timestamptz"} and \code{"timestamp"}.
+If \code{"timestamptz"} is selected (the default), a \code{POSIXct} column becomes a
+\code{TIMESTAMPTZ} column holding the instant itself, which is what a \code{POSIXct}
+value means (\href{https://github.com/duckdb/duckdb-r/issues/184}{#184}).
 Reading such a column back labels it with the session \code{TimeZone},
 not with the zone it was written from.
+If \code{"timestamp"} is selected, it becomes a \code{TIMESTAMP} column holding the
+UTC rendering of each instant, and its time zone is lost.
+This is the mapping earlier versions used, and the way back to it.
 The setting reaches \code{\link[DBI:dbWriteTable]{dbWriteTable()}}, \code{\link[DBI:dbAppendTable]{dbAppendTable()}},
 \code{\link[=duckdb_register]{duckdb_register()}}, bound parameters, \code{\link[DBI:dbDataType]{dbDataType()}} and
-\code{\link[DBI:dbQuoteLiteral]{dbQuoteLiteral()}}.}
+\code{\link[DBI:dbQuoteLiteral]{dbQuoteLiteral()}}.
+It does not reach a data frame picked up by name under
+\code{duckdb(environment_scan = TRUE)}, nor the relational API behind
+\pkg{duckplyr}, which both stay on \code{TIMESTAMP}.}
 
 \item{conn}{A \code{duckdb_connection} object}
 

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -51,6 +51,14 @@ ConvertOpts::MapShape string_to_map_shape(const std::string &str) {
 	rapi_error_with_context("string_to_map_shape", "Invalid map value: " + str);
 }
 
+ConvertOpts::PosixctType string_to_posixct_type(const std::string &str) {
+	if (str == "timestamp")
+		return ConvertOpts::PosixctType::TIMESTAMP;
+	if (str == "timestamptz")
+		return ConvertOpts::PosixctType::TIMESTAMPTZ;
+	rapi_error_with_context("string_to_posixct_type", "Invalid posixct value: " + str);
+}
+
 ConvertOpts::ArrowConversion bool_to_arrow_conversion(bool use_arrow) {
 	return use_arrow ? ConvertOpts::ArrowConversion::ENABLED : ConvertOpts::ArrowConversion::DISABLED;
 }
@@ -91,6 +99,9 @@ ConvertOpts::ConvertOpts(cpp11::sexp options_nullable) {
 
 	// Extract map
 	map = string_to_map_shape(as_cpp<std::string>(options["map"]));
+
+	// Extract posixct
+	posixct = string_to_posixct_type(as_cpp<std::string>(options["posixct"]));
 
 	// Extract arrow
 	arrow = bool_to_arrow_conversion(as_cpp<bool>(options["arrow"]));

--- a/src/include/convert.hpp
+++ b/src/include/convert.hpp
@@ -34,7 +34,7 @@ struct ConvertOpts {
 	ArrayConversion array = ArrayConversion::NONE;
 	GeometryConversion geometry = GeometryConversion::BLOB;
 	MapShape map = MapShape::DATA_FRAME;
-	PosixctType posixct = PosixctType::TIMESTAMP;
+	PosixctType posixct = PosixctType::TIMESTAMPTZ;
 	ArrowConversion arrow = ArrowConversion::DISABLED;
 	ResultStreaming streaming = ResultStreaming::DISABLED;
 	ExperimentalFeatures experimental = ExperimentalFeatures::DISABLED;

--- a/src/include/convert.hpp
+++ b/src/include/convert.hpp
@@ -17,6 +17,8 @@ struct ConvertOpts {
 
 	enum class MapShape { DATA_FRAME, LIST_OF };
 
+	enum class PosixctType { TIMESTAMP, TIMESTAMPTZ };
+
 	enum class ArrowConversion { DISABLED, ENABLED };
 
 	enum class ResultStreaming { DISABLED, ENABLED };
@@ -32,6 +34,7 @@ struct ConvertOpts {
 	ArrayConversion array = ArrayConversion::NONE;
 	GeometryConversion geometry = GeometryConversion::BLOB;
 	MapShape map = MapShape::DATA_FRAME;
+	PosixctType posixct = PosixctType::TIMESTAMP;
 	ArrowConversion arrow = ArrowConversion::DISABLED;
 	ResultStreaming streaming = ResultStreaming::DISABLED;
 	ExperimentalFeatures experimental = ExperimentalFeatures::DISABLED;
@@ -50,10 +53,10 @@ struct ConvertOpts {
 
 	// Constructor with parameters
 	ConvertOpts(std::string timezone_out_p, TzOutConvert tz_out_convert_p, BigIntType bigint_p, ArrayConversion array_p,
-	            GeometryConversion geometry_p, MapShape map_p, ArrowConversion arrow_p,
+	            GeometryConversion geometry_p, MapShape map_p, PosixctType posixct_p, ArrowConversion arrow_p,
 	            ExperimentalFeatures experimental_p, StrictRelational strict_relational_p)
 	    : timezone_out(std::move(timezone_out_p)), tz_out_convert(tz_out_convert_p), bigint(bigint_p), array(array_p),
-	      geometry(geometry_p), map(map_p), arrow(arrow_p), experimental(experimental_p),
+	      geometry(geometry_p), map(map_p), posixct(posixct_p), arrow(arrow_p), experimental(experimental_p),
 	      strict_relational(strict_relational_p) {
 	}
 };

--- a/src/include/typesr.hpp
+++ b/src/include/typesr.hpp
@@ -28,6 +28,7 @@ enum class RTypeId {
 	DATE,
 	DATE_INTEGER,
 	TIMESTAMP,
+	TIMESTAMP_TZ,
 	INTERVAL_SECONDS,
 	INTERVAL_MINUTES,
 	INTERVAL_HOURS,
@@ -86,6 +87,7 @@ struct RType {
 	static constexpr const RTypeId DATE = RTypeId::DATE;
 	static constexpr const RTypeId DATE_INTEGER = RTypeId::DATE_INTEGER;
 	static constexpr const RTypeId TIMESTAMP = RTypeId::TIMESTAMP;
+	static constexpr const RTypeId TIMESTAMP_TZ = RTypeId::TIMESTAMP_TZ;
 	static constexpr const RTypeId INTERVAL_SECONDS = RTypeId::INTERVAL_SECONDS;
 	static constexpr const RTypeId INTERVAL_MINUTES = RTypeId::INTERVAL_MINUTES;
 	static constexpr const RTypeId INTERVAL_HOURS = RTypeId::INTERVAL_HOURS;
@@ -122,12 +124,14 @@ private:
 };
 
 struct RApiTypes {
-	static RType DetectRType(SEXP v, bool integer64);
+	// `timestamptz` picks the type a POSIXct column maps to: TIMESTAMP_TZ when set,
+	// TIMESTAMP otherwise. Handbook: handbook/usage/timestamps/README.md
+	static RType DetectRType(SEXP v, bool integer64, bool timestamptz = false);
 	static LogicalType LogicalTypeFromRType(const RType &rtype, bool experimental);
 	static string DetectLogicalType(const LogicalType &stype, const char *caller);
 	static R_len_t GetVecSize(RType rtype, SEXP coldata);
 	static R_len_t GetVecSize(SEXP coldata, bool integer64 = false);
-	static Value SexpToValue(SEXP valsexp, R_len_t idx, bool typed_logical_null = true);
+	static Value SexpToValue(SEXP valsexp, R_len_t idx, bool typed_logical_null = true, bool timestamptz = false);
 	static SEXP ValueToSexp(const Value &val, const ConvertOpts &convert_opts);
 };
 

--- a/src/register.cpp
+++ b/src/register.cpp
@@ -37,6 +37,7 @@ using namespace duckdb;
 		parameter_map["integer64"] = convert_opts.bigint == ConvertOpts::BigIntType::INTEGER64;
 		parameter_map["experimental"] = convert_opts.experimental == ConvertOpts::ExperimentalFeatures::ENABLED;
 		parameter_map["map_list_of"] = convert_opts.map == ConvertOpts::MapShape::LIST_OF;
+		parameter_map["timestamptz"] = convert_opts.posixct == ConvertOpts::PosixctType::TIMESTAMPTZ;
 
 		conn->conn->TableFunction("r_dataframe_scan", {Value::POINTER((uintptr_t)value.data())}, parameter_map)
 		    ->CreateView(name, overwrite, true);

--- a/src/relational.cpp
+++ b/src/relational.cpp
@@ -153,7 +153,8 @@ void check_column_validity(SEXP col, const std::string &col_name, ConvertOpts::S
 		stop("expr_constant: Need value of length one");
 	}
 	check_column_validity(val, "val", convert_opts.strict_relational, convert_opts.timezone_out);
-	auto const_value = RApiTypes::SexpToValue(val, 0, false);
+	auto const_value =
+	    RApiTypes::SexpToValue(val, 0, false, convert_opts.posixct == ConvertOpts::PosixctType::TIMESTAMPTZ);
 	auto out = make_external<ConstantExpression>("duckdb_expr", const_value);
 	if (alias != "") {
 		out->SetAlias(std::move(alias));
@@ -304,6 +305,7 @@ void check_column_validity(SEXP col, const std::string &col_name, ConvertOpts::S
 	}
 
 	named_parameter_map_t other_params;
+	other_params["timestamptz"] = convert_opts.posixct == ConvertOpts::PosixctType::TIMESTAMPTZ;
 	auto alias = StringUtil::Format("dataframe_%d_%d", (uintptr_t)(SEXP)df,
 	                                (int32_t)(NumericLimits<int32_t>::Maximum() * unif_rand()));
 	auto rel =

--- a/src/scan.cpp
+++ b/src/scan.cpp
@@ -38,6 +38,7 @@ static data_ptr_t GetColDataPtr(const RType &rtype, SEXP coldata) {
 	case RType::STRING:
 		return ReadOnlyDataPtr(DATAPTR_RO(coldata));
 	case RType::TIMESTAMP:
+	case RType::TIMESTAMP_TZ:
 		return (data_ptr_t)NUMERIC_POINTER(coldata);
 	case RType::INTERVAL_SECONDS:
 	case RType::INTERVAL_MINUTES:
@@ -142,6 +143,7 @@ static void AppendListColumnSegment(const RType &rtype, SEXP *source_data, idx_t
 	source_data += sexp_offset;
 	auto &result_mask = FlatVector::Validity(result);
 	auto child_rtype = rtype.GetListChildType();
+	auto child_timestamptz = child_rtype.id() == RTypeId::TIMESTAMP_TZ;
 	auto result_data = FlatVector::GetData<list_entry_t>(result);
 	for (idx_t i = 0; i < count; i++) {
 		auto val = source_data[i];
@@ -151,7 +153,7 @@ static void AppendListColumnSegment(const RType &rtype, SEXP *source_data, idx_t
 			auto len = RApiTypes::GetVecSize(child_rtype, val);
 			result_data[i].offset = ListVector::GetListSize(result);
 			for (R_len_t child_idx = 0; child_idx < len; ++child_idx) {
-				auto child_item = RApiTypes::SexpToValue(val, child_idx);
+				auto child_item = RApiTypes::SexpToValue(val, child_idx, true, child_timestamptz);
 				ListVector::PushBack(result, child_item);
 			}
 			result_data[i].length = len;
@@ -168,6 +170,7 @@ static void AppendMapEntriesListColumnSegment(const RType &rtype, SEXP *source_d
 	auto &result_mask = FlatVector::Validity(result);
 	auto child_rtype = rtype.GetListChildType();
 	D_ASSERT(child_rtype.id() == RTypeId::STRUCT);
+	auto value_timestamptz = child_rtype.GetStructChildTypes()[1].second.id() == RTypeId::TIMESTAMP_TZ;
 	auto result_data = FlatVector::GetData<list_entry_t>(result);
 
 	for (idx_t i = 0; i < count; i++) {
@@ -186,7 +189,7 @@ static void AppendMapEntriesListColumnSegment(const RType &rtype, SEXP *source_d
 			for (R_len_t j = 0; j < len; ++j) {
 				child_list_t<Value> kv;
 				kv.push_back({"key", RApiTypes::SexpToValue(key_col, j)});
-				kv.push_back({"value", RApiTypes::SexpToValue(value_col, j)});
+				kv.push_back({"value", RApiTypes::SexpToValue(value_col, j, true, value_timestamptz)});
 				ListVector::PushBack(result, Value::STRUCT(std::move(kv)));
 			}
 		} else {
@@ -201,7 +204,7 @@ static void AppendMapEntriesListColumnSegment(const RType &rtype, SEXP *source_d
 					// Treat element NULL as a SQL NULL of the column's value type
 					kv.push_back({"value", Value()});
 				} else {
-					kv.push_back({"value", RApiTypes::SexpToValue(value_sexp, 0)});
+					kv.push_back({"value", RApiTypes::SexpToValue(value_sexp, 0, true, value_timestamptz)});
 				}
 				ListVector::PushBack(result, Value::STRUCT(std::move(kv)));
 			}
@@ -351,7 +354,10 @@ static void AppendAnyColumnSegment(const RType &rtype, bool experimental, data_p
 		}
 		break;
 	}
-	case RType::TIMESTAMP: {
+	case RType::TIMESTAMP:
+	case RType::TIMESTAMP_TZ: {
+		// Both carry microseconds since the UTC epoch in an INT64 payload,
+		// so only the declared type differs
 		auto data_ptr = (double *)coldata_ptr;
 		AppendColumnSegment<double, timestamp_t, RTimestampType>(data_ptr, sexp_offset, v, this_count);
 		break;
@@ -495,6 +501,14 @@ static bool get_map_list_of_param(named_parameter_map_t &named_parameters) {
 	return false;
 }
 
+static bool get_timestamptz_param(named_parameter_map_t &named_parameters) {
+	auto entry = named_parameters.find("timestamptz");
+	if (entry != named_parameters.end()) {
+		return BooleanValue::Get(entry->second);
+	}
+	return false;
+}
+
 // Returns true when `coldata` is a list column whose non-NULL cells are all
 // named lists (and not data frames or blobs) that the caller has opted into
 // scanning as MAP entries via `dbConnect(map = "list_of")`. The cells'
@@ -502,7 +516,7 @@ static bool get_map_list_of_param(named_parameter_map_t &named_parameters) {
 //
 // On success, `value_rtype` is set to the common value RType and the column's
 // rtype should be overridden to `LIST(STRUCT(key = STRING, value = V))`.
-static bool DetectNamedListMapColumn(SEXP coldata, bool integer64, RType &value_rtype) {
+static bool DetectNamedListMapColumn(SEXP coldata, bool integer64, bool timestamptz, RType &value_rtype) {
 	if (TYPEOF(coldata) != VECSXP) {
 		return false;
 	}
@@ -538,7 +552,7 @@ static bool DetectNamedListMapColumn(SEXP coldata, bool integer64, RType &value_
 			if (v_j == R_NilValue) {
 				continue;
 			}
-			RType t = RApiTypes::DetectRType(v_j, integer64);
+			RType t = RApiTypes::DetectRType(v_j, integer64, timestamptz);
 			if (!common_set) {
 				value_rtype = t;
 				common_set = true;
@@ -602,6 +616,7 @@ static duckdb::unique_ptr<FunctionData> DataFrameScanBind(ClientContext &context
 	auto integer64 = get_integer64_param(input.named_parameters);
 	auto experimental = get_experimental_param(input.named_parameters);
 	auto map_list_of = get_map_list_of_param(input.named_parameters);
+	auto timestamptz = get_timestamptz_param(input.named_parameters);
 
 	auto df_names = df.names();
 	vector<RType> rtypes;
@@ -613,12 +628,12 @@ static duckdb::unique_ptr<FunctionData> DataFrameScanBind(ClientContext &context
 
 		auto coldata = df[col_idx];
 		TouchColumn(coldata);
-		auto rtype = RApiTypes::DetectRType(coldata, integer64);
+		auto rtype = RApiTypes::DetectRType(coldata, integer64, timestamptz);
 
 		bool is_named_list_map = false;
 		if (map_list_of && (rtype.id() == RTypeId::LIST || rtype.id() == RTypeId::LIST_OF_NULLS)) {
 			RType value_rtype;
-			if (DetectNamedListMapColumn(coldata, integer64, value_rtype)) {
+			if (DetectNamedListMapColumn(coldata, integer64, timestamptz, value_rtype)) {
 				child_list_t<RType> struct_children;
 				struct_children.push_back({"key", RType(RTypeId::STRING)});
 				struct_children.push_back({"value", value_rtype});
@@ -738,6 +753,7 @@ DataFrameScanFunction::DataFrameScanFunction()
 	named_parameters["integer64"] = LogicalType::BOOLEAN;
 	named_parameters["experimental"] = LogicalType::BOOLEAN;
 	named_parameters["map_list_of"] = LogicalType::BOOLEAN;
+	named_parameters["timestamptz"] = LogicalType::BOOLEAN;
 	projection_pushdown = true;
 	global_initialization = TableFunctionInitialization::INITIALIZE_ON_SCHEDULE;
 }

--- a/src/statement.cpp
+++ b/src/statement.cpp
@@ -184,7 +184,8 @@ static SEXP rapi_execute_impl(RStatement *stmt, const duckdb::ConvertOpts &conve
 	for (idx_t row_idx = 0; row_idx < (size_t)n_rows; ++row_idx) {
 		for (idx_t param_idx = 0; param_idx < (idx_t)params.size(); param_idx++) {
 			SEXP valsexp = params[(size_t)param_idx];
-			auto val = RApiTypes::SexpToValue(valsexp, row_idx);
+			auto val = RApiTypes::SexpToValue(valsexp, row_idx, true,
+			                                  convert_opts.posixct == ConvertOpts::PosixctType::TIMESTAMPTZ);
 			stmt->parameters[param_idx] = val;
 		}
 

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -107,9 +107,9 @@ child_list_t<RType> RType::GetStructChildTypes() const {
 	return aux_;
 }
 
-RType RApiTypes::DetectRType(SEXP v, bool integer64) {
+RType RApiTypes::DetectRType(SEXP v, bool integer64, bool timestamptz) {
 	if (TYPEOF(v) == REALSXP && Rf_inherits(v, "POSIXct")) {
-		return RType::TIMESTAMP;
+		return timestamptz ? RType::TIMESTAMP_TZ : RType::TIMESTAMP;
 	} else if (TYPEOF(v) == REALSXP && Rf_inherits(v, "Date")) {
 		return RType::DATE;
 	} else if (TYPEOF(v) == INTSXP && Rf_inherits(v, "Date")) {
@@ -193,7 +193,7 @@ RType RApiTypes::DetectRType(SEXP v, bool integer64) {
 
 			cpp11::strings names = GET_NAMES(v);
 			for (R_xlen_t i = 0; i < ncol; ++i) {
-				RType child = DetectRType(VECTOR_ELT(v, i), integer64);
+				RType child = DetectRType(VECTOR_ELT(v, i), integer64, timestamptz);
 				if (child == RType::UNKNOWN) {
 					return (RType::UNKNOWN);
 				}
@@ -209,7 +209,7 @@ RType RApiTypes::DetectRType(SEXP v, bool integer64) {
 			for (; i < len; ++i) {
 				auto elt = VECTOR_ELT(v, i);
 				if (elt != R_NilValue) {
-					type = DetectRType(elt, integer64);
+					type = DetectRType(elt, integer64, timestamptz);
 					break;
 				}
 			}
@@ -221,7 +221,7 @@ RType RApiTypes::DetectRType(SEXP v, bool integer64) {
 			for (; i < len; ++i) {
 				auto elt = VECTOR_ELT(v, i);
 				if (elt != R_NilValue) {
-					auto new_type = DetectRType(elt, integer64);
+					auto new_type = DetectRType(elt, integer64, timestamptz);
 					if (new_type != type) {
 						return RType::UNKNOWN;
 					}
@@ -261,6 +261,8 @@ LogicalType RApiTypes::LogicalTypeFromRType(const RType &rtype, bool experimenta
 		break;
 	case RType::TIMESTAMP:
 		return LogicalType::TIMESTAMP;
+	case RType::TIMESTAMP_TZ:
+		return LogicalType::TIMESTAMP_TZ;
 	case RType::INTERVAL_SECONDS:
 	case RType::INTERVAL_MINUTES:
 	case RType::INTERVAL_HOURS:

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -151,8 +151,8 @@ R_len_t RApiTypes::GetVecSize(SEXP coldata, bool integer64) {
 	return GetVecSize(rtype, coldata);
 }
 
-Value RApiTypes::SexpToValue(SEXP valsexp, R_len_t idx, bool typed_logical_null) {
-	auto rtype = RApiTypes::DetectRType(valsexp, false); // TODO
+Value RApiTypes::SexpToValue(SEXP valsexp, R_len_t idx, bool typed_logical_null, bool timestamptz) {
+	auto rtype = RApiTypes::DetectRType(valsexp, false, timestamptz); // TODO
 	switch (rtype.id()) {
 	case RType::LOGICAL: {
 		auto lgl_val = INTEGER_POINTER(valsexp)[idx];
@@ -195,6 +195,15 @@ Value RApiTypes::SexpToValue(SEXP valsexp, R_len_t idx, bool typed_logical_null)
 			return Value::TIMESTAMP(RTimestampType::Convert(ts_val));
 		} else {
 			return Value(LogicalType::TIMESTAMP);
+		}
+	}
+	case RType::TIMESTAMP_TZ: {
+		auto ts_val = NUMERIC_POINTER(valsexp)[idx];
+		bool is_null = RTimestampType::IsNull(ts_val);
+		if (!is_null) {
+			return Value::TIMESTAMPTZ(timestamp_tz_t(RTimestampType::Convert(ts_val).value));
+		} else {
+			return Value(LogicalType::TIMESTAMP_TZ);
 		}
 	}
 	case RType::DATE: {

--- a/tests/testthat/_snaps/backend-dbplyr__duckdb_connection.md
+++ b/tests/testthat/_snaps/backend-dbplyr__duckdb_connection.md
@@ -384,7 +384,7 @@
       test_datetime <- as.POSIXct("2020-01-01 01:23:45 UTC", tz = "UTC")
       escape(test_datetime)
     Output
-      <SQL> '2020-01-01 01:23:45'::timestamp
+      <SQL> '2020-01-01 01:23:45+00:00'::timestamptz
     Code
       escape("2020-01-01 01:23:45 UTC")
     Output
@@ -393,7 +393,7 @@
       test_datetime_tz <- as.POSIXct("2020-01-01 18:23:45 UTC", tz = "America/Los_Angeles")
       escape(test_datetime_tz)
     Output
-      <SQL> '2020-01-02 02:23:45'::timestamp
+      <SQL> '2020-01-02 02:23:45+00:00'::timestamptz
     Code
       escape("2020-01-01 18:23:45 PST")
     Output

--- a/tests/testthat/test-backend-dbplyr__duckdb_connection.R
+++ b/tests/testthat/test-backend-dbplyr__duckdb_connection.R
@@ -529,7 +529,7 @@ test_that("datetime escaping working as in DBI", {
   test_datetime <- as.POSIXct("2020-01-01 01:23:45 UTC", tz = "UTC")
   expect_equal(
     escape(test_datetime),
-    sql(r"{'2020-01-01 01:23:45'::timestamp}")
+    sql(r"{'2020-01-01 01:23:45+00:00'::timestamptz}")
   )
   expect_equal(
     escape("2020-01-01 01:23:45 UTC"),
@@ -542,7 +542,7 @@ test_that("datetime escaping working as in DBI", {
   )
   expect_equal(
     escape(test_datetime_tz),
-    sql(r"{'2020-01-02 02:23:45'::timestamp}")
+    sql(r"{'2020-01-02 02:23:45+00:00'::timestamptz}")
   )
   expect_equal(
     escape("2020-01-01 18:23:45 PST"),
@@ -1080,10 +1080,13 @@ test_that("an escaped POSIXct is sent as the instant it names", {
     })
   }
 
-  expect_equal(escape_at("UTC"), "'2025-03-01 18:00:00'::timestamp")
+  expect_equal(escape_at("UTC"), "'2025-03-01 18:00:00+00:00'::timestamptz")
   expect_equal(
     escape_at("America/Indiana/Indianapolis"),
-    "'2025-03-01 23:00:00'::timestamp"
+    "'2025-03-01 23:00:00+00:00'::timestamptz"
   )
-  expect_equal(escape_at("Europe/Zurich"), "'2025-03-01 17:00:00'::timestamp")
+  expect_equal(
+    escape_at("Europe/Zurich"),
+    "'2025-03-01 17:00:00+00:00'::timestamptz"
+  )
 })

--- a/tests/testthat/test-timezone.R
+++ b/tests/testthat/test-timezone.R
@@ -390,3 +390,136 @@ test_that("tz_out_convert = force handles invalid timestamps during DST transiti
   )
   expect_equal(res2[[1]], expected2)
 })
+
+test_that("POSIXct columns are sent as TIMESTAMP by default (#184)", {
+  con <- local_con()
+
+  df <- data.frame(a = as.POSIXct("2024-01-10 13:03:12", tz = "UTC"))
+  duckdb_register(con, "df", df)
+
+  expect_equal(dbGetQuery(con, "DESCRIBE FROM df")$column_type, "TIMESTAMP")
+  expect_equal(dbDataType(con, df$a), "TIMESTAMP")
+})
+
+test_that("posixct = 'timestamptz' sends POSIXct columns as TIMESTAMPTZ (#2574)", {
+  con <- local_con(posixct = "timestamptz")
+
+  df <- data.frame(a = as.POSIXct("2024-01-10 13:03:12", tz = "UTC"))
+  duckdb_register(con, "df", df)
+
+  expect_equal(
+    dbGetQuery(con, "DESCRIBE FROM df")$column_type,
+    "TIMESTAMP WITH TIME ZONE"
+  )
+  expect_equal(dbDataType(con, df$a), "TIMESTAMPTZ")
+  # The instant survives, whatever zone labels it on the way back
+  expect_equal(dbGetQuery(con, "FROM df")$a, df$a, ignore_attr = TRUE)
+})
+
+test_that("posixct = 'timestamptz' reaches dbWriteTable() and dbAppendTable() (#2574)", {
+  con <- local_con(posixct = "timestamptz")
+
+  df <- data.frame(a = as.POSIXct("2024-01-10 13:03:12", tz = "UTC"))
+  dbWriteTable(con, "t", df)
+
+  expect_equal(
+    dbGetQuery(con, "DESCRIBE t")$column_type,
+    "TIMESTAMP WITH TIME ZONE"
+  )
+
+  dbAppendTable(con, "t", df)
+  expect_equal(dbReadTable(con, "t")$a, rep(df$a, 2), ignore_attr = TRUE)
+})
+
+test_that("posixct = 'timestamptz' reaches nested columns (#2574)", {
+  con <- local_con(posixct = "timestamptz")
+
+  instant <- as.POSIXct("2024-01-10 13:03:12", tz = "UTC")
+  df <- data.frame(row = 1L)
+  df$l <- list(instant)
+  df$s <- data.frame(t = instant)
+  duckdb_register(con, "df", df)
+
+  types <- dbGetQuery(con, "DESCRIBE FROM df")$column_type
+  expect_equal(
+    types,
+    c(
+      "INTEGER",
+      "TIMESTAMP WITH TIME ZONE[]",
+      "STRUCT(t TIMESTAMP WITH TIME ZONE)"
+    )
+  )
+})
+
+test_that("posixct = 'timestamptz' reaches rel_from_df() (#2574)", {
+  con <- local_con(posixct = "timestamptz")
+
+  df <- data.frame(a = as.POSIXct("2024-01-10 13:03:12", tz = "UTC"))
+  rel <- rel_from_df(con, df)
+  rel_to_table(rel, "main", "t", FALSE)
+
+  expect_equal(
+    dbGetQuery(con, "DESCRIBE t")$column_type,
+    "TIMESTAMP WITH TIME ZONE"
+  )
+  expect_equal(as.data.frame(rel)$a, df$a, ignore_attr = TRUE)
+})
+
+test_that("posixct = 'timestamptz' reaches bound parameters and literals (#2574)", {
+  con <- local_con(posixct = "timestamptz")
+
+  instant <- as.POSIXct("2024-01-10 13:03:12", tz = "UTC")
+  dbExecute(con, "CREATE TABLE t (a TIMESTAMPTZ)")
+  dbExecute(con, "INSERT INTO t VALUES (?)", params = list(instant))
+
+  expect_equal(dbReadTable(con, "t")$a, instant, ignore_attr = TRUE)
+
+  literal <- dbQuoteLiteral(con, instant)
+  expect_match(as.character(literal), "::timestamptz$")
+  expect_equal(
+    dbGetQuery(con, paste0("SELECT ", literal, " AS a"))$a,
+    instant,
+    ignore_attr = TRUE
+  )
+})
+
+test_that("posixct = 'timestamptz' round-trips the zone via the session TimeZone (#184)", {
+  skip_if_no_icu()
+
+  con <- local_con(posixct = "timestamptz")
+
+  dbExecute(con, "INSTALL icu")
+  dbExecute(con, "LOAD icu")
+  dbExecute(con, "SET TimeZone = 'America/New_York'")
+
+  df <- data.frame(
+    a = as.POSIXct("2000-01-01 12:13:14", tz = "America/New_York")
+  )
+  dbWriteTable(con, "t", df)
+
+  # Instant *and* label survive, which the TIMESTAMP mapping cannot do
+  expect_equal(dbReadTable(con, "t"), df)
+})
+
+test_that("a bound POSIXct compares equal to a TIMESTAMPTZ column under a non-UTC session zone (#2574)", {
+  skip_if_no_icu()
+
+  con <- local_con(posixct = "timestamptz")
+
+  dbExecute(con, "INSTALL icu")
+  dbExecute(con, "LOAD icu")
+  dbExecute(con, "SET TimeZone = 'America/New_York'")
+
+  instant <- as.POSIXct("2000-01-01 12:13:14", tz = "America/New_York")
+  dbWriteTable(con, "t", data.frame(a = instant))
+
+  res <- dbGetQuery(con, "SELECT * FROM t WHERE a = ?", params = list(instant))
+  expect_equal(nrow(res), 1L)
+})
+
+test_that("dbConnect() rejects an unknown posixct value (#2574)", {
+  drv <- duckdb()
+  on.exit(duckdb_shutdown(drv))
+
+  expect_error(dbConnect(drv, posixct = "nope"), "posixct")
+})

--- a/tests/testthat/test-timezone.R
+++ b/tests/testthat/test-timezone.R
@@ -391,18 +391,8 @@ test_that("tz_out_convert = force handles invalid timestamps during DST transiti
   expect_equal(res2[[1]], expected2)
 })
 
-test_that("POSIXct columns are sent as TIMESTAMP by default (#184)", {
+test_that("POSIXct columns are sent as TIMESTAMPTZ by default (#184)", {
   con <- local_con()
-
-  df <- data.frame(a = as.POSIXct("2024-01-10 13:03:12", tz = "UTC"))
-  duckdb_register(con, "df", df)
-
-  expect_equal(dbGetQuery(con, "DESCRIBE FROM df")$column_type, "TIMESTAMP")
-  expect_equal(dbDataType(con, df$a), "TIMESTAMP")
-})
-
-test_that("posixct = 'timestamptz' sends POSIXct columns as TIMESTAMPTZ (#2574)", {
-  con <- local_con(posixct = "timestamptz")
 
   df <- data.frame(a = as.POSIXct("2024-01-10 13:03:12", tz = "UTC"))
   duckdb_register(con, "df", df)
@@ -416,8 +406,18 @@ test_that("posixct = 'timestamptz' sends POSIXct columns as TIMESTAMPTZ (#2574)"
   expect_equal(dbGetQuery(con, "FROM df")$a, df$a, ignore_attr = TRUE)
 })
 
-test_that("posixct = 'timestamptz' reaches dbWriteTable() and dbAppendTable() (#2574)", {
-  con <- local_con(posixct = "timestamptz")
+test_that("posixct = 'timestamp' is the way back to the naive mapping (#2574)", {
+  con <- local_con(posixct = "timestamp")
+
+  df <- data.frame(a = as.POSIXct("2024-01-10 13:03:12", tz = "UTC"))
+  duckdb_register(con, "df", df)
+
+  expect_equal(dbGetQuery(con, "DESCRIBE FROM df")$column_type, "TIMESTAMP")
+  expect_equal(dbDataType(con, df$a), "TIMESTAMP")
+})
+
+test_that("the default reaches dbWriteTable() and dbAppendTable() (#2574)", {
+  con <- local_con()
 
   df <- data.frame(a = as.POSIXct("2024-01-10 13:03:12", tz = "UTC"))
   dbWriteTable(con, "t", df)
@@ -431,8 +431,8 @@ test_that("posixct = 'timestamptz' reaches dbWriteTable() and dbAppendTable() (#
   expect_equal(dbReadTable(con, "t")$a, rep(df$a, 2), ignore_attr = TRUE)
 })
 
-test_that("posixct = 'timestamptz' reaches nested columns (#2574)", {
-  con <- local_con(posixct = "timestamptz")
+test_that("the default reaches nested columns (#2574)", {
+  con <- local_con()
 
   instant <- as.POSIXct("2024-01-10 13:03:12", tz = "UTC")
   df <- data.frame(row = 1L)
@@ -451,11 +451,25 @@ test_that("posixct = 'timestamptz' reaches nested columns (#2574)", {
   )
 })
 
-test_that("posixct = 'timestamptz' reaches rel_from_df() (#2574)", {
-  con <- local_con(posixct = "timestamptz")
+# A relation promises the data frame back unchanged, which TIMESTAMPTZ cannot
+# keep: it comes back labeled with the session zone. Measured in
+# experiments/2026-08-09-rel-from-df-posixct/README.md.
+test_that("rel_from_df() stays on TIMESTAMP under the default (#2574)", {
+  con <- local_con()
 
   df <- data.frame(a = as.POSIXct("2024-01-10 13:03:12", tz = "UTC"))
   rel <- rel_from_df(con, df)
+  rel_to_table(rel, "main", "t", FALSE)
+
+  expect_equal(dbGetQuery(con, "DESCRIBE t")$column_type, "TIMESTAMP")
+  expect_equal(rel_to_altrep(rel), df)
+})
+
+test_that("rel_from_df() follows `convert_opts` when the caller passes it (#2574)", {
+  con <- local_con()
+
+  df <- data.frame(a = as.POSIXct("2024-01-10 13:03:12", tz = "UTC"))
+  rel <- rel_from_df(con, df, convert_opts = con@convert_opts)
   rel_to_table(rel, "main", "t", FALSE)
 
   expect_equal(
@@ -465,8 +479,8 @@ test_that("posixct = 'timestamptz' reaches rel_from_df() (#2574)", {
   expect_equal(as.data.frame(rel)$a, df$a, ignore_attr = TRUE)
 })
 
-test_that("posixct = 'timestamptz' reaches bound parameters and literals (#2574)", {
-  con <- local_con(posixct = "timestamptz")
+test_that("the default reaches bound parameters and literals (#2574)", {
+  con <- local_con()
 
   instant <- as.POSIXct("2024-01-10 13:03:12", tz = "UTC")
   dbExecute(con, "CREATE TABLE t (a TIMESTAMPTZ)")
@@ -483,10 +497,10 @@ test_that("posixct = 'timestamptz' reaches bound parameters and literals (#2574)
   )
 })
 
-test_that("posixct = 'timestamptz' round-trips the zone via the session TimeZone (#184)", {
+test_that("the default round-trips the zone via the session TimeZone (#184)", {
   skip_if_no_icu()
 
-  con <- local_con(posixct = "timestamptz")
+  con <- local_con()
 
   dbExecute(con, "INSTALL icu")
   dbExecute(con, "LOAD icu")
@@ -504,7 +518,7 @@ test_that("posixct = 'timestamptz' round-trips the zone via the session TimeZone
 test_that("a bound POSIXct compares equal to a TIMESTAMPTZ column under a non-UTC session zone (#2574)", {
   skip_if_no_icu()
 
-  con <- local_con(posixct = "timestamptz")
+  con <- local_con()
 
   dbExecute(con, "INSTALL icu")
   dbExecute(con, "LOAD icu")
@@ -522,4 +536,15 @@ test_that("dbConnect() rejects an unknown posixct value (#2574)", {
   on.exit(duckdb_shutdown(drv))
 
   expect_error(dbConnect(drv, posixct = "nope"), "posixct")
+})
+
+test_that("expr_constant() stays on TIMESTAMP with the relational path (#2574)", {
+  con <- local_con()
+
+  instant <- as.POSIXct("2024-01-10 13:03:12", tz = "UTC")
+  rel <- rel_from_df(con, data.frame(a = 1L))
+  rel <- rel_project(rel, list(expr_constant(instant, alias = "t", con = con)))
+  rel_to_table(rel, "main", "t", FALSE)
+
+  expect_equal(dbGetQuery(con, "DESCRIBE t")$column_type, "TIMESTAMP")
 })


### PR DESCRIPTION
Closes #184. Closes #2574.

## What changes

A `POSIXct` column now crosses to DuckDB as `TIMESTAMPTZ` — the instant itself, which is what the R value means — where it used to cross as the `TIMESTAMP` column holding that instant's UTC rendering. `dbConnect(posixct = "timestamp")` is the way back to the old mapping.

**This is a breaking change**: tables written by `dbWriteTable()` get a different column type, and results come back labeled with the session `TimeZone` rather than `timezone_out`. Flagged for revdepchecks.

Reading `TIMESTAMPTZ` was already handled (#2401); this is the writing direction, which is what #184 had left open and what #2574 asked for.

## Where the setting reaches

`dbWriteTable()`, `dbAppendTable()`, `duckdb_register()`, bound parameters, `dbDataType()`, and `dbQuoteLiteral()` — which is also how dbplyr's `!!` escaping picks it up. Nested columns follow, so a list or packed-data-frame column of `POSIXct` becomes `TIMESTAMPTZ[]` or `STRUCT(… TIMESTAMPTZ)`.

Two paths deliberately stay on `TIMESTAMP`:

- A data frame picked up by name under `duckdb(environment_scan = TRUE)`. The replacement scan reaches the database, not the connection carrying the option — the same gap `integer64` and `map_list_of` already have. Verified, not assumed.
- `rel_from_df()` and `expr_constant()`, pinned on purpose. See below.

## The payoff

With the session `TimeZone` set to the column's zone, a data frame now round-trips identically, zone label included — the old mapping could not, because the column it wrote carried no zone. A bound `POSIXct` also compares equal to a `TIMESTAMPTZ` column under a non-UTC session zone, where before it matched 0 rows.

## Why the relational path is exempt

duckplyr needs `rel_from_df()` to return the data frame it was given, and a `TIMESTAMPTZ` column comes back labeled with the session zone. The strict `tzone` check was written to guard exactly that, against `timezone_out` — the wrong zone once the column is `TIMESTAMPTZ`.

`experiments/2026-08-09-rel-from-df-posixct/` measures all four candidate policies over 36 cells (column label × `timezone_out` × session `TimeZone`), each a real rebuild driven by `run.sh` from the patches under `patches/`. A cell is `ok`, `refused` (duckplyr falls back to dplyr — slower, correct), or `relabeled` (wrong answer, nothing reports it):

- `baseline` (pre-`posixct` tree) — 9 ok / 24 refused / 3 relabeled
- `timestamp-rel` (what ships) — 9 / 24 / 3
- `follow` (take the setting, check unchanged) — 2 / 24 / 10
- `session-tz` (check against the session zone) — 6 / 30 / 0
- `relaxed` (accept every `POSIXct`) — 6 / 0 / 30

`timestamp-rel` reproduces the baseline cell for cell, which is the point of shipping it: duckplyr sees no change at all. `session-tz` is the principled fix and the surprising loser — it never relabels, but it accepts only columns whose label string-matches the session zone, so on an icu-linked build (session zone `Etc/UTC`) a plain `"UTC"` column is refused while a build without icu accepts it. Making duckplyr's fast path depend on how the binary was built costs more than the refusals it buys. A caller who wants `TIMESTAMPTZ` on a relation can pass `convert_opts` themselves.

## Docs and tests

`?duckdb` documents the argument and both exemptions. `handbook/usage/timestamps/` gains the writing direction (its scope sentence widened to admit it, its deepen line retargeted), and `handbook/usage/relational/` gains why `rel_from_df()` declines the setting. `NEWS.md` untouched — fledge owns it.

Full `testthat::test_local()` green, on a fast-path build against libduckdb 1.5.5 where icu is linked in, so the icu-gated tests actually ran. `air format`, `make format-check`, roxygen and `tools::checkDocFiles()` clean. `main` merged in and re-verified after the `abort()` refactor landed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FpKcr8u1V4oSbVnVwAmQuv
