### PR TITLE
fix(ci): Keep the gate's `-Wno-*` out of the build `R CMD check` reads

### DIFF
--- a/.github/workflows/custom/after-install/action.yml
+++ b/.github/workflows/custom/after-install/action.yml
@@ -51,6 +51,32 @@ runs:
         max-size: 200M
         verbose: 1
 
+    # The vendored half of the compiler-warning gate
+    # (handbook/build/warnings/README.md). It rides the build that is already
+    # happening rather than compiling the engine a second time: the flags go on
+    # the install below, and the scan step after it judges that install's log.
+    # Only where the vendored sources are actually compiled -- under
+    # DUCKDB_R_USE_SYSTEM_LIB the engine is linked, not built, and there would be
+    # nothing to read.
+    #
+    # Here rather than in before-install, because ~/.R/Makevars is read by every
+    # build that follows, not only by the one being scanned: from before-install
+    # the flags also reached `R CMD check`'s build, and reached each.yaml's
+    # per-commit builds, which run before-install without this action at all.
+    # Written next to the install it belongs to, the flags cover it and nothing
+    # else in the job that matters to the gate.
+    #
+    # CPPFLAGS rather than CXX17FLAGS, because R appends CPPFLAGS to the
+    # package's own and replaces CXX17FLAGS -- which would drop the platform's
+    # optimisation settings. The vendored tree has no C sources, so a C++-only
+    # flag never reaches a C compile.
+    - name: Put the vendored warning flags on this build
+      if: env.DUCKDB_R_USE_SYSTEM_LIB != '1'
+      run: |
+        mkdir -p ~/.R
+        echo "CPPFLAGS += $(scripts/warnings.sh flags vendored)" | tee -a ~/.R/Makevars
+      shell: bash
+
     - name: Install to avoid R CMD INSTALL --pre-clean run otherwise
       run: |
         set -o pipefail

--- a/.github/workflows/custom/before-install/action.yml
+++ b/.github/workflows/custom/before-install/action.yml
@@ -101,27 +101,11 @@ runs:
         fi
       shell: bash
 
-    # The vendored half of the compiler-warning gate
-    # (handbook/build/warnings/README.md). It rides the build that is already
-    # happening rather than compiling the engine a second time: put the warning
-    # flags on this entry's build here, and the scan step in after-install
-    # judges its log. Only where the vendored sources are actually compiled --
-    # under DUCKDB_R_USE_SYSTEM_LIB the engine is linked, not built, and there
-    # would be nothing to read.
-    #
-    # This must come after the two steps above that decide the build mode:
-    # a GITHUB_ENV write is visible to later steps, not to the one that made it.
-    #
-    # CPPFLAGS rather than CXX17FLAGS, because R appends CPPFLAGS to the
-    # package's own and replaces CXX17FLAGS -- which would drop the platform's
-    # optimisation settings. The vendored tree has no C sources, so a C++-only
-    # flag never reaches a C compile.
-    - name: Put the vendored warning flags on this build
-      if: env.DUCKDB_R_USE_SYSTEM_LIB != '1'
-      run: |
-        mkdir -p ~/.R
-        echo "CPPFLAGS += $(scripts/warnings.sh flags vendored)" | tee -a ~/.R/Makevars
-      shell: bash
+    # The vendored half of the compiler-warning gate used to put its flags on
+    # the build here. It now does so in after-install, next to the install it
+    # rides and the scan that reads it -- ~/.R/Makevars is read by every later
+    # build in the job, and each.yaml runs this action without after-install, so
+    # from here the flags reached builds the gate never looks at.
 
     # Create the shared DuckDB home (~/.duckdb) so CI exercises the "shared"
     # storage-resolution path. The package only treats ~/.duckdb as the home for

--- a/handbook/build/warnings/README.md
+++ b/handbook/build/warnings/README.md
@@ -97,6 +97,29 @@ These are a gate's flags, applied from outside the package —
 which is also why an `-Wno-` here is not a suppression:
 it says a category is not enforced, not that a warning is hidden.
 
+**Outside the package is not outside `R CMD check`.**
+A build the gate rides rather than drives is R's,
+so R takes the flags from the user Makevars —
+and `R CMD check --as-cran` reads that same file,
+reports every `-Wno-*` in it as a non-portable flag suppressing warnings,
+and fails the check over it.
+So the ride-along set enables and never suppresses:
+`scripts/warnings.sh flags <scope>` drops the `-Wno-*`,
+and `scan` drops the categories they name
+from the log instead of never raising them.
+The list stays single —
+one `-Wno-` written once, read by the compile and by the scan —
+so the two routes cannot come to different verdicts.
+The flags also stay next to the install they are for
+rather than in a step that runs earlier
+([`.github/workflows/custom/after-install/action.yml`](/.github/workflows/custom/after-install/action.yml)):
+a user Makevars is read by every build that follows it in a job,
+and from `before-install` these reached
+`R CMD check`'s build and the per-commit builds of
+[`each.yaml`](/.github/workflows/each.yaml),
+neither of which the gate looks at
+([#2651](https://github.com/duckdb/duckdb-r/pull/2651)).
+
 The gate is GCC's.
 Clang names some of these differently and finds a different set;
 running it is welcome, wiring a second flag list into the gate is not,

--- a/scripts/warnings.sh
+++ b/scripts/warnings.sh
@@ -8,13 +8,19 @@
 #   scripts/warnings.sh all           # both, glue first
 #   scripts/warnings.sh <scope> --all # ... and list what other scopes own, too
 #
-#   scripts/warnings.sh flags <scope>       # print the scope's warning flags
+#   scripts/warnings.sh flags <scope>       # print the scope's ride-along flags
 #   scripts/warnings.sh scan <scope> <log>  # judge a build log compiled with them
 #
 # `flags` and `scan` are the halves of the same check for a build that is
 # happening anyway: put the flags on it, keep its output, judge that. The
 # vendored scope is checked that way in CI, because compiling the engine twice
 # to read it a second time costs an hour and proves nothing new.
+#
+# A ride-along build is R's, so R takes the flags from the user Makevars -- and
+# `R CMD check --as-cran` reads that file too, reporting every -Wno-* in it as a
+# non-portable flag suppressing warnings and failing the check over it. So
+# `flags` enables and never suppresses, and `scan` drops the categories the
+# -Wno-* name instead. Both routes reach the same verdict from the same list.
 #
 # A warning is attributed to the file it points at, not to the translation unit
 # that raised it: a glue file including an engine header is not answerable for
@@ -55,6 +61,24 @@ warnings_of() {
   echo $w
 }
 
+# The same set, minus what suppresses, for a build this script does not drive
+# (the header says why). Everything that stays is a flag R CMD check accepts.
+ride_along_flags_of() {
+  local w
+  w=$(warnings_of "$1") || return
+  # shellcheck disable=SC2086
+  echo $(printf '%s\n' $w | grep -v '^-Wno-')
+}
+
+# What the dropped flags would have silenced, spelled the way GCC closes a
+# warning line with it: `… [-Wunused-parameter]`.
+suppressed_categories_of() {
+  local w
+  w=$(warnings_of "$1") || return
+  # shellcheck disable=SC2086
+  printf '%s\n' $w | sed -n 's/^-Wno-\(.*\)$/[-W\1]/p'
+}
+
 # Which scope owns the file a diagnostic points at. Paths arrive three ways --
 # relative to src/ (our own compile), absolute (an R CMD INSTALL log), and
 # relative to the *engine's* own root, where a `#line` in a generated file
@@ -91,6 +115,10 @@ scan() {
   local scope=$1 log=$2 all mine theirs
   all=$(grep -E '^[^ ].*:[0-9]+:[0-9]+: warning:' "$log" | sed 's/^ *//' | sort -u |
     awk -F: "$classify"'scope_of($1) != "generated"' || true)
+  # A compile this script drives never raises the suppressed categories; a
+  # ride-along build does, because its flags may not suppress. Drop them here so
+  # the two agree.
+  all=$(echo "$all" | grep -F -v -f <(suppressed_categories_of "$scope") || true)
   mine=$(echo "$all" | grep . | awk -F: -v want="$scope" "$classify"'
     scope_of($1) == want' || true)
   theirs=$(echo "$all" | grep . | awk -F: -v want="$scope" "$classify"'
@@ -206,7 +234,7 @@ run_scope() {
 
 case "${1:-all}" in
   flags)
-    warnings_of "${2:?usage: scripts/warnings.sh flags <scope>}"
+    ride_along_flags_of "${2:?usage: scripts/warnings.sh flags <scope>}"
     exit
     ;;
   scan)


### PR DESCRIPTION
The vendored half of the compiler-warning gate rides `R CMD INSTALL` rather than compiling the engine a second time, and puts its flags on that build by appending to `~/.R/Makevars` in `custom/before-install`.

That file is global to the job, and two things follow, both wrong.

`R CMD check --as-cran` reads it too. It sees `-Wno-redundant-move` and `-Wno-unused-parameter`, and reports:

```
* checking compilation flags used ... WARNING
Compilation used the following non-portable flag(s):
  ‘-Wno-redundant-move’ ‘-Wno-unused-parameter’
including flag(s) suppressing warnings
...
0 errors ✔ | 1 warning ✖ | 0 notes ✔
Error: R CMD check found WARNINGs
```

And `each.yaml` runs `custom/before-install` without `custom/after-install` (deliberately — its ccache and archive steps are per-commit constructs a multi-commit job cannot use), so every per-commit build inherited flags nothing in that workflow ever scans.

### What it cost

Every commit in flight went red on the `check` gate, on all six series, including trees that predate the gate itself: `each.yaml` runs `before-install` once from the branch tip, so the tip's `~/.R/Makevars` decided commits whose own tree has no warning gate at all. As of this morning, with the same `check`-gate failure and the same two flags named in each log:

- `main` — 78 of 78 in flight
- `main-fwd` — 480 of 493
- `v1.5-variegata` — 77 of 77
- `v1.5-variegata-fwd` — 29 of 29
- `v1.4-andium` — 1 of 1
- `v1.4-andium-fwd` — 1 of 1

`main`'s own `rcc` has been red since fb859ab94 for the same reason, on the vendored-build entries (the ones that reach the flags step) — the last green run was 77b1d47dd, immediately before it.

### The fix

The ride-along set enables and never suppresses. `scripts/warnings.sh flags <scope>` drops the `-Wno-*`, and `scan` drops the categories they name from the log instead of never raising them. Both halves read the same list, so the compile and the scan cannot come to different verdicts, and what the gate enforces does not change: `-Wredundant-move` and `-Wunused-parameter` stay unenforced, for the reasons the handbook already gives.

The flags step also moves from `before-install` to `after-install`, immediately before the install it rides and the scan that reads it. A user Makevars is read by every build that follows it in a job; written there, it covers the install being scanned and nothing else that matters — and `each.yaml`, which does not run `after-install`, stops seeing it at all.

### Recovery, once this merges

Not covered here, and not automatic: the affected commits carry a `failure` status, so `each.yaml` will not replan them. Each series needs the port (stage 4 of the series loop puts the fixed tooling on `<S>-dev`) and then an `each-rcc` dispatch with `force=true`. That is roughly 666 commits rebuilding.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VP73F3CQKuEiC7Tkp1NAw2)_