### PR TITLE
docs(meta): Make `authoring/` obey itself, name evidence in the rules, and refresh the `meta/` node

### DIFF
--- a/handbook/meta/README.md
+++ b/handbook/meta/README.md
@@ -1,12 +1,12 @@
 # `meta/`
 
-The documentation system itself.
+The documentation system itself, and the prose rules that reach past it into every file this repository authors.
 
 **A rule stated here binds every page above it.**
 Shape and prose are conventions rather than preferences: a page that departs from them is corrected in review.
 A preference nobody has enforced is not yet a rule, and does not belong on these pages.
 
-* [`authoring/`](authoring/): the prose checklist for writing a page
+* [`authoring/`](authoring/): the prose rules, for every page and every source comment
 * [`experiments/`](experiments/): recorded evidence, and what earns a directory
 * [`glossary/`](glossary/): the terms of art, each linking its owner
 * [`handbook/`](handbook/): the rules of this tree

--- a/handbook/meta/authoring/README.md
+++ b/handbook/meta/authoring/README.md
@@ -2,10 +2,8 @@
 
 How prose is written here: the rules an author follows and a review enforces, owned on this page in full.
 They cover every Markdown file this repository authors, the handbook included, and the comments and roxygen blocks under `R/` and `tests/`.
-The tree's structure, its growth moves, and their enforcement are
-[`meta/handbook/`](/handbook/meta/handbook/README.md)'s;
-extending the tree means following this page,
-and a rewrite that loses a fact is a regression, not an edit.
+The tree's structure, its growth moves, and their enforcement are [`meta/handbook/`](/handbook/meta/handbook/README.md)'s;
+extending the tree means following this page, and a rewrite that loses a fact is a regression, not an edit.
 
 They stop in two places.
 A GitHub issue or pull request body takes reflowed paragraphs instead, because a single newline renders there as a visible break.
@@ -18,150 +16,92 @@ until then it is a preference, and preferences are not enforced.
 ## Before writing a sentence
 
 Walk these in order, and stop at the first that answers.
-Only the two that ask whether it is a fact and whether it is true end in
-nothing being written, and what they discard is not a fact;
+Only the two that ask whether it is a fact and whether it is true end in nothing being written, and what they discard is not a fact;
 the rest move the fact somewhere better than a paragraph.
 
 1. **Is it a fact about how the system works today?**
-   A failure narrative, before-and-after framing, a rejected
-   alternative, where a file came from,
-   or a design for work not done is none:
-   all but the last are git's and the issues',
-   and the last is [`plan/`](/plan/README.md)'s.
+   A failure narrative, before-and-after framing, a rejected alternative, where a file came from, or a design for work not done is none:
+   all but the last are git's and the issues', and the last is [`plan/`](/plan/README.md)'s.
 2. **Is it true?**
    Verify on a build that can show the claim:
-   one the fast path's release library could distort needs a vendored
-   build ([`build/fast-paths/`](/handbook/build/fast-paths/README.md)),
+   one the fast path's release library could distort needs a vendored build ([`build/fast-paths/`](/handbook/build/fast-paths/README.md)),
    and for everything the two builds share, either will do.
-   When a claim is contested or surprising, read the script or run the
-   diff, and discuss before editing.
+   When a claim is contested or surprising, read the script or run the diff, and discuss before editing.
 3. **Does another leaf, a file header, or a reference page own it?**
    Link it: never restate it, and never paraphrase it.
 4. **Does an artifact already state it?**
-   Never re-enumerate what a file lists (the file is the list),
-   and never exhaustively enumerate facts another leaf owns:
+   Never re-enumerate what a file lists (the file is the list), and never exhaustively enumerate facts another leaf owns:
    state the principle that locates them, and stop.
 5. **Could a check state it instead?**
-   A trap that keeps happening deserves a guard that refuses it,
-   not a paragraph asking readers to remember;
-   where a guard is out of reach, the leaf gets the trigger and the
-   action, never the anatomy.
-   A behavioural claim lands with the test that pins it,
-   a repo-shape claim graduates into the consistency checks,
+   A trap that keeps happening deserves a guard that refuses it, not a paragraph asking readers to remember;
+   where a guard is out of reach, the leaf gets the trigger and the action, never the anatomy.
+   A behavioural claim lands with the test that pins it, a repo-shape claim graduates into the consistency checks,
    and a finding too expensive to re-derive becomes an experiment
-   ([`meta/experiments/`](/handbook/meta/experiments/README.md))
-   that the leaf links.
+   ([`meta/experiments/`](/handbook/meta/experiments/README.md)) that the leaf links.
    A one-off derivation stays in the pull request.
-6. **Then write it, as short as it can be and stay correct
-   ([below](#how-long-an-entry-is)),
+6. **Then write it, as short as it can be and stay correct ([below](#how-long-an-entry-is)),
    and leave a breadcrumb where the reader stands.**
-   When detail moves into a leaf,
-   the source it came from (a document, a script header,
-   an inline comment) keeps its essentials
-   and links the leaf that now carries the rest,
-   so a fact is edited in one place
-   and found from the place it is about.
+   When detail moves into a leaf, the source it came from (a document, a script header, an inline comment) keeps its essentials
+   and links the leaf that now carries the rest, so a fact is edited in one place and found from the place it is about.
 
-**A behaviour that looks wrong rather than chosen is settled before the
-ladder, not on it.**
-A fact can be true and still be one nobody should have to read,
-and no rung can tell which:
-nothing mechanical distinguishes a deliberate limitation from an unfixed
-one, because both are only what the code does.
-So it is a discussion, not a test:
-is the behaviour *desirable*, or is it a mere *limitation*?
+**A behaviour that looks wrong rather than chosen is settled before the ladder, not on it.**
+A fact can be true and still be one nobody should have to read, and no rung can tell which:
+nothing mechanical distinguishes a deliberate limitation from an unfixed one, because both are only what the code does.
+So it is a discussion, not a test: is the behaviour *desirable*, or is it a mere *limitation*?
 Desirable, and it is an ordinary fact, taking the ladder like any other.
 A limitation, and the two costs are weighed against each other.
-A fix of one to three lines, with consequences obvious enough to approve
-at a glance, is cheaper than the paragraph and every later edit of it:
-make it, and write nothing.
-Anything larger is work carrying its own risk, review and timeline,
-so the limitation is real for as long as that takes.
-The tree requires the leaf to state its limits,
-with the issue that will remove it, so the fact reads as provisional.
-Silence is the one answer never available:
-a limitation nobody wrote down is one the next reader rediscovers,
-and pays for twice.
+A fix of one to three lines, with consequences obvious enough to approve at a glance,
+is cheaper than the paragraph and every later edit of it: make it, and write nothing.
+Anything larger is work carrying its own risk, review and timeline, so the limitation is real for as long as that takes.
+The tree requires the leaf to state its limits, with the issue that will remove it, so the fact reads as provisional.
+Silence is the one answer never available: a limitation nobody wrote down is one the next reader rediscovers, and pays for twice.
 
 ## Where the handbook stops
 
-The rungs asking after another owner, an artifact, and a check
-all ask the same question (is something else a better home for this?),
+The rungs asking after another owner, an artifact, and a check all ask the same question (is something else a better home for this?),
 and the answer generalises.
-**The tree owns what the code cannot say about itself**, which is three
-things:
+**The tree owns what the code cannot say about itself**, which is three things:
 
 * **Why.**
-  No file records why the engine is vendored rather than carried as a
-  submodule, or why linearity is worth the rebases it costs.
+  No file records why the engine is vendored rather than carried as a submodule, or why linearity is worth the rebases it costs.
 * **Across.**
-  A relationship spanning files that no single one of them contains:
-  an invariant, or the direction R-side work is allowed to travel.
+  A relationship spanning files that no single one of them contains: an invariant, or the direction R-side work is allowed to travel.
 * **Not.**
   A limit, a declined request, an absence.
-  Nothing in `R/` can say that an argument is accepted and ignored,
-  because the fact *is* the missing method.
+  Nothing in `R/` can say that an argument is accepted and ignored, because the fact *is* the missing method.
 
-Everything else the artifact owns, and owns better: what exists, how
-many, what the values are now, and what a mechanism does step by step.
-Prose that enumerates goes stale without anyone noticing,
-because nothing fails when it does.
+Everything else the artifact owns, and owns better: what exists, how many, what the values are now, and what a mechanism does step by step.
+Prose that enumerates goes stale without anyone noticing, because nothing fails when it does.
 
 Which artifact that is differs by area, and the leaf is what says which:
-a script or workflow under `operations/`,
-a reference page under `usage/`, itself prose and shipped to readers
-who do not have this tree,
+a script or workflow under `operations/`, a reference page under `usage/`, itself prose and shipped to readers who do not have this tree,
 the generator rather than its output under `architecture/`.
 Where an area has none, prose carries the weight alone:
-the series invariants are enforced by nothing
-([`branches/invariants/`](/handbook/branches/invariants/README.md)),
-which is why they are written out in full, in one place, and cited from
-everywhere that depends on them.
+the series invariants are enforced by nothing ([`branches/invariants/`](/handbook/branches/invariants/README.md)),
+which is why they are written out in full, in one place, and cited from everywhere that depends on them.
 
 ## How long an entry is
 
-An **entry** (what one change lands on a page)
-is the shortest statement of its fact that is still correct.
-Length is not thoroughness:
-three sentences where one would do
-leave the reader to find the one,
-and every later edit carries the other two.
-Write the fact, what it means for the reader,
-and the link that supports it; then stop.
-Short is not less true:
-what the entry leaves out stays reachable,
-in the source it links or the leaf it splits into,
+An **entry** (what one change lands on a page) is the shortest statement of its fact that is still correct.
+Length is not thoroughness: three sentences where one would do leave the reader to find the one, and every later edit carries the other two.
+Write the fact, what it means for the reader, and the link that supports it; then stop.
+Short is not less true: what the entry leaves out stays reachable, in the source it links or the leaf it splits into,
 and an edit that loses a fact is a regression however short it reads.
 
-**What supports a fact is not part of the fact,**
-and the pull to write the support out is strongest
-where the work was hardest.
+**What supports a fact is not part of the fact,** and the pull to write the support out is strongest where the work was hardest.
 Each source keeps what it is for:
 
-* An **experiment** keeps the method, the full grid,
-  and the day it was true of;
-  the entry takes the finding and links the directory.
-  A grid copied out of one is a second copy of a record that ages,
-  and the leaf is the copy nobody re-runs.
-* An **issue** keeps the report, the reproduction, and the discussion;
-  the entry takes the answer.
-  How the answer was reached is not part of it,
-  and a limitation is one sentence
-  and the issue that will remove it.
-* A **plan** keeps the design, its alternatives, and its sequencing;
-  the entry takes what is true today,
-  and links the plan for the rest.
+* An **experiment** keeps the method, the full grid, and the day it was true of; the entry takes the finding and links the directory.
+  A grid copied out of one is a second copy of a record that ages, and the leaf is the copy nobody re-runs.
+* An **issue** keeps the report, the reproduction, and the discussion; the entry takes the answer.
+  How the answer was reached is not part of it, and a limitation is one sentence and the issue that will remove it.
+* A **plan** keeps the design, its alternatives, and its sequencing; the entry takes what is true today, and links the plan for the rest.
 
 **Detail that survives all of that is a leaf, not a longer section.**
-A fact needing more than a paragraph or two
-has outgrown the page that cites it,
-and splitting it out is a growth move of its own
-([`meta/handbook/`](/handbook/meta/handbook/README.md)).
-The page that keeps the sentence and the link stays about one thing,
-which is what its scope sentence claims;
-a page that absorbed three such facts instead
-can no longer say what it is about,
-and that, not the length, is the defect.
+A fact needing more than a paragraph or two has outgrown the page that cites it,
+and splitting it out is a growth move of its own ([`meta/handbook/`](/handbook/meta/handbook/README.md)).
+The page that keeps the sentence and the link stays about one thing, which is what its scope sentence claims;
+a page that absorbed three such facts instead can no longer say what it is about, and that, not the length, is the defect.
 
 **A leaf past 120 lines owes an answer to why it is still one topic.**
 Semantic line breaks put a sentence on a line, so 120 of them is a long stretch on one subject.
@@ -173,11 +113,8 @@ Compressing to get under the number is the wrong move in both cases, because sen
 
 ## Writing the sentence
 
-* **Break lines at meaning boundaries**
-  ([semantic line breaks](https://sembr.org)):
-  widen a line rather than split a phrase;
-  never leave a one-word line,
-  and never start a line with one word and a comma.
+* **Break lines at meaning boundaries** ([semantic line breaks](https://sembr.org)):
+  widen a line rather than split a phrase; never leave a one-word line, and never start a line with one word and a comma.
 * **Prose aims for 140 characters**, because a line much longer than that hides its own edits in a diff.
   Meaning wins where it will not fit, so a longer line is tolerated rather than corrected.
   A break moved to save characters is a break in the wrong place.
@@ -194,47 +131,32 @@ Compressing to get under the number is the wrong move in both cases, because sen
 * **No em dashes**, here or in code, commit messages, or pull requests.
   A comma, a colon, a semicolon, or a parenthesis says the same thing.
 * **Default to a bullet list; make a table earn its columns.**
-  A list extends one line at a time and diffs the same way,
-  so an enumeration is bullets, each item led by its name.
-  A table is for genuinely two-dimensional content,
-  where the reader compares along both axes;
-  a two-column table whose second column is prose
-  is a list wearing borders.
+  A list extends one line at a time and diffs the same way, so an enumeration is bullets, each item led by its name.
+  A table is for genuinely two-dimensional content, where the reader compares along both axes;
+  a two-column table whose second column is prose is a list wearing borders.
 * **State what stays true as the code moves:**
   a number an ordinary commit invalidates is a hostage.
-  Name the mechanism instead:
-  the file that lists the members is durable, the count is not.
+  Name the mechanism instead: the file that lists the members is durable, the count is not.
   A list that names its members is safe where a tally is not.
-  A measurement stays when the text says it is one, and against what;
-  a count stays when it *is* the design, like the version counters
+  A measurement stays when the text says it is one, and against what; a count stays when it *is* the design, like the version counters
   ([`operations/releases/versioning/`](/handbook/operations/releases/versioning/README.md)).
 * **Treat a default as a fact:**
-  a default governs behaviour, so name the value *and* where it is set;
-  the page stays useful when the two drift apart.
+  a default governs behaviour, so name the value *and* where it is set; the page stays useful when the two drift apart.
 * **Link a provisional fact to the issue or plan that will change it:**
-  without the link a reader cannot tell
-  "how it works" from "how it works for now";
-  a behaviour that survives only because nobody has fixed it yet
-  is documented as such, and stops being when the issue closes.
+  without the link a reader cannot tell "how it works" from "how it works for now";
+  a behaviour that survives only because nobody has fixed it yet is documented as such, and stops being when the issue closes.
 * **Never refer by position: name the thing.**
   "The first two" breaks silently when the list above is reordered.
 * **Illustrate with a placeholder or a named example, and label which.**
-  A placeholder never goes stale but makes every reader substitute;
-  a named example reads fluently but ages into a snapshot.
+  A placeholder never goes stale but makes every reader substitute; a named example reads fluently but ages into a snapshot.
   Both are legitimate, and the guardrails are the same either way.
-  Declare a placeholder scheme once, where it starts,
-  and keep to one notation:
-  a page running three is worse than either choice made badly.
-  Say what a named example is a snapshot *of*,
-  so a later reader treats it as history rather than as status;
+  Declare a placeholder scheme once, where it starts, and keep to one notation: a page running three is worse than either choice made badly.
+  Say what a named example is a snapshot *of*, so a later reader treats it as history rather than as status;
   refreshing it is then an ordinary edit, not a correction.
-  A live inventory is neither: it *is* the fact, so it must be current,
-  and a dated snapshot is exactly wrong for it.
+  A live inventory is neither: it *is* the fact, so it must be current, and a dated snapshot is exactly wrong for it.
 * **Cite the claim, not its label.**
-  An identifier from another page's numbering
-  (an invariant number, a state number) means nothing where it is read,
-  and resolves only for someone holding that table:
-  say what the invariant says, in the clause that depends on it.
+  An identifier from another page's numbering (an invariant number, a state number) means nothing where it is read,
+  and resolves only for someone holding that table: say what the invariant says, in the clause that depends on it.
 
 ## Linking between leaves
 
@@ -243,24 +165,17 @@ and it is also the tree's only maintenance cost that grows with its size.
 Both halves of that matter.
 
 **Link a boundary once per page, and link the owner.**
-The load-bearing form is a page naming the boundary it does not own
-("the engine underneath is `engine/`"), stated once, where the reader
-first needs it.
-A second link to the same target on the same page adds no reachability
-and costs another edit when the target moves;
-if a reader can enter mid-page and need it again, the page is too long,
-and splitting it is the fix.
+The load-bearing form is a page naming the boundary it does not own ("the engine underneath is `engine/`"),
+stated once, where the reader first needs it.
+A second link to the same target on the same page adds no reachability and costs another edit when the target moves;
+if a reader can enter mid-page and need it again, the page is too long, and splitting it is the fix.
 Never link an internal node where one of its leaves owns the fact:
-the node will look like an owner and collect citations its children
-deserve.
+the node will look like an owner and collect citations its children deserve.
 
 **A fact that moves takes its inbound links with it.**
-Before changing where a fact lives
-(renaming a leaf, splitting one in two, moving a section),
+Before changing where a fact lives (renaming a leaf, splitting one in two, moving a section),
 search the tree for what points at it and update those pages in the same change.
 The links are one-directional, so nothing else will catch a stale one;
-a leaf that has quietly become the wrong destination still resolves, and
-reads as if it were right, which is worse than a broken link.
-The same search settles the cheaper question: if nothing points at a
-leaf, its scope sentence is probably claiming a boundary no other page
-recognises.
+a leaf that has quietly become the wrong destination still resolves, and reads as if it were right, which is worse than a broken link.
+The same search settles the cheaper question:
+if nothing points at a leaf, its scope sentence is probably claiming a boundary no other page recognises.

--- a/handbook/meta/authoring/README.md
+++ b/handbook/meta/authoring/README.md
@@ -29,16 +29,16 @@ the rest move the fact somewhere better than a paragraph.
    all but the last are git's and the issues',
    and the last is [`plan/`](/plan/README.md)'s.
 2. **Is it true?**
-   Verify on a build that can show the claim —
+   Verify on a build that can show the claim:
    one the fast path's release library could distort needs a vendored
    build ([`build/fast-paths/`](/handbook/build/fast-paths/README.md)),
    and for everything the two builds share, either will do.
    When a claim is contested or surprising, read the script or run the
    diff, and discuss before editing.
 3. **Does another leaf, a file header, or a reference page own it?**
-   Link it — never restate it, and never paraphrase it.
+   Link it: never restate it, and never paraphrase it.
 4. **Does an artifact already state it?**
-   Never re-enumerate what a file lists — the file is the list —
+   Never re-enumerate what a file lists (the file is the list),
    and never exhaustively enumerate facts another leaf owns:
    state the principle that locates them, and stop.
 5. **Could a check state it instead?**
@@ -52,12 +52,12 @@ the rest move the fact somewhere better than a paragraph.
    ([`meta/experiments/`](/handbook/meta/experiments/README.md))
    that the leaf links.
    A one-off derivation stays in the pull request.
-6. **Then write it — as short as it can be and stay correct
-   ([below](#how-long-an-entry-is)) —
+6. **Then write it, as short as it can be and stay correct
+   ([below](#how-long-an-entry-is)),
    and leave a breadcrumb where the reader stands.**
    When detail moves into a leaf,
-   the source it came from — a document, a script header,
-   an inline comment — keeps its essentials
+   the source it came from (a document, a script header,
+   an inline comment) keeps its essentials
    and links the leaf that now carries the rest,
    so a fact is edited in one place
    and found from the place it is about.
@@ -68,7 +68,7 @@ A fact can be true and still be one nobody should have to read,
 and no rung can tell which:
 nothing mechanical distinguishes a deliberate limitation from an unfixed
 one, because both are only what the code does.
-So it is a discussion, not a test —
+So it is a discussion, not a test:
 is the behaviour *desirable*, or is it a mere *limitation*?
 Desirable, and it is an ordinary fact, taking the ladder like any other.
 A limitation, and the two costs are weighed against each other.
@@ -76,8 +76,8 @@ A fix of one to three lines, with consequences obvious enough to approve
 at a glance, is cheaper than the paragraph and every later edit of it:
 make it, and write nothing.
 Anything larger is work carrying its own risk, review and timeline,
-so the limitation is real for as long as that takes —
-and the tree requires the leaf to state its limits,
+so the limitation is real for as long as that takes.
+The tree requires the leaf to state its limits,
 with the issue that will remove it, so the fact reads as provisional.
 Silence is the one answer never available:
 a limitation nobody wrote down is one the next reader rediscovers,
@@ -86,7 +86,7 @@ and pays for twice.
 ## Where the handbook stops
 
 The rungs asking after another owner, an artifact, and a check
-all ask the same question — is something else a better home for this? —
+all ask the same question (is something else a better home for this?),
 and the answer generalises.
 **The tree owns what the code cannot say about itself**, which is three
 things:
@@ -107,7 +107,7 @@ many, what the values are now, and what a mechanism does step by step.
 Prose that enumerates goes stale without anyone noticing,
 because nothing fails when it does.
 
-Which artifact that is differs by area, and the leaf is what says which —
+Which artifact that is differs by area, and the leaf is what says which:
 a script or workflow under `operations/`,
 a reference page under `usage/`, itself prose and shipped to readers
 who do not have this tree,
@@ -120,7 +120,7 @@ everywhere that depends on them.
 
 ## How long an entry is
 
-An **entry** — what one change lands on a page —
+An **entry** (what one change lands on a page)
 is the shortest statement of its fact that is still correct.
 Length is not thoroughness:
 three sentences where one would do
@@ -128,7 +128,7 @@ leave the reader to find the one,
 and every later edit carries the other two.
 Write the fact, what it means for the reader,
 and the link that supports it; then stop.
-Short is not less true —
+Short is not less true:
 what the entry leaves out stays reachable,
 in the source it links or the leaf it splits into,
 and an edit that loses a fact is a regression however short it reads.
@@ -161,7 +161,7 @@ The page that keeps the sentence and the link stays about one thing,
 which is what its scope sentence claims;
 a page that absorbed three such facts instead
 can no longer say what it is about,
-and that — not the length — is the defect.
+and that, not the length, is the defect.
 
 **A leaf past 120 lines owes an answer to why it is still one topic.**
 Semantic line breaks put a sentence on a line, so 120 of them is a long stretch on one subject.
@@ -201,38 +201,38 @@ Compressing to get under the number is the wrong move in both cases, because sen
   a two-column table whose second column is prose
   is a list wearing borders.
 * **State what stays true as the code moves:**
-  a number an ordinary commit invalidates is a hostage —
-  name the mechanism instead:
+  a number an ordinary commit invalidates is a hostage.
+  Name the mechanism instead:
   the file that lists the members is durable, the count is not.
   A list that names its members is safe where a tally is not.
   A measurement stays when the text says it is one, and against what;
   a count stays when it *is* the design, like the version counters
   ([`operations/releases/versioning/`](/handbook/operations/releases/versioning/README.md)).
 * **Treat a default as a fact:**
-  a default governs behaviour, so name the value *and* where it is set —
+  a default governs behaviour, so name the value *and* where it is set;
   the page stays useful when the two drift apart.
 * **Link a provisional fact to the issue or plan that will change it:**
   without the link a reader cannot tell
   "how it works" from "how it works for now";
   a behaviour that survives only because nobody has fixed it yet
   is documented as such, and stops being when the issue closes.
-* **Never refer by position — name the thing.**
+* **Never refer by position: name the thing.**
   "The first two" breaks silently when the list above is reordered.
-* **Illustrate with a placeholder or a named example — and label which.**
+* **Illustrate with a placeholder or a named example, and label which.**
   A placeholder never goes stale but makes every reader substitute;
   a named example reads fluently but ages into a snapshot.
   Both are legitimate, and the guardrails are the same either way.
   Declare a placeholder scheme once, where it starts,
-  and keep to one notation — a page running three is worse than either
-  choice made badly.
+  and keep to one notation:
+  a page running three is worse than either choice made badly.
   Say what a named example is a snapshot *of*,
   so a later reader treats it as history rather than as status;
   refreshing it is then an ordinary edit, not a correction.
   A live inventory is neither: it *is* the fact, so it must be current,
   and a dated snapshot is exactly wrong for it.
 * **Cite the claim, not its label.**
-  An identifier from another page's numbering — an invariant number,
-  a state number — means nothing where it is read,
+  An identifier from another page's numbering
+  (an invariant number, a state number) means nothing where it is read,
   and resolves only for someone holding that table:
   say what the invariant says, in the clause that depends on it.
 
@@ -243,8 +243,8 @@ and it is also the tree's only maintenance cost that grows with its size.
 Both halves of that matter.
 
 **Link a boundary once per page, and link the owner.**
-The load-bearing form is a page naming the boundary it does not own —
-"the engine underneath is `engine/`" — stated once, where the reader
+The load-bearing form is a page naming the boundary it does not own
+("the engine underneath is `engine/`"), stated once, where the reader
 first needs it.
 A second link to the same target on the same page adds no reachability
 and costs another edit when the target moves;
@@ -255,9 +255,9 @@ the node will look like an owner and collect citations its children
 deserve.
 
 **A fact that moves takes its inbound links with it.**
-Before changing where a fact lives — renaming a leaf, splitting one in
-two, moving a section — search the tree for what points at it and update
-those pages in the same change.
+Before changing where a fact lives
+(renaming a leaf, splitting one in two, moving a section),
+search the tree for what points at it and update those pages in the same change.
 The links are one-directional, so nothing else will catch a stale one;
 a leaf that has quietly become the wrong destination still resolves, and
 reads as if it were right, which is worse than a broken link.

--- a/handbook/meta/authoring/README.md
+++ b/handbook/meta/authoring/README.md
@@ -2,64 +2,65 @@
 
 How prose is written here: the rules an author follows and a review enforces, owned on this page in full.
 They cover every Markdown file this repository authors, the handbook included, and the comments and roxygen blocks under `R/` and `tests/`.
-The tree's structure, its growth moves, and their enforcement are [`meta/handbook/`](/handbook/meta/handbook/README.md)'s;
-extending the tree means following this page, and a rewrite that loses a fact is a regression, not an edit.
+The tree's structure, its growth moves, and their enforcement are [`meta/handbook/`](/handbook/meta/handbook/README.md)'s.
+Extending the tree means following this page.
 
 They stop in two places.
 A GitHub issue or pull request body takes reflowed paragraphs instead, because a single newline renders there as a visible break.
 Text this repository does not author is nobody's to reformat: the vendored engine under `src/duckdb/`, and anything generated.
 Generated here is `man/*.Rd` and the two rendered `README.md` files whose source is [`README.Rmd`](/README.Rmd).
 
-A rule joins this page once a review has enforced it twice, or once the repository adopts it outright;
-until then it is a preference, and preferences are not enforced.
+A rule joins this page once a review has enforced it twice, or once the repository adopts it outright.
+Until then it is a preference, and preferences are not enforced.
 
 ## Before writing a sentence
 
 Walk these in order, and stop at the first that answers.
-Only the two that ask whether it is a fact and whether it is true end in nothing being written, and what they discard is not a fact;
-the rest move the fact somewhere better than a paragraph.
+Only the two that ask whether it is a fact and whether it is true end in nothing being written, and what they discard is not a fact.
+The rest move the fact somewhere better than a paragraph.
 
 1. **Is it a fact about how the system works today?**
-   A failure narrative, before-and-after framing, a rejected alternative, where a file came from, or a design for work not done is none:
-   all but the last are git's and the issues', and the last is [`plan/`](/plan/README.md)'s.
+   A failure narrative, before-and-after framing, a rejected alternative, where a file came from, or a design for work not done is none.
+   All but the last are git's and the issues', and the last is [`plan/`](/plan/README.md)'s.
 2. **Is it true?**
-   Verify on a build that can show the claim:
-   one the fast path's release library could distort needs a vendored build ([`build/fast-paths/`](/handbook/build/fast-paths/README.md)),
-   and for everything the two builds share, either will do.
+   Verify on a build that can show the claim.
+   One the fast path's release library could distort needs a vendored build ([`build/fast-paths/`](/handbook/build/fast-paths/README.md)).
+   For everything the two builds share, either will do.
    When a claim is contested or surprising, read the script or run the diff, and discuss before editing.
 3. **Does another leaf, a file header, or a reference page own it?**
    Link it: never restate it, and never paraphrase it.
 4. **Does an artifact already state it?**
-   Never re-enumerate what a file lists (the file is the list), and never exhaustively enumerate facts another leaf owns:
-   state the principle that locates them, and stop.
+   Never re-enumerate what a file lists, because the file is the list.
+   Never exhaustively enumerate facts another leaf owns: state the principle that locates them, and stop.
 5. **Could a check state it instead?**
-   A trap that keeps happening deserves a guard that refuses it, not a paragraph asking readers to remember;
-   where a guard is out of reach, the leaf gets the trigger and the action, never the anatomy.
-   A behavioural claim lands with the test that pins it, a repo-shape claim graduates into the consistency checks,
-   and a finding too expensive to re-derive becomes an experiment
-   ([`meta/experiments/`](/handbook/meta/experiments/README.md)) that the leaf links.
+   A trap that keeps happening deserves a guard that refuses it, not a paragraph asking readers to remember.
+   Where a guard is out of reach, the leaf gets the trigger and the action, never the anatomy.
+   A behavioural claim lands with the test that pins it, and a repo-shape claim graduates into the consistency checks.
+   A finding too expensive to re-derive becomes an experiment that the leaf links
+   ([`meta/experiments/`](/handbook/meta/experiments/README.md)).
    A one-off derivation stays in the pull request.
-6. **Then write it, as short as it can be and stay correct ([below](#how-long-an-entry-is)),
-   and leave a breadcrumb where the reader stands.**
-   When detail moves into a leaf, the source it came from (a document, a script header, an inline comment) keeps its essentials
-   and links the leaf that now carries the rest, so a fact is edited in one place and found from the place it is about.
+6. **Then write it, as short as it can be and stay correct ([below](#how-long-an-entry-is)).
+   Leave a breadcrumb where the reader stands.**
+   When detail moves into a leaf, the source it came from (a document, a script header, an inline comment) keeps its essentials.
+   The source also links the leaf that now carries the rest, so a fact is edited in one place and found from the place it is about.
 
 **A behaviour that looks wrong rather than chosen is settled before the ladder, not on it.**
-A fact can be true and still be one nobody should have to read, and no rung can tell which:
-nothing mechanical distinguishes a deliberate limitation from an unfixed one, because both are only what the code does.
+A fact can be true and still be one nobody should have to read, and no rung can tell which.
+Nothing mechanical distinguishes a deliberate limitation from an unfixed one, because both are only what the code does.
 So it is a discussion, not a test: is the behaviour *desirable*, or is it a mere *limitation*?
 Desirable, and it is an ordinary fact, taking the ladder like any other.
 A limitation, and the two costs are weighed against each other.
-A fix of one to three lines, with consequences obvious enough to approve at a glance,
-is cheaper than the paragraph and every later edit of it: make it, and write nothing.
+A fix of one to three lines, with consequences obvious enough to approve at a glance, is cheaper than the paragraph and every later edit.
+Make it, and write nothing.
 Anything larger is work carrying its own risk, review and timeline, so the limitation is real for as long as that takes.
 The tree requires the leaf to state its limits, with the issue that will remove it, so the fact reads as provisional.
-Silence is the one answer never available: a limitation nobody wrote down is one the next reader rediscovers, and pays for twice.
+Silence is the one answer never available.
+A limitation nobody wrote down is one the next reader rediscovers, and pays for twice.
 
 ## Where the handbook stops
 
-The rungs asking after another owner, an artifact, and a check all ask the same question (is something else a better home for this?),
-and the answer generalises.
+The rungs asking after another owner, an artifact, and a check all ask the same question: is something else a better home for this?
+The answer generalises.
 **The tree owns what the code cannot say about itself**, which is three things:
 
 * **Why.**
@@ -73,20 +74,24 @@ and the answer generalises.
 Everything else the artifact owns, and owns better: what exists, how many, what the values are now, and what a mechanism does step by step.
 Prose that enumerates goes stale without anyone noticing, because nothing fails when it does.
 
-Which artifact that is differs by area, and the leaf is what says which:
-a script or workflow under `operations/`, a reference page under `usage/`, itself prose and shipped to readers who do not have this tree,
-the generator rather than its output under `architecture/`.
-Where an area has none, prose carries the weight alone:
-the series invariants are enforced by nothing ([`branches/invariants/`](/handbook/branches/invariants/README.md)),
-which is why they are written out in full, in one place, and cited from everywhere that depends on them.
+Which artifact that is differs by area, and the leaf is what says which.
+Under `operations/` it is a script or workflow.
+Under `usage/` it is a reference page, itself prose and shipped to readers who do not have this tree.
+Under `architecture/` it is the generator rather than its output.
+Where an area has none, prose carries the weight alone.
+Nothing enforces the series invariants ([`branches/invariants/`](/handbook/branches/invariants/README.md)).
+That is why they are written out in full, in one place, and cited from everywhere that depends on them.
 
 ## How long an entry is
 
 An **entry** (what one change lands on a page) is the shortest statement of its fact that is still correct.
-Length is not thoroughness: three sentences where one would do leave the reader to find the one, and every later edit carries the other two.
-Write the fact, what it means for the reader, and the link that supports it; then stop.
-Short is not less true: what the entry leaves out stays reachable, in the source it links or the leaf it splits into,
-and an edit that loses a fact is a regression however short it reads.
+Length is not thoroughness.
+Three sentences where one would do leave the reader to find the one, and every later edit carries the other two.
+Write the fact, what it means for the reader, and the link that supports it.
+Then stop.
+Short is not less true.
+What the entry leaves out stays reachable, in the source it links or the leaf it splits into.
+An edit that loses a fact is a regression however short it reads.
 
 **What supports a fact is not part of the fact,** and the pull to write the support out is strongest where the work was hardest.
 Each source keeps what it is for:
@@ -98,15 +103,14 @@ Each source keeps what it is for:
 * A **plan** keeps the design, its alternatives, and its sequencing; the entry takes what is true today, and links the plan for the rest.
 
 **Detail that survives all of that is a leaf, not a longer section.**
-A fact needing more than a paragraph or two has outgrown the page that cites it,
-and splitting it out is a growth move of its own ([`meta/handbook/`](/handbook/meta/handbook/README.md)).
-The page that keeps the sentence and the link stays about one thing, which is what its scope sentence claims;
-a page that absorbed three such facts instead can no longer say what it is about, and that, not the length, is the defect.
+A fact needing more than a paragraph or two has outgrown the page that cites it.
+Splitting it out is a growth move of its own.
+The page that keeps the sentence and the link stays about one thing, which is what its scope sentence claims.
+A page that absorbed three such facts instead can no longer say what it is about, and that, not the length, is the defect.
 
 **A leaf past 120 lines owes an answer to why it is still one topic.**
 Semantic line breaks put a sentence on a line, so 120 of them is a long stretch on one subject.
 A leaf that long has usually grown a section a reader would look for under its own name.
-The number asks the question rather than settling it.
 A leaf that is genuinely one topic stays whole however long it runs.
 One that is not splits at the heading that could stand alone, which is the growth move rather than an edit.
 Compressing to get under the number is the wrong move in both cases, because sentences cut to fit lose facts that a split keeps.
@@ -114,7 +118,8 @@ Compressing to get under the number is the wrong move in both cases, because sen
 ## Writing the sentence
 
 * **Break lines at meaning boundaries** ([semantic line breaks](https://sembr.org)):
-  widen a line rather than split a phrase; never leave a one-word line, and never start a line with one word and a comma.
+  widen a line rather than split a phrase.
+  Never leave a one-word line, and never start a line with one word and a comma.
 * **Prose aims for 140 characters**, because a line much longer than that hides its own edits in a diff.
   Meaning wins where it will not fit, so a longer line is tolerated rather than corrected.
   A break moved to save characters is a break in the wrong place.
@@ -132,50 +137,56 @@ Compressing to get under the number is the wrong move in both cases, because sen
   A comma, a colon, a semicolon, or a parenthesis says the same thing.
 * **Default to a bullet list; make a table earn its columns.**
   A list extends one line at a time and diffs the same way, so an enumeration is bullets, each item led by its name.
-  A table is for genuinely two-dimensional content, where the reader compares along both axes;
-  a two-column table whose second column is prose is a list wearing borders.
+  A table is for genuinely two-dimensional content, where the reader compares along both axes.
+  A two-column table whose second column is prose is a list wearing borders.
 * **State what stays true as the code moves:**
   a number an ordinary commit invalidates is a hostage.
-  Name the mechanism instead: the file that lists the members is durable, the count is not.
+  Name the mechanism instead.
+  The file that lists the members is durable, the count is not.
   A list that names its members is safe where a tally is not.
-  A measurement stays when the text says it is one, and against what; a count stays when it *is* the design, like the version counters
+  A measurement stays when the text says it is one, and against what.
+  A count stays when it *is* the design, like the version counters
   ([`operations/releases/versioning/`](/handbook/operations/releases/versioning/README.md)).
 * **Treat a default as a fact:**
-  a default governs behaviour, so name the value *and* where it is set; the page stays useful when the two drift apart.
+  a default governs behaviour, so name the value *and* where it is set.
+  The page stays useful when the two drift apart.
 * **Link a provisional fact to the issue or plan that will change it:**
-  without the link a reader cannot tell "how it works" from "how it works for now";
-  a behaviour that survives only because nobody has fixed it yet is documented as such, and stops being when the issue closes.
+  without the link a reader cannot tell "how it works" from "how it works for now".
+  A behaviour that survives only because nobody has fixed it yet is documented as such, and stops being when the issue closes.
 * **Never refer by position: name the thing.**
   "The first two" breaks silently when the list above is reordered.
 * **Illustrate with a placeholder or a named example, and label which.**
-  A placeholder never goes stale but makes every reader substitute; a named example reads fluently but ages into a snapshot.
+  A placeholder never goes stale but makes every reader substitute.
+  A named example reads fluently but ages into a snapshot.
   Both are legitimate, and the guardrails are the same either way.
-  Declare a placeholder scheme once, where it starts, and keep to one notation: a page running three is worse than either choice made badly.
-  Say what a named example is a snapshot *of*, so a later reader treats it as history rather than as status;
-  refreshing it is then an ordinary edit, not a correction.
-  A live inventory is neither: it *is* the fact, so it must be current, and a dated snapshot is exactly wrong for it.
+  Declare a placeholder scheme once, where it starts, and keep to one notation.
+  A page running three is worse than either choice made badly.
+  Say what a named example is a snapshot *of*, so a later reader treats it as history rather than as status.
+  Refreshing it is then an ordinary edit, not a correction.
+  A live inventory is neither.
+  It *is* the fact, so it must be current, and a dated snapshot is exactly wrong for it.
 * **Cite the claim, not its label.**
-  An identifier from another page's numbering (an invariant number, a state number) means nothing where it is read,
-  and resolves only for someone holding that table: say what the invariant says, in the clause that depends on it.
+  An identifier from another page's numbering (an invariant number, a state number) means nothing where it is read.
+  It resolves only for someone holding that table.
+  Say what the invariant says, in the clause that depends on it.
 
 ## Linking between leaves
 
-A link from one leaf to another is how the tree stays free of repetition,
-and it is also the tree's only maintenance cost that grows with its size.
-Both halves of that matter.
+A link from one leaf to another is how the tree stays free of repetition.
+It is also the tree's only maintenance cost that grows with its size.
 
 **Link a boundary once per page, and link the owner.**
-The load-bearing form is a page naming the boundary it does not own ("the engine underneath is `engine/`"),
-stated once, where the reader first needs it.
-A second link to the same target on the same page adds no reachability and costs another edit when the target moves;
-if a reader can enter mid-page and need it again, the page is too long, and splitting it is the fix.
-Never link an internal node where one of its leaves owns the fact:
-the node will look like an owner and collect citations its children deserve.
+The load-bearing form is a page naming the boundary it does not own ("the engine underneath is `engine/`").
+It is stated once, where the reader first needs it.
+A second link to the same target on the same page adds no reachability, and costs another edit when the target moves.
+If a reader can enter mid-page and need it again, the page is too long, and splitting it is the fix.
+Never link an internal node where one of its leaves owns the fact.
+The node will look like an owner and collect citations its children deserve.
 
 **A fact that moves takes its inbound links with it.**
-Before changing where a fact lives (renaming a leaf, splitting one in two, moving a section),
-search the tree for what points at it and update those pages in the same change.
-The links are one-directional, so nothing else will catch a stale one;
-a leaf that has quietly become the wrong destination still resolves, and reads as if it were right, which is worse than a broken link.
-The same search settles the cheaper question:
-if nothing points at a leaf, its scope sentence is probably claiming a boundary no other page recognises.
+Before changing where a fact lives (renaming a leaf, splitting one in two, moving a section), search the tree for what points at it.
+Update those pages in the same change.
+The links are one-directional, so nothing else will catch a stale one.
+A leaf that has quietly become the wrong destination still resolves, and reads as if it were right, which is worse than a broken link.
+The same search settles the cheaper question.
+If nothing points at a leaf, its scope sentence is probably claiming a boundary no other page recognises.

--- a/handbook/meta/experiments/README.md
+++ b/handbook/meta/experiments/README.md
@@ -54,3 +54,7 @@ A long one is bulk nobody reads, it ages the same as the page, and it buries the
 Some directories predate these rules, in their name or in their shape, and are left as they are.
 Renaming one breaks every inbound link for no gain,
 and reshaping a record to a convention younger than it gives a reader nothing they did not have.
+
+*To deepen: state what [`experiments/README.md`](/experiments/README.md) is,
+and what registering a new directory in it takes,
+which this page leaves to that file today.*

--- a/handbook/meta/handbook/README.md
+++ b/handbook/meta/handbook/README.md
@@ -63,6 +63,16 @@ has exactly one place in this tree.
   and each affected leaf links the plan that carries its intent.
   A plan that has become fact is documented as fact,
   in the leaf, with no trace of its having once been a proposal.
+* **Evidence lives outside the tree.**
+  A measurement too expensive to re-derive is recorded under
+  [`experiments/`](/experiments/README.md),
+  one directory per run, with the method that produced it.
+  The leaf that leans on it takes the finding and links the record;
+  [`meta/experiments/`](/handbook/meta/experiments/README.md) explains
+  that directory and the conventions that govern it.
+  A leaf states what is true,
+  which is not the same kind of writing
+  as a record of what was measured on one day.
 * **The tree is the single source of truth.**
   Everything outside it is secondary —
   user-facing surfaces (the root `README.md`, reference pages),


### PR DESCRIPTION
Five follow-ups in `handbook/meta/` from the consolidation in #2672, plus one decision taken deliberately rather than a fix. Three of them are the same defect: `meta/authoring/README.md` states rules that the page itself broke.

**No em dashes.** The page states "No em dashes, here or in code, commit messages, or pull requests" and contained 29 of them across 25 lines, which is the one place where the violation undermines the rule it is stating. Each is replaced by the punctuation that says the same thing at that site rather than by one blanket substitution: a colon where the dash introduced an elaboration or a list, parentheses where it fenced an appositive whose contents already carry commas, plain commas where the aside is short, a semicolon where two clauses stay one thought, and a full stop with a second sentence where the sentence had simply outrun its line.

**140-character semantic line breaks.** The page told authors that prose aims for 140 characters and then wrapped itself at about 70, so most of its sentences were split three ways at points that were not meaning boundaries. It is now one sentence per line, broken further only where a sentence would run past 140. That pass changed no words: the text was identical to the previous revision once whitespace was normalised.

**Two sentences beat one clause break.** The page says exactly that, and then joined two independent clauses with a semicolon or a colon 23 times. Each of those is now two sentences. The median sentence drops from 21 words to 14, the mean from 20.6 to 14.8, and the number of sentences past 30 words from 24 to 4. Every line now ends with a full stop, a bold run-in, or a colon introducing a list, except the two whose following line carries a link too long to fit, which is the case the page's own rule sanctions. Separately, the three-way enumeration of which artifact owns which area becomes one sentence per area, since the page says an enumeration is a list with each item led by its name.

**Four cuts, each because the page already says it elsewhere.** "A rewrite that loses a fact is a regression, not an edit" in the scope block was a second copy of "an edit that loses a fact is a regression however short it reads" under **How long an entry is**. The second link to `meta/handbook/` was the page's own "link a boundary once per page, and link the owner" broken on itself. "The number asks the question rather than settling it" is what the two sentences after it already say. "Both halves of that matter" pointed at two bold run-ins the reader can see. Nothing else came out: every other sentence carries a fact, and the page's own rule is that an edit losing one is a regression however short it reads.

**The rest of the tree keeps its em dashes and its narrow wrapping for now.** Roughly 735 em dashes remain across the other handbook pages, and most of those pages wrap narrow too. Sweeping either is its own change, not a rider on this one: it touches nearly every page, each em dash substitution is a judgment call about what the dash was doing, and mixing that volume in would make all of it unreviewable. Deferring it is a decision, not an oversight. The one page that states the rules is the page where breaking them actually costs something.

**`meta/handbook/README.md` gains an evidence principle.** The rules page had "Intent lives outside the tree" pointing at `plan/` and `meta/plans/`, and nothing beside it for evidence, so `experiments/` existed as a leaf and as a root-README paragraph without ever being a principle of the tree. A new bullet follows the intent one: a measurement too expensive to re-derive is recorded under `experiments/`, one directory per run with the method that produced it; the leaf that leans on it takes the finding and links the record, citing `meta/experiments/` for the conventions; and a leaf states what is true, which is not the same kind of writing as a record of what was measured on one day.

**`meta/README.md` catches up with authoring's widened scope.** Its scope sentence said "The documentation system itself" and its child list called authoring "the prose checklist for writing a page", while that page now governs every Markdown file this repository authors plus the comments and roxygen blocks under `R/` and `tests/`. Both are widened to match. This is exactly the cheaper defect the rules page warns about under "A scope sentence states a boundary, not a child list": a node whose wording excludes what sits under it, with the child list agreeing and nobody noticing.

**`meta/experiments/README.md` gets a deepen line.** It carried none, which under the shared rules asserts the page is comprehensive. It reads thorough, but it was born from last week's split, and it does not say what `experiments/README.md` is or what registering a new directory in it takes, where the sibling `meta/plans/` states exactly that convention for `plan/README.md`. The root index is what names every directory and is where a new one registers, so the comprehensiveness claim was wrong, and the page now says what remains instead.