### PR TITLE
fix(series-advance): Carry the twin's work in a file the buffer also touched

### DIFF
--- a/.claude/skills/series-loop.md
+++ b/.claude/skills/series-loop.md
@@ -939,7 +939,7 @@ and a replay of everything above it.
 So as each buffer commit is consumed,
 `series-advance.sh` looks its base twin up by vendored SHA
 and folds into the same commit
-whatever that twin touched and its own `-build` commit did not,
+whatever that twin's tree holds and its own `-build` commit's does not,
 with the twin's message and a `Carried from` trailer.
 
 **The carry is a difference, not a list of directories,
@@ -951,6 +951,18 @@ a test, a check, a platform r-universe reached and the gate never did —
 and holding it back would strand exactly the fixes this exists to move.
 The difference is also what stops the glue the buffer already carries
 from being applied twice.
+
+**The difference is by content, and a filename is not content.**
+A file the buffer commit touched is still a file the twin may have
+taken further, and skipping it because the name appears on both sides
+drops that further work without saying so.
+The vendor gate only syntax-checks the glue,
+so a declaration carried without its definition compiles
+and fails at the link, one whole CI cycle later
+(duckdb/duckdb-r#2657).
+Where the two genuinely diverge the three-way apply conflicts
+and the stage stops, which is the attended path below —
+a stop is the cost of the carry being complete.
 Two kinds stay behind, neither of them a judgement about the fix:
 the buffer's own strand — `src/duckdb/` and `patch/`,
 since a forward regenerates the tree from its own patches —

--- a/scripts/series-advance.sh
+++ b/scripts/series-advance.sh
@@ -232,16 +232,27 @@ twin_of() { # <buffer commit> -> the base -dev commit for the same upstream SHA
   echo "${TWIN[$sha]:-}"
 }
 
-# What the twin folded in beyond vendoring: the paths its own diff touches that
-# its `-build` twin's does not, less the two kinds that are not a fix.
+# What the twin folded in beyond vendoring: the paths its own diff touches,
+# less the two kinds that are not a fix, and less those the buffer already ends
+# up with byte for byte.
 #
 # The difference is the load-bearing part, and it is what lets `src/` through.
 # The gate compiles the glue at every buffer commit, so whatever the buffer
 # holds there is already enough to build; anything the `-dev` twin has *on top*
 # of it in `src/` was demanded by something later than the compiler -- a test,
 # a check, a platform r-universe reached and the gate did not. Those are
-# legitimate and they carry. Taking the difference is also what stops the glue
-# the buffer already has from being applied twice.
+# legitimate and they carry. Comparing the resulting blobs is also what stops
+# the glue the buffer already has from being applied twice.
+#
+# **The difference is by content, never by filename.** Excluding every path the
+# buffer commit happened to touch drops the twin's further work in that same
+# file, and drops it silently: the vendor gate only syntax-checks the glue, so a
+# declaration carried without its definition compiles and then fails to link.
+# That is duckdb/duckdb-r#2657 -- `84370b8a3` on `main-fwd-dev` took the twin's
+# `src/include/rapi.hpp`, `src/connection.cpp` and `src/register.cpp` but not
+# its `src/statement.cpp`, because the buffer commit had moved three call sites
+# in that file, and the install failed with
+# `undefined symbol: duckdb::RCallbackScope::~RCallbackScope()`.
 #
 # Two kinds are excluded, and neither is a judgement about the fix:
 #
@@ -256,21 +267,36 @@ twin_of() { # <buffer commit> -> the base -dev commit for the same upstream SHA
 #
 # Tooling is stage 4's, ported from `main` rather than carried sideways.
 carry_paths() { # <buffer commit> <base -dev commit>
+  local c=$1 d=$2 f
+  { git show --format= --name-only --no-renames "$d" | sort -u |
+      grep -vE '^(src/duckdb/|patch/|\.github/|scripts/|\.claude/|man/figures/)' |
+      grep -vxE 'DESCRIPTION|R/version\.R|src/include/sources\.mk|src/Makevars(\.win|\.in)?' ||
+      true; } |
+    while IFS= read -r f; do
+      # Same blob on both sides: the buffer already carries exactly this, and
+      # re-applying it is the double application the difference exists to avoid.
+      if [ "$(git rev-parse --quiet --verify "$c:$f" 2>/dev/null)" \
+           = "$(git rev-parse --quiet --verify "$d:$f" 2>/dev/null)" ]; then
+        continue
+      fi
+      printf '%s\n' "$f"
+    done
+}
+
+# Glue the base `-dev` has and the base `-build` lacks *entirely* -- a fix
+# folded during a repair and never mirrored onto the buffer, so the next tree
+# regenerated there still wants it (.claude/skills/series-loop.md, stage 2).
+# Carried like the rest, but said out loud, because it is buffer drift.
+#
+# Deliberately the filename test rather than carry_paths': a file the buffer
+# also touched is one the buffer knows about, so the twin's further work in it
+# is an ordinary carry, not drift the buffer is missing.
+glue_paths() { # <buffer commit> <base -dev commit>
   comm -13 \
     <(git show --format= --name-only --no-renames "$1" | sort -u) \
     <(git show --format= --name-only --no-renames "$2" | sort -u) |
-    grep -vE '^(src/duckdb/|patch/|\.github/|scripts/|\.claude/|man/figures/)' |
-    grep -vxE 'DESCRIPTION|R/version\.R|src/include/sources\.mk|src/Makevars(\.win|\.in)?' ||
-    true
-}
-
-# Glue among the carried paths. Carried like the rest -- the series needs it to
-# go green -- but said out loud, because a glue fix the base `-dev` has and the
-# base `-build` lacks is buffer drift: the fix was folded during a repair and
-# never mirrored onto the buffer, so the next tree regenerated there still
-# wants it (.claude/skills/series-loop.md, stage 2).
-glue_paths() { # <buffer commit> <base -dev commit>
-  carry_paths "$1" "$2" | grep -E '^src/' || true
+    grep -E '^src/' | grep -vE '^src/duckdb/' |
+    grep -vxE 'src/include/sources\.mk|src/Makevars(\.win|\.in)?' || true
 }
 
 # Check the counter rather than assume it: a replay that silently froze it


### PR DESCRIPTION
Stage 5's carry took the difference between the twin's and the buffer commit's touched **filenames**, so a file both of them changed was dropped whole — and with it whatever the base `-dev` twin had done in that file beyond what the buffer already had.

```sh
carry_paths() { # <buffer commit> <base -dev commit>
  comm -13 \
    <(git show --format= --name-only --no-renames "$1" | sort -u) \
    <(git show --format= --name-only --no-renames "$2" | sort -u) | ...
```

The comment above it already said the right thing — "what carries is the **difference** between the twin and its `-build` commit, not an allow-list of directories" — but `comm -13` over two name lists is not that difference. A file is not an atom: the buffer adapting three call sites in it does not mean the twin's eighty further lines are already there.

**Observed today on `main-fwd`.** `84370b8a3` vendors `duckdb/duckdb@b5e4f5be` (the `PreparedStatement` rework, upstream #24273). Its twin `3312fa9e9` on `main-dev` had folded in an `RCallbackScope` guard — a class declared in `src/include/rapi.hpp` and defined in `src/statement.cpp`, plus `RStatement::~RStatement()` and the `EXPLAIN ANALYZE` profiler arming. The buffer commit `42a26c756` touched `DESCRIPTION`, `R/version.R` and `src/statement.cpp`; the twin touched `R/version.R`, `src/connection.cpp`, `src/include/rapi.hpp`, `src/register.cpp` and `src/statement.cpp`. So the carry took the header and both call-site files and dropped `src/statement.cpp`, leaving the declarations and every use of them with no definition anywhere.

The vendor gate syntax-checks the glue against the freshly vendored headers and never links, so nothing caught it. `R CMD INSTALL` did, one CI cycle later:

```
** testing if installed package can be loaded from temporary location
Error: package or namespace load failed for 'duckdb.dev' in dyn.load(file, DLLpath = DLLpath, ...):
 unable to load shared object '.../duckdb.dev.so':
  .../duckdb.dev.so: undefined symbol: _ZN6duckdb14RCallbackScopeD1Ev
```

That was run [31743600051](https://github.com/krlmlr/duckdb-r/actions/runs/31743600051), shard 14, and it red-lined that commit and the 67 above it — every one of them `failed_stages: ["install"]`, the same symbol. Repaired by hand on `main-fwd-dev` this firing; this PR is so the next carry does not need the repair.

**The fix** takes the twin's paths, less the same two excluded kinds, and drops only those whose *resulting blob* the buffer commit already has:

```sh
if [ "$(git rev-parse --quiet --verify "$c:$f" 2>/dev/null)" \
     = "$(git rev-parse --quiet --verify "$d:$f" 2>/dev/null)" ]; then
  continue
fi
```

That is the content difference the comment claimed, and it keeps the property the filename test was protecting: glue the buffer already carries byte for byte is still not applied twice.

Where the two genuinely diverge, `apply_carry`'s existing `git apply --3way` does the merging. Replaying the real case against `84370b8a3` shows exactly that shape — `src/connection.cpp`, `src/include/rapi.hpp` and `src/register.cpp` apply cleanly, and `src/statement.cpp` conflicts on the two hunks where the buffer's compile fix and the twin's further change overlap:

```
Applied patch to 'src/connection.cpp' cleanly.
Applied patch to 'src/include/rapi.hpp' cleanly.
Applied patch to 'src/register.cpp' cleanly.
Applied patch to 'src/statement.cpp' with conflicts.
```

A stop is the right outcome there. Resolving toward the twin is what the hand repair did, and an attended stop is the documented behaviour for a carry the series has moved out from under — much better than a chain that compiles and does not link.

`glue_paths()` keeps the filename test, deliberately: it reports **buffer drift**, which is glue the base `-build` lacks entirely and wants mirroring. A file the buffer also touched is one the buffer knows about, so the twin's further work in it is an ordinary carry, not drift. Its exclusions are spelled out locally now that it no longer borrows `carry_paths`'.

Scanned the rest of `main-fwd-green..main-fwd-dev` for the same shape: six commits carry from a twin, and `84370b8a3` is the only one where the twin and the buffer commit touched a common non-excluded path. So the hand repair covers the whole range.

`scripts/series-advance-test.sh`: 47 passed, 0 failed. `.claude/skills/series-loop.md`'s stage 5 gains the content-not-filename rule.

---
_Generated by [Claude Code](https://claude.ai/code/session_011ECGQpUrXAD1xpqA9BP3mz)_