### PR TITLE
fix(series): Refuse to replay when the `ours-version` merge driver is missing

### DIFF
--- a/scripts/series-advance.sh
+++ b/scripts/series-advance.sh
@@ -78,6 +78,16 @@ if [ -n "$ABORT" ]; then
   exit 0
 fi
 
+# Every buffer commit stage 5 replays moves `Version:`, so the `ours-version`
+# merge driver decides DESCRIPTION on each pick. The name -> command mapping
+# lives in .git/config and cannot be committed, so a fresh clone has the
+# attribute (.gitattributes) and not the driver, and the replay stops on a
+# DESCRIPTION conflict indistinguishable from one a human has to resolve.
+# Refuse up front, as scripts/series-forward-build.sh already does. After the
+# --abort branch, so a stopped replay can always be discarded.
+git config --get merge.ours-version.driver >/dev/null ||
+  { echo "Error: merge driver not registered, run scripts/setup-git.sh" >&2; exit 1; }
+
 git fetch -q "$remote"
 green="$remote/$S-green"; dev="$remote/$S-dev"; build="$remote/$S-build"; base="$remote/$S-build-base"
 for r in "$green" "$dev" "$build" "$base"; do

--- a/scripts/series-port.sh
+++ b/scripts/series-port.sh
@@ -110,6 +110,13 @@ vendor_subject_re='^vendor:|duckdb/duckdb@[0-9a-f]+'
 # (series-open.md step 2, series-forward.md step 1).
 seed_re='^chore: Update flavor patch to '
 
+# A pick that moves `Version:` is decided by the `ours-version` merge driver,
+# whose name -> command mapping lives in .git/config and cannot be committed.
+# A fresh clone has the attribute and not the driver, so refuse here rather
+# than stop mid-sequence on a DESCRIPTION conflict nobody has to resolve.
+git config --get merge.ours-version.driver >/dev/null ||
+  { echo "Error: merge driver not registered, run scripts/setup-git.sh" >&2; exit 1; }
+
 git fetch -q "$remote"
 dev="$remote/$S-dev" main="$remote/main"
 git rev-parse -q --verify "$dev" >/dev/null || { echo "Error: no $S-dev on $remote"; exit 1; }


### PR DESCRIPTION
`scripts/series-forward-build.sh` already checks for the `ours-version` merge driver before it replays. `scripts/series-advance.sh` and `scripts/series-port.sh` do not, and both cherry-pick commits that move `DESCRIPTION:Version`.

The name → command mapping has to live in `.git/config` (`scripts/setup-git.sh`); only the `DESCRIPTION merge=ours-version` attribute is committed, in `.gitattributes`. A fresh clone therefore carries the attribute without the driver, and stage 5 stops on the first buffer commit it replays:

```
Auto-merging DESCRIPTION
CONFLICT (content): Merge conflict in DESCRIPTION
error: could not apply d94da42ed... vendor: Update vendored sources to duckdb/duckdb@efcd7906c2bae482c2c89fee985c887be912b6a0

Error: main — replaying d94da42ed conflicted:
  DESCRIPTION
  cd /tmp/tmp.X4ieGvIxCT
  scripts/series-advance.sh main --continue      # or --abort to discard
```

That is indistinguishable from a conflict a human is meant to resolve — the script keeps the worktree and asks for `--continue`. Resolving it by hand instead of registering the driver takes our side of every counter and freezes the fifth version component for the whole replayed chain, which is exactly what the merge driver exists to prevent.

Both checks sit after argument handling, so `series-advance.sh <S> --abort` still discards a stopped replay in an unconfigured clone.

Evidence: the 2026-08-15 firing of the series loop hit this on `main` in a clone of `krlmlr/duckdb-r` made that morning; `scripts/setup-git.sh` unstuck it, and the same firing then replayed 60 commits onto `main-dev` cleanly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKrzUtbUeMuScpViRcNj5y)_