### PR TITLE
feat(rcc): Add `rcc-drop.sh`, for verdicts the job decided rather than the tree

### DIFF
--- a/.claude/skills/docs-consistency/docs-readme.R
+++ b/.claude/skills/docs-consistency/docs-readme.R
@@ -138,7 +138,7 @@ groups <- list(
     owner = "handbook/operations/ci/per-commit/store",
     globs = c(
       "each-harvest.sh", "rcc-consolidate.sh", "rcc-cutover.sh",
-      "rcc-lib.sh", "rcc-logs.sh", "rcc-publish.sh",
+      "rcc-drop.sh", "rcc-lib.sh", "rcc-logs.sh", "rcc-publish.sh",
       "rcc-run-fields.jq", "rcc-store-test.sh"
     )
   ),

--- a/.claude/skills/series-loop.md
+++ b/.claude/skills/series-loop.md
@@ -1154,16 +1154,45 @@ The store applies the same newest-run-wins rule to its copy,
 so the leg *replaces* a record rather than appending —
 the one case where a decided commit legitimately changes state.
 
-**Dropping a result by hand is a store-side operation**,
-and only concerns a firing that is reading the store:
-remove `runs2.d/<xx>/<sha>.ndjson` and `logs2.d/<xx>/<sha>.log`,
-then dispatch `rcc-logs.yaml` to re-derive both from the fresh status,
-provided the commit is still inside the store's 30-day window.
-The removal alone no longer does anything:
-nothing sweeps on a schedule to notice the gap,
-so a deletion left unaccompanied is a record simply gone.
+**Dropping a result by hand is a store-side operation**:
+
+```sh
+scripts/rcc-drop.sh <sha>...          # or --stdin, one per line
+```
+
+It removes `runs2.d/<xx>/<sha>.ndjson` and `logs2.d/<xx>/<sha>.log`,
+which is what makes the commit undecided —
+work selection reads presence and nothing else (`rcc-decided.sh`) —
+so the next `each-rcc` run on the branch plans it
+like a commit that had never been built.
 A run's own results are immutable;
 there a newer run is the only thing that supersedes an older one.
+
+**Reach for it when the job decided the commit, not the tree.**
+The composite actions come from the branch tip that triggered the run,
+not from the commit under test,
+so a bad workflow turns commits red
+whose own trees have nothing to do with it,
+at the scale of everything the run touched:
+duckdb/duckdb-r#2620 put `-Wno-*` flags in `~/.R/Makevars`,
+where `R CMD check --as-cran` refused them as non-portable,
+and 166 commits across three series were red for it
+until duckdb/duckdb-r#2652 landed and the records were dropped.
+That is not `retry-<S>-dev`'s question:
+the retry replans one tip and runs the workflow from *that commit's* tree,
+where a drop asks for a verdict under the tooling the branch carries today.
+And it is not a repair either —
+dropping the record of a commit its own tree broke
+costs a rebuild to learn the same verdict
+and erases the log that said why.
+
+**Do not dispatch `rcc-logs.yaml` behind a drop.**
+The commit keeps its stale `rcc` status until the rebuild writes a fresh one,
+and that sweep derives records for undecided commits from exactly those,
+so it puts back what the drop removed.
+Where the sweep *is* what is wanted —
+a record the leg never published, from a run cancelled whole —
+there is nothing to drop first.
 
 **Both mechanisms live in the tree at the commit under retry.**
 `each.yaml` and its scripts are read from the retried ref, not from `main`,

--- a/handbook/operations/ci/per-commit/store/README.md
+++ b/handbook/operations/ci/per-commit/store/README.md
@@ -73,11 +73,29 @@ Now it means re-reading the tip and re-staging the same files.
 |---|---|---|
 | an `each-rcc` leg | once per commit built (~2/min at `max-parallel: 20`) | its own record, its own log |
 | `rcc-logs.yaml` | on dispatch | records for commits it finds undecided |
+| [`rcc-drop.sh`](/scripts/rcc-drop.sh) | by hand | removes the records and logs it is named |
 | [`rcc-consolidate.sh`](/scripts/rcc-consolidate.sh) | by hand | **all of it** |
 
 Nobody rewrites anything that is not their own commit's —
 except a verdict they are overturning, below —
 and that is what makes the concurrency work without a lock.
+
+`rcc-drop.sh` is the one writer that only ever removes,
+and it removes so that something else can decide again:
+work selection reads presence
+([`rcc-decided.sh`](/scripts/rcc-decided.sh)),
+so a commit whose record is gone is planned like one never built.
+What it is for is a verdict the *job* decided rather than the tree —
+the composite actions come from the branch tip that triggered the run,
+not from the commit under test,
+so a bad workflow turns commits red that had nothing to do with it.
+It writes through `rcc-publish.sh`'s `.remove` staging,
+which is why it needs no race protocol of its own.
+Two things it deliberately leaves alone are worth knowing before reaching
+for it: the commit's `rcc` status, which stays red until the rebuild
+writes a fresh one, and `rcc-logs.yaml`, which must *not* be dispatched
+behind a drop — it derives records for undecided commits from exactly
+those stale statuses, and would put back what the drop removed.
 
 ## Retention is one window
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -91,6 +91,7 @@ Root of the documentation tree: [`handbook/`](/handbook/README.md).
 |---|---|
 | [`rcc-consolidate.sh`](rcc-consolidate.sh) | Consolidate the orphan `rcc2` branch: drop everything past the retention window, and squash the whole history to two commits. |
 | [`rcc-cutover.sh`](rcc-cutover.sh) | One-shot: build the `rcc2` verdict store from what the old `rcc` branch holds. |
+| [`rcc-drop.sh`](rcc-drop.sh) | Drop named commits' verdicts from the store on the orphan `rcc2` branch. |
 | [`rcc-lib.sh`](rcc-lib.sh) | Shared helpers for the verdict store on the orphan `rcc2` branch. |
 | [`rcc-logs.sh`](rcc-logs.sh) | Collect rcc results and failure logs for commits the verdict store has no record for, and stage them for publication to the orphan `rcc2` branch. |
 | [`rcc-publish.sh`](rcc-publish.sh) | Publish a staging directory to the verdict store on the orphan `rcc2` branch. |

--- a/scripts/rcc-drop.sh
+++ b/scripts/rcc-drop.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+# Drop named commits' verdicts from the store on the orphan `rcc2` branch.
+#
+# A verdict is normally overturned by a newer run judging the same commit
+# (scripts/each-shard.sh), and that is the route to prefer: it replaces one
+# record with another and leaves the store self-consistent. This script is for
+# the case that route cannot reach -- a verdict the *harness* decided, which no
+# rerun of the commit as it stands would overturn, because the commit was never
+# what failed.
+#
+# Removing the record is what makes the commit undecided: work selection reads
+# presence and nothing else (scripts/rcc-decided.sh), so the next `each-rcc` run
+# on the branch plans it like a commit that had never been built. The log goes
+# with it, because a log whose record is gone is read by nothing and dated by
+# nothing (scripts/rcc-consolidate.sh drops such orphans anyway).
+#
+# ## When this is the right tool
+#
+# When the job decided the commit rather than the tree. The shape it was written
+# for: a change to `.github/workflows/` reaches every build in the job -- the
+# composite actions are resolved from the branch tip that triggered the run, not
+# from the commit under test -- so a bad one turns commits red whose own trees
+# have nothing to do with it, at the scale of everything the run touched.
+# duckdb/duckdb-r#2620 appended `-Wno-redundant-move -Wno-unused-parameter` to
+# `~/.R/Makevars`, where `R CMD check --as-cran` read them and refused them as
+# non-portable flags; 166 commits across three series were red for it, and every
+# one of them went green once duckdb/duckdb-r#2652 had landed and the records
+# were dropped.
+#
+# `retry-<S>-dev` is the answer for one commit and is not this (see
+# .claude/skills/series-loop.md): it replans the tip of the retry branch alone,
+# and it runs the workflow from the *retried commit's* tree, which is a
+# different question from "judge it again under the tooling the branch carries
+# today".
+#
+# ## When it is not
+#
+# A commit the tree genuinely broke is a repair, not a drop. Dropping its record
+# only costs a rebuild to learn the same verdict again, and it erases the log
+# that says why. The test is whether the same commit, built again on the branch
+# as it stands now, would reach a different verdict; if the answer needs no
+# change anywhere, this is not the tool.
+#
+# ## Two things it deliberately does not do
+#
+# It does not touch the commit's `rcc` commit status. That is a display surface
+# and nothing decides from it -- but it means the commit still *shows* red until
+# its rebuild writes a fresh one, which is expected, not a second thing to fix.
+#
+# And it must not be followed by dispatching `rcc-logs.yaml`. That workflow
+# derives records for commits the store has no record for, from exactly those
+# stale statuses, so a sweep behind a drop puts back what the drop removed.
+#
+# Usage:
+#   scripts/rcc-drop.sh <sha>...          # drop these commits' verdicts
+#   scripts/rcc-drop.sh --stdin < shas    # one SHA per line, `#` comments ok
+#   scripts/rcc-drop.sh --dry-run <sha>...
+#
+# Environment variables:
+#   GH_TOKEN / GITHUB_TOKEN - token with contents:write on the repository
+#   GITHUB_REPOSITORY       - owner/repo (required unless RCC_REMOTE is set)
+#   RCC_REMOTE              - remote URL, overriding the above
+#   BRANCH                  - default: rcc2
+#   RCC_DROP_REASON         - one line quoted into the commit message, saying
+#                             what decided these verdicts if not the commits
+
+set -euo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+. "${here}/rcc-lib.sh"
+
+usage='usage: rcc-drop.sh [--dry-run] [--stdin] [<sha>...]'
+
+DRY_RUN=
+FROM_STDIN=
+shas=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run) DRY_RUN=1; shift ;;
+    --stdin) FROM_STDIN=1; shift ;;
+    -*) echo "$usage" >&2; exit 1 ;;
+    *) shas+=("$1"); shift ;;
+  esac
+done
+
+if [ -n "${FROM_STDIN}" ]; then
+  while IFS= read -r line; do
+    line="${line%%#*}"
+    line="$(printf '%s' "${line}" | tr -d '[:space:]')"
+    [ -n "${line}" ] && shas+=("${line}")
+  done
+fi
+
+[ "${#shas[@]}" -gt 0 ] || { echo "$usage" >&2; exit 1; }
+
+# Full 40-hex only. An abbreviated SHA names no path in the store, so it would
+# drop nothing and report success -- the one failure mode that looks like a
+# clean run.
+for sha in "${shas[@]}"; do
+  case "${sha}" in
+    [0-9a-f]*) ;;
+    *) echo "not a lowercase hex SHA: ${sha}" >&2; exit 1 ;;
+  esac
+  [ "${#sha}" -eq 40 ] || {
+    echo "not a full 40-character SHA: ${sha}" >&2
+    exit 1
+  }
+done
+
+BRANCH="${BRANCH:-rcc2}"
+
+stage="$(mktemp -d)"
+trap 'rm -rf "${stage}"' EXIT
+
+# The staging directory carries removals and nothing else: `rcc-publish.sh`
+# reads `.remove` for paths to unstage, and every other file in the directory as
+# a path to add. So the drop reuses its whole race protocol -- fetch the tip,
+# rebuild the index, retry on a lost push -- and adds no second way to write to
+# this branch.
+for sha in "${shas[@]}"; do
+  rcc_part_path "${sha}" >> "${stage}/.remove"
+  printf '\n' >> "${stage}/.remove"
+  rcc_log_path "${sha}" >> "${stage}/.remove"
+  printf '\n' >> "${stage}/.remove"
+done
+
+if [ -n "${DRY_RUN}" ]; then
+  echo "Would drop ${#shas[@]} verdict(s) from ${BRANCH}:"
+  cat "${stage}/.remove"
+  exit 0
+fi
+
+message="chore(${BRANCH}): Drop ${#shas[@]} verdict(s) the commits did not decide"
+if [ -n "${RCC_DROP_REASON:-}" ]; then
+  message="${message}
+
+${RCC_DROP_REASON}"
+fi
+message="${message}
+
+These commits are undecided again and the next each-rcc run on their branch
+plans them. Their stale rcc statuses stay until that run writes fresh ones;
+rcc-logs.yaml must not be dispatched behind this, or it derives the dropped
+records back from them (scripts/rcc-drop.sh)."
+
+"${here}/rcc-publish.sh" "${message}" "${stage}"


### PR DESCRIPTION
The verdict store has no way to say *this verdict was never about the commit*. A rerun overturns one by deciding the commit again, and `retry-<S>-dev` asks for exactly one commit to be judged again — but it runs the workflow from **that commit's** tree, which is a different question from "judge it under the tooling the branch carries today".

That question comes up whenever a workflow change decides commits. The composite actions are resolved from the branch tip that triggered the run, not from the commit under test, so a bad one reaches every build in the job.

Today's series-loop firing hit it at scale. #2620 appended `-Wno-redundant-move -Wno-unused-parameter` to `~/.R/Makevars`, where `R CMD check --as-cran` read them back:

```
❯ checking compilation flags used ... WARNING
  Compilation used the following non-portable flag(s):
    '-Wno-redundant-move' '-Wno-unused-parameter'
  including flag(s) suppressing warnings
Error: R CMD check found WARNINGs
```

166 commits across `main` (3), `v1.5-variegata` (6) and `main-fwd` (157) were red for it, every one of them decided by a run on 2026-08-10/11, and every one of their own trees carrying no warning gate at all. #2652 fixed the cause and every `-dev` tip already carried the port, so the trees were fine and only the records were wrong. The firing removed them by hand and the commits are being rebuilt green as I write this — this PR is that operation, so the next firing does not repeat it with a shell loop over `git rm`.

**What it does.** Removing the record is what makes the commit undecided: work selection reads presence and nothing else (`scripts/rcc-decided.sh`), so the next `each-rcc` run on the branch plans it like a commit that had never been built. The log goes with it, because a log whose record is gone is read by nothing and dated by nothing — `rcc-consolidate.sh` drops such orphans anyway.

```sh
scripts/rcc-drop.sh <sha>...          # or --stdin, one per line
scripts/rcc-drop.sh --dry-run <sha>...
```

**How it writes.** Through `rcc-publish.sh`'s `.remove` staging, which already existed and is already unit-tested, so the drop inherits the whole race protocol — fetch the tip, rebuild the index, retry on a lost push — and adds no second way to write to `rcc2`. Full 40-character SHAs only: an abbreviation names no path in the store, so it would drop nothing and report success, which is the one failure mode that looks like a clean run.

**Two behaviours documented rather than fixed.** The commit's `rcc` status stays red until its rebuild writes a fresh one; it is a display surface and nothing decides from it. And `rcc-logs.yaml` must **not** be dispatched behind a drop — it derives records for undecided commits from exactly those stale statuses, and would put back what the drop removed. Where the sweep is what is wanted (a record a cancelled leg never published), there is nothing to drop first.

**When it is the wrong tool**, stated in the header and the skill: a commit its own tree broke is a repair. Dropping its record costs a rebuild to learn the same verdict and erases the log that said why.

Also here: the `store/` handbook page's writer table gains the row, `.claude/skills/series-loop.md`'s *Dropping a result by hand* paragraph now points at the script instead of describing the file surgery, and `scripts/README.md` is regenerated after adding the file to the ownership map in `docs-readme.R`.

Verified against a local bare remote seeded through `rcc-publish.sh`: a drop removes record and log, a second run of the same drop reports `Already published`, the `--stdin` form drops a record that has no log, and an abbreviated SHA is refused before anything is staged.

---
_Generated by [Claude Code](https://claude.ai/code/session_014L1uEjcXAz5tLoBP6xr1sj)_