### PR TITLE
fix(series): Read every universe that publishes a green, not just `duckdb`

### DIFF
--- a/.claude/skills/series-loop.md
+++ b/.claude/skills/series-loop.md
@@ -608,7 +608,12 @@ It prints, per package, the version and the commit built —
 naming the local ref when this clone knows it,
 which is how a red is attributed to a series —
 then one line per target that is not OK, with the log URL.
-Three access facts it exists to encapsulate, each paid for once:
+Four access facts it exists to encapsulate, each paid for once:
+the greens are published in **more than one universe** —
+`duckdb.r-universe.dev` builds the base series' greens
+and `krlmlr.r-universe.dev` the forward ones —
+so a read of one of them answers for half the series
+and reports all-OK over a failing `-fwd-green`;
 the `/builds` dashboard answers 403 to some fetchers
 while `https://<universe>.r-universe.dev` answers a plain curl;
 the build logs live in the GitHub repository `r-universe/<universe>`,

--- a/scripts/r-universe-check.sh
+++ b/scripts/r-universe-check.sh
@@ -7,17 +7,28 @@
 # and still ship a package that does not build, and nothing in the harvest on
 # branch `rcc` would say so. This script is that missing read.
 #
-# For every package in the universe it prints the version, the commit it was
-# built from, the local ref that commit is (when this clone knows it), and one
-# line per target that is not OK, with the URL of the log that says why.
+# For every package built from this repository it prints the version, the
+# commit it was built from, the local ref that commit is (when this clone knows
+# it), and one line per target that is not OK, with the URL of the log that
+# says why.
 #
 # Usage:
-#   r-universe-check.sh [<package>...]   # default: every package in the universe
-#   r-universe-check.sh --log <job-id>   # the full job log, to stdout
-#   RUNIVERSE=<name> r-universe-check.sh # another universe (default: duckdb)
+#   r-universe-check.sh [<package>...]    # default: every duckdb-r package
+#   r-universe-check.sh --log <job-id>    # the full job log, to stdout
+#   RUNIVERSE="<name>..." r-universe-check.sh  # other universes
 #
-# Three access facts, each paid for once (2026-08-03):
+# Four access facts, each paid for once (2026-08-03, 2026-08-18):
 #
+#   * **The greens are published in more than one universe**, so reading one of
+#     them answers for half the series. `duckdb.r-universe.dev` builds the base
+#     series' greens, `krlmlr.r-universe.dev` builds the forward (`-fwd`) ones,
+#     and a default covering only the first reports "all targets OK" while a
+#     `-fwd-green` is failing (`main-fwd-green` bf48f2a8f, two macOS x86_64
+#     targets timed out, 2026-08-18). Both are read by default; `RUNIVERSE`
+#     takes a space-separated list to narrow or extend that. A universe holds
+#     packages from other repositories too -- `krlmlr` publishes a dozen -- so
+#     the default package list is filtered to those whose `_upstream` is a
+#     `duckdb-r`; naming packages explicitly overrides the filter.
 #   * The `/builds` dashboard answers 403 to some fetchers, and the apex
 #     `r-universe.dev` may be unreachable where the per-universe subdomain is
 #     not. Everything below is on `https://<universe>.r-universe.dev`, which
@@ -37,25 +48,25 @@
 
 set -euo pipefail
 
-universe=${RUNIVERSE:-duckdb}
-host="https://$universe.r-universe.dev"
+read -r -a universes <<<"${RUNIVERSE:-duckdb krlmlr}"
 
 fetch() { curl -fsSL --retry 3 --max-time 120 "$1"; }
 
+# A job id belongs to whichever universe ran it, and the caller pasting one off
+# a log URL does not have to say which; ask each in turn.
 if [ "${1:-}" = "--log" ]; then
   job=${2:?usage: r-universe-check.sh --log <job-id>}
-  fetch "$host/api/actions/logs/$job"
-  exit
+  for universe in "${universes[@]}"; do
+    curl -fsL --retry 3 --max-time 120 \
+      "https://$universe.r-universe.dev/api/actions/logs/$job" && exit
+  done
+  echo "no universe served job $job" >&2
+  exit 1
 fi
 
 command -v jq >/dev/null || { echo "jq is required" >&2; exit 1; }
 
-packages=$(fetch "$host/api/packages")
-
 wanted=("$@")
-if [ ${#wanted[@]} -eq 0 ]; then
-  mapfile -t wanted < <(jq -r '.[].Package' <<<"$packages")
-fi
 
 # The ref this clone knows the built commit as. Exact hits only: the built
 # commit is a tip by construction (r-universe builds a branch), and walking
@@ -77,55 +88,83 @@ checktable() {
 }
 
 status=0
+seen=()
 
-for pkg in "${wanted[@]}"; do
-  meta=$(jq --arg p "$pkg" '.[] | select(.Package == $p)' <<<"$packages")
-  [ -n "$meta" ] || { echo "=== $pkg: not in $universe.r-universe.dev"; status=1; continue; }
+for universe in "${universes[@]}"; do
+  host="https://$universe.r-universe.dev"
+  packages=$(fetch "$host/api/packages")
 
-  version=$(jq -r '.Version' <<<"$meta")
-  commit=$(jq -r '._commit.id' <<<"$meta")
-  upstream=$(jq -r '._upstream' <<<"$meta")
-  ref=$(ref_for "$commit")
-
-  echo "=== $pkg $version -- ${commit:0:9} ${ref:+($ref) }<$upstream>"
-
-  rows=$(checktable "$pkg" || true)
-  if [ -z "$rows" ]; then
-    echo "  no check table -- the page moved, or the first build has not finished"
-    status=1
-    continue
+  # Naming packages overrides the filter; the default keeps the ones this
+  # repository publishes, since a universe carries other people's too.
+  if [ ${#wanted[@]} -gt 0 ]; then
+    pkgs=("${wanted[@]}")
+  else
+    mapfile -t pkgs < <(
+      jq -r '.[] | select(._upstream | test("/duckdb-r$")) | .Package' <<<"$packages"
+    )
   fi
 
-  bad=0
-  while IFS=$'\t' read -r target result seconds job; do
-    [ "$result" = OK ] && continue
-    bad=$((bad + 1))
-    printf '  %-8s %-24s %5ss  %s/api/actions/logs/%s\n' \
-      "$result" "$target" "$seconds" "$host" "$job"
-  done <<<"$rows"
-  [ "$bad" -eq 0 ] && echo "  all $(grep -c . <<<"$rows") targets OK"
-  [ "$bad" -eq 0 ] || status=1
+  header="--- $universe.r-universe.dev"
 
-  # A target whose newest binary is *older* than the indexed version is one
-  # whose build stopped producing artifacts: whoever installs from this
-  # universe is served that older one, however long ago it was built. Rows
-  # ahead of the index are the ordinary lag between building and indexing and
-  # say nothing. Versions compare component-wise as numbers, not as strings:
-  # `.9006` is not less than `.999`.
-  jq -r --arg v "$version" '
-      def vnum: [splits("[.]")] | map(tonumber);
-      ($v | vnum) as $cur
-      | [ ._binaries[]? | select(.version | vnum < $cur) ]
-      | group_by(.os + "-" + (.arch // "?"))
-      | map(max_by(.date))
-      | .[]
-      | [ "\(.os)-\(.arch // "?")", .version, .date[0:10] ]
-      | @tsv
-    ' <<<"$meta" |
-    sort |
-    while IFS=$'\t' read -r target older when; do
-      printf '  %-8s %-24s newest binary is %s, built %s\n' STALE "$target" "$older" "$when"
-    done
+  for pkg in "${pkgs[@]}"; do
+    meta=$(jq --arg p "$pkg" '.[] | select(.Package == $p)' <<<"$packages")
+    [ -n "$meta" ] || continue
+    seen+=("$pkg")
+    [ -n "$header" ] && { echo "$header"; header=; }
+
+    version=$(jq -r '.Version' <<<"$meta")
+    commit=$(jq -r '._commit.id' <<<"$meta")
+    upstream=$(jq -r '._upstream' <<<"$meta")
+    ref=$(ref_for "$commit")
+
+    echo "=== $pkg $version -- ${commit:0:9} ${ref:+($ref) }<$upstream>"
+
+    rows=$(checktable "$pkg" || true)
+    if [ -z "$rows" ]; then
+      echo "  no check table -- the page moved, or the first build has not finished"
+      status=1
+      continue
+    fi
+
+    bad=0
+    while IFS=$'\t' read -r target result seconds job; do
+      [ "$result" = OK ] && continue
+      bad=$((bad + 1))
+      printf '  %-8s %-24s %5ss  %s/api/actions/logs/%s\n' \
+        "$result" "$target" "$seconds" "$host" "$job"
+    done <<<"$rows"
+    [ "$bad" -eq 0 ] && echo "  all $(grep -c . <<<"$rows") targets OK"
+    [ "$bad" -eq 0 ] || status=1
+
+    # A target whose newest binary is *older* than the indexed version is one
+    # whose build stopped producing artifacts: whoever installs from this
+    # universe is served that older one, however long ago it was built. Rows
+    # ahead of the index are the ordinary lag between building and indexing and
+    # say nothing. Versions compare component-wise as numbers, not as strings:
+    # `.9006` is not less than `.999`.
+    jq -r --arg v "$version" '
+        def vnum: [splits("[.]")] | map(tonumber);
+        ($v | vnum) as $cur
+        | [ ._binaries[]? | select(.version | vnum < $cur) ]
+        | group_by(.os + "-" + (.arch // "?"))
+        | map(max_by(.date))
+        | .[]
+        | [ "\(.os)-\(.arch // "?")", .version, .date[0:10] ]
+        | @tsv
+      ' <<<"$meta" |
+      sort |
+      while IFS=$'\t' read -r target older when; do
+        printf '  %-8s %-24s newest binary is %s, built %s\n' STALE "$target" "$older" "$when"
+      done
+  done
+done
+
+# A named package missing from one universe is ordinary -- the base and forward
+# greens publish to different ones. Missing from all of them is a finding.
+for pkg in "${wanted[@]+"${wanted[@]}"}"; do
+  printf '%s\n' "${seen[@]+"${seen[@]}"}" | grep -qxF "$pkg" && continue
+  echo "=== $pkg: in none of ${universes[*]}"
+  status=1
 done
 
 exit "$status"


### PR DESCRIPTION
`scripts/r-universe-check.sh` defaults to `RUNIVERSE=duckdb`, and that universe builds only the **base** series' greens. The forward (`-fwd`) greens are published in the `krlmlr` universe, so a firing running the script the way `.claude/skills/series-loop.md` stage 3 spells it reads half the series and is told nothing about the other half.

## Evidence from today's firing (2026-08-18)

The default run reported every package OK:

```
=== duckdb.dev 1.5.99.9003.1200 -- 4da8d50bb (origin/main-green)
  all 15 targets OK
```

while the same script pointed at the other universe reported:

```
=== duckdb.dev 1.5.5.9013.1213 -- bf48f2a8f (origin/main-fwd-green)
  FAIL     macos-release-x86_64      3757s  https://krlmlr.r-universe.dev/api/actions/logs/95713617503
  FAIL     macos-oldrel-x86_64       4277s  https://krlmlr.r-universe.dev/api/actions/logs/95713617533
  STALE    mac-x86_64               newest binary is 1.5.5.9013.1210, built 2026-08-17
```

Both logs end in `##[error]The action has timed out.`, with `clang++` still compiling `duckdb/ub_src_planner_*.cpp` — r-universe's one-hour job budget, not a defect in the tree. So nothing had to change on the series, but the loop had no way of knowing that: stage 3 calls this read the one that closes the gap for the platforms the `rcc` gate never covers, and for a forward series it was not happening at all. That matters most just before a cutover, which is the one moment a forward green becomes the serving one — and all three forward series are reported as caught up today.

The firing worked around it by hand (`RUNIVERSE=krlmlr scripts/r-universe-check.sh`) and recorded the finding in the message of the `main-fwd-dev` commit it produced, per stage 3.

## The change

`RUNIVERSE` becomes a space-separated list, defaulting to `duckdb krlmlr`, and the per-package loop runs once per universe under a `--- <universe>` header. Two consequences follow from a universe holding other repositories' packages — `krlmlr` publishes a dozen unrelated ones:

- the default package list is filtered to those whose `_upstream` is a `duckdb-r`;
- a package named on the command line is a finding only when **no** universe has it, since the base and forward packages live in different ones.

`--log` asks each universe in turn, because a job id pasted off a log URL does not say which one ran it.

The skill's stage 3 prose gains the same fact as a fourth access fact, beside the three already there.

## Verification

- `bash -n scripts/r-universe-check.sh` clean.
- Default run prints both universes, 8 package sections, and exits 1 on the two macOS reds above.
- `r-universe-check.sh duckdb nosuchpkg` prints the one package under the `duckdb` header only, then `nosuchpkg: in none of duckdb krlmlr`.
- `r-universe-check.sh --log 95713617503` serves the log from the second universe after the first answers 400, with no curl noise on stderr.

---
_Generated by [Claude Code](https://claude.ai/code/session_017narrpeRjTNBTq2PiwEfjv)_