### PR TITLE
docs(meta): Consolidate the authoring rules, and split recorded evidence into its own leaf

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,17 +11,24 @@ This page only routes there.
 
 ## The first five minutes
 
-| To | Read |
-|---|---|
-| get a working environment, cold start | [`contributors/setup/`](/handbook/contributors/setup/README.md) |
-| build in seconds instead of minutes | [`build/fast-paths/`](/handbook/build/fast-paths/README.md) |
-| build from source, the way CRAN does | [`build/source-build/`](/handbook/build/source-build/README.md) |
-| find the build knobs and what they cost | [`build/configuration/`](/handbook/build/configuration/README.md) |
-| run the suite, or one test file | [`testing/suite/`](/handbook/testing/suite/README.md) |
-| write R the way this package does, flavor seam included | [`architecture/r-layer/conventions/`](/handbook/architecture/r-layer/conventions/README.md) |
-| know which tidyverse rules are enforced here, and where we deviate | [`architecture/r-layer/style/`](/handbook/architecture/r-layer/style/README.md) |
-| write C++ glue the way this package does | [`architecture/glue/`](/handbook/architecture/glue/README.md) |
-| operate the vendoring loop | [`operations/vendoring/series-loop/`](/handbook/operations/vendoring/series-loop/README.md) and `.claude/skills/` |
+* get a working environment, cold start:
+  [`contributors/setup/`](/handbook/contributors/setup/README.md)
+* build in seconds instead of minutes:
+  [`build/fast-paths/`](/handbook/build/fast-paths/README.md)
+* build from source, the way CRAN does:
+  [`build/source-build/`](/handbook/build/source-build/README.md)
+* find the build knobs and what they cost:
+  [`build/configuration/`](/handbook/build/configuration/README.md)
+* run the suite, or one test file:
+  [`testing/suite/`](/handbook/testing/suite/README.md)
+* write R the way this package does, flavor seam included:
+  [`architecture/r-layer/conventions/`](/handbook/architecture/r-layer/conventions/README.md)
+* know which tidyverse rules are enforced here, and where we deviate:
+  [`architecture/r-layer/style/`](/handbook/architecture/r-layer/style/README.md)
+* write C++ glue the way this package does:
+  [`architecture/glue/`](/handbook/architecture/glue/README.md)
+* operate the vendoring loop:
+  [`operations/vendoring/series-loop/`](/handbook/operations/vendoring/series-loop/README.md) and `.claude/skills/`
 
 ## Everything else
 

--- a/experiments/README.md
+++ b/experiments/README.md
@@ -1,29 +1,14 @@
 # `experiments/` — measured evidence
 
-*Handbook: [`meta/plans/`](/handbook/meta/plans/README.md)
-explains this directory alongside `plan/`.*
+*Handbook: [`meta/experiments/`](/handbook/meta/experiments/README.md)
+owns this directory's conventions.*
 
 One directory per experiment, holding everything it needs:
 a `README.md` that says what was measured, when, on what,
 and which handbook page relies on it,
 plus whatever the run took — scripts, inputs, recorded output.
 
-An experiment is evidence, not a check.
-It does not re-run itself, and nothing here gates a build:
-what a test can pin is a test
-([`testing/suite/`](/handbook/testing/suite/README.md)),
-and what a scan can enforce is a check
-([`testing/guards/`](/handbook/testing/guards/README.md)).
-What lands here is the finding too expensive to re-derive on demand —
-a measurement, a survey, a build that takes an hour —
-kept so the leaf that cites it can be trusted
-without the reader repeating the work.
-
-A record ages rather than rots:
-it is true of the day it names,
-and a leaf that leans on it says so.
-Re-running is how it is refreshed;
-the directory keeps the method so that is possible.
+This file is what names the contents, so nothing here is an orphan.
 
 * [`2026-03-vendor-build-cost/`](2026-03-vendor-build-cost/) —
   churn per vendor commit, ccache hit rate on adjacent commits,

--- a/handbook/README.md
+++ b/handbook/README.md
@@ -14,6 +14,12 @@ and the same question brings both to the same leaf —
 an audience split would need the same fact in two places,
 and the tree holds every fact once.
 
+Two bodies of writing stay outside the tree, and the handbook says what each owns and links it rather than restating either.
+[`plan/`](/plan/README.md) holds intent: a design for work not done, and the record of one that came true or was overtaken.
+[`experiments/`](/experiments/README.md) holds the evidence a leaf leans on: what was measured, when, and on what.
+A leaf that paraphrases a plan has created a second copy of a proposal.
+A leaf that copies out a measurement has created a second copy of a record that ages.
+
 * [`usage/`](usage/) — installation and flavors, connections,
   statements, types, timestamps, extensions, memory, data import,
   storage, integrations, the relational API, interactive use

--- a/handbook/meta/README.md
+++ b/handbook/meta/README.md
@@ -6,7 +6,8 @@ The documentation system itself.
 Shape and prose are conventions rather than preferences: a page that departs from them is corrected in review.
 A preference nobody has enforced is not yet a rule, and does not belong on these pages.
 
-* [`authoring/`](authoring/) — the prose checklist for writing a page
-* [`glossary/`](glossary/) — the terms of art, each linking its owner
-* [`handbook/`](handbook/) — the rules of this tree
-* [`plans/`](plans/) — active designs, superseded records
+* [`authoring/`](authoring/): the prose checklist for writing a page
+* [`experiments/`](experiments/): recorded evidence, and what earns a directory
+* [`glossary/`](glossary/): the terms of art, each linking its owner
+* [`handbook/`](handbook/): the rules of this tree
+* [`plans/`](plans/): active designs, superseded records

--- a/handbook/meta/README.md
+++ b/handbook/meta/README.md
@@ -2,6 +2,10 @@
 
 The documentation system itself.
 
+**A rule stated here binds every page above it.**
+Shape and prose are conventions rather than preferences: a page that departs from them is corrected in review.
+A preference nobody has enforced is not yet a rule, and does not belong on these pages.
+
 * [`authoring/`](authoring/) — the prose checklist for writing a page
 * [`glossary/`](glossary/) — the terms of art, each linking its owner
 * [`handbook/`](handbook/) — the rules of this tree

--- a/handbook/meta/authoring/README.md
+++ b/handbook/meta/authoring/README.md
@@ -1,12 +1,18 @@
 # Authoring
 
-How the prose of a handbook page is written —
-the rules an author follows and a review enforces, owned here in full.
+How prose is written here: the rules an author follows and a review enforces, owned on this page in full.
+They cover every Markdown file this repository authors, the handbook included, and the comments and roxygen blocks under `R/` and `tests/`.
 The tree's structure, its growth moves, and their enforcement are
 [`meta/handbook/`](/handbook/meta/handbook/README.md)'s;
 extending the tree means following this page,
 and a rewrite that loses a fact is a regression, not an edit.
-A rule joins this page once a review has enforced it twice;
+
+They stop in two places.
+A GitHub issue or pull request body takes reflowed paragraphs instead, because a single newline renders there as a visible break.
+Text this repository does not author is nobody's to reformat: the vendored engine under `src/duckdb/`, and anything generated.
+Generated here is `man/*.Rd` and the two rendered `README.md` files whose source is [`README.Rmd`](/README.Rmd).
+
+A rule joins this page once a review has enforced it twice, or once the repository adopts it outright;
 until then it is a preference, and preferences are not enforced.
 
 ## Before writing a sentence
@@ -156,6 +162,14 @@ a page that absorbed three such facts instead
 can no longer say what it is about,
 and that — not the length — is the defect.
 
+**A leaf past 120 lines owes an answer to why it is still one topic.**
+Semantic line breaks put a sentence on a line, so 120 of them is a long stretch on one subject.
+A leaf that long has usually grown a section a reader would look for under its own name.
+The number asks the question rather than settling it.
+A leaf that is genuinely one topic stays whole however long it runs.
+One that is not splits at the heading that could stand alone, which is the growth move rather than an edit.
+Compressing to get under the number is the wrong move in both cases, because sentences cut to fit lose facts that a split keeps.
+
 ## Writing the sentence
 
 * **Break lines at meaning boundaries**
@@ -163,8 +177,21 @@ and that — not the length — is the defect.
   widen a line rather than split a phrase;
   never leave a one-word line,
   and never start a line with one word and a comma.
-  Aim under 80 characters, but meaning wins over length,
-  and a long link or code token may stand alone.
+* **Prose aims for 140 characters**, because a line much longer than that hides its own edits in a diff.
+  Meaning wins where it will not fit, so a longer line is tolerated rather than corrected.
+  A break moved to save characters is a break in the wrong place.
+  A URL too long to break stands alone.
+* **A comment takes the code's budget, not the prose budget.**
+  A comment and a roxygen line aim for the `line-width` that [`air.toml`](/air.toml) sets, which is air's default of 80 characters today.
+  A comment shares its file with code held to that width, and a reader who sized a window for the code reads the comment in the same one.
+  The number is a soft aim in exactly the way 140 is, and every other rule here holds there unchanged, the semantic break first of all.
+  Holding it is the author's job, because air formats the code around a comment and leaves the prose inside it alone.
+* **A line ends with a full stop**, and anything else wants a very good reason.
+  A heading, a bold run-in, a list marker, and a colon introducing a list are the reasons, and there are few others.
+  A line ending in a comma is the one to look at twice.
+  It says the sentence outran the line, and two sentences almost always beat one clause break.
+* **No em dashes**, here or in code, commit messages, or pull requests.
+  A comma, a colon, a semicolon, or a parenthesis says the same thing.
 * **Default to a bullet list; make a table earn its columns.**
   A list extends one line at a time and diffs the same way,
   so an enumeration is bullets, each item led by its name.
@@ -207,12 +234,6 @@ and that — not the length — is the defect.
   a state number — means nothing where it is read,
   and resolves only for someone holding that table:
   say what the invariant says, in the clause that depends on it.
-* **Write links that leave their directory from the repository root**,
-  with a leading `/` —
-  GitHub resolves them against the root on any branch or fork;
-  same-directory and downward links stay relative.
-  Such links do not resolve in a local preview;
-  the handbook is read on GitHub, and that is the trade taken.
 
 ## Linking between leaves
 

--- a/handbook/meta/authoring/README.md
+++ b/handbook/meta/authoring/README.md
@@ -49,7 +49,8 @@ the rest move the fact somewhere better than a paragraph.
    A behavioural claim lands with the test that pins it,
    a repo-shape claim graduates into the consistency checks,
    and a finding too expensive to re-derive becomes an experiment
-   ([`experiments/`](/experiments/README.md)) that the leaf links.
+   ([`meta/experiments/`](/handbook/meta/experiments/README.md))
+   that the leaf links.
    A one-off derivation stays in the pull request.
 6. **Then write it — as short as it can be and stay correct
    ([below](#how-long-an-entry-is)) —

--- a/handbook/meta/experiments/README.md
+++ b/handbook/meta/experiments/README.md
@@ -1,0 +1,56 @@
+# Experiments
+
+Evidence lives outside the handbook, under [`experiments/`](/experiments/README.md):
+one directory per run, holding what it measured and everything the run took.
+A leaf states what is true, and an experiment records what was measured, when, and on what.
+The two are different kinds of writing, which is why they live apart.
+Intent is [`meta/plans/`](/handbook/meta/plans/README.md)'s.
+
+The leaf that leans on a finding links the directory carrying it, which is what lets a reader weigh the finding without repeating the work.
+A finding no leaf cites is an orphan: the tree is how anything here is found, and nobody reads a directory of results looking for an answer.
+
+## What earns a directory
+
+**Only what is too expensive to re-derive.**
+The cheaper homes come first, and
+[`meta/authoring/`](/handbook/meta/authoring/README.md) walks them in order:
+a claim a test can pin, a claim a check can enforce, a derivation a reader can redo in a minute.
+What is left is the measurement that needs a specific platform, an old package version, or an hour of compute.
+It is committed while the result is fresh, because session scratch space, chat transcripts, and CI logs all expire,
+and a finding that lived only there is the same work waiting to be done again.
+
+**An experiment is evidence, not a check.**
+Nothing under `experiments/` runs on its own, and nothing there gates a merge.
+It carries no intent either.
+A finding that argues for a change is quoted by the plan that carries it, and the experiment stays a record of what was measured.
+
+**A record ages rather than rots.**
+It is true of the day it names, on the versions it names,
+and a leaf leaning on it says so rather than presenting a measurement as a permanent property.
+Refreshing one is re-running it, which is why the method is committed.
+The finding it replaces is git's, not a section of the page.
+
+## The shape of a directory
+
+The directory is named for the date and the topic, as `YYYY-MM-DD-<topic>/`.
+
+Its `README.md` opens with three italic-labelled paragraphs before anything else,
+saying what it measures, when and on what, and what it supports.
+The rest is the method, the findings, and how to replicate them.
+Everything the run took is committed beside that page.
+
+Whatever can be a standalone R script is recorded as one,
+rendered to Markdown with `reprex::reprex(si = TRUE)` and committed beside the script it came from.
+An experiment may hold several, one per run,
+where the runs are separate questions or the same question against separate builds.
+
+Where reprex cannot host the run, the findings go in the experiment's `README.md` instead.
+A run driven from a shell, or one needing a background process, a build, a second machine, or subprocesses, does not fit in a reprex.
+What would have been the transcript becomes quoted excerpts chosen for what the finding rests on,
+with the driver committed beside them, and whatever output the run recorded.
+A raw transcript is committed only where it is short enough to be read whole, and never in place of the excerpts.
+A long one is bulk nobody reads, it ages the same as the page, and it buries the handful of lines that carried the point.
+
+Some directories predate these rules, in their name or in their shape, and are left as they are.
+Renaming one breaks every inbound link for no gain,
+and reshaping a record to a convention younger than it gives a reader nothing they did not have.

--- a/handbook/meta/handbook/README.md
+++ b/handbook/meta/handbook/README.md
@@ -201,9 +201,8 @@ it has the lifetime of the child list
 (a fact an ordinary commit could falsify has a leaf);
 and it names no particulars —
 no paths, scripts, variables, versions, counts, or commands.
-A node whose leaves share no such constraint gets no principle;
-where an area has a leaf whose topic is the area's own rules,
-the principles are that leaf's, and the node stays navigation-only.
+A node whose leaves share no such constraint gets no principle,
+and a node never restates a rule that a leaf under it owns.
 
 **A link that leaves its own directory is written from the repository
 root**, with a leading `/`;

--- a/handbook/meta/plans/README.md
+++ b/handbook/meta/plans/README.md
@@ -5,6 +5,7 @@ the handbook describes how the system works today,
 and a plan describes work proposed, in progress, or superseded —
 filing proposals among descriptions would make the tree assert
 things that are not so.
+Evidence is [`meta/experiments/`](/handbook/meta/experiments/README.md)'s.
 
 A plan sits in `plan/` as `PLAN-<topic>.md` while it is open.
 What becomes of it decides which way it leaves:
@@ -19,23 +20,3 @@ and where a plan and the owner disagree, the owner is right.
 names every document; a file it does not name is an orphan.
 Each leaf whose topic a plan carries
 links that plan from its own text.
-
-Evidence lives outside the tree the same way,
-in [`experiments/`](/experiments/README.md):
-one directory per experiment,
-holding what it measured and everything the run took.
-A leaf states what is true;
-an experiment records what was measured, when, and on what,
-and the leaf that leans on it links it —
-which is what lets a reader weigh a finding
-without repeating the work.
-
-Prefer durable storage for a result that is hard to reproduce —
-one that needs an old package version, a long build,
-a specific platform, or hours of compute:
-commit the script *and* the recorded output under `experiments/`
-while the result is fresh.
-The output should be a Markdown file created with `reprex::reprex(si = TRUE)`.
-Session scratch space, chat transcripts, and CI logs all expire,
-and a finding that lived only there
-is the same work waiting to be done again.


### PR DESCRIPTION
Two commits, from review practice.

## Commit 1: the rules

`meta/authoring/` opened as the rules for "the prose of a handbook page". It is the rules for every Markdown file this repository authors and for the comments and roxygen blocks under `R/` and `tests/`, so the page now says so, and names where they stop: a GitHub issue or pull request body, where a single newline renders as a visible break, and text this repository does not author.

The rules added:

- **Prose aims for 140 characters** rather than 80, because a line much longer than that hides its own edits in a diff. Meaning still wins where it will not fit.
- **A comment takes the code's budget**, which is the `line-width` `air.toml` sets, air's default of 80 today. Every other rule holds there unchanged, the semantic break first of all, and holding it is the author's job because air leaves the prose inside a comment alone.
- **A line ends with a full stop.** A line ending in a comma says the sentence outran the line, and two sentences almost always beat one clause break.
- **No em dashes**, here or in code, commit messages, or pull requests.
- **A leaf past 120 lines owes an answer to why it is still one topic.** The number asks the question rather than settling it.

A rule now also joins the page once the repository adopts it outright, not only once a review has enforced it twice. Without that second door a rule adopted by decision has nowhere to be written down, which is the situation this change is in.

Existing pages are not reflowed to 140 here, and the em dash sweep is deliberately not in this PR. A width aim is soft, and reflowing every line of every page destroys blame and makes the real changes unreviewable; pages get fixed as they are next edited. The one exception is `meta/README.md`'s child list, since that page now states the principle and should not be the page breaking the newest rule on it.

Alongside:

- `meta/handbook/`'s principle tests banned a node from carrying *any* principle wherever a rules leaf sat under it. That is stronger than the intent and would have banned the `meta/` principle this PR adds. The test is now that a node never restates a rule a leaf under it owns, which is what actually matters.
- `meta/` gains that principle: a rule stated there binds every page above it.
- The handbook root names `plan/` and `experiments/`, which a reader previously learned only by reaching `meta/`.
- `AGENTS.md`'s "first five minutes" is a bullet list, since a two-column table whose second column is a link is a list wearing borders. Every destination is unchanged.

**On the 120-line rule and this page.** `meta/authoring/` is 265 lines and gets longer here, so it owes the answer. My reading matches yours: it stays whole. The page is one topic end to end, and "Linking between leaves" is not a section a reader would look for under its own name — it is the last rung of how a sentence gets written, and splitting it would leave two pages that only make sense read together. `meta/handbook/` is 290 lines and the same answer applies to it.

## Commit 2: split `meta/plans/`

`meta/plans/` carried two topics: intent under `plan/`, and evidence under `experiments/`. Fourteen directories under `experiments/` is well past the point where the evidence half earns its own leaf, so `meta/experiments/` is created and `meta/plans/` keeps intent, with its scope sentence no longer claiming evidence. `experiments/README.md` keeps its index, which is what makes nothing under it an orphan, and backreferences the new leaf for the conventions it used to restate.

Every rule on the new leaf was checked against what `experiments/` actually contains before it was written, and three came back amended:

- The proposed rule said a committed transcript of a shell-driven run is always the wrong artifact. `2026-08-08-interrupt-reach/` commits two short ones *and* quotes the excerpts the findings rest on. So the page says the excerpts are the record either way, and a raw transcript is committed only where it is short enough to be read whole, never in place of the excerpts.
- "One reprex per script" is not what `2026-08-temp-storage-spill/` does: two scripts, four builds, eight recorded runs. The page says one per run, where the runs are separate questions or the same question against separate builds.
- The naming rule and the three-italic-paragraph rule are both stated with the directories that predate them left alone. Four directories are named for a month rather than a day, and three open in a shape settled after they were measured. Renaming one breaks every inbound link for no gain.

The rule about committing a result while it is fresh moves across from `meta/plans/` rather than being dropped, so the split loses no fact.

## One deviation worth flagging

The brief asked the authoring page to exempt "the vendored files under `.claude/`". They are not vendored here: all six files under `.claude/skills/` are authored in this repository and carry the house-style handbook backreference. Writing a false exemption onto the page would fail the page's own second rung, so the exemption names only the vendored engine under `src/duckdb/` and the generated files (`man/*.Rd` and the two rendered `README.md` files whose source is `README.Rmd`). Say the word if `.claude/` should be exempt for a reason the tree does not record, and I will add it with the real reason.

## Checks

- Every relative link in every Markdown file outside `src/duckdb/` resolves to a file that exists (0 broken, checked across the whole tree, not just the touched pages).
- `meta/README.md`'s child list matches the directories under `meta/`.
- Each rule added appears exactly once in the tree. The one near-overlap is deliberate: the authoring ladder's rung 5 routes a finding to an experiment and now links `meta/experiments/`, which states the admission threshold rather than re-enumerating the cheaper homes.
- No line added by this PR exceeds 140 characters, and none carries an em dash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Do5tyBorV4TZgu4dwjjmy

---
_Generated by [Claude Code](https://claude.ai/code/session_019Do5tyBorV4TZgu4dwjjmy)_