### PR TITLE
fix(rcc): Run the testsuite when `rcc-one.sh` runs outside Actions

### DIFF
--- a/scripts/rcc-one.sh
+++ b/scripts/rcc-one.sh
@@ -48,6 +48,9 @@
 #                           <dir>/outcomes.tsv, so scripts/each-shard.sh can
 #                           quote the failing stage into the run summary
 #   RCMDCHECK_ERROR_ON    - passed through to rcmdcheck (default: note)
+#   DUCKDB_R_RUN_TESTS    - read by tests/testthat.R; the `check` gate defaults
+#                           it to true so the suite runs outside Actions too,
+#                           and never overrides a value the caller set
 #   EACH_TIMEOUT_<STAGE>  - seconds a stage may take before it is presumed stuck
 #                           and killed (see stage_budget below); 0 disables the
 #                           bound for that stage
@@ -419,6 +422,11 @@ gate_check() {
 # package is not on CRAN, so every commit picks up a "New submission" NOTE.
 if (Sys.getenv("_R_CHECK_FORCE_SUGGESTS_", "") == "") Sys.setenv("_R_CHECK_FORCE_SUGGESTS_" = "false")
 if (Sys.getenv("_R_CHECK_CRAN_INCOMING_", "") == "") Sys.setenv("_R_CHECK_CRAN_INCOMING_" = "false")
+# `tests/testthat.R` falls back to GITHUB_ACTIONS / MY_UNIVERSE when this is
+# unset, so the suite runs in CI and silently does not run anywhere else. Opt in
+# here, without overriding a value the caller already set: the versions matrix
+# forces it to `false` under engine poisoning.
+if (Sys.getenv("DUCKDB_R_RUN_TESTS", "") == "") Sys.setenv("DUCKDB_R_RUN_TESTS" = "true")
 rcmdcheck::rcmdcheck(
   args = c("--no-manual", "--as-cran", "--no-multiarch"),
   build_args = "--no-manual",


### PR DESCRIPTION
`tests/testthat.R` guards the suite behind `DUCKDB_R_RUN_TESTS`, falling back to `GITHUB_ACTIONS` / `MY_UNIVERSE` when it is unset. `scripts/rcc-one.sh` never sets it, so its `check` gate runs the whole suite in CI and silently runs none of it anywhere else.

That matters because `rcc-one.sh` exists to be the same verdict as CI's — its own header calls it "the per-commit `rcc` gate … so the local verdict is CI's verdict, not an approximation of it" — and `.claude/skills/series-loop.md` stage 2 tells a firing to build and check a repair with it before force-pushing, on the grounds that "a repair that was not run locally is a guess". The repairs that stage folds in are mostly test-side: snapshot folds, test fixes, R code fixes. For exactly those, a green local run says nothing at all.

## Evidence from today's firing (2026-08-18)

The `main` series' r-universe build was red on `macos-oldrel-x86_64` in `test-storage-home.R:301` (`Out of Memory Error: failed to pin block of size 256.0 KiB (76.1 MiB/76.2 MiB used)`). The repair is a one-constant test change, so the firing ran the local gate on it first, per stage 2:

```
$ EACH_GATES="style check" scripts/rcc-one.sh
install  success
style    failure
check    failure
```

The `check` gate had reached `R CMD check` and reported `0 errors ✔ | 1 warning ✖ | 1 note ✖` — and the test output it printed was:

```
==============================================================================
Skipping the duckdb test suite.
...
==============================================================================
```

Nearly an hour of engine build, and the one file the repair touched was never executed. Note also how the two verdicts read together: `check` went red for `checking top-level files ... WARNING` (a missing `checkbashisms` on the host, nothing about the tree) while the thing under test quietly did not run. A firing reading only the outcome line gets the worst of both — a red that is not about the commit, over a pass that was never earned.

The firing worked around it by hand and finished, per stage 7: the repaired file is byte-identical to `main-fwd-dev`'s, whose chain is green on the same Linux gate at the same upstream tip, so the sibling branch's CI stood in for the local run.

## The change

Set `DUCKDB_R_RUN_TESTS` in `gate_check`, beside the two defaults the gate already applies, and guarded the same way — only when unset, so a value the caller set still wins. That last part is load-bearing: `.github/workflows/custom/before-install/action.yml` forces `DUCKDB_R_RUN_TESTS=false` under engine poisoning, via `$GITHUB_ENV`, and the versions matrix relies on it. `scripts/snapshot-accept.sh` already exports the same variable for the same reason, so the fix has precedent next door.

In CI nothing changes: `GITHUB_ACTIONS=true` already selected the suite there, and the poisoned leg still sets `false` first.

## Verification

Against the guard exactly as `tests/testthat.R` spells it:

```
off Actions, before        FALSE
off Actions, after         TRUE
caller set false, after    FALSE
```

`bash -n scripts/rcc-one.sh` clean.

Not in scope here, and mentioned only so it is not diagnosed twice: `gate_style` invokes `clang-format-21` by name, which turns the style gate red on any host that has a different clang-format, independently of the tree.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lir2Jp75Z9pYJupztZc9Th)_