### PR TITLE
fix(flavor): Run the flavor-rename guard where it can actually fire

### DIFF
--- a/handbook/operations/ci/per-commit/contract/README.md
+++ b/handbook/operations/ci/per-commit/contract/README.md
@@ -32,7 +32,7 @@ How the to-do list is computed is
   A **run's conclusion is not a verdict**: a leg exits 0 whatever its commits
   did, deliberately, so that a red commit reads as a result rather than as a
   broken job.
-* **Gate applied per commit** — style, snapshots, roxygen, clean tree,
+* **Gate applied per commit** — flavor, style, snapshots, roxygen, clean tree,
   `R CMD check`, pkgdown. The *order* is the contract;
   the list is `rcc-one.sh`'s `ALL_GATES`.
   The copy that runs is the **commit's own**, not the branch tip's:

--- a/handbook/testing/guards/README.md
+++ b/handbook/testing/guards/README.md
@@ -78,3 +78,19 @@ All three run in the same `rcc-smoke` step
 (`.github/workflows/custom/after-install/action.yml`)
 and are wrapped for the suite by
 `tests/testthat/test-flavor-package-name.R`.
+
+**The two companion scans also run per commit**,
+as `rcc-one.sh`'s `flavor` gate
+([`operations/ci/per-commit/contract/`](/handbook/operations/ci/per-commit/contract/README.md)),
+and that is the only place they can do any work.
+`rcc-smoke` runs on `main` and on pull requests to it,
+where `Package: duckdb` makes both return early by construction;
+the branches they exist for are judged by the per-commit gate alone.
+Until the gate carried them,
+`flavor_unflavored_paths()` reported `src/duckdb-win.def`
+on `v1.5-variegata-dev` for a fortnight
+while every commit on that branch was judged green.
+The content scan stays in `rcc-smoke` only:
+it does not return early, so `rcc-smoke` already exercises it,
+and a frozen series' seed-era R code
+would red the whole series the moment it ran per commit.

--- a/scripts/rcc-one.sh
+++ b/scripts/rcc-one.sh
@@ -17,6 +17,7 @@
 #   |-----------------------|-------------------------------------------------|
 #   | versions-matrix       | skipped upstream too (workflow_dispatch, no opt-in) |
 #   | dep-suggests-matrix   | skipped upstream too                            |
+#   | flavor-package-name   | gate `flavor`, the two flavor-only scans of it   |
 #   | style                 | gate `style`                                    |
 #   | update-snapshots      | gate `snapshots`, incl. the snapshot-<sha> branch |
 #   | roxygenize            | gate `roxygen`                                  |
@@ -54,7 +55,7 @@
 
 set -uo pipefail
 
-ALL_GATES="style snapshots roxygen clean check pkgdown"
+ALL_GATES="flavor style snapshots roxygen clean check pkgdown"
 GATES="${EACH_GATES:-${ALL_GATES}}"
 SNAPSHOT_BRANCH="${EACH_SNAPSHOT_BRANCH:-${GITHUB_ACTIONS:-false}}"
 STAGE_DIR="${EACH_STAGE_DIR:-}"
@@ -167,6 +168,7 @@ stage_budget() {
   fi
   case "$1" in
     install) echo 3600 ;;    # cold ccache, no reuse at all
+    flavor) echo 300 ;;      # a base-R scan of the checkout
     style) echo 600 ;;
     snapshots) echo 3600 ;;  # the full test suite
     roxygen) echo 900 ;;
@@ -284,6 +286,49 @@ if [ -z "${STAGE_ONLY}" ]; then
 fi
 
 # -------------------------------------------------------------------- gates --
+
+# The half of `.github/workflows/custom/after-install/action.yml`'s flavor-rename
+# guard that only a flavored checkout can answer.
+#
+# That step runs `if: github.job == 'rcc-smoke'`, and `rcc-smoke` runs on `main`
+# and on pull requests to it. Two of its three scans return early when
+# `DESCRIPTION` says `Package: duckdb` -- so on the only job that runs them they
+# are no-ops by construction, and on the branches where they could find
+# something, the per-commit gate is the only thing judging and it did not run
+# them. `flavor_unflavored_paths()` reported `src/duckdb-win.def` on
+# `v1.5-variegata-dev` for a fortnight while every commit on that branch was
+# judged green.
+#
+# `flavor_package_name_offenders()` is deliberately not here: it does not return
+# early, so `rcc-smoke` already exercises it on every commit that reaches `main`.
+# Running it per commit would also red the frozen v1.4 series at once, over four
+# seed-era lines its R code is not ported away from -- a separate question from
+# a file that arrived under the wrong name and nothing rewrote.
+gate_flavor() {
+  rscript <<'EOF'
+source("scripts/flavor-package-name.R")
+
+unflavored <- flavor_unflavored_paths(".")
+if (length(unflavored) > 0) {
+  writeLines(unflavored)
+  stop(
+    "A file scripts/flavor.patch renames still carries the mainline name; ",
+    "see scripts/flavor-package-name.R for how to resolve this."
+  )
+}
+writeLines("No file left under the mainline name.")
+
+readmes <- flavor_mainline_readme_offenders(".")
+if (length(readmes) > 0) {
+  writeLines(readmes)
+  stop(
+    "A generated README still tells a reader to install the mainline package; ",
+    "see scripts/flavor-package-name.R for how to resolve this."
+  )
+}
+writeLines("No generated README pointing at the mainline package.")
+EOF
+}
 
 # Mirrors .github/workflows/style/action.yml. Tool installation is the caller's
 # job; this only runs the formatters.
@@ -453,7 +498,7 @@ if [ -n "${STAGE_ONLY}" ]; then
   exit $?
 fi
 
-for gate in style snapshots roxygen clean check pkgdown; do
+for gate in flavor style snapshots roxygen clean check pkgdown; do
   run_gate "${gate}"
 done
 

--- a/scripts/series-converge.sh
+++ b/scripts/series-converge.sh
@@ -56,15 +56,24 @@
 #     on all three live series, 2026-08-15, and the same difference on each:
 #     the base still described itself as "the LTS version 1.3 of DuckDB" where
 #     the forward names its flavor.
-#   * The **Windows export list**, `src/*-win.def` -- but only when the two
-#     differ by the flavor rename alone. Both the file name and the single
-#     symbol in it carry the package name, and scripts/flavor.patch rewrites
-#     both, so a base seeded before that flavoring holds `src/duckdb-win.def`
-#     exporting `R_init_duckdb` where its forward holds
-#     `src/duckdb.1.5.dev-win.def` exporting `R_init_duckdb_1_5_dev`
-#     (`v1.5-variegata`, 2026-08-15). The comment prose is compared verbatim and
-#     only the `R_init_` line is allowed to differ, so a real edit to the list
-#     is still a finding.
+#   * The **Windows export list**, `src/*-win.def` -- but only when each side
+#     carries the list its own package needs and the two then differ by the
+#     flavor rename alone. Both the file name and the single symbol in it are a
+#     function of `Package:`, so a base whose seed predates the file holds
+#     `src/duckdb.1.5.dev-win.def` exporting `R_init_duckdb_1_5_dev` once the
+#     commit adding it is ported and renamed, and its forward -- reseeded on
+#     today's `main` -- holds the same file under the same name. The comment
+#     prose is compared verbatim and only the `R_init_` line may differ, so a
+#     real edit to the list is still a finding.
+#
+#     This class read `v1.5-variegata` as explained from 2026-08-15 while the
+#     base carried `src/duckdb-win.def` exporting `R_init_duckdb` under
+#     `Package: duckdb.1.5.dev` -- a port of the `main` commit that added the
+#     file, never renamed, so R found no export list and generated one from
+#     every object. A side that is simply unrenamed and a side that is correctly
+#     renamed are indistinguishable to a comparison that only takes the
+#     `R_init_` line out, which is why each side is now checked against its own
+#     `Package:` before the two are compared at all.
 #
 # Note what is *not* here. Stage 5's carry excludes the same generated files
 # (scripts/series-advance.sh), but for an unrelated reason -- so the twin's copy
@@ -144,11 +153,33 @@ vendored_sha() {
   echo "$sha"
 }
 
-# True when the two branches' Windows export lists differ by the flavor rename
-# and nothing else. The rename means the file is present on one side under one
-# name and on the other under another, so the pair cannot be found by path --
-# it is found by suffix, one per branch, and their contents are then compared
-# with the flavored `R_init_` symbol taken out.
+# The name and symbol a branch's Windows export list must carry, printed as
+# "<path> <symbol>". R links against `<dll base>-win.def`, and the dll base is
+# the package name, so both are a function of that branch's `Package:` alone --
+# which is what makes this answerable per branch rather than by comparison.
+def_expected() {
+  local pkg
+  pkg=$(git show "$1:DESCRIPTION" | sed -n 's/^Package: *//p' | head -n 1)
+  echo "src/$pkg-win.def R_init_${pkg//./_}"
+}
+
+# True when each branch's Windows export list is the one its own package needs,
+# and the two differ by the flavor rename and nothing else.
+#
+# Comparing the two files to each other is not enough, and used to be all this
+# did. Both sides can be self-consistent and differ by the rename; so can a side
+# that simply never got renamed, and the two shapes are identical to a
+# comparison that only takes the `R_init_` line out. `v1.5-variegata-dev` held
+# `src/duckdb-win.def` exporting `R_init_duckdb` under `Package: duckdb.1.5.dev`
+# from 2026-08-05 -- a stage 4 port of a `main` commit that added the file,
+# carrying the mainline name because scripts/flavor.patch runs at seed time and
+# nothing rewrites a ported file afterwards. R then finds no export list at all
+# and falls back to generating one from every object, which is what the file
+# exists to prevent. This read called it CONVERGED every firing in between.
+#
+# So each side is checked against its own `Package:` first, and only then are
+# the two compared. The rename means the pair cannot be found by path -- it is
+# found by suffix, one per branch.
 def_renamed_only() {
   local dev_def fwd_def
   dev_def=$(git ls-tree -r --name-only "$dev" src/ | grep -- '-win\.def$' || true)
@@ -156,6 +187,11 @@ def_renamed_only() {
   # One on each side, or there is no pair and the difference is not a rename.
   [ "$(grep -c . <<<"$dev_def")" = 1 ] || return 1
   [ "$(grep -c . <<<"$fwd_def")" = 1 ] || return 1
+  # Each side's file named, and exporting, what its own package needs.
+  [ "$dev_def $(git show "$dev:$dev_def" | grep '^R_init_')" \
+      = "$(def_expected "$dev")" ] || return 1
+  [ "$fwd_def $(git show "$fwd:$fwd_def" | grep '^R_init_')" \
+      = "$(def_expected "$fwd")" ] || return 1
   cmp -s <(git show "$dev:$dev_def" | grep -v '^R_init_') \
          <(git show "$fwd:$fwd_def" | grep -v '^R_init_')
 }
@@ -205,17 +241,18 @@ while IFS=$'\t' read -r add del f; do
       explained+=("$f|$add/$del|flavored doc, never ported; each branch carries its seed's wording")
       ;;
     src/*-win.def)
-      # Only the flavor rename is explained. The file's own comment says the
-      # name and the symbol both carry the package name; everything above
-      # `EXPORTS` is prose that is the same on every flavor, so compare that
-      # verbatim and allow only the `R_init_` line to differ. A path that is
-      # present on one side alone diffs against the empty tree, and its prose
-      # then differs too -- which is exactly the rename, so pair the two by
-      # their suffix before comparing.
+      # Only the flavor rename is explained, and only between two sides that are
+      # each already correct for themselves. The file's own comment says the name
+      # and the symbol both carry the package name, so each side is checked
+      # against its own `Package:`; everything above `EXPORTS` is prose that is
+      # the same on every flavor, so compare that verbatim and allow only the
+      # `R_init_` line to differ. A path that is present on one side alone diffs
+      # against the empty tree, and its prose then differs too -- which is
+      # exactly the rename, so pair the two by their suffix before comparing.
       if def_renamed_only; then
         explained+=("$f|$add/$del|Windows export list, flavor-renamed")
       else
-        unexplained+=("$f|$add/$del|export list differs beyond its R_init_ symbol")
+        unexplained+=("$f|$add/$del|export list not named for its own package, or edited beyond its R_init_ symbol")
       fi
       ;;
     src/duckdb/* | patch/* | R/version.R | src/include/sources.mk | \


### PR DESCRIPTION
`flavor_unflavored_paths()` and `flavor_mainline_readme_offenders()` both return early when `DESCRIPTION` says `Package: duckdb`, because on the mainline flavor the mainline name is the right one. The only job that runs them is `rcc-smoke`, which runs on `main` and on pull requests to it — so both scans have been no-ops by construction everywhere they have ever run, and the flavored series branches they exist for are judged by `scripts/rcc-one.sh`, which did not carry them.

## The gap, observed

`v1.5-variegata-dev` has carried `src/duckdb-win.def` exporting `R_init_duckdb` under `Package: duckdb.1.5.dev` since 2026-08-05. `scripts/flavor.patch` renames that file and the symbol in it, but it runs once, when a series is seeded — and the file did not exist then. It was added on `main` by `fix(windows): Export only the registration entry point from the DLL` (361d5e33c) and reached the series as an ordinary stage 4 port of that commit, carrying the mainline name with it. Nothing rewrites a ported file afterwards.

R's `share/make/winshlib.mk` therefore looked for `src/duckdb.1.5.dev-win.def`, did not find it, and fell back to generating an export list with `nm` over every object — the whole vendored engine, past the 65535 ordinals a PE export table can address, which is the outcome that file exists to prevent. Every commit on the branch was judged green throughout, and `duckdb.r-universe.dev` published `duckdb.1.5.dev` from it.

`flavor_unflavored_paths()` reported the path the whole time. Nothing ran it.

## What changes

**`scripts/rcc-one.sh`** — the two flavor-only scans become a `flavor` gate, first in the order, ahead of `style`. It is a base-R scan of the checkout, so it needs no install and costs about a second.

`flavor_package_name_offenders()` deliberately stays behind. It does not return early, so `rcc-smoke` already exercises it on everything that reaches `main`; and running it per commit would red the frozen v1.4 series immediately, over four seed-era lines its R code is deliberately not ported away from. That is a separate question from a file that arrived under the wrong name and nothing rewrote.

**`scripts/series-converge.sh`** — the `src/*-win.def` class read this same defect as explained, because it compared the two branches' export lists to each other with the `R_init_` line taken out. A side that was never renamed and a side that was correctly renamed are indistinguishable to that comparison. Each side is now checked against its own `Package:` before the two are compared at all.

**Handbook** — `operations/ci/per-commit/contract/` gains the gate in its ordered list; `testing/guards/` says where the companion scans actually run, and why the content scan stays in `rcc-smoke` only.

## Verification

The gate was run against every live `-dev` branch, via `EACH_STAGE_ONLY=gate_flavor`, with each branch's own tree:

- `main-dev`, `v1.4-andium-dev`, `v1.5-variegata-dev`, `v1.5-variegata-fwd-dev` — pass, exit 0. No series is turned red by this.
- `v1.5-variegata-dev` at its pre-repair commit `31494f618` — fails, exit 1, printing `src/duckdb-win.def` and the guard's own message.

For the convergence read, with the base repaired: `v1.5-variegata` reads CONVERGED again, and the export list drops out of the difference list entirely; `main` and `v1.4-andium` are unchanged. Against the unrepaired base it reports the path as UNEXPLAINED, which is how the incomplete first attempt at the repair was caught.

The series-side repair is `fix(flavor): Rename the Windows export list to this series' flavor` on `krlmlr/duckdb-r`'s `v1.5-variegata-dev`; the renamed file is byte-identical to the one `v1.5-variegata-fwd-dev` already carries, which r-universe builds green on all 15 targets, both Windows x86_64 entries included. Nothing on Linux reads a `.def`, so the gate that judges these commits cannot see the change either way.

## Not covered here

`v1.4-andium-dev` and `v1.4-andium-fwd-dev` carry no `-win.def` at all — the commit that adds it was never ported to a frozen series — so they have the same fallback behaviour and the scan cannot see it, since it only reports files that exist. Their Windows builds are currently green, so this is left as a finding rather than folded in.

---
_Generated by [Claude Code](https://claude.ai/code/session_017oTpj2qphc845HsK8pDfoJ)_