### PR TITLE
fix(series): Make the `ours-version` driver reach the clone that needs it

### DIFF
--- a/scripts/series-advance-test.sh
+++ b/scripts/series-advance-test.sh
@@ -86,6 +86,12 @@ cp "$HERE/series-advance.sh" "$HERE/setup-git.sh" "$HERE/merge-version.sh" scrip
 chmod +x scripts/*.sh
 echo 'DESCRIPTION merge=ours-version' > .gitattributes
 
+# The attribute is committed and the name -> command mapping is not, so a fresh
+# clone has the first and never the second -- which is what series-advance.sh
+# refuses on up front (duckdb/duckdb-r#2659). Register it here, as every real
+# clone does, or the suite fails at the refusal rather than at what it checks.
+scripts/setup-git.sh >/dev/null
+
 desc() { printf 'Package: duckdb\nVersion: %s\n' "$1" > DESCRIPTION; }
 verfile() { echo "duckdb_version <- \"$1\"" > R/version.R; }
 

--- a/scripts/series-advance.sh
+++ b/scripts/series-advance.sh
@@ -496,7 +496,7 @@ else
   # driver exists for; register it here as series-port.sh does, so only genuine
   # conflicts reach the judgement above.
   if [ -x "$(dirname "$0")/setup-git.sh" ]; then
-    "$(dirname "$0")/setup-git.sh" >/dev/null
+    VENDOR_REPO="$(git rev-parse --show-toplevel)" "$(dirname "$0")/setup-git.sh" >/dev/null
   fi
 
   # Where the run stops, and how it says so. The worktree is kept: it holds the

--- a/scripts/series-port.sh
+++ b/scripts/series-port.sh
@@ -243,7 +243,7 @@ fi
 # keeps that line off the conflict list. Idempotent; .git/config is shared with
 # the worktree.
 if [ -x "$(dirname "$0")/setup-git.sh" ]; then
-  "$(dirname "$0")/setup-git.sh" >/dev/null
+  VENDOR_REPO="$(git rev-parse --show-toplevel)" "$(dirname "$0")/setup-git.sh" >/dev/null
 fi
 
 # The default fill is what a frozen series does not get: `--list --apply` shows

--- a/scripts/setup-git.sh
+++ b/scripts/setup-git.sh
@@ -5,9 +5,26 @@
 #
 # The merge-driver *name -> command* mapping must live in .git/config; only the
 # `DESCRIPTION merge=ours-version` attribute itself is committed (.gitattributes).
+#
+# The checkout to configure, so a caller running `main`'s copy of this script
+# configures the clone it is operating on rather than the one the script came
+# from. The series loop invokes tooling from `main` against another checkout
+# (.claude/skills/series-loop.md stage 1), and without this the config lands in
+# the `main` checkout, the target clone keeps no driver at all, and the only
+# report is a success line naming neither. Same variable, and the same worktree
+# check, as scripts/vendor-one.sh: one export configures whichever clone the
+# firing is working in.
 set -euo pipefail
 
-cd "$(dirname "$0")/.."
+cd "${VENDOR_REPO:-$(dirname "$0")/..}"
+toplevel=$(git rev-parse --show-toplevel 2>/dev/null) || {
+  echo "Error: $PWD is not a git worktree" >&2
+  exit 1
+}
+[ "$toplevel" -ef . ] || {
+  echo "Error: $PWD is not the root of its worktree ($toplevel)" >&2
+  exit 1
+}
 
 git config merge.ours-version.name   "Combine DESCRIPTION version counters (see scripts/merge-version.sh)"
 git config merge.ours-version.driver "scripts/merge-version.sh %O %A %B"
@@ -19,4 +36,4 @@ git config rerere.enabled true
 # patch/am backend bypasses them. Pin it so rebases honour the driver.
 git config rebase.backend merge
 
-echo "git configured: merge driver 'ours-version', rerere, rebase.backend=merge"
+echo "git configured in $toplevel: merge driver 'ours-version', rerere, rebase.backend=merge"


### PR DESCRIPTION
Two ways the `ours-version` merge driver fails to reach the clone that needs it, both found by one firing of the series loop, both about the half of the registration that cannot be versioned.

**`scripts/setup-git.sh` configured the wrong repository.** The loop is told to run `main`'s copy of the tooling against the checkout it is operating on (`.claude/skills/series-loop.md`, stage 1), and this script resolved its target from `$(dirname "$0")/..` — the checkout it came *from*. Run that way it configured the `main` checkout, printed `git configured: merge driver 'ours-version', …` naming no repository, and left the target clone with no driver at all. `series-advance.sh` and `series-port.sh` then refuse with `Error: merge driver not registered, run scripts/setup-git.sh`, pointing at the script that had just reported success. It now takes its target from `VENDOR_REPO` — the variable `scripts/vendor-one.sh` already uses for exactly this, with the same worktree check — and names the repository it configured, because the failure it closes was a success message about a different one. The two internal call sites in `series-advance.sh` and `series-port.sh` pass the worktree they are replaying in; before this they re-registered the driver in the script's own checkout, so the safety net they exist to be was a no-op whenever the caller came from elsewhere.

**`scripts/series-advance-test.sh` has been red since #2659.** That change added the up-front refusal, and the offline suite builds its clone from scratch: it commits the `.gitattributes` entry, which is the versioned half, and never registers the mapping, which is not. So every run since has stopped at the refusal before reaching anything it checks — five failures and an `awk` error where the state file should have been. No workflow runs the script, so nothing reported it. Registering the driver in the fixture, as every real clone does, brings it back: 54 passed, 0 failed.

The two are one subject and land together because verifying the first needs the second green; they are on one branch because this session is confined to it.

Evidence, from the firing that hit it: `VENDOR_REPO` unset, `main`'s `setup-git.sh` run against a separate `krlmlr/duckdb-r` clone reported `git configured: …` and `git config --get merge.ours-version.driver` in that clone answered empty. With the change, the same invocation answers `scripts/merge-version.sh %O %A %B`, and the no-`VENDOR_REPO` path is unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_019t3geNmor5LNzNuRFTPy9Y)_