### PR TITLE
fix(rcc): Tell a missing `clang-format` apart from a misformatted tree

### DIFF
--- a/scripts/rcc-one.sh
+++ b/scripts/rcc-one.sh
@@ -47,6 +47,8 @@
 #                           in <dir>/<stage>.log and its verdict appended to
 #                           <dir>/outcomes.tsv, so scripts/each-shard.sh can
 #                           quote the failing stage into the run summary
+#   CLANG_FORMAT          - the C++ formatter the style gate runs
+#                           (default: clang-format-21, what CI installs)
 #   RCMDCHECK_ERROR_ON    - passed through to rcmdcheck (default: note)
 #   EACH_TIMEOUT_<STAGE>  - seconds a stage may take before it is presumed stuck
 #                           and killed (see stage_budget below); 0 disables the
@@ -287,15 +289,34 @@ fi
 
 # Mirrors .github/workflows/style/action.yml. Tool installation is the caller's
 # job; this only runs the formatters.
+#
+# A formatter that is not installed is not a style violation, and it used to read
+# as one: `clang-format-21` absent leaves `git status --short` empty and still
+# returns 1, so the gate reports `style failure` about a tree it never looked at
+# (duckdb/duckdb-r#2669). Say which of the two it is.
+#
+# The name stays pinned. CI installs clang-format-21, different majors format
+# differently, and falling back to whatever `clang-format` resolves to would
+# trade a legible failure for a verdict that is not CI's -- either reformatting
+# code CI is happy with, or passing code CI will reject. `CLANG_FORMAT` is for a
+# host that has the right major under another name, not for using another major.
 gate_style() {
-  local rc=0
+  local rc=0 clang_format="${CLANG_FORMAT:-clang-format-21}"
   if [ -f air.toml ]; then
     air format . || rc=1
   fi
   if [ -f .clang-format ]; then
-    shopt -s nullglob
-    clang-format-21 -i src/*.{c,cc,cpp,h,hpp} || rc=1
-    shopt -u nullglob
+    if ! command -v "${clang_format}" >/dev/null 2>&1; then
+      echo "Error: ${clang_format} is not on PATH, so the C++ sources were not" \
+        "formatted -- this says nothing about the tree." >&2
+      echo "  Install it (see .github/workflows/style/action.yml), or set" \
+        "CLANG_FORMAT to a build of the same major." >&2
+      rc=1
+    else
+      shopt -s nullglob
+      "${clang_format}" -i src/*.{c,cc,cpp,h,hpp} || rc=1
+      shopt -u nullglob
+    fi
   fi
   git status --short
   return "${rc}"


### PR DESCRIPTION
`gate_style` in `scripts/rcc-one.sh` invoked `clang-format-21` by name. On a host with a different major — or none — the call fails with "command not found", `rc` becomes 1, and `git status --short` prints nothing. The gate then reports `style failure` about a tree it never read.

That verdict is the one thing this script exists not to produce. Its own header calls it the per-commit `rcc` gate "so the local verdict is CI's verdict, not an approximation of it", and `.claude/skills/series-loop.md` stage 2 sends a firing here before it force-pushes a repair, because "a repair that was not run locally is a guess". A red that is about the host but wears the shape of a red about the tree costs the firing its diagnosis, and can cost it the repair.

## The change

Separate the two, the way `scripts/vendor-one.sh` already separates "the glue is broken" from "the check could not run": when the formatter is not on `PATH`, say that the C++ sources were not formatted, say that this tells you nothing about the tree, and name the two ways out. The gate still fails — a check that did not run is not a pass — but it now fails legibly.

The pinned name stays pinned. CI installs `clang-format-21` (`.github/workflows/style/action.yml`), different majors format differently, and falling back to whatever `clang-format` resolves to would trade a legible failure for a verdict that is not CI's: either reformatting code CI is happy with, or passing code CI will reject. The new `CLANG_FORMAT` variable is therefore for a host that carries the right major under another name, not for substituting another major, and it is documented that way in the header's environment-variable block.

## Evidence

Found by the series-loop firing of 2026-08-19, which ran the gate over a glue change on `main-fwd-dev`. Its host is Ubuntu 24.04, which carries `clang-format-18` and no `clang-format-21`. The whole of the style stage's log was one line:

```
scripts/rcc-one.sh: line 297: clang-format-21: command not found
```

and the outcome table around it read:

```
install     success
style       failure
snapshots   skipped
roxygen     success
clean       success
```

Note how those read together: `style` is red while `clean` — which is the gate that fails on a formatting diff — is green, because there was no diff to find. Nothing about the tree was wrong. The firing formatted its change by hand with the clang-format it had and finished, per stage 7.

Behaviour of the patched gate, run against a scratch tree:

- `clang-format-21` absent: the error names the missing binary, `git status --short` stays empty, `rc=1`.
- `CLANG_FORMAT=clang-format-18` present: formats `src/*.cpp`, `git status --short` shows the modification, `rc=0` — which is what the `clean` gate then turns into a failure, unchanged.

`bash -n scripts/rcc-one.sh` is clean. Nothing changes in CI, where the action installs the pinned major before the gate runs.

## Relation to #2669

#2669 fixes the other half of the same "the gate did not measure what it says it did" problem — that its `check` gate silently skips the testsuite off Actions — and notes this one as out of scope so it would not be diagnosed twice. Separate causes, so separate pull requests; they touch different functions of the same file and can be reviewed and merged in either order.