### PR TITLE
feat(docs-consistency): Catch the drift classes a full review found by hand

### DIFF
--- a/.claude/skills/docs-consistency/SKILL.md
+++ b/.claude/skills/docs-consistency/SKILL.md
@@ -8,8 +8,10 @@ handbook pages, free-floating `.md` files, script headers,
 generated indexes — and periodically as a scheduled sweep.
 
 Judgment lives here; mechanics live in helpers.
-The one helper today is [`docs-readme.R`](docs-readme.R) in this
-directory, which renders and diffs the generated `scripts/` index.
+Two helpers live in this directory:
+[`docs-readme.R`](docs-readme.R) renders and diffs the generated
+`scripts/` index, and [`docs-links.py`](docs-links.py) walks the
+tracked Markdown for the link checks below.
 Helpers are not entry points of their own.
 
 ## Checks
@@ -20,7 +22,9 @@ Helpers are not entry points of their own.
    in its parent's navigation list, with a scope phrase.
    The root's per-area sketch names each area's actual
    next level; a renamed, added, or removed child
-   updates the sketch in the same change.
+   updates the sketch in the same change —
+   hold `ls -d handbook/*/*/` beside the sketch to see a child
+   the prose skipped, since the sketch reads fluently either way.
    Internal nodes navigate and may govern:
    a scope sentence, optionally the area's principles,
    and the list — nothing else,
@@ -30,31 +34,26 @@ Helpers are not entry points of their own.
    deepen line naming what remains.
 
 2. **Link integrity** (mechanical).
-   Every link under `handbook/` resolves,
-   and no link traverses upward with `../`
+   Every internal link under `handbook/` resolves,
+   no handbook link traverses upward with `../`
    (the rules, "The forms": a link that leaves its own directory
-   is written from the repository root).
+   is written from the repository root),
+   every `/handbook/…` link in a tracked `.md` outside the tree —
+   the backreferences — resolves too,
+   and every fragment on an internal Markdown link
+   matches a heading of the file it points into.
 
    ```sh
-   python3 - <<'EOF'
-   import os, re, sys
-   bad = 0
-   for dirpath, _, files in os.walk("handbook"):
-       for f in files:
-           p = os.path.join(dirpath, f)
-           for m in re.finditer(r"\]\(([^)#]+?)\)", open(p).read()):
-               t = m.group(1)
-               if t.startswith("http"):
-                   continue
-               if t.startswith(".."):
-                   print("UPWARD", p, t); bad += 1
-                   continue
-               base = "." if t.startswith("/") else dirpath
-               if not os.path.exists(os.path.normpath(base + "/" + t)):
-                   print("DANGLING", p, t); bad += 1
-   sys.exit(1 if bad else 0)
-   EOF
+   python3 .claude/skills/docs-consistency/docs-links.py
    ```
+
+   External links are outside the helper's reach.
+   Check this repository's own issue and pull-request links
+   with whatever GitHub access the session has,
+   and treat an unreachable foreign domain as unverified, not broken:
+   in a sandboxed session the proxy answers 000 or 403
+   for anything off the allow-list,
+   which says nothing about the link.
 
 3. **Generated indexes are fresh** (mechanical).
 
@@ -65,9 +64,35 @@ Helpers are not entry points of their own.
    Stale → regenerate and include the result in the same change.
    Never edit a generated file by hand.
 
-4. **Source-to-leaf coverage** (judgment).
+4. **Directory maps are complete** (mechanical, then judgment).
+   A leaf that presents itself as the map of a directory
+   is compared against that directory, both ways.
+   The one such map today is the workflow inventory
+   ([`handbook/operations/ci/workflows/`](/handbook/operations/ci/workflows/README.md)):
+
+   ```sh
+   diff <(basename -a .github/workflows/*.yaml | sort) \
+        <(grep -o '[A-Za-z0-9._-]*\.yaml' \
+            handbook/operations/ci/workflows/README.md | sort -u)
+   ```
+
+   A missing or extra row is repaired in the same change.
+   Whether each row's *fires on* still matches the file's `on:` block
+   is judged by reading the blocks — triggers drift silently,
+   and the prose keeps rendering either way.
+
+5. **Deepen lines are live** (mechanical, then judgment).
+   A deepen line's promises must still be redeemable.
+   List them with `grep -rn -A3 -- '\*To deepen:' handbook/`,
+   then check each issue a *drain* clause names
+   against the tracker with whatever GitHub access the session has —
+   a closed issue is drained or dropped, never left promised —
+   and each `§`-named section against the headings
+   of the file it would absorb.
+
+6. **Source-to-leaf coverage** (judgment).
    Every tracked source path is claimed by exactly one handbook
-   leaf. `scripts/` is machine-mapped in the helper's `groups`;
+   leaf. `scripts/` is machine-mapped in `docs-readme.R`'s `groups`;
    for the rest, walk the top-level directories
    (`R/`, `src/`, `tests/`, `.github/`, `patch/`, `inst/`, …)
    against the leaves' scope and deepen lines.
@@ -77,7 +102,7 @@ Helpers are not entry points of their own.
    per the address rule in
    [`handbook/operations/triage/`](/handbook/operations/triage/README.md).
 
-5. **Backreferences** (judgment).
+7. **Backreferences** (judgment).
    The tree is the single source of truth;
    every secondary document — the root `README.md`'s sections,
    reference pages, per-directory indexes,
@@ -86,16 +111,16 @@ Helpers are not entry points of their own.
    Any secondary document touched by the change under review
    must carry its backreference; add it or flag it.
 
-6. **Headers describe their files** (judgment).
-   The helper only extracts a first sentence;
+8. **Headers describe their files** (judgment).
+   `docs-readme.R` only extracts a first sentence;
    whether that sentence says what the file does is judged here.
    A weak or missing header is fixed at the source file,
    never patched over in the index.
 
-7. **Report and repair.**
+9. **Report and repair.**
    Apply the small fixes in the same change:
    regenerated indexes, navigation lists, links, backreferences,
-   header punctuation.
+   map rows, stale drain pointers, header punctuation.
    Report the structural findings instead of acting on them:
    unclaimed surface, a grouping that looks wrong,
    an internal node accreting prose, a leaf outgrowing its scope,

--- a/.claude/skills/docs-consistency/docs-links.py
+++ b/.claude/skills/docs-consistency/docs-links.py
@@ -1,0 +1,135 @@
+# Link integrity for the documentation system.
+# Run through the docs-consistency skill (SKILL.md in this directory);
+# helpers are not entry points of their own.
+#
+# Three claims, checked in one pass over the tracked Markdown:
+#
+#   1. every internal link in handbook/ resolves,
+#      and none climbs out of its directory with ../
+#      (the rules: a link that leaves its directory is root-relative);
+#   2. every /handbook/... link in a tracked .md outside the tree --
+#      the backreferences -- resolves too,
+#      which is what keeps a moved leaf from silently orphaning them;
+#   3. every fragment on an internal Markdown link matches a heading
+#      of the file it points into (GitHub's slug rules, approximated).
+#
+# External links are skipped entirely: http(s) targets cannot be
+# judged from here, and in a sandboxed session most domains are
+# unreachable anyway -- SKILL.md says what to do about them.
+#
+# Prints one line per finding (UPWARD / DANGLING / ANCHOR) and exits
+# non-zero when there are any; a clean run prints a one-line count.
+
+import os
+import re
+import subprocess
+import sys
+
+ROOT = subprocess.run(
+    ["git", "rev-parse", "--show-toplevel"],
+    capture_output=True, text=True, check=True,
+).stdout.strip()
+
+# Directories whose Markdown is written by foreign generators;
+# their links are the generator's, not this repository's to fix.
+FOREIGN = ("revdep/",)
+
+LINK = re.compile(r"\]\(([^)\s]+)\)")
+HEADING = re.compile(r"#{1,6}\s+(.*)")
+
+
+def tracked_md():
+    # Tracked plus untracked-but-not-ignored, so a page that is being
+    # written is checked before it is ever staged.
+    out = subprocess.run(
+        ["git", "ls-files", "--cached", "--others",
+         "--exclude-standard", "*.md"],
+        capture_output=True, text=True, check=True, cwd=ROOT,
+    ).stdout.splitlines()
+    return sorted(p for p in set(out) if not p.startswith(FOREIGN))
+
+
+def lines_outside_fences(path):
+    in_fence = False
+    with open(path, encoding="utf-8") as fh:
+        for line in fh:
+            if line.lstrip().startswith("```"):
+                in_fence = not in_fence
+                continue
+            if not in_fence:
+                yield line
+
+
+def slug(text):
+    # GitHub's ASCII slug: strip inline markup, lowercase,
+    # drop punctuation except - and _, spaces become hyphens.
+    text = re.sub(r"\[([^\]]*)\]\([^)]*\)", r"\1", text)
+    text = re.sub(r"[`*_]", "", text.strip())
+    text = re.sub(r"[^\w\- ]", "", text.lower())
+    return text.replace(" ", "-")
+
+
+def heading_slugs(path):
+    seen = {}
+    for line in lines_outside_fences(path):
+        m = HEADING.match(line)
+        if not m:
+            continue
+        s = slug(m.group(1))
+        n = seen.get(s, 0)
+        seen[s] = n + 1
+        if n:
+            seen[f"{s}-{n}"] = 1
+    return set(seen)
+
+
+def main():
+    bad = 0
+    links = 0
+    slug_cache = {}
+    files = tracked_md()
+
+    for rel in files:
+        path = os.path.join(ROOT, rel)
+        inside = rel.startswith("handbook/")
+        for line in lines_outside_fences(path):
+            for m in LINK.finditer(line):
+                raw = m.group(1)
+                if raw.startswith(("http://", "https://", "mailto:")):
+                    continue
+                target, _, frag = raw.partition("#")
+
+                if target == "":
+                    resolved = rel                      # same-page fragment
+                else:
+                    if inside and target.startswith(".."):
+                        print("UPWARD", rel, raw)
+                        bad += 1
+                        continue
+                    base = "" if target.startswith("/") else os.path.dirname(rel)
+                    resolved = os.path.normpath(
+                        os.path.join(base, target.lstrip("/"))
+                    )
+                    if not inside and not resolved.startswith("handbook/"):
+                        continue                        # outside: handbook links only
+                    links += 1
+                    if not os.path.exists(os.path.join(ROOT, resolved)):
+                        print("DANGLING", rel, raw)
+                        bad += 1
+                        continue
+
+                if frag and resolved.endswith(".md"):
+                    if resolved not in slug_cache:
+                        slug_cache[resolved] = heading_slugs(
+                            os.path.join(ROOT, resolved)
+                        )
+                    if frag not in slug_cache[resolved]:
+                        print("ANCHOR", rel, raw)
+                        bad += 1
+
+    print(f"{len(files)} files, {links} internal links, {bad} bad")
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/handbook/meta/handbook/README.md
+++ b/handbook/meta/handbook/README.md
@@ -270,8 +270,8 @@ takes no backreference; `man/*.Rd` is the only such case here.
 ## Enforcement
 
 Consistency is agent work.
-The checks — mechanical on shape, links and index freshness,
-judgment on mapping and headers —
+The checks — mechanical where a claim can be computed,
+judgment where it cannot —
 are the `docs-consistency` skill's
 (`.claude/skills/docs-consistency/`), which is the list;
 it runs when documentation is touched


### PR DESCRIPTION
Companion to #2667. The cover-to-cover handbook review behind that PR found five kinds of drift the `docs-consistency` skill could not see; this PR teaches the skill each of them, so the next occurrence is caught mechanically instead of by an hour of reading.

## What changes

**The inline link script becomes a helper, and checks more.** `docs-links.py` keeps the existing checks (every handbook link resolves, no upward `../`) and adds two the review had to do by hand: every `/handbook/…` backreference link in tracked Markdown *outside* the tree resolves (nothing else would catch a moved leaf orphaning them), and every fragment on an internal link matches a heading of its target file, using GitHub's slug rules. It scans tracked plus untracked-but-not-ignored files, so a page being written is checked before it is staged; `revdep/` is excluded as foreign-generated. Verified: a clean run on the current tree (137 files, 675 links), and deliberate negative tests for each finding class (DANGLING, UPWARD, ANCHOR — in both directions, inside the tree and from outside into it).

**A note on external links.** The helper skips `http(s)` deliberately; the skill now says what to do instead — verify this repository's own tracker links with whatever GitHub access the session has, and treat proxy-blocked foreign domains as unverified rather than broken (in a sandboxed session the proxy answers 000/403 for anything off the allow-list).

**Tree shape gains the sketch aid.** The root's per-area sketch check existed but was easy to skim past — the review found the `build/` sketch had been missing `warnings/` for a while. One command (`ls -d handbook/*/*/`) held beside the sketch makes a skipped child visible.

**New check: directory maps are complete.** A leaf that presents itself as the map of a directory is diffed against that directory, both ways. The workflow inventory is the one such map today; a one-line `diff` catches a missing row (on current `main` it flags `revdep2.yaml`, which #2667 repairs), and the trigger column stays a judgment read against the `on:` blocks.

**New check: deepen lines are live.** A `drain #N` promise on a closed issue and an `absorb § X` promise on a vanished section are both stale debt; the review found two of the former (#172, #1147, both closed upstream). The check lists the deepen lines mechanically and reads their promises against the tracker and the named files.

The Enforcement paragraph in `handbook/meta/handbook/` used to enumerate the check kinds and would have gone stale with this change; it now defers to the skill, which the rules already name as the list.

## Interplay with #2667

Not stacked — this branches from `main`. Until #2667 lands, two checks flag the pre-existing drift it repairs: the index-freshness check reports the stale `scripts/README.md`, and the new map check reports the missing `revdep2.yaml` row. Both go green once #2667 merges, in either merge order.

## Open question

The skill says it runs "when documentation is touched and periodically as a scheduled sweep", but nothing names where the periodic sweep lives — the stale `scripts/README.md` sitting unregenerated suggests the periodic half is not firing. Wiring it (a scheduled agent routine, or `docs-readme.R --check` plus `docs-links.py` as a cheap gate step) is left out of this PR deliberately, since where it should run is a maintainer's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MaFeMSqmQc3HxTpXpawDz7

---
_Generated by [Claude Code](https://claude.ai/code/session_01MaFeMSqmQc3HxTpXpawDz7)_