### PR TITLE
feat(series): Carry `patch/` entries onto the buffer as part of porting

### DIFF
--- a/.claude/skills/series-loop.md
+++ b/.claude/skills/series-loop.md
@@ -745,6 +745,23 @@ and the commit that reaches `-dev` from it
 arrives broken again on exactly the platform the patch was for.
 Commit it onto `<S>-build` as well, in the same firing.
 
+**The entry a firing did not write is the one that goes missing.**
+Stage 4's port carries whole `main` commits onto `-dev`,
+`patch/` files included,
+so an entry born as a pull request against `main`
+reaches every `-dev` without any firing deciding to put it there —
+and reaches no buffer at all.
+The drift is quiet while upstream leaves the patched file alone,
+because the buffer is then internally consistent
+and its commits carry no delta for that file;
+it bites the first time upstream touches it,
+and the fix is reverted on `-dev`
+by a commit that looks like an ordinary vendor.
+`scripts/series-check.sh` prints a PATCH DRIFT line per series
+naming what the two stacks differ by, in both directions —
+a renamed entry is one of each — and closing it is stage 3's work
+like any patch this stage writes.
+
 ### 4. Port from `main`
 
 The goal is identity, not curation:

--- a/.claude/skills/series-loop.md
+++ b/.claude/skills/series-loop.md
@@ -745,22 +745,45 @@ and the commit that reaches `-dev` from it
 arrives broken again on exactly the platform the patch was for.
 Commit it onto `<S>-build` as well, in the same firing.
 
-**The entry a firing did not write is the one that goes missing.**
-Stage 4's port carries whole `main` commits onto `-dev`,
+**The entry a firing did not write is carried by stage 4, not by hand.**
+Stage 4's port brings whole `main` commits onto `-dev`,
 `patch/` files included,
 so an entry born as a pull request against `main`
 reaches every `-dev` without any firing deciding to put it there —
-and reaches no buffer at all.
-The drift is quiet while upstream leaves the patched file alone,
+and used to reach no buffer at all.
+`scripts/series-port.sh --apply` now closes that as part of porting,
+through `scripts/series-patch-sync.sh <S>`,
+which is a read-only report on its own.
+The drift it exists to prevent is quiet
+while upstream leaves the patched file alone,
 because the buffer is then internally consistent
 and its commits carry no delta for that file;
 it bites the first time upstream touches it,
 and the fix is reverted on `-dev`
 by a commit that looks like an ordinary vendor.
-`scripts/series-check.sh` prints a PATCH DRIFT line per series
-naming what the two stacks differ by, in both directions —
-a renamed entry is one of each — and closing it is stage 3's work
-like any patch this stage writes.
+
+**The carry decides by test-applying, never by the file list.**
+A buffer runs ahead of `main`,
+so an entry `main` needs may not fit the engine the buffer has vendored,
+and committing it there regardless breaks the next vendor run
+(`vendor.sh`'s "patches moved" exit) rather than helping anything.
+Three answers, three situations:
+*carry* applies cleanly and is taken with its effect on the tree;
+*satisfied* reverse-applies, so only the entry is taken,
+to keep the two stacks named alike;
+*stale* is neither — upstream moved the code out from under it,
+and it reaches the buffer if and when the code it answers does.
+A candidate whose files an entry the buffer has and `-dev` lacks
+also touches is a **supersession** and is never carried:
+applying both is how the next vendor run breaks,
+and which of the two the buffer should end up with is judgement.
+
+`scripts/series-check.sh` still prints a PATCH DRIFT line per series,
+naming what the two stacks differ by in both directions —
+a renamed entry is one of each.
+It is the backstop, not the mechanism:
+what it reports after a port is what the carry deliberately declined,
+which is a stage 3 repair like any patch this stage writes.
 
 ### 4. Port from `main`
 

--- a/patch/0034-Guard-explicit-producer-token-in-concurrent-queue.patch
+++ b/patch/0034-Guard-explicit-producer-token-in-concurrent-queue.patch
@@ -1,0 +1,50 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Kirill=20M=C3=BCller?= <kirill@cynkra.com>
+Date: Sat, 19 Jul 2026 00:00:00 +0200
+Subject: [PATCH] Guard explicit producer token in concurrent queue
+
+The explicit-token enqueue paths in the vendored concurrent queue
+(moodycamel) dereference token.producer without a null check, unlike
+their implicit-producer siblings which return false when no producer is
+available. Because the compiler cannot prove token.producer is non-null,
+GCC 12+ (notably Rtools45's GCC 14.3.0 on Windows) assumes the atomic
+object may live at address zero and emits a false-positive
+-Wstringop-overflow ("writing 8 bytes into a region of size 0") for the
+8-byte atomic load inlined from ExplicitProducer::enqueue_bulk into
+EvictionQueue::PurgeIteration, which R CMD check reports as a
+significant warning.
+
+Add the same null guard already used by the implicit-producer overloads.
+This both silences the false positive at the source (no diagnostic
+pragma or compiler-flag override required) and makes the explicit-token
+enqueue paths as robust as the rest of the API.
+---
+ src/duckdb/third_party/concurrentqueue/concurrentqueue.h | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/src/duckdb/third_party/concurrentqueue/concurrentqueue.h b/src/duckdb/third_party/concurrentqueue/concurrentqueue.h
+index b62b637..e613c6a 100644
+--- a/src/duckdb/third_party/concurrentqueue/concurrentqueue.h
++++ b/src/duckdb/third_party/concurrentqueue/concurrentqueue.h
+@@ -1306,7 +1306,8 @@ private:
+ 	template<AllocationMode canAlloc, typename U>
+ 	inline bool inner_enqueue(producer_token_t const& token, U&& element)
+ 	{
+-		return static_cast<ExplicitProducer*>(token.producer)->ConcurrentQueue::ExplicitProducer::template enqueue<canAlloc>(std::forward<U>(element));
++		auto producer = static_cast<ExplicitProducer*>(token.producer);
++		return producer == nullptr ? false : producer->ConcurrentQueue::ExplicitProducer::template enqueue<canAlloc>(std::forward<U>(element));
+ 	}
+ 	
+ 	template<AllocationMode canAlloc, typename U>
+@@ -1319,7 +1320,8 @@ private:
+ 	template<AllocationMode canAlloc, typename It>
+ 	inline bool inner_enqueue_bulk(producer_token_t const& token, It itemFirst, size_t count)
+ 	{
+-		return static_cast<ExplicitProducer*>(token.producer)->ConcurrentQueue::ExplicitProducer::template enqueue_bulk<canAlloc>(itemFirst, count);
++		auto producer = static_cast<ExplicitProducer*>(token.producer);
++		return producer == nullptr ? false : producer->ConcurrentQueue::ExplicitProducer::template enqueue_bulk<canAlloc>(itemFirst, count);
+ 	}
+ 	
+ 	template<AllocationMode canAlloc, typename It>
+-- 
+2.52.0

--- a/patch/0035-Silence-deprecated-Catalog-GetEntry-self-delegation.patch
+++ b/patch/0035-Silence-deprecated-Catalog-GetEntry-self-delegation.patch
@@ -1,0 +1,58 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Kirill=20M=C3=BCller?= <kirill@cynkra.com>
+Date: Fri, 31 Jul 2026 00:00:00 +0000
+Subject: [PATCH] Silence deprecated Catalog::GetEntry() self-delegation
+
+duckdb/duckdb@6d4f5328 deprecated the schema- and catalog/schema-qualified
+Catalog::GetEntry() overloads in favour of folding the qualification into
+EntryLookupInfo, but kept the old overloads as compatibility shims that
+delegate to one another. GCC warns on every one of those internal calls,
+even though the caller is itself deprecated (clang does not), and R CMD
+check reports them as significant warnings:
+
+  duckdb/src/catalog/catalog.cpp:1154:24: warning: '...GetEntry(...)' is
+  deprecated: Fold the schema into the EntryLookupInfo and use
+  GetEntry(retriever, EntryLookupInfo) [-Wdeprecated-declarations]
+
+Scope the diagnostic off for the one translation unit that holds the
+shims. Rewriting them to avoid the delegation would mean duplicating the
+private lookup logic in the vendored tree, and the deprecation is advisory
+only -- upstream keeps the overloads working.
+
+---
+ src/duckdb/src/catalog/catalog.cpp | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+diff --git a/src/duckdb/src/catalog/catalog.cpp b/src/duckdb/src/catalog/catalog.cpp
+index 1cd024735..a91cc7a8a 100644
+--- a/src/duckdb/src/catalog/catalog.cpp
++++ b/src/duckdb/src/catalog/catalog.cpp
+@@ -43,6 +43,16 @@
+ #include "duckdb/main/settings.hpp"
+ #include <algorithm>
+ 
++// For CRAN
++// The deprecated Catalog::GetEntry() compatibility overloads defined below
++// delegate to one another, which GCC reports as a significant warning during
++// R CMD check.  The delegation is upstream's own.
++#ifdef __GNUC__
++#  pragma GCC diagnostic push
++#  pragma GCC diagnostic ignored "-Wdeprecated-declarations"
++#endif
++// For CRAN
++
+ namespace duckdb {
+ 
+ Catalog::Catalog(AttachedDatabase &db) : db(db) {
+@@ -1396,3 +1406,9 @@ bool Catalog::HasConflictingAttachOptions(const string &path, const AttachOption
+ }
+ 
+ } // namespace duckdb
++
++// For CRAN
++#ifdef __GNUC__
++#  pragma GCC diagnostic pop
++#endif
++// For CRAN
+-- 
+2.54.0

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -119,6 +119,7 @@ Root of the documentation tree: [`handbook/`](/handbook/README.md).
 | [`series-cutover.sh`](series-cutover.sh) | Atomically replace a series with its forward counterpart. |
 | [`series-forward-build.sh`](series-forward-build.sh) | Populate `<S>-fwd-build`: replay every vendor commit of the old `<S>-build` onto HEAD, which must be the freshly flavored seed on current `main` (.claude/ski... |
 | [`series-glue.sh`](series-glue.sh) | Every R-side glue adaptation a series carries, in one read. |
+| [`series-patch-sync.sh`](series-patch-sync.sh) | Carry `patch/` entries from `<S>-dev` onto `<S>-build`, the way stage 5 carries tests and glue onto a forward series. |
 | [`series-port.sh`](series-port.sh) | Bring a series' -dev branch level with `main` — stage 4 of the series loop (.claude/skills/series-loop.md). |
 
 ## [`testing/snapshots/`](/handbook/testing/snapshots/README.md)

--- a/scripts/series-check.sh
+++ b/scripts/series-check.sh
@@ -316,21 +316,33 @@ for S in "${series[@]}"; do
   #
   # Reported in both directions, because a renamed entry is one of each and
   # neither half alone says so.
+  # Compared by blob, not by name: `main` also edits an entry in place, and the
+  # port brings the new content to `-dev` under a name the buffer already has,
+  # which a name-only comparison calls level.
   only_dev=$(comm -23 \
     <(git ls-tree --name-only "$dev" patch/ | sort) \
     <(git ls-tree --name-only "$build" patch/ | sort))
   only_build=$(comm -13 \
     <(git ls-tree --name-only "$dev" patch/ | sort) \
     <(git ls-tree --name-only "$build" patch/ | sort))
-  if [ -n "$only_dev$only_build" ]; then
+  differs=$(for n in $(comm -12 \
+      <(git ls-tree --name-only "$dev" patch/ | sort) \
+      <(git ls-tree --name-only "$build" patch/ | sort)); do
+    [ "$(git rev-parse "$dev:$n")" = "$(git rev-parse "$build:$n")" ] || echo "$n"
+  done)
+  if [ -n "$only_dev$only_build$differs" ]; then
     echo "  PATCH DRIFT  the two patch stacks of $S differ:"
     if [ -n "$only_dev" ]; then
-      sed 's|^patch/|               -dev only:   |' <<<"$only_dev"
+      sed 's|^patch/|               -dev only:    |' <<<"$only_dev"
     fi
     if [ -n "$only_build" ]; then
-      sed 's|^patch/|               -build only: |' <<<"$only_build"
+      sed 's|^patch/|               -build only:  |' <<<"$only_build"
     fi
-    echo "               bring $S-build level, each entry with its effect on the tree"
+    if [ -n "$differs" ]; then
+      sed 's|^patch/|               both, differ: |' <<<"$differs"
+    fi
+    echo "               scripts/series-patch-sync.sh $S says which of these it can carry;"
+    echo "               after a port, what is left is what it declined — stage 3 work"
   fi
 
   # Suggested, never done: a firing reports a ready cutover and stops

--- a/scripts/series-check.sh
+++ b/scripts/series-check.sh
@@ -16,6 +16,10 @@
 # gets a CUTOVER line: the command to run, for a human to run. The loop never
 # swaps a serving green itself (.claude/skills/series-loop.md).
 #
+# A series whose `-dev` carries `patch/` entries its `-build` lacks gets a
+# PATCH DRIFT line: the buffer regenerates its tree from its own patch stack, so
+# an entry that never reached it is one the next vendor run will not apply.
+#
 # Classification is by positive evidence only (.claude/skills/series-loop.md);
 # "Job is waiting for a hosted runner" appears in every log and means nothing.
 #
@@ -297,6 +301,36 @@ for S in "${series[@]}"; do
     echo "  IDLE   nothing in flight, buffer empty — vendor"
   else
     echo "  ADVANCE"
+  fi
+
+  # A `patch/` entry that only ever reached `-dev` is absent the next time the
+  # buffer vendors: `vendor-one.sh` applies the *buffer's* patch stack to every
+  # tree it regenerates (.claude/skills/series-loop.md stage 3). Stage 4's port
+  # is how such an entry arrives -- it carries whole `main` commits onto `-dev`,
+  # `patch/` files included -- and `-build` takes no ports by design, so nothing
+  # closes the gap by itself. The drift is quiet while upstream leaves the
+  # patched file alone, because the buffer is then internally consistent and its
+  # commits carry no delta for that file; it bites the first time upstream
+  # touches it, and the fix is reverted on `-dev` by a commit that looks like an
+  # ordinary vendor.
+  #
+  # Reported in both directions, because a renamed entry is one of each and
+  # neither half alone says so.
+  only_dev=$(comm -23 \
+    <(git ls-tree --name-only "$dev" patch/ | sort) \
+    <(git ls-tree --name-only "$build" patch/ | sort))
+  only_build=$(comm -13 \
+    <(git ls-tree --name-only "$dev" patch/ | sort) \
+    <(git ls-tree --name-only "$build" patch/ | sort))
+  if [ -n "$only_dev$only_build" ]; then
+    echo "  PATCH DRIFT  the two patch stacks of $S differ:"
+    if [ -n "$only_dev" ]; then
+      sed 's|^patch/|               -dev only:   |' <<<"$only_dev"
+    fi
+    if [ -n "$only_build" ]; then
+      sed 's|^patch/|               -build only: |' <<<"$only_build"
+    fi
+    echo "               bring $S-build level, each entry with its effect on the tree"
   fi
 
   # Suggested, never done: a firing reports a ready cutover and stops

--- a/scripts/series-patch-sync.sh
+++ b/scripts/series-patch-sync.sh
@@ -1,0 +1,185 @@
+#!/bin/bash
+# Carry `patch/` entries from `<S>-dev` onto `<S>-build`, the way stage 5 carries
+# tests and glue onto a forward series.
+#
+# `vendor-one.sh` applies the *buffer's* `patch/*.patch` to every tree it
+# regenerates, so the buffer is where an entry has to live to have any effect on
+# what the series vendors next. Entries arrive on `-dev` two ways, and only one
+# of them puts them there:
+#
+#   * a firing writes one during a repair -- stage 3 says to commit it onto
+#     `<S>-build` in the same firing, and that is the half that works;
+#   * stage 4's port carries whole `main` commits onto `-dev`, `patch/` files
+#     included, so an entry born as a pull request against `main` reaches every
+#     `-dev` without any firing deciding to put it there -- and reaches no
+#     buffer at all, because `-build` takes no ports by design (stage 1).
+#
+# The second half is what this closes. The drift is quiet while upstream leaves
+# the patched file alone, because the buffer is then internally consistent and
+# its commits carry no delta for that file; it bites the first time upstream
+# touches one, and the fix is reverted on `-dev` by a commit that reads as an
+# ordinary vendor.
+#
+# **What carries is decided by test-applying, never by the file list.** A buffer
+# runs ahead of `main`, so an entry that `main` needs may not fit the engine the
+# buffer has vendored, and committing it there regardless would break the next
+# vendor run outright (`vendor.sh`'s "patches moved" exit) rather than help
+# anything. Each candidate is applied against the buffer's own tree first, and
+# the three answers are three different situations:
+#
+#   carry      applies cleanly -- taken, with its effect on the tree
+#   satisfied  reverse-applies: the effect is already in the buffer's tree, so
+#              only the entry itself is taken, to keep the two stacks identical
+#   stale      neither -- upstream moved the code out from under it. Reported and
+#              left alone: on this series' engine the entry answers nothing, and
+#              it reaches the buffer if and when the code it answers does.
+#
+# A candidate is any entry `-dev` has that the buffer does not have *in the same
+# bytes*. Comparing names alone misses the entry `main` edits in place -- widened
+# to cover more, or re-rooted after upstream moved -- which the port brings to
+# `-dev` while the buffer keeps the old content, under a name that matches.
+# `0009-Remove-stderr-for-zstd` is the standing example, and a name-only
+# comparison calls those two stacks level.
+#
+# A candidate whose files are also touched by an entry the buffer has and `-dev`
+# does not is a **supersession**, not an addition -- `0003-Fix-clang-warnings-in-re2`
+# replacing `0003-Try-to-ignore-clang-warnings` is the standing example, the real
+# fix displacing the pragma that used to stand in for it. Which of the two the
+# buffer should end up with is judgement, and applying both is how the next
+# vendor run breaks, so those are reported and never carried.
+#
+# Entries the buffer has and `-dev` does not are the series' own, written by a
+# repair against an engine `main` has not reached. They are listed for the sake
+# of the other direction of this question -- one that applies to `main`'s tree
+# today belongs on `main`, where stage 4 spreads it by itself
+# (.claude/skills/series-loop.md stage 3) -- and never removed here.
+#
+# Usage: series-patch-sync.sh <series> [--apply]     # default: report only
+
+set -euo pipefail
+
+usage='usage: series-patch-sync.sh <series> [--apply]'
+S=${1:?$usage}
+apply=
+case "${2:-}" in
+  '') ;;
+  --apply) apply=1 ;;
+  *) echo "$usage" >&2; exit 1 ;;
+esac
+
+remote=${REMOTE:-origin}
+git fetch -q "$remote"
+
+build="refs/remotes/$remote/$S-build"
+dev="refs/remotes/$remote/$S-dev"
+for r in "$build" "$dev"; do
+  git rev-parse -q --verify "$r" >/dev/null || { echo "$S: no $r" >&2; exit 1; }
+done
+
+targets() { sed -nr 's|^\+\+\+ b/(.*)$|\1|p' "$1" | sed 's/\t.*//' | sort -u; }
+
+dev_only=$(comm -23 \
+  <(git ls-tree --name-only "$dev" patch/ | sort) \
+  <(git ls-tree --name-only "$build" patch/ | sort))
+build_only=$(comm -13 \
+  <(git ls-tree --name-only "$dev" patch/ | sort) \
+  <(git ls-tree --name-only "$build" patch/ | sort))
+
+# An entry can drift without either side gaining or losing a name: `main` edits
+# one in place -- widening what it covers, re-rooting it after upstream moved --
+# and the port brings the new content to `-dev` while the buffer keeps the old.
+# A name-only comparison reports the two stacks level and is wrong, so the
+# entries both sides have are compared by blob and join the candidates.
+both=$(comm -12 \
+  <(git ls-tree --name-only "$dev" patch/ | sort) \
+  <(git ls-tree --name-only "$build" patch/ | sort))
+for n in $both; do
+  if [ "$(git rev-parse "$dev:$n")" != "$(git rev-parse "$build:$n")" ]; then
+    dev_only=$(printf '%s\n%s' "$dev_only" "$n")
+  fi
+done
+dev_only=$(printf '%s' "$dev_only" | grep . | sort || true)
+
+if [ -z "$dev_only$build_only" ]; then
+  echo "$S: patch stacks level"
+  exit 0
+fi
+
+wt=$(mktemp -d "${TMPDIR:-/tmp}/series-patch-sync-$S-XXXXXX")
+trap 'git worktree remove --force "$wt" 2>/dev/null || true' EXIT
+git worktree add -q --detach "$wt" "$build"
+
+# Files the buffer's own entries speak for; a candidate touching one of them is
+# a supersession for somebody to decide, not an addition to make.
+claimed=$(for n in $build_only; do
+  git show "$build:$n" > "$wt/.sync-patch" && targets "$wt/.sync-patch"
+done | sort -u)
+rm -f "$wt/.sync-patch"
+
+carried=() satisfied=() stale=() superseded=()
+for n in $dev_only; do
+  p="$wt/.sync-candidate"
+  git show "$dev:$n" > "$p"
+  if [ -n "$claimed" ] && comm -12 <(targets "$p") <(printf '%s\n' "$claimed") | grep -q .; then
+    superseded+=("$n"); rm -f "$p"; continue
+  fi
+  if patch -d "$wt" -i "$p" -p1 --forward --dry-run >/dev/null 2>&1; then
+    carried+=("$n")
+  elif patch -d "$wt" -i "$p" -p1 --reverse --forward --dry-run >/dev/null 2>&1; then
+    satisfied+=("$n")
+  else
+    stale+=("$n")
+  fi
+  rm -f "$p"
+done
+
+report() {
+  local label=$1 first=1; shift
+  for x in "$@"; do
+    [ -n "$x" ] || continue
+    printf '  %-11s %s\n' "$([ "$first" = 1 ] && echo "$label")" "$x"
+    first=0
+  done
+}
+echo "=== $S"
+report carry "${carried[@]:-}"
+report satisfied "${satisfied[@]:-}"
+report stale "${stale[@]:-}"
+report supersedes "${superseded[@]:-}"
+# shellcheck disable=SC2086  # one entry per line, split deliberately
+report buffer-own $build_only
+
+if [ -z "$apply" ]; then
+  [ "${#carried[@]}${#satisfied[@]}" = "00" ] || echo "  (report only — rerun with --apply)"
+  exit 0
+fi
+if [ "${#carried[@]}" = 0 ] && [ "${#satisfied[@]}" = 0 ]; then
+  echo "  nothing to carry"
+  exit 0
+fi
+
+for n in "${carried[@]:-}" "${satisfied[@]:-}"; do
+  [ -n "$n" ] || continue
+  git show "$dev:$n" > "$wt/$n"
+done
+for n in "${carried[@]:-}"; do
+  [ -n "$n" ] || continue
+  patch -d "$wt" -i "$wt/$n" -p1 --forward --no-backup-if-mismatch
+done
+
+git -C "$wt" add -A
+git -C "$wt" commit -q -F - <<EOF
+fix(patch): Carry $((${#carried[@]} + ${#satisfied[@]})) entr$([ $((${#carried[@]} + ${#satisfied[@]})) -eq 1 ] && echo y || echo ies) from $S-dev onto the buffer
+
+\`vendor-one.sh\` applies the buffer's own \`patch/*.patch\` to every tree it
+regenerates, so an entry that only ever reached \`-dev\` is absent from the next
+vendor run and the commit that reaches \`-dev\` from it arrives broken again.
+
+Each was test-applied against this buffer's tree before being taken:
+${carried[*]:+carried with its effect: ${carried[*]}}
+${satisfied[*]:+already in the tree, entry taken to match the names: ${satisfied[*]}}
+EOF
+
+next=$(git -C "$wt" rev-parse HEAD)
+git push "$remote" "$next:refs/heads/$S-build"
+echo "  build -> $(git rev-parse --short "$next")"

--- a/scripts/series-port.sh
+++ b/scripts/series-port.sh
@@ -284,7 +284,17 @@ next=$(git -C "$wt" rev-parse HEAD)
 git worktree remove --force "$wt"
 if [ "$next" = "$(git rev-parse "$dev")" ]; then
   echo "nothing to port"
-  exit 0
+else
+  git push "$remote" "$next:refs/heads/$S-dev"
+  echo "dev -> $(git rev-parse --short "$next")"
 fi
-git push "$remote" "$next:refs/heads/$S-dev"
-echo "dev -> $(git rev-parse --short "$next")"
+
+# A port is how a `patch/` entry written against `main` reaches this series, and
+# `-dev` is not where it does anything: `vendor-one.sh` applies the *buffer's*
+# stack to every tree it regenerates. Carrying it on is part of porting, not a
+# separate errand somebody remembers -- so it runs here, on every --apply, and
+# whether or not this run had commits to pick. The carry decides by
+# test-applying against the buffer's own tree, because a buffer runs ahead of
+# `main` and an entry that does not fit its engine would break the next vendor
+# run rather than help it.
+"$(dirname "$0")/series-patch-sync.sh" "$S" --apply

--- a/src/duckdb/src/catalog/catalog.cpp
+++ b/src/duckdb/src/catalog/catalog.cpp
@@ -43,6 +43,16 @@
 #include "duckdb/main/settings.hpp"
 #include <algorithm>
 
+// For CRAN
+// The deprecated Catalog::GetEntry() compatibility overloads defined below
+// delegate to one another, which GCC reports as a significant warning during
+// R CMD check.  The delegation is upstream's own.
+#ifdef __GNUC__
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+// For CRAN
+
 namespace duckdb {
 
 Catalog::Catalog(AttachedDatabase &db) : db(db) {
@@ -1338,3 +1348,9 @@ bool Catalog::HasConflictingAttachOptions(const string &path, const AttachOption
 }
 
 } // namespace duckdb
+
+// For CRAN
+#ifdef __GNUC__
+#  pragma GCC diagnostic pop
+#endif
+// For CRAN

--- a/src/duckdb/third_party/concurrentqueue/concurrentqueue.h
+++ b/src/duckdb/third_party/concurrentqueue/concurrentqueue.h
@@ -1306,7 +1306,8 @@ private:
 	template<AllocationMode canAlloc, typename U>
 	inline bool inner_enqueue(producer_token_t const& token, U&& element)
 	{
-		return static_cast<ExplicitProducer*>(token.producer)->ConcurrentQueue::ExplicitProducer::template enqueue<canAlloc>(std::forward<U>(element));
+		auto producer = static_cast<ExplicitProducer*>(token.producer);
+		return producer == nullptr ? false : producer->ConcurrentQueue::ExplicitProducer::template enqueue<canAlloc>(std::forward<U>(element));
 	}
 	
 	template<AllocationMode canAlloc, typename U>
@@ -1319,7 +1320,8 @@ private:
 	template<AllocationMode canAlloc, typename It>
 	inline bool inner_enqueue_bulk(producer_token_t const& token, It itemFirst, size_t count)
 	{
-		return static_cast<ExplicitProducer*>(token.producer)->ConcurrentQueue::ExplicitProducer::template enqueue_bulk<canAlloc>(itemFirst, count);
+		auto producer = static_cast<ExplicitProducer*>(token.producer);
+		return producer == nullptr ? false : producer->ConcurrentQueue::ExplicitProducer::template enqueue_bulk<canAlloc>(itemFirst, count);
 	}
 	
 	template<AllocationMode canAlloc, typename It>


### PR DESCRIPTION
A `patch/` entry does nothing on `-dev`. `vendor-one.sh` applies the **buffer's** stack to every tree it regenerates, so `<S>-build` is where an entry has to live to affect what the series vendors next.

Entries reach `-dev` two ways and only one of them puts them there. A firing writing one during a repair is told by stage 3 to commit it onto the buffer in the same firing — that half works. But stage 4's port brings whole `main` commits over, `patch/` files included, so an entry born as a pull request against `main` arrives on every `-dev` without any firing deciding to put it there, and reaches no buffer at all, `-build` taking no ports by design.

The drift is quiet while upstream leaves the patched file alone, because the buffer is then internally consistent and its commits carry no delta for that file. It bites the first time upstream touches one: the buffer regenerates that file without the fix, and the commit that reaches `-dev` from it reverts the fix while reading as an ordinary vendor commit.

## What this changes

**Carry it where the port already runs**, rather than detecting the gap afterwards. `series-port.sh --apply` now finishes by calling the new `series-patch-sync.sh <S> --apply`, which is a read-only report on its own.

**What carries is decided by test-applying against the buffer's own tree**, never by the file list — a buffer runs ahead of `main`, so an entry `main` needs may not fit the engine the buffer has vendored, and committing it there regardless breaks the next vendor run outright rather than helping anything:

- `carry` — applies cleanly, taken with its effect on the tree
- `satisfied` — reverse-applies, so the effect is already there; the entry is taken alone, to keep the two stacks identical
- `stale` — neither: upstream moved the code out from under it, so on this engine the entry answers nothing

Two shapes are reported and never carried, because both are judgement and both break the next vendor run if guessed at:

- a **supersession** — a candidate whose files an entry the buffer has and `-dev` lacks also touches. `0003-Fix-clang-warnings-in-re2` displacing `0003-Try-to-ignore-clang-warnings` is the standing example: the real fix, hoisting and naming the anonymous struct, replacing the two `#pragma clang diagnostic ignored` lines that stood in for it.
- an entry **`main` edited in place**, which the port brings to `-dev` under a name the buffer already has. Candidates are therefore compared by blob; a name-only comparison calls those two stacks level. `0009-Remove-stderr-for-zstd` is that one today.

`series-check.sh` gains a `PATCH DRIFT` line per series, printed beside the verdict like `CUTOVER` is, naming what the two stacks differ by in all three directions. It is the **backstop, not the mechanism**: after a port, what it reports is precisely what the carry declined, which is stage 3 work.

Finally, two entries born on a series buffer are routed to `main`, which is where the loop says a fix belongs when it is not series-specific: `0034-Guard-explicit-producer-token-in-concurrent-queue` and `0035-Silence-deprecated-Catalog-GetEntry-self-delegation`. Both apply cleanly to `main`'s vendored tree today, and both keep the names the buffers already use, so the stacks match rather than growing a third spelling of the same diff.

## Measured, not assumed

Every entry in the union of the stacks was test-applied, reverse-applied and neither, against every buffer and every `-dev`. That is what separated the four cases above, and it caught one that a file-list carry would have got wrong: `0036-Mark-two-assert-only-bindings-used` and `0038-Initialize-every-member-of-DependencySubject` are on `main`, and on the `main` series' newer engine they fit nothing. Committing them to that buffer would have failed its next vendor run with `vendor.sh`'s "patches moved" exit.

The three entries born on a buffer that do **not** appear in the routing commit — `0036-Guard-assert-only-plan-verifiers`, `0037-Cast-to-void-in-the-default-aggregate-state-memset` and `0039-Return-past-the-exhaustive-DatePart-specifier-switches` — do not apply to `main`'s engine at all, so they stay series-specific by engine version and reach `main` when `main`'s engine reaches the code they answer.

## Effect on the branches

Run against all six series, the carry closed the drift on the four that had it (`main`, `main-fwd`, `v1.5-variegata`, `v1.5-variegata-fwd`; the two `v1.4-andium` series are frozen, take no ports, and were already level). The `0003` supersession was then resolved by hand as stage 3 work, reversing the entry being replaced and applying the replacement, with `src/duckdb/third_party/re2` verified byte-identical to each `-dev` afterwards.

What remains is `stale` only, and correctly so. No `-dev` branch was touched: buffers carry no CI, so closing all of this cost no check runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D36f3J68XGNUAu4o1DX5xD