### PR TITLE
feat(series): Keep forwarding a base series with a live `-fwd`, and check the two converge

### DIFF
--- a/.claude/skills/series-forward.md
+++ b/.claude/skills/series-forward.md
@@ -158,10 +158,12 @@ the replay then populates `<S>-fwd-build`.
 3. Nothing else is special:
    a forward series is a series,
    and the loop discovers and drives it like any other.
-   The base series stops consuming
-   (its stage 5 is skipped while a live `<S>-fwd-build` exists)
-   but keeps verifying and promoting what is already in flight —
+   **The base series keeps consuming too**, at full speed,
+   vendoring, repairing, porting and extending as if no forward existed;
    `<S>-green` still serves consumers, unchanged, on the old lineage.
+   The two run level until a human swaps them,
+   which is what the invariant below needs
+   and what the loop's stage 5 used to prevent.
 
 ## A WIP forward series is not pinned to its base
 
@@ -187,6 +189,66 @@ all four refs replayed as they stand, nothing rederived.
 A series that has cut over is no longer WIP:
 its green serves consumers,
 and moving it means a new forward series, not a rebase.
+
+## What a forwarding has to end up with
+
+A forward is the same series rebuilt on a newer `main`,
+so its history differs by construction
+and its content must not.
+That is the invariant:
+
+> At the end of a forwarding,
+> `<S>-dev` and `<S>-fwd-dev` are **identical**,
+> or every difference between them is **explicable**.
+
+Read it as a claim about trees, never about ancestry —
+the two share a seed generation and nothing below it,
+the version counters are renumbered,
+and the ported commits the replay leaves behind
+are content the new seed already carries.
+Ancestry says nothing here; the working trees say everything.
+
+```sh
+scripts/series-converge.sh <S>
+```
+
+prints the difference and sorts it into the two.
+What is explicable is a short, evidenced list —
+`DESCRIPTION`'s `Version:` line, which the replay renumbers;
+`NEWS.md`, the release paperwork stage 4 never ports;
+and the **vendored strand** —
+`src/duckdb/`, `patch/`, `R/version.R`, `src/include/sources.mk`
+and the Makevars —
+*only while the two vendor different upstream commits*,
+where it is the gap and not a finding.
+Every file in that strand is a function of the upstream tree:
+`R/version.R` carries the engine's own version,
+the source list and the Makevars are generated from it,
+and `patch/` retires entries as upstream absorbs them.
+Once both sit on the same upstream SHA the whole strand must agree:
+a forward regenerates the vendored tree from its own patch stack,
+which is what step 1's tree check verifies at replay time.
+
+Everything else is a finding —
+glue, tests, R code, the READMEs, the tooling directories —
+and it belongs to whichever stage should have moved it:
+a carry stage 5 could not make,
+a port that reached one branch and not the other,
+a fix folded on one and not the other.
+The swap does not resolve a finding; it inherits it,
+onto the lineage r-universe builds from.
+
+**An explanation can go stale, and then it reads like a clean result.**
+So the class list stays short,
+and an explained difference is still printed with its line counts
+rather than filed away.
+A class is earned by evidence that the difference is benign —
+not by another script excluding the same path,
+which it may do for a reason that has nothing to do with this one.
+Stage 5's carry excludes the generated files
+so the twin's copy cannot overwrite what the buffer just regenerated;
+that says nothing about whether the two branches may differ there,
+and on the live series they do not.
 
 ## Cut over — by hand, always
 

--- a/.claude/skills/series-loop.md
+++ b/.claude/skills/series-loop.md
@@ -80,7 +80,7 @@ every walk below is bounded by `<S>-green`, from the first firing on.
 
 Set up first, then work through the stages in order;
 each stage is skippable when it has nothing to do, the setup is not.
-Five scripts carry the mechanical parts:
+Six scripts carry the mechanical parts:
 `scripts/series-check.sh`
 (read-only — walks every series, classifies from the `rcc2` store,
 which is stage 2's fallback source, not its first one;
@@ -98,9 +98,12 @@ refuses on any failure, and on a `-green` that would not fast-forward),
 cherry-picks plus a tooling sync),
 `scripts/r-universe-check.sh`
 (read-only — what r-universe made of every published green, stage 3),
-and `scripts/series-glue.sh <S>`
+`scripts/series-glue.sh <S>`
 (read-only — every R-side glue adaptation a series carries, in one read;
-what stage 2 mines and what a forward replays).
+what stage 2 mines and what a forward replays),
+and `scripts/series-converge.sh <S>`
+(read-only — `<S>-dev` against `<S>-fwd-dev`, every difference sorted
+into what the forwarding explains and what it does not, stage 6).
 Judgement — repairs, review, vendoring — stays here.
 
 ### 0. Setup
@@ -872,9 +875,14 @@ What stays judgement:
 - an OTHER commit that cannot work against this series' engine —
   apply an explicit subset without it,
   fix it on `main` (a guard, a runtime seam),
-  and port the fixed commit instead;
-- a series with a live forward counterpart is being replaced —
-  port only what its remaining verification needs.
+  and port the fixed commit instead.
+
+A live forward counterpart changes nothing here.
+Both lineages are ported the same way, every firing,
+because the thing that says a cutover is safe
+is that the two `-dev` branches carry the same package —
+and a port that reached one of them and not the other
+is precisely a difference nobody can explain at the swap.
 
 Ported and sync commits are ordinary `-dev` commits:
 green per commit like everything else,
@@ -922,10 +930,26 @@ and the patch-stack fixes that edit `src/duckdb/` in place
 without vendoring anything —
 and the anchor is about how much of the buffer has been consumed,
 which only vendor commits record.
-Exception: a series with a **live** forward counterpart
-(`<S>-fwd-build` exists and is not cutover litter)
-is being replaced —
-verify and promote it, but do not extend it.
+
+**A live forward counterpart is not an exception, and used to be.**
+A series being replaced kept consuming nothing:
+its refs stayed where the forward went live,
+and the loop verified only what was already in flight.
+That froze the one branch a cutover is measured against.
+A forward is the same series rebuilt on a newer `main`,
+so what makes the swap safe is that the two `-dev` branches
+carry the same package (stage 6) —
+and a frozen base can be compared only at the commit it stopped on,
+which is the single point the two are already known to agree.
+It also starved the carry below:
+past the base's frontier there is no twin to match by vendored SHA,
+so every fix the base had proved
+was rediscovered on the forward as a red,
+costing a repair and a replay of everything above it.
+So a base series consumes its buffer like any other.
+The cost is real — CI on a lineage about to be retired, twice over —
+and it buys the only thing that makes retiring it a check
+rather than a hope.
 
 **On a forward series, the base's fixes are folded in here.**
 `<S>-fwd-build` was replayed out of `<S>-build`,
@@ -1006,9 +1030,49 @@ The store's own writer (the leg's publish;
 `rcc-logs.yaml` only when dispatched)
 just fills the fallback copy behind it.
 
-### 6. Suggest a cutover — never perform one
+### 6. Read the forwarding, and suggest a cutover — never perform one
 
-A forward series that has caught up is **reported, not swapped**.
+**Every series with a forward counterpart is read here, caught up or not.**
+The two lineages carry the same package or they do not,
+and the answer is worth having while there is still time to act on it:
+
+```sh
+scripts/series-converge.sh <S>
+```
+
+It diffs `<S>-dev` against `<S>-fwd-dev`
+and sorts every differing path into
+what the forwarding explains and what it does not —
+the version counter the replay renumbers,
+the release paperwork stage 4 never ports,
+and the vendored strand,
+only while the two still vendor different upstream commits.
+Everything else is a finding, and the stage carries it into the report.
+
+**The invariant is the reason the stage exists.**
+At the end of a forwarding,
+`<S>-dev` and `<S>-fwd-dev` are identical,
+or every difference between them is explicable —
+a statement about trees, never about ancestry,
+since the histories differ by construction.
+Both branches advancing is what makes it readable at the frontier
+rather than only at the commit a frozen base stopped on (stage 5).
+
+A finding here is not repaired by the swap; it is inherited by it.
+Fix it where it belongs —
+a missing carry is stage 5's, a missing port stage 4's,
+a fix folded on one branch and not the other is stage 2's —
+and say so in the commit message that answers it,
+which is where a later forward reads it.
+An explained difference still gets read, not skipped:
+an explanation can go stale,
+and a stale one reads exactly like a clean result.
+So the class list is deliberately short,
+and it grows only where a firing has shown a new class benign —
+never on the strength of another script excluding the same path,
+which it may well do for an unrelated reason.
+
+**A caught-up forward is reported, not swapped.**
 When `<S>-fwd-green` vendors the upstream commit `<S>-green` vendors,
 `series-check.sh` says so beside that series' verdict,
 and the firing carries the line into its summary:
@@ -1033,6 +1097,14 @@ Its coverage gate is also the one gate the loop cannot fully evaluate:
 the ancestry check needs an upstream clone,
 and degrades to a warning without one,
 so an unattended firing would be authorizing the swap on a warning.
+Coverage is in any case only half the question —
+it asks how much upstream the forward reaches
+and nothing about what it carries —
+so `series-cutover.sh` prints the convergence report
+immediately before it asks for confirmation.
+It reports rather than refuses:
+whether a difference is explicable is exactly the judgement
+no script can make.
 Verification is mechanical, so the loop owns it;
 deciding that r-universe should build a different lineage today
 is not, so a human owns that.

--- a/handbook/branches/invariants/README.md
+++ b/handbook/branches/invariants/README.md
@@ -29,6 +29,12 @@ The families, in one breath:
   born beside the vendor commit that forces it.
 * **CI / green** — a `-green` ref only ever fast-forwards to
   commits with recorded successful runs.
+* **Forward convergence** — at the end of a forwarding, `<S>-dev` and
+  `<S>-fwd-dev` are identical, or every difference between them is
+  explicable. A forward is the same series rebuilt on a newer `main`
+  ([`.claude/skills/series-forward.md`](/.claude/skills/series-forward.md)),
+  so the histories differ by construction and only the trees carry the
+  claim.
 * **Prerelease** — while a release stabilises, only `main` and the dev
   branches move, so an unfinished release is abandoned by walking away;
   what ships is an ancestor of what was revdep-tested;
@@ -49,6 +55,17 @@ it is confirmed to carry a version strictly above its parent's.
 `-build-base` is not a third: it is set rather than advanced,
 recomputed from the match each time and force-pushed,
 which is why nothing gates it.
+
+Forward convergence sits between the two families:
+it is **measured on every firing and enforced by nobody**.
+[`scripts/series-converge.sh`](/scripts/series-converge.sh) reports it,
+and [`scripts/series-cutover.sh`](/scripts/series-cutover.sh) prints the
+same reading immediately before it asks to swap the refs —
+but neither refuses, because the invariant's second half is
+*explicable*, and whether a difference is explicable is a judgement no
+script can make. What the tooling can do, and does, is keep the list of
+differences it explains away short and evidenced, so that what is left
+is a work list rather than a verdict.
 The structural and flavor families hold **by construction** —
 the rename is one patch applied by
 [`scripts/flavor.sh`](/scripts/flavor.sh), which prepares and checks the

--- a/handbook/operations/vendoring/series-loop/README.md
+++ b/handbook/operations/vendoring/series-loop/README.md
@@ -66,11 +66,37 @@ to do, and they run in this order:
   This stage is **attended**: a carry the series has moved out from
   under stops the run with the conflict in a worktree it keeps, writes
   no ref, and resumes with `--continue` or is discarded with `--abort`.
-* **Suggest a cutover** — a caught-up `-fwd` counterpart is *reported*
-  with the command, never executed; that move is a human's.
+  A live forward counterpart does **not** hold the base series back: it
+  consumes, ports and verifies at full speed until a human swaps the
+  refs, which costs CI on a lineage about to be retired and buys the
+  only thing that makes retiring it checkable rather than hopeful
+  (below).
+* **Read the forwarding, and suggest a cutover** — for every series
+  with a forward counterpart,
+  [`scripts/series-converge.sh`](/scripts/series-converge.sh) diffs
+  `<S>-dev` against `<S>-fwd-dev` and sorts each differing path into
+  what the forwarding explains and what it does not; the findings go
+  into the report and to the stage that should have moved them. A
+  caught-up counterpart is *reported* with the cutover command, never
+  executed; that move is a human's, and the script prints the same
+  comparison before it asks for confirmation.
 * **Report what the tooling got wrong** — a firing that had to work
   around a script opens a pull request against it,
   so the next firing does not have to.
+
+**A forwarding ends where the two lineages agree.**
+A forward series is the same series rebuilt on a newer `main`, so its
+history differs by construction and its content must not: at the end of
+a forwarding `<S>-dev` and `<S>-fwd-dev` are identical, or every
+difference between them is explicable
+([`branches/invariants/`](/handbook/branches/invariants/README.md)).
+That is why the base keeps consuming. A base frozen where the forward
+went live can be compared only at the commit it stopped on — the one
+point the two are already known to agree — so every commit the forward
+vendored afterwards had nothing to check against; and past that frontier
+stage 5 finds no twin to match by vendored SHA, so each fix the base had
+already proved came back as a red on the forward, at a repair plus a
+replay of everything above it.
 
 **A forward carries the vendor strand, and the rest is placed by hand.**
 `<S>-fwd-build` is replayed from the buffer's `vendor:` commits alone, so

--- a/scripts/series-advance-test.sh
+++ b/scripts/series-advance-test.sh
@@ -6,7 +6,7 @@
 # `-build` holds what the code needs to **compile**, because that is what the
 # vendor gate checks, and `-dev` holds everything CI asked for after that --
 # including glue, which is why the carry is a difference and not an allow-list.
-# A forward series inherits only the first when its buffer is replayed. Ten
+# A forward series inherits only the first when its buffer is replayed. Eleven
 # things are checked.
 #
 #   1. A buffered commit whose base `-dev` twin folded a test-side fix is minted
@@ -34,6 +34,9 @@
 #      over the resolution; `--abort` discards it and writes no ref.
 #  10. The fifth version component still rises once per vendor commit, carry or
 #      no carry.
+#  11. A base series with a *live* forward counterpart consumes its buffer like
+#      any other. It used to be refused, which froze the branch a cutover is
+#      measured against and left the forward with no twin to mine.
 #
 # Usage:
 #   scripts/series-advance-test.sh
@@ -170,6 +173,14 @@ git commit -qm 'test: the forward series has its own types snapshot'
 git branch base-fwd-green base-fwd-dev
 git branch base-fwd-build-base base-fwd-build
 
+# --- the base series' own buffer, one commit past its -dev (claim 11) --------
+# Added after `base-fwd-build` was branched, so the forward's buffer stays at
+# five and only the base has something left to consume. `base-fwd-green` carries
+# a commit `base-green` does not, so the forward is live rather than cutover
+# litter -- which is the shape this stage used to refuse to extend over.
+git checkout -q base-build
+bvendor fff9999 1.0.0.9000.6 h.cpp
+
 # --- a series with no forward and no base to mine (claim 4) -----------------
 git checkout -q -b solo-dev base-seed
 git branch solo-green solo-dev
@@ -191,11 +202,21 @@ git push -q origin main base-seed base-build base-dev base-green base-build-base
 git fetch -q origin
 
 run() { set +e; scripts/series-advance.sh "$@" 2>&1; echo "EXIT=$?"; set -e; }
+# Collected, then matched -- never piped straight into `grep -m1`. The grep
+# leaves as soon as it matches, and the SIGPIPE that hands `git log` surfaces
+# through `pipefail` as a failed command, aborting the whole run with 141
+# instead of failing a check. Whether it fires at all depends on how much the
+# log still had to write, so the same suite passes three times and dies on the
+# fourth. The same rule, for the same reason, as scripts/series-check.sh.
 at() { # <series> <upstream sha> -> the -dev commit vendoring it
-  git log --format='%H %s' "origin/$1-green..origin/$1-dev" | grep -m1 "duckdb@$2" | cut -d' ' -f1
+  local log
+  log=$(git log --format='%H %s' "origin/$1-green..origin/$1-dev")
+  grep -m1 "duckdb@$2" <<<"$log" | cut -d' ' -f1
 }
 wat() { # <upstream sha> -> the same, inside the kept worktree
-  git -C "$WT" log --format='%H %s' | grep -m1 "duckdb@$1" | cut -d' ' -f1
+  local log
+  log=$(git -C "$WT" log --format='%H %s')
+  grep -m1 "duckdb@$1" <<<"$log" | cut -d' ' -f1
 }
 
 # --- claims 1-3, 5, 8: extend the forward series ----------------------------
@@ -325,6 +346,25 @@ has   "and moves the ref"           "$out" 'dev ->'
 git fetch -q origin
 is "the dev tip is a buffer commit verbatim, not a replay" \
   "$(git rev-parse origin/solo-dev)" "$(git rev-parse origin/solo-build)"
+
+# --- claim 11: a base series with a live forward counterpart still consumes ---
+echo
+echo "== a base series whose forward counterpart is live"
+is "the forward is live, not cutover litter" \
+  "$(git merge-base --is-ancestor origin/base-fwd-green origin/base-green &&
+       echo litter || echo live)" live
+out=$(run base)
+hasnt "does not refuse over the counterpart" "$out" 'live forward counterpart'
+has   "and moves the ref"                    "$out" 'dev ->'
+hasnt "with nothing to mine, being a base"   "$out" 'carry a fix from'
+git fetch -q origin
+is "the buffered commit reached dev" \
+  "$(git rev-list --count origin/base-green..origin/base-dev)" 1
+F=$(at base fff9999)
+is "replayed onto the base's own tip, not the buffer's" \
+  "$(git rev-parse "$F^")" "$(git rev-parse origin/base-green)"
+is "and the counter rose once for it" \
+  "$(git show "$F:DESCRIPTION" | sed -n 's/^Version: //p')" 1.0.0.9000.6
 
 echo
 echo "$pass passed, $fail failed"

--- a/scripts/series-advance.sh
+++ b/scripts/series-advance.sh
@@ -371,13 +371,27 @@ if [ -n "$CONTINUE" ] && [ ! -f "$STATE" ]; then
   exit 1
 fi
 
-# A live forward counterpart replaces this series; leftover -fwd refs whose
-# green is an ancestor of ours are cutover litter and do not block.
-if git rev-parse -q --verify "$remote/$S-fwd-build" >/dev/null &&
-   ! git merge-base --is-ancestor "$remote/$S-fwd-green" "$green" 2>/dev/null; then
-  echo "$S has a live forward counterpart — not extending"
-  exit 0
-fi
+# A live forward counterpart is not a reason to stop consuming, and this stage
+# used to treat it as one. The series being replaced kept its refs and stopped
+# moving, which cost twice:
+#
+#   * **The cutover became unverifiable.** A forward is the same series rebuilt
+#     on a newer `main`, so the thing that says it is safe to swap is that the
+#     two `-dev` branches carry the same package -- identical, or different only
+#     where the forwarding explains it (scripts/series-converge.sh). A base
+#     frozen where the forward went live can only be compared at the commit it
+#     stopped on, which is the one point the two are known to agree. Every
+#     commit the forward vendored afterwards had nothing to be checked against.
+#   * **It starved the carry below.** Stage 5 folds the base `-dev`'s test-side
+#     fixes into the forward as each buffer commit is consumed, matched by
+#     vendored SHA. Past the base's frontier there is no twin to match, so every
+#     fix the base had already proved was rediscovered as a red -- a repair plus
+#     a replay of everything above it -- or reached the forward by hand out of
+#     `-build`, which is what `main-fwd-dev` shows above `main-dev`'s frontier.
+#
+# So a base series consumes its buffer like any other, and the two lineages run
+# level until a human swaps them. It is more CI on a series about to be retired;
+# it is also the only thing that makes retiring it a check rather than a hope.
 # Pending work does not hold the buffer (.claude/skills/series-loop.md stage 5):
 # each.yaml plans every commit in green..tip that has no status, so a longer tip
 # is more work planned in the same pass, not work deferred. A known failure does

--- a/scripts/series-check.sh
+++ b/scripts/series-check.sh
@@ -306,5 +306,8 @@ for S in "${series[@]}"; do
   if [ -n "$cutover" ]; then
     echo "  CUTOVER  $S covers $cutover's green — a manual step, never a firing's:"
     echo "           scripts/series-cutover.sh $cutover $remote <upstream-clone>"
+    echo "           Coverage is only half of it; what the two branches carry is"
+    echo "           the other half, and the cutover prints it before it asks:"
+    echo "           scripts/series-converge.sh $cutover"
   fi
 done

--- a/scripts/series-converge.sh
+++ b/scripts/series-converge.sh
@@ -1,0 +1,211 @@
+#!/bin/bash
+# Does a forward series still carry the same package as the series it replaces?
+#
+# A forward series is the same series rebuilt on a newer `main`
+# (.claude/skills/series-forward.md). Its *history* differs by construction -- a
+# regenerated seed, version counters renumbered as a true counter, the ported
+# commits the replay leaves behind -- and its *content* must not. So the
+# statement a cutover rests on is about trees, not ancestry:
+#
+#   at the end of a forwarding, `<S>-dev` and `<S>-fwd-dev` are identical, or
+#   every difference between them is explicable.
+#
+# This prints the difference and sorts it into those two, so "explicable" is
+# something a reader checks rather than something a cutover assumes. Nothing is
+# hidden: an explained difference is still printed, with its line counts, so one
+# that changed by more than its explanation accounts for stays visible rather
+# than being filed away.
+#
+# It is also why the loop keeps consuming a base series that has a live forward
+# counterpart (scripts/series-advance.sh, stage 5). A base frozen where the
+# forward went live can only be compared at the commit it stopped on, which is
+# the one point the two are known to agree; every commit the forward vendored
+# afterwards is unverifiable against anything. Both series advancing is what
+# turns this from a claim into a reading.
+#
+# **Read-only.** It writes no ref, makes no commit, and touches no worktree.
+#
+# What counts as explicable, and why each one:
+#
+#   * `DESCRIPTION` -- but only its `Version:` line. The replay renumbers the
+#     fifth component as a counter of its own chain, so the versions differ by
+#     construction. Anything else in that file is a real difference, and the
+#     file is diffed line-wise to tell the two apart.
+#   * `NEWS.md` -- the release paperwork a `fledge:` commit carries, and stage 4
+#     never ports a VERSION commit: `main`'s R-client counter is not a series'
+#     (.claude/skills/series-loop.md). So the two branches hold whatever their
+#     seeds' release lines held, and the file is fledge-maintained, never edited
+#     by hand.
+#   * The **vendored strand** -- `src/duckdb/`, `patch/`, `R/version.R`,
+#     `src/include/sources.mk` and the Makevars -- but **only while the two
+#     branches vendor different upstream commits**, where it is the gap itself
+#     rather than a finding. Everything in it is a function of the upstream tree:
+#     `R/version.R` carries the engine's own version (`1.6.0-dev12322` against
+#     `1.6.0-dev12739` on `main` today), the source list and the Makevars are
+#     generated from that tree, and `patch/` retires entries as upstream absorbs
+#     them. Once both sit on the same upstream SHA every one of them must agree:
+#     the forward regenerates the vendored tree from its own patch stack, and
+#     series-forward-build.sh verifies exactly that at replay time.
+#
+# Note what is *not* here. Stage 5's carry excludes the same generated files
+# (scripts/series-advance.sh), but for an unrelated reason -- so the twin's copy
+# does not overwrite the one the buffer's own vendor run just produced -- and
+# that exclusion is no evidence they may differ. On the three live series they
+# do not: at a matching upstream SHA `R/version.R`, `src/include/sources.mk` and
+# the Makevars are identical, and the logos under `man/figures/` are not derived
+# from upstream at all, so a difference there is a finding like any other.
+#
+# Everything else is unexplained and printed as a finding -- glue under `src/`,
+# tests, R code, the READMEs, and the tooling directories, which stage 4 brings
+# to `main`'s state on both branches every firing and which therefore have no
+# reason to differ at all.
+#
+# The list is deliberately short. A class is added here only once something has
+# shown the difference to be benign, because a check that explains away what it
+# has not accounted for is worse than no check: it reads as a clean bill. When a
+# firing proves a new class benign, it adds it with the evidence.
+#
+# Usage: series-converge.sh <series> [remote] [--no-fetch]
+#   series-converge.sh main            # the base name
+#   series-converge.sh main-fwd        # or the forward's; the same comparison
+#
+# Exit status: 0 when nothing is unexplained, 1 when something is, 2 on a usage
+# or lookup error -- so a caller can gate on it. `--no-fetch` is for a caller
+# that has just fetched (scripts/series-cutover.sh).
+
+set -euo pipefail
+
+usage='usage: series-converge.sh <series> [remote] [--no-fetch]'
+S=${1:?$usage}
+shift
+remote=origin
+fetch=1
+for a in "$@"; do
+  case "$a" in
+    --no-fetch) fetch= ;;
+    -*) echo "$usage" >&2; exit 2 ;;
+    *) remote=$a ;;
+  esac
+done
+
+# Either name asks the same question, so neither is wrong to type.
+S=${S%-fwd}
+dev="$remote/$S-dev"
+fwd="$remote/$S-fwd-dev"
+
+[ -z "$fetch" ] || git fetch -q "$remote"
+
+for r in "$dev" "$fwd"; do
+  git rev-parse -q --verify "$r" >/dev/null || {
+    echo "Error: ${r#"$remote"/} does not exist on $remote" >&2
+    echo "  There is no forwarding to check unless both branches are there." >&2
+    exit 2
+  }
+done
+
+# The same helper, the same bound and the same reasons as scripts/series-advance.sh
+# and scripts/series-cutover.sh: the pathspec narrows the walk, the subject
+# decides, and an empty answer explains itself on stderr rather than lying.
+base_scan_depth="${BASE_SCAN_DEPTH:-20}"
+vendored_sha() {
+  local subjects sha n
+  subjects=$(git log -n "$base_scan_depth" --format=%s "$1" -- src/duckdb || true)
+  sha=$(sed -nr 's/^.*duckdb.duckdb@([0-9a-f]+)( .*)?$/\1/p' <<<"$subjects" | head -n 1)
+  if [ -z "$sha" ]; then
+    n=$(grep -c . <<<"$subjects" || true)
+    if [ "$n" -ge "$base_scan_depth" ]; then
+      echo "vendored_sha: $base_scan_depth src/duckdb commits on $1, none of them vendoring;" >&2
+      echo "  if that is genuine, raise BASE_SCAN_DEPTH" >&2
+    else
+      echo "vendored_sha: no vendor commit among $n src/duckdb commits on $1" >&2
+    fi
+  fi
+  echo "$sha"
+}
+
+dev_up=$(vendored_sha "$dev")
+fwd_up=$(vendored_sha "$fwd")
+# An `if`, not an `&&` chain: as a bare statement the chain's own failure is
+# what `set -e` would have to be trusted to overlook, and a reader should not
+# have to know that rule to see that this line is safe.
+same=
+if [ -n "$dev_up" ] && [ "$dev_up" = "$fwd_up" ]; then
+  same=1
+fi
+
+printf '=== %s\n' "$S"
+printf '  %-26s %s  vendors %s\n' "$S-dev" "$(git rev-parse --short "$dev")" "${dev_up:0:10}"
+printf '  %-26s %s  vendors %s\n' "$S-fwd-dev" "$(git rev-parse --short "$fwd")" "${fwd_up:0:10}"
+if [ -z "$same" ]; then
+  echo "  The two are not on the same upstream commit, so this is an interim read:"
+  echo "  the vendored strand (src/duckdb/, patch/, and the files generated from"
+  echo "  that tree) is the gap between them, counted rather than listed."
+  echo "  Everything else still has to agree."
+fi
+echo
+
+explained=()
+unexplained=()
+gap=0
+
+while IFS=$'\t' read -r add del f; do
+  case "$f" in
+    DESCRIPTION)
+      # Line-wise, because only one line of this file is allowed to differ.
+      # `^[+-][^+-]` takes the changed lines and leaves the `+++`/`---` headers.
+      other=$(git diff "$dev" "$fwd" -- DESCRIPTION |
+                sed -n '/^[+-][^+-]/p' | grep -vE '^[+-]Version:' || true)
+      if [ -n "$other" ]; then
+        unexplained+=("$f|$add/$del|differs beyond its Version: line")
+      else
+        explained+=("$f|$add/$del|version counter, renumbered by the replay")
+      fi
+      ;;
+    NEWS.md)
+      explained+=("$f|$add/$del|release paperwork; stage 4 never ports a VERSION commit")
+      ;;
+    src/duckdb/* | patch/* | R/version.R | src/include/sources.mk | \
+    src/Makevars | src/Makevars.win | src/Makevars.in)
+      if [ -n "$same" ]; then
+        unexplained+=("$f|$add/$del|vendored strand, at one and the same upstream commit")
+      else
+        gap=$((gap + 1))
+      fi
+      ;;
+    *)
+      unexplained+=("$f|$add/$del|")
+      ;;
+  esac
+# --no-renames, so every path is classified as itself. Rename detection prints
+# the pair as one `src/{a => b}` entry, which matches no case below and is not a
+# path anything else here could act on.
+done < <(git diff --numstat --no-renames "$dev" "$fwd")
+
+show() { # <heading> <entries...>
+  local heading=$1 e f n w
+  shift
+  [ $# -gt 0 ] || return 0
+  printf '  %s (%d):\n' "$heading" "$#"
+  for e in "$@"; do
+    IFS='|' read -r f n w <<<"$e"
+    printf '    %-44s %-9s %s\n' "$f" "$n" "$w"
+  done
+  echo
+}
+
+show "explained by the forwarding" ${explained[@]+"${explained[@]}"}
+if [ "$gap" -gt 0 ]; then
+  printf '  upstream gap: %d path(s) in the vendored strand\n\n' "$gap"
+fi
+show "UNEXPLAINED" ${unexplained[@]+"${unexplained[@]}"}
+
+if [ ${#unexplained[@]} -eq 0 ]; then
+  echo "CONVERGED: the two branches differ only where the forwarding explains it."
+  exit 0
+fi
+echo "DIVERGED: ${#unexplained[@]} path(s) the forwarding does not explain."
+echo "  Each is a difference somebody has to account for before the swap:"
+echo "  a fix folded on one branch and not the other, a port that reached one"
+echo "  of them, or a carry that stage 5 could not make. See"
+echo "  .claude/skills/series-forward.md."
+exit 1

--- a/scripts/series-cutover.sh
+++ b/scripts/series-cutover.sh
@@ -100,6 +100,26 @@ if [ -n "$old_up" ]; then
   fi
 fi
 
+# Convergence: the coverage gate above asks whether the forward has vendored far
+# enough, which is a statement about how much upstream it reaches and none at all
+# about what it carries. This asks the other half -- whether the two branches
+# still hold the same package -- and prints it here so the operator confirms with
+# it on screen. It reports rather than refuses: the invariant's second half is
+# *explicable*, and whether a difference is explicable is a judgement no script
+# can make -- which is why this prints and the human decides.
+echo
+rc=0
+"$(dirname "$0")/series-converge.sh" "$S" "$remote" --no-fetch || rc=$?
+# 1 is a divergence to read; 2 is the comparison not being available at all --
+# a series that started as `-fwd` has no `<S>-dev` to compare against, and the
+# script has already said so on its own.
+if [ "$rc" -eq 1 ]; then
+  echo
+  echo "  ^ read these before confirming. A swap does not resolve them: it makes"
+  echo "    them the serving branch's, on the lineage r-universe builds from."
+fi
+echo
+
 leases=()
 refspecs=()
 echo "refs to swap:"


### PR DESCRIPTION
Stage 5 refused to extend a series whose forward counterpart was live — `series-advance.sh` printed `has a live forward counterpart — not extending` and stopped. The series being replaced then kept its refs and stopped moving. That costs twice.

**The cutover became unverifiable.** A forward series is the same series rebuilt on a newer `main`, so its history differs by construction and its content must not. What says a swap is safe is that the two `-dev` branches carry the same package. A base frozen where the forward went live can only be compared at the commit it stopped on — the one point the two are already known to agree — so every commit the forward vendored afterwards had nothing to be checked against. On `main` today that is 73 upstream commits: `main-green` vendors `76dd1e7d6f` while `main-fwd-green` sits on the upstream tip `f8e1c96a53`.

**It starved the carry.** Stage 5 folds the base `-dev`'s test-side fixes into the forward as each buffer commit is consumed, matched by vendored SHA (#2594). Past the base's frontier there is no twin to match, so a fix the base had already proved comes back as a red on the forward — a repair plus a replay of everything above it. `main-fwd-dev` shows it directly: of its ten `Carried from` commits, six were written by the script and all sit below `main-dev`'s frontier; the newest one above it had to be made by hand out of `main-build`.

So a base series now consumes, ports and verifies like any other, and the two lineages run level until a human swaps them. This is deliberately more CI on a lineage about to be retired. It is also the only thing that makes retiring it a check rather than a hope.

## The invariant

Stated in `handbook/branches/invariants/` and in `series-forward.md`, for a series `S`:

> At the end of a forwarding, `S-dev` and `S-fwd-dev` are identical, or every difference between them is explicable.

A claim about trees, never about ancestry — the two share a seed generation and nothing below it, the version counters are renumbered, and the ported commits the replay leaves behind are content the new seed already carries.

`scripts/series-converge.sh` (new, read-only) reads it: diffs the two branches and sorts every differing path into what the forwarding explains and what it does not. Three classes are explained, each on its own evidence:

- `DESCRIPTION`'s `Version:` line, which the replay renumbers — checked line-wise, so anything else in that file is still a finding.
- `NEWS.md`, the release paperwork a `fledge:` commit carries and stage 4 never ports.
- The **vendored strand** — `src/duckdb/`, `patch/`, `R/version.R`, `src/include/sources.mk` and the Makevars — but **only while the two branches vendor different upstream commits**. Every file in it is a function of the upstream tree: `R/version.R` carries the engine's own version (`1.6.0-dev12322` against `1.6.0-dev12739` on `main` today), the source list and the Makevars are generated from that tree, and `patch/` retires entries as upstream absorbs them. Once both sit on the same upstream SHA the whole strand must agree, which is what `series-forward-build.sh` already verifies at replay time.

Everything else is a finding. It reports and never refuses — whether a difference is explicable is a judgement no script can make. `series-cutover.sh` prints the same reading immediately before it asks for confirmation, and `series-check.sh` names it beside the CUTOVER line.

The class list stays short by design, and an explained difference is still printed with its line counts. A class is earned by evidence that the difference is benign, never by another script excluding the same path: stage 5's carry excludes the generated files so the twin's copy cannot overwrite what the buffer just regenerated, which says nothing about whether the two branches may differ there — and on the live series they do not.

## What it finds today

Run against the three live series (interim reads; none of the pairs is at the same upstream commit yet):

- `main` — 10 unexplained paths, including `src/database.cpp`, `src/register.cpp`, `src/statement.cpp`, `src/utils.cpp`, `tests/testthat/_snaps/types.md`, and `tests/testthat/test-variant.R`, which the forward lacks entirely (202 lines).
- `v1.5-variegata` — 4, including `src/duckdb-win.def` on the base against `src/duckdb.1.5.dev-win.def` on the forward, which is a flavor-identity difference.
- `v1.4-andium` — 9, mostly `plan/` and `AGENTS.md` the forward's seed lacks, plus `configure`.

These are findings for the series, not for this PR; they belong to the stages that should have moved them.

## Also in here

A SIGPIPE flake in `series-advance-test.sh`: its `at()` and `wat()` helpers piped `git log` into `grep -m1`, and the early exit surfaced through `pipefail` as an intermittent `141` that aborted the run rather than failing a check — the same rule `series-check.sh` already documents for `grep -q`. It bit once in four runs here. Fixed in place, because the suite has to be trustworthy to review the rest of this.

## Verification

- `scripts/series-advance-test.sh`: 54 passed, 0 failed, four consecutive runs. Gains an eleventh claim covering the change; reverting `series-advance.sh` alone fails three of its checks.
- `scripts/series-converge.sh` run against all three real series, and against a synthetic pair for the branches real data does not reach: the same-upstream-SHA case, where the generated files and the vendored tree must all be findings; `DESCRIPTION` differing beyond `Version:`; and the fully converged case (exit 0).
- Exit codes: 0 converged, 1 diverged, 2 no comparison available. `series-cutover.sh` distinguishes 1 from 2 so a series opened directly as a forward does not draw a spurious warning.

## Note on scope

This changes how much CI the loop spends: a base series with a live forward now builds every commit its buffer holds, alongside the forward doing the same work. `main` has 60 such commits buffered today. That cost is the point of the change rather than an oversight, but it is the thing to push back on if the trade is wrong.