### PR TITLE
fix(rcc): Pin the sweep's push trigger to `main`, so a series ref move stops dispatching it

### DIFF
--- a/.github/workflows/rcc-logs.yaml
+++ b/.github/workflows/rcc-logs.yaml
@@ -20,10 +20,21 @@
 # The leg's own publish stays, and is the store's one automatic writer. A run
 # takes 2-13 minutes, so a firing that needs this dispatches it and reads the
 # result on its next pass rather than waiting.
+#
+# The push trigger is a smoke test of this workflow's own code, so it is pinned
+# to `main`, where that code lands. Without the branch filter it fires on a push
+# to *any* ref -- and `paths` is evaluated over the whole pushed range, so a
+# series ref fast-forwarding over the commit that last touched `rcc-logs.sh`
+# matches it. Every `<S>-green` and `<S>-dev` line carries that commit, so an
+# ordinary ref move by the series loop was dispatching the sweep, which then
+# re-derived records from stale `rcc` statuses -- putting back verdicts a firing
+# had deliberately dropped (114 of them on 2026-08-13, across two ref moves).
 
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
     paths:
       - ".github/workflows/rcc-logs.yaml"
       - "scripts/rcc-logs.sh"

--- a/handbook/operations/ci/per-commit/store/README.md
+++ b/handbook/operations/ci/per-commit/store/README.md
@@ -79,6 +79,22 @@ Nobody rewrites anything that is not their own commit's —
 except a verdict they are overturning, below —
 and that is what makes the concurrency work without a lock.
 
+**"On dispatch" has to be enforced by a branch filter, not just intended.**
+`rcc-logs.yaml` also carries a `push` trigger,
+so that a change to its own code is smoke-tested when it lands;
+`paths` is what keeps that narrow.
+But `paths` is evaluated over the *whole pushed range*,
+and a `push` trigger with no `branches` filter fires on every ref,
+so a series ref fast-forwarding over the commit
+that last touched `scripts/rcc-logs.sh`
+matched it and dispatched the sweep.
+Every `<S>-green` and `<S>-dev` line carries that commit,
+which made an ordinary stage 3 fast-forward a store writer —
+and the sweep derives records for commits it finds undecided
+from their `rcc` statuses,
+so it put back verdicts a firing had deliberately dropped.
+The trigger is pinned to `main` for that reason.
+
 ## Retention is one window
 
 The store keeps `RCC_RETENTION_DAYS` (30) of history,


### PR DESCRIPTION
`rcc-logs.yaml` says it is dispatch-only, and the store handbook's writer table says `on dispatch`. Neither is true today: the workflow also carries a `push` trigger, meant as a smoke test of its own code, and that trigger has no `branches` filter.

```yaml
on:
  workflow_dispatch:
  push:
    paths:
      - ".github/workflows/rcc-logs.yaml"
      - "scripts/rcc-logs.sh"
```

So it fires on a push to **any** ref, and GitHub evaluates `paths` over the whole pushed range — not against the tip. A series ref that fast-forwards over the commit which last touched `scripts/rcc-logs.sh` therefore matches it. That commit is #2578, the one that retired the schedule, and every `<S>-green` and `<S>-dev` line carries it. An ordinary stage 3 fast-forward is a store writer.

That would be harmless if the sweep were idempotent, but it is not. It derives a record for every commit it finds undecided from that commit's `rcc` status — and a commit whose record was deliberately dropped is exactly a commit it finds undecided, wearing a red status nothing has refreshed. So the sweep puts the dropped verdict back.

**Observed twice on 2026-08-13.** #2620 appended `-Wno-redundant-move -Wno-unused-parameter` to `~/.R/Makevars` through a composite action resolved from the branch tip, where `R CMD check --as-cran` read them back as `checking compilation flags used ... WARNING`; #2652 fixed it. A firing dropped the 166 records that gate had decided rather than the trees (`d8eebe124` on `rcc2`). The `rcc-logs` run triggered by that firing's own `main-green` and `v1.4-andium-green` fast-forwards restored 110 of them (`710ea515e`).

The next firing found 9 of those still carrying the stale failure — `series-check.sh` reporting `REPAIR fb76c0416…` on `main-fwd` — dropped them again, then advanced `v1.5-variegata-green` over 78 commits. Run `31743264656`, event `push`, branch `v1.5-variegata-green`, restored 4 of the 9 four minutes later (`7bb6963fa`). Both ranges contain #2578.

**The fix** pins the push trigger to `main`, where the sweep's own code lands, so the smoke test keeps working and nothing else dispatches it. The `paths` filter stays.

Also here: the store handbook's *Who writes what* section says why `on dispatch` needs the branch filter to be true, rather than only intended.

This is orthogonal to #2654, which adds `rcc-drop.sh` for the drop itself and documents "do not dispatch `rcc-logs.yaml` behind a drop". That advice assumes the firing controls the dispatch — here nothing did, and the drop was undone by a ref move the loop makes every firing.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NG1Z3CFRrauoZxbStQvZZo

---
_Generated by [Claude Code](https://claude.ai/code/session_01NG1Z3CFRrauoZxbStQvZZo)_