### PR TITLE
fix(series): Register the `ours-version` driver before refusing over it

### DIFF
--- a/scripts/series-advance.sh
+++ b/scripts/series-advance.sh
@@ -83,8 +83,16 @@ fi
 # lives in .git/config and cannot be committed, so a fresh clone has the
 # attribute (.gitattributes) and not the driver, and the replay stops on a
 # DESCRIPTION conflict indistinguishable from one a human has to resolve.
-# Refuse up front, as scripts/series-forward-build.sh already does. After the
-# --abort branch, so a stopped replay can always be discarded.
+#
+# Register it, then refuse if it is still missing. This script already knew how
+# to register it -- below, in the replay branch -- and a refusal reached first
+# made every firing run scripts/setup-git.sh by hand, because a firing runs in a
+# fresh clone. Idempotent, and .git/config is shared with the worktree the
+# replay uses. After the --abort branch, so a stopped replay can always be
+# discarded.
+if [ -x "$(dirname "$0")/setup-git.sh" ]; then
+  VENDOR_REPO="$(git rev-parse --show-toplevel)" "$(dirname "$0")/setup-git.sh" >/dev/null
+fi
 git config --get merge.ours-version.driver >/dev/null ||
   { echo "Error: merge driver not registered, run scripts/setup-git.sh" >&2; exit 1; }
 
@@ -493,11 +501,8 @@ else
   # Every buffer commit bumps DESCRIPTION's vendor counter, so a -dev that has
   # taken a fledge bump conflicts on the `Version:` line at the first replayed
   # commit and at every one after it. That line is what the ours-version merge
-  # driver exists for; register it here as series-port.sh does, so only genuine
-  # conflicts reach the judgement above.
-  if [ -x "$(dirname "$0")/setup-git.sh" ]; then
-    VENDOR_REPO="$(git rev-parse --show-toplevel)" "$(dirname "$0")/setup-git.sh" >/dev/null
-  fi
+  # driver exists for, and the gate at the top of this script has registered it
+  # already, so only genuine conflicts reach the judgement above.
 
   # Where the run stops, and how it says so. The worktree is kept: it holds the
   # conflict, and whoever resolves it needs somewhere to do that. Nothing has

--- a/scripts/series-port.sh
+++ b/scripts/series-port.sh
@@ -112,8 +112,13 @@ seed_re='^chore: Update flavor patch to '
 
 # A pick that moves `Version:` is decided by the `ours-version` merge driver,
 # whose name -> command mapping lives in .git/config and cannot be committed.
-# A fresh clone has the attribute and not the driver, so refuse here rather
-# than stop mid-sequence on a DESCRIPTION conflict nobody has to resolve.
+# A fresh clone has the attribute and not the driver, so register it here and
+# refuse only if it is still missing -- refusing first made every firing run
+# scripts/setup-git.sh by hand for a step this script already took under
+# --apply. Idempotent; .git/config is shared with the worktree.
+if [ -x "$(dirname "$0")/setup-git.sh" ]; then
+  VENDOR_REPO="$(git rev-parse --show-toplevel)" "$(dirname "$0")/setup-git.sh" >/dev/null
+fi
 git config --get merge.ours-version.driver >/dev/null ||
   { echo "Error: merge driver not registered, run scripts/setup-git.sh" >&2; exit 1; }
 
@@ -240,11 +245,8 @@ fi
 
 # A pick can still meet DESCRIPTION's `Version:` -- a named VERSION commit, a
 # forward-port that carries one -- and the ours-version merge driver is what
-# keeps that line off the conflict list. Idempotent; .git/config is shared with
-# the worktree.
-if [ -x "$(dirname "$0")/setup-git.sh" ]; then
-  VENDOR_REPO="$(git rev-parse --show-toplevel)" "$(dirname "$0")/setup-git.sh" >/dev/null
-fi
+# keeps that line off the conflict list. The gate at the top of this script has
+# registered it already.
 
 # The default fill is what a frozen series does not get: `--list --apply` shows
 # the walk and still ports nothing, because seeing the candidates is not the


### PR DESCRIPTION
`scripts/series-advance.sh` and `scripts/series-port.sh` each refuse up front when `merge.ours-version.driver` is absent, telling the operator to run `scripts/setup-git.sh` — and each then registers the driver itself further down: `series-advance.sh` in its replay branch (added by #2659, given `VENDOR_REPO` by #2663), `series-port.sh` under `--apply`.

The guard reaches a fresh clone first, so the registration below it never runs and the refusal stands. Every firing of the series loop starts in a fresh container, which turns the one step both scripts already know how to take into a manual one on every single run.

Evidence from today's firing (2026-08-17), on the first ref motion of the pass:

```
$ scripts/series-advance.sh v1.4-andium
Error: merge driver not registered, run scripts/setup-git.sh
```

The guard is `scripts/series-advance.sh:88` and `scripts/series-port.sh:117`; the registration each script performs anyway is at `series-advance.sh:499` and `series-port.sh:245`. The firing worked around it by hand and finished, per stage 7 of `.claude/skills/series-loop.md`.

## The change

Register first, refuse only if the driver is still missing. The guard keeps its whole point — refuse rather than stop mid-replay on a `DESCRIPTION` conflict indistinguishable from one a human has to resolve — and the two later call sites become the no-ops they now are, so they go.

`scripts/series-forward-build.sh` refuses the same way and is deliberately left alone: it never registers the driver itself, so its guard is coherent, and it is a one-shot script a human runs during a forwarding rather than something a firing meets every time.

## Verification

- `scripts/series-advance-test.sh`: 54 passed, 0 failed.
- Against a clone with `merge.ours-version.driver` unset, both scripts now register it and carry on (`series-port.sh v1.5-variegata` printed its candidate list, `series-advance.sh v1.5-variegata` reported `green unchanged` / `buffer empty`), where before the patch both exited 1 with the message above.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JowKA86WUSFDnZdNLmh3Ac)_