### PR TITLE
fix(ci): Give the warning gate its own flags, and skip what a dropped `Suggests` cannot support

### DIFF
--- a/.github/workflows/custom/after-install/action.yml
+++ b/.github/workflows/custom/after-install/action.yml
@@ -51,28 +51,29 @@ runs:
         max-size: 200M
         verbose: 1
 
-    - name: Install to avoid R CMD INSTALL --pre-clean run otherwise
-      run: |
-        set -o pipefail
-        mkdir ../lib
-        R CMD INSTALL --library=$(dirname $(pwd))/lib -d --no-byte-compile . 2>&1 |
-          tee "${RUNNER_TEMP}/install.log"
-      shell: bash
-
     # The vendored half of the compiler-warning gate
-    # (handbook/build/warnings/README.md): judge the log of the build that just
-    # ran, which before-install put the vendored warning flags on. Nothing is
-    # compiled twice.
+    # (handbook/build/warnings/README.md) rides this install rather than
+    # compiling the engine a second time: `warnings.sh ride` puts the vendored
+    # warning flags on this one command and judges the log it produces, so
+    # nothing is compiled twice and no other build in the job is affected.
+    # Where the engine is linked rather than built -- DUCKDB_R_USE_SYSTEM_LIB --
+    # there is nothing to read, so the install runs unridden.
     #
-    # It reads what this entry actually compiled. Objects restored from
+    # The gate reads what this entry actually compiled. Objects restored from
     # DUCKDB_R_PREBUILT_ARCHIVE are not recompiled and so raise nothing -- but
     # that cache is keyed on hashFiles('src/duckdb/**'), so a vendored tree that
     # changed is always built afresh, which is the tree this gate is for.
     # ccache, by contrast, replays a cached compile's diagnostics, so it hides
     # nothing.
-    - name: Check that the vendored sources compiled without warnings
-      if: env.DUCKDB_R_USE_SYSTEM_LIB != '1'
-      run: scripts/warnings.sh scan vendored "${RUNNER_TEMP}/install.log"
+    - name: Install to avoid R CMD INSTALL --pre-clean run otherwise
+      run: |
+        mkdir ../lib
+        install=(R CMD INSTALL --library="$(dirname "$(pwd)")/lib" -d --no-byte-compile .)
+        if [ "${DUCKDB_R_USE_SYSTEM_LIB:-}" = "1" ]; then
+          "${install[@]}"
+        else
+          scripts/warnings.sh ride vendored "${RUNNER_TEMP}/install.log" -- "${install[@]}"
+        fi
       shell: bash
 
     - name: Show ccache stats

--- a/.github/workflows/custom/before-install/action.yml
+++ b/.github/workflows/custom/before-install/action.yml
@@ -101,27 +101,12 @@ runs:
         fi
       shell: bash
 
-    # The vendored half of the compiler-warning gate
-    # (handbook/build/warnings/README.md). It rides the build that is already
-    # happening rather than compiling the engine a second time: put the warning
-    # flags on this entry's build here, and the scan step in after-install
-    # judges its log. Only where the vendored sources are actually compiled --
-    # under DUCKDB_R_USE_SYSTEM_LIB the engine is linked, not built, and there
-    # would be nothing to read.
-    #
-    # This must come after the two steps above that decide the build mode:
-    # a GITHUB_ENV write is visible to later steps, not to the one that made it.
-    #
-    # CPPFLAGS rather than CXX17FLAGS, because R appends CPPFLAGS to the
-    # package's own and replaces CXX17FLAGS -- which would drop the platform's
-    # optimisation settings. The vendored tree has no C sources, so a C++-only
-    # flag never reaches a C compile.
-    - name: Put the vendored warning flags on this build
-      if: env.DUCKDB_R_USE_SYSTEM_LIB != '1'
-      run: |
-        mkdir -p ~/.R
-        echo "CPPFLAGS += $(scripts/warnings.sh flags vendored)" | tee -a ~/.R/Makevars
-      shell: bash
+    # The vendored half of the compiler-warning gate used to append its flags to
+    # ~/.R/Makevars here. It now carries them itself, on the one install it
+    # rides, in after-install (handbook/build/warnings/README.md): that file is
+    # read by every later build in the job -- `R CMD check`'s among them, which
+    # fails over the flags -- and each.yaml runs this action without
+    # after-install, so from here they reached builds the gate never looks at.
 
     # Create the shared DuckDB home (~/.duckdb) so CI exercises the "shared"
     # storage-resolution path. The package only treats ~/.duckdb as the home for

--- a/handbook/build/warnings/README.md
+++ b/handbook/build/warnings/README.md
@@ -97,6 +97,40 @@ These are a gate's flags, applied from outside the package —
 which is also why an `-Wno-` here is not a suppression:
 it says a category is not enforced, not that a warning is hidden.
 
+**Outside the package is not `~/.R/Makevars`, either.**
+A build the gate rides rather than drives is R's,
+so the flags have to reach it the way R takes extra flags —
+from the user Makevars.
+That file is the job's, not the command's:
+every later build reads it too,
+and `R CMD check` is one of those builds.
+It failed there twice over,
+each failure enough to fail the check on its own:
+`-Wno-redundant-move` and `-Wno-unused-parameter`
+are reported under `checking compilation flags used`
+as non-portable flags that suppress warnings,
+and `-Wall -Wextra` turned an engine diagnostic
+into a *significant warning* under
+`checking whether package … can be installed`.
+Written from `before-install` the flags also reached
+[`each.yaml`](/.github/workflows/each.yaml)'s per-commit builds,
+which run that action without `after-install` and so scan nothing —
+red on six series at once, and the whole vendoring loop with it
+([#2652](https://github.com/duckdb/duckdb-r/pull/2652)).
+
+So the gate carries its flags itself, for one command:
+`scripts/warnings.sh ride` writes a Makevars,
+points `R_MAKEVARS_USER` at it for the build it is judging,
+and nothing else in the job ever sees it.
+R reads exactly one user Makevars —
+`R_MAKEVARS_USER` replaces the default rather than adding to it —
+so that file `include`s whatever was already there:
+in CI, ccache's compiler wrappers and the job's `MAKEFLAGS`,
+and the engine tripwire's `-D` in the poisoning entry
+([`testing/guards/`](/handbook/testing/guards/README.md)).
+Dropping those would be a cold serial rebuild of the engine,
+or a guard with a hole in it and nothing to say so.
+
 The gate is GCC's.
 Clang names some of these differently and finds a different set;
 running it is welcome, wiring a second flag list into the gate is not,
@@ -132,8 +166,9 @@ it found these two, and named the same two GCC 15 did.
   The answer is the same in every matrix entry, so it runs in one.
 * **On the entry that builds from source**, the `vendored` scope —
   and it compiles nothing extra.
-  `scripts/warnings.sh flags vendored` puts the flags on that build,
-  `scripts/warnings.sh scan vendored` judges its log:
+  `scripts/warnings.sh ride vendored <log> -- R CMD INSTALL …`
+  puts the flags on the install that entry runs anyway
+  and judges the log it produces:
   reading a build that already takes an hour beats running a second one.
 
 That last split is what keeps newly vendored code honest without

--- a/scripts/warnings.sh
+++ b/scripts/warnings.sh
@@ -8,13 +8,21 @@
 #   scripts/warnings.sh all           # both, glue first
 #   scripts/warnings.sh <scope> --all # ... and list what other scopes own, too
 #
+#   scripts/warnings.sh ride <scope> <log> -- <command>...
+#                                           # run a build with the scope's flags
+#                                           # on it, keep <log>, and judge that
 #   scripts/warnings.sh flags <scope>       # print the scope's warning flags
 #   scripts/warnings.sh scan <scope> <log>  # judge a build log compiled with them
 #
-# `flags` and `scan` are the halves of the same check for a build that is
-# happening anyway: put the flags on it, keep its output, judge that. The
-# vendored scope is checked that way in CI, because compiling the engine twice
-# to read it a second time costs an hour and proves nothing new.
+# `ride` is the check for a build that is happening anyway: put the flags on it,
+# keep its output, judge that. The vendored scope is checked that way in CI,
+# because compiling the engine twice to read it a second time costs an hour and
+# proves nothing new.
+#
+# The flags reach that build in a Makevars written for the one command `ride`
+# runs, and not in ~/.R/Makevars, which is the job's: every later build reads
+# that file, `R CMD check` among them, and it fails over these flags. The
+# handbook page says which checks and why.
 #
 # A warning is attributed to the file it points at, not to the translation unit
 # that raised it: a glue file including an engine header is not answerable for
@@ -118,6 +126,88 @@ scan() {
   echo "-- $scope: clean"
 }
 
+# --- riding a build this script does not drive ------------------------------
+
+# The user Makevars R would read on its own, or nothing. Asked of R rather than
+# guessed at, because the rule has several candidates -- R_MAKEVARS_USER, a
+# platform-suffixed file, the plain one -- and R reads whichever comes first.
+# The fallback covers an R that cannot answer: dropping this file silently is
+# what a lost ccache wrapper or a missing tripwire -D looks like, and both are
+# worth a guess.
+user_makevars() {
+  local f
+  f=$(Rscript --vanilla -e 'cat(tools:::makevars_user())' 2>/dev/null) || f=
+  if [ -z "$f" ]; then
+    for f in "${R_MAKEVARS_USER:-}" "$HOME/.R/Makevars"; do
+      [ -n "$f" ] && [ -f "$f" ] && break
+      f=
+    done
+  fi
+  echo "$f"
+}
+
+# R on Windows is a native program, and mktemp hands out a path only MSYS
+# understands. R_MAKEVARS_USER is read through file.exists(), which simply says
+# no to such a path -- and then R falls back to nothing at all rather than to
+# the file it would otherwise have read. That is how the flags would go missing
+# without a word, so translate here rather than hope.
+r_path() {
+  if command -v cygpath >/dev/null 2>&1; then
+    cygpath -m "$1"
+  else
+    echo "$1"
+  fi
+}
+
+# Run a build with the scope's flags on it, keep its output in <log>, and judge
+# that.
+#
+# R_MAKEVARS_USER replaces the user Makevars rather than adding to it, so what
+# was already there is carried in by an `include` -- in CI, ccache's compiler
+# wrappers, the job's MAKEFLAGS, and the engine tripwire's -D.
+#
+# CPPFLAGS rather than CXX17FLAGS, because R appends CPPFLAGS to the package's
+# own and replaces CXX17FLAGS, which would drop the platform's optimisation
+# settings. The vendored tree has no C sources, so a C++-only flag never
+# reaches a C compile.
+ride() {
+  local scope=$1 log=$2
+  shift 2
+  [ "${1:-}" = "--" ] && shift
+  if [ $# -eq 0 ]; then
+    echo "usage: scripts/warnings.sh ride <scope> <log> -- <command>..." >&2
+    return 2
+  fi
+
+  # Before anything is built, so an unknown scope costs a second and not an hour.
+  local flags
+  flags=$(warnings_of "$scope") || return 2
+
+  local dir makevars inherited status
+  dir=$(mktemp -d)
+  makevars=$dir/Makevars
+  inherited=$(user_makevars)
+  if [ -n "$inherited" ]; then
+    printf 'include %s\n' "$inherited" >"$makevars"
+  fi
+  printf 'CPPFLAGS += %s\n' "$flags" >>"$makevars"
+
+  echo "== $scope: riding \`$*\` with $flags"
+  set +e
+  R_MAKEVARS_USER=$(r_path "$makevars") "$@" 2>&1 | tee "$log"
+  status=${PIPESTATUS[0]}
+  set -e
+  rm -rf "$dir"
+
+  # A build that failed says nothing about warnings, and its log is a list of
+  # what did not happen. Report the build, and leave the log for reading.
+  if [ "$status" -ne 0 ]; then
+    echo "-- the build failed (exit $status); $log is not judged."
+    return "$status"
+  fi
+  scan "$scope" "$log"
+}
+
 # --- compiling a scope ourselves --------------------------------------------
 
 prepare_compile() {
@@ -214,9 +304,16 @@ case "${1:-all}" in
       "${3:?usage: scripts/warnings.sh scan <scope> <log>}"
     exit
     ;;
+  ride)
+    ride "${2:?usage: scripts/warnings.sh ride <scope> <log> -- <command>...}" \
+      "${3:?usage: scripts/warnings.sh ride <scope> <log> -- <command>...}" \
+      "${@:4}"
+    exit
+    ;;
   glue | vendored | all) scope=${1:-all} ;;
   *)
     echo "usage: scripts/warnings.sh [glue|vendored|all] [--all]" >&2
+    echo "       scripts/warnings.sh ride <scope> <log> -- <command>..." >&2
     echo "       scripts/warnings.sh flags <scope>" >&2
     echo "       scripts/warnings.sh scan <scope> <log>" >&2
     exit 2

--- a/tests/testthat/test-dbplyr-version.R
+++ b/tests/testthat/test-dbplyr-version.R
@@ -23,6 +23,12 @@ test_that("the loaded version is read from the namespace, not the library", {
 })
 
 test_that("an old dbplyr warns, a current one is silent", {
+  # Every version here is mocked, and the package is still needed: the check
+  # returns early unless dbplyr's namespace is *loaded*, which is the one thing
+  # `local_mocked_bindings()` cannot arrange. `skip_if_not_installed()` loads it
+  # as a side effect of asking, so this is also what puts it there.
+  skip_if_not_installed("dbplyr")
+
   local_mocked_bindings(loaded_dbplyr_version = function() {
     package_version("2.5.0")
   })
@@ -45,6 +51,8 @@ test_that("an old dbplyr warns, a current one is silent", {
 # --- message wording (snapshot) ----------------------------------------------
 
 test_that("the warning wording is stable", {
+  skip_if_not_installed("dbplyr")
+
   # The wording carries the package name, so it goes through the flavor
   # normalisation every snapshot that can name the package uses.
   local_mocked_bindings(loaded_dbplyr_version = function() {
@@ -58,6 +66,8 @@ test_that("the warning wording is stable", {
 })
 
 test_that("the warning names this package through the flavor seam", {
+  skip_if_not_installed("dbplyr")
+
   local_mocked_bindings(
     loaded_dbplyr_version = function() package_version("2.5.0"),
     get_package_name = function() "someflavor"
@@ -67,6 +77,10 @@ test_that("the warning names this package through the flavor seam", {
 })
 
 test_that("a dbplyr loading later is caught by a hook", {
+  # The other hooks registered there resolve `dbplyr::` when called, so calling
+  # them below is an error rather than a skip when dbplyr is absent.
+  skip_if_not_installed("dbplyr")
+
   hooks <- getHook(packageEvent("dbplyr", "onLoad"))
   expect_gt(length(hooks), 0L)
 
@@ -96,6 +110,10 @@ test_that("a dbplyr loading later is caught by a hook", {
 })
 
 test_that("attaching does not load dbplyr just to check its version", {
+  # An absent dbplyr passes this for the wrong reason: nothing could have loaded
+  # it either way.
+  skip_if_not_installed("dbplyr")
+
   loaded <- callr::r(
     function(pkg) {
       library(pkg, character.only = TRUE)

--- a/tests/testthat/test-instance-settings.R
+++ b/tests/testthat/test-instance-settings.R
@@ -9,10 +9,26 @@ test_that("reusing an instance is silent when nothing collides", {
   con <- dbConnect(drv)
   withr::defer(dbDisconnect(con))
 
-  # Same settings again, and `bigint`, which `dbConnect()` does pick up.
+  # Same settings again.
   expect_no_error(duckdb(path))
-  expect_no_error(duckdb(path, bigint = "integer64"))
   expect_no_error(dbDisconnect(dbConnect(drv)))
+})
+
+test_that("a differing `bigint` is not a collision", {
+  # `bigint` is a connection setting that `dbConnect()` picks up, not one the
+  # instance binds -- so asking for another one is not a collision. Its own case
+  # because `bigint = "integer64"` needs bit64, and the rest of the file does
+  # not (handbook/operations/ci/matrix/README.md).
+  skip_if_not_installed("bit64")
+
+  path <- file.path(withr::local_tempdir(), "db.duckdb")
+
+  drv <- duckdb(path)
+  withr::defer(duckdb_shutdown(drv))
+  con <- dbConnect(drv)
+  withr::defer(dbDisconnect(con))
+
+  expect_no_error(duckdb(path, bigint = "integer64"))
 })
 
 test_that("a `read_only` that the instance cannot honor is reported", {


### PR DESCRIPTION
Two red CI gates, unrelated to each other. Supersedes #2651, which fixes the first one differently — see below.

## 1. The vendored warning gate patched a global file

The vendored half of the compiler-warning gate rides `R CMD INSTALL` rather than compiling the engine a second time, and put its flags on that build by appending to `~/.R/Makevars` in `custom/before-install`. That file is the job's, not the command's, and it reached two builds the gate never looks at.

`R CMD check` is one of them, and it failed there twice over, each enough on its own:

```
* checking compilation flags used ... WARNING
Compilation used the following non-portable flag(s):
  '-Wno-redundant-move' '-Wno-unused-parameter'
including flag(s) suppressing warnings
```

and, from `-Wall -Wextra` reaching check's own build:

```
* checking whether package 'duckdb.dev' can be installed ... WARNING
Found the following significant warnings:
  duckdb/src/include/duckdb/parser/parsed_data/alter_info.hpp:33:8: warning:
  '<unnamed>.duckdb::AlterEntryData::if_not_found' is used uninitialized [-Wuninitialized]
```

`each.yaml` is the other: it runs `before-install` without `after-install` (deliberately), so every per-commit build inherited flags nothing in that workflow ever scans.

### The fix

`scripts/warnings.sh ride <scope> <log> -- <command>` now carries the flags itself. It writes a Makevars for the one command it runs, points `R_MAKEVARS_USER` at it, keeps the output, and judges it. The gate is then what it always claimed to be — applied from outside the package — and nothing else in the job sees a flag of its, so `R CMD check` stays clean and the enforced set does not change: the `-Wno-*` stay in, with the reasons the handbook already gives.

`R_MAKEVARS_USER` replaces the user Makevars rather than adding to it, so the generated file `include`s whatever was already there. In CI that is ccache's compiler wrappers and the job's `MAKEFLAGS` (dropping them would mean a cold serial rebuild of the engine) and, in the poisoning entry, the tripwire's `-D` (dropping it would leave a guard with a hole and nothing to say so). On Windows the path is handed to R through `cygpath -m`, because R reads `R_MAKEVARS_USER` through `file.exists()` and falls back to *nothing* — not to the default file — when it cannot open it.

The flags step in `before-install` and the separate scan step in `after-install` both go away; the install they belonged to now says so itself.

## 2. Five nightly `Without <package>` entries were red

The nightly matrix drops one `Suggests` package per entry. Failing as of last night: `bit64`, `dbplyr`, and the three whose removal takes dbplyr with it (`dplyr`, `tibble`, `vctrs`).

- `test-dbplyr-version.R` mocks the loaded dbplyr version, but `warn_if_dbplyr_too_old()` returns early unless dbplyr's namespace is *loaded*, which mocking cannot arrange — so with dbplyr absent the warning never came and four cases failed. `skip_if_not_installed()` guards them, and loads the namespace as a side effect of asking, so it is also what puts the tests in the state they assume.
- `test-instance-settings.R` asked for `bigint = "integer64"` in the middle of an instance-reuse case, and that setting needs bit64. The expectation moves to a case of its own, guarded, so the rest of the reuse case still runs where bit64 is gone.

## Verification

Neither gate runs on a same-repo pull request: the vendored entries live in `rcc-full` and the `Without <package>` entries in `rcc-suggests`, and both are gated to the nightly schedule or a `workflow_dispatch`. I could not dispatch one (the app token has no `actions: write` here), so both halves were verified locally instead, and a dispatch of `rcc` on this branch with `versions-matrix`, `run-rcc-full`, `dep-suggests-matrix` and `run-rcc-suggests` is what would confirm them in CI before merge.

Locally, on a build against a prebuilt libduckdb:

- `warnings.sh ride` puts the flags on the compile line, the inherited ccache wrapper survives the `include`, a warning the scope owns fails the command, a build that fails is reported with its log left unjudged, an unknown scope costs a second rather than an hour, and `~/.R/Makevars` is untouched throughout. `scripts/warnings.sh glue` still runs clean (464 warnings counted in other scopes, none owned).
- Both test files were run against a library with `dbplyr` removed and with `bit64` removed: the failures reproduce before the change and are skips after it, with every other case in both files still running.

## Relationship to #2651

Same first diagnosis, different remedy. #2651 keeps writing to `~/.R/Makevars` and makes the ride-along set stop suppressing — dropping the `-Wno-*` from the flags and filtering those categories out of the log instead — plus moves the step to `after-install`. That leaves the same list expressed twice and still puts `-Wall -Wextra` on `R CMD check`'s build, which is the second WARNING quoted above; the move to `after-install` is what covers it there. Scoping the flags to the command removes the need for either half. #2651 can be closed in favour of this, or this rebased onto it if it lands first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qsvc2dkAFGPou3przpibqe