### PR TITLE
fix(series-check): Classify an `R CMD check` gate failure instead of giving up on it

### DIFF
--- a/.claude/skills/series-loop.md
+++ b/.claude/skills/series-loop.md
@@ -401,6 +401,7 @@ is reading; they are the same bytes:
 | `Error ('test-….R:N:M')` | real test failure | fix test/R code at origin |
 | the cause is in `src/duckdb/` itself and the next upstream commit fixes it | upstream was transiently broken | fold the pair into one; if the next one is red too, forward-port (below) |
 | `Changes detected in workflow_dispatch build` | style / roxygen drift | fix formatting at origin |
+| `Error: R CMD check found WARNINGs` / `ERRORs`, with the `❯ checking …` headers above it naming which checks | `R CMD check --as-cran` is unhappy about the tree, or about the environment CI built it in | read the named checks; fix at origin, or on `main` when the cause is the job's own setup |
 | a gate reached out and was refused — `cannot open URL`, `SSL connect error`, a refused or reset connection — while the tests themselves passed | infra, not the tree | rerun the commit: `retry-<S>-dev` (below) |
 | none of the above and no test phase | cancelled or infra | rerun the commit: `retry-<S>-dev` (below) |
 

--- a/scripts/series-check.sh
+++ b/scripts/series-check.sh
@@ -175,6 +175,14 @@ classify() { # <sha> -> "<kind>|<one line>"; kind `transient` means rerun, do no
     echo "test|test failure ($(grep -oE "Error \('test-[^']+'\)" <<<"$log" | head -1))"
   elif grep -q "Changes detected in workflow_dispatch build" <<<"$log"; then
     echo "style|style/roxygen drift"
+  elif grep -qE '^Error: R CMD check found (ERROR|WARNING|NOTE)' <<<"$log"; then
+    # The check gate's own verdict, and it is definite: `--as-cran` named the
+    # checks it is unhappy about, so a rerun buys the same answer. Ahead of the
+    # network rule for that reason, and behind the three above it because a
+    # snapshot, a test or a style diff says more precisely what to fix.
+    echo "check|$(grep -oE 'R CMD check found .*' <<<"$log" | head -1)" \
+      "($(grep -E '^❯ checking' <<<"$log" | sed 's/^❯ //; s/ \.\.\..*//' |
+        tr '\n' '\a' | sed 's/\a$//; s/\a/; /g'))"
   elif grep -qE "$net_re" <<<"$log"; then
     gate=$(failed_gate "$log")
     echo "transient|network failure in the ${gate:-unnamed} gate ($(grep -oE "$net_re" <<<"$log" | head -1))"


### PR DESCRIPTION
`scripts/series-check.sh` has no classification rule for the shape a red commit most often takes: `R CMD check --as-cran` failing the check gate. Every such failure comes back as `unclassified: review logs2.d/… by hand`.

Today's series-loop firing hit that at full scale. All six series were red end to end — 679 commits in `<S>-green..<S>-dev` — and the script answered `unclassified` for every one, so the firing opened the logs itself to read what each of them said plainly:

```
❯ checking compilation flags used ... WARNING
  Compilation used the following non-portable flag(s):
    '-Wno-redundant-move' '-Wno-unused-parameter'
  including flag(s) suppressing warnings
0 errors ✔ | 1 warning ✖ | 0 notes ✔
Error: R CMD check found WARNINGs
```

(That particular cause is #2652, already merged — this PR is about the diagnosis being unavailable, not about the bug it was hiding.)

The new rule reads the gate's own verdict and quotes the `❯ checking …` headers beside it, which is what says where to look without opening anything:

```
REPAIR c2cc7259c…
       R CMD check found WARNINGs (checking compilation flags used)
```

and, where the injected flags also made the install noisy:

```
       R CMD check found WARNINGs (checking whether package ‘duckdb.dev’ can be installed; checking compilation flags used)
```

Placement in the `classify()` chain:

- behind the snapshot, test and style rules — when one of those matches it names a fix more precisely;
- ahead of the network rule, because `Error: R CMD check found WARNINGs` is a definite answer. `--as-cran` named the checks it is unhappy about, so this is a REPAIR and a rerun buys the same ones again.

`.claude/skills/series-loop.md`'s classification table gains the matching row.

Verified against the two real logs above, taken from `rcc2` at `c2cc7259c` (`main-dev`) and `2a4fbc6b0` (`main-fwd-dev`).

---
_Generated by [Claude Code](https://claude.ai/code/session_018zSTP8ynd8m2TJY1vQEAtN)_