### PR TITLE
fix(vendor): Refuse an upstream clone that cannot name a version

### DIFF
--- a/.claude/skills/series-loop.md
+++ b/.claude/skills/series-loop.md
@@ -133,6 +133,12 @@ and every one of those meets the graft boundary
 and answers wrong or refuses.
 Tags are not optional either:
 `vendor-one.sh` reads `git describe --tags` for the version it stamps.
+A clone that cannot reach a versioning tag used to stamp `v0.0.0`
+and vendor on without a word,
+which reaches CI as a test failure looking like the engine's —
+every extension download 404s on `extensions.duckdb.org/v0.0.0/`.
+The script now refuses such a clone before it vendors anything;
+treat that refusal as the answer and fetch the tags.
 
 **Establish how this firing reads results, once.**
 Verdicts and logs come from the `each-rcc` runs that produced them (stage 2),

--- a/scripts/vendor-one.sh
+++ b/scripts/vendor-one.sh
@@ -101,6 +101,42 @@ fi
 # against.
 git -C "$upstream_dir" config core.abbrev 10
 
+# The version stamp comes from the same clone, and a clone without versioning
+# tags stamps a placeholder instead of failing. Upstream's
+# `package_build.get_git_describe()` -- which rconfigure.py reaches through
+# `build_package()` -- catches the `git describe` failure and answers
+# `v0.0.0-0-gdeadbeeff`, so `DUCKDB_VERSION` becomes `v0.0.0` and the tree
+# builds, installs and passes the glue gate. What it does not do is load an
+# extension: every download then asks
+# extensions.duckdb.org/v0.0.0/<platform>/<name>.duckdb_extension.gz and gets
+# an HTTP 404, which surfaces a whole CI cycle later as a test failure that
+# looks like the engine's.
+#
+# Ask upstream's own resolver rather than reimplementing its tag match, which
+# depends on MAIN_BRANCH_VERSIONING and is upstream's to change.
+#
+# The probe is allowed to fail -- upstream owns that file and may move it --
+# and says so rather than refusing, because only the placeholder is evidence.
+upstream_describe=$(cd "$upstream_dir" && python3 -c \
+  'import sys; sys.path.insert(0, "scripts"); from package_build import get_git_describe; print(get_git_describe())' \
+  2>/dev/null) || upstream_describe=
+if [ -z "$upstream_describe" ]; then
+  echo "Warning: could not read the version $upstream_dir would stamp" >&2
+fi
+if [ "$upstream_describe" = "v0.0.0-0-gdeadbeeff" ]; then
+  echo ""
+  echo "=== NO VERSION IN THE UPSTREAM CLONE ==="
+  echo "$upstream_dir, cloned from $upstream_basedir, has no versioning tag that"
+  echo "'git describe' can reach, so every commit vendored from it would carry"
+  echo "DUCKDB_VERSION \"v0.0.0\" and fail to install any extension."
+  echo "A shallow clone, or one fetched without tags, is the usual cause:"
+  echo "  git -C $upstream_basedir fetch --unshallow origin"
+  echo "  git -C $upstream_basedir fetch --tags origin"
+  echo "Then rerun this script."
+  rm -rf "$upstream_dir"
+  exit 6
+fi
+
 if [ -n "$(git status --porcelain)" ]; then
   echo "Error: working directory not clean"
   exit 1


### PR DESCRIPTION
An upstream clone with no versioning tag stamps `v0.0.0` into the vendored tree and vendors on without a word.

DuckDB's `scripts/package_build.py` resolves the stamp in `get_git_describe()`, which runs `git describe --tags --long --match` and, on a non-zero exit, returns the literal `v0.0.0-0-gdeadbeeff` rather than failing. `scripts/rconfigure.py` reaches that through `build_package()`, so `DUCKDB_VERSION` becomes `v0.0.0` and `DUCKDB_SOURCE_ID` becomes `deadbeeff` in `src/duckdb/src/function/table/version/pragma_version.cpp`, and `R/version.R` follows.

Nothing downstream notices. The tree compiles, the glue gate passes, the package installs, and the whole testsuite runs — until a test loads an extension. Every download then asks `extensions.duckdb.org/v0.0.0/<platform>/<name>.duckdb_extension.gz`, gets an HTTP 404, and the commit is red on `check` one full CI cycle later, with a log that reads like an engine failure rather than a vendoring one.

## Evidence

The series loop's 2026-08-24 firing found four red commits with this cause, two per series on `main` and `main-fwd`:

- `main-dev` e72a1e0b7 and ff51be1e3, `main-fwd-dev` 486f3132a and 8f5c1da5b, all `failure` on stage `check`.
- The log for e72a1e0b7 shows six errors in `test-timezone.R` and one in `test-duckdb-extensions.R`, every one of them `Failed to download extension "icu" at URL "http://extensions.duckdb.org/v0.0.0/linux_amd64/icu.duckdb_extension.gz" (HTTP 404)`.
- `git show e72a1e0b7:src/duckdb/src/function/table/version/pragma_version.cpp` carries `DUCKDB_VERSION "v0.0.0"` and `DUCKDB_SOURCE_ID "deadbeeff"`; the green commit below it carries `v1.6.0-dev13151` and `044a04a7cd`.
- Re-vendoring the same upstream commit from a clone with tags produced a tree differing from the broken one in exactly two files: `R/version.R` and `pragma_version.cpp`.

Repairing it meant rewinding both buffers to `-build-base` and re-vendoring the whole span.

## The change

`scripts/vendor-one.sh` refuses such a clone up front, before any commit is vendored, and says what to fetch.

The check asks upstream's own resolver rather than reimplementing its tag match, which depends on `MAIN_BRANCH_VERSIONING` and is upstream's to change. Only the literal placeholder is treated as evidence; a probe that cannot run at all warns instead of refusing, since upstream owns that file and may move it.

Verified both ways: a `--depth 1` clone of `duckdb/duckdb` is refused with exit 6 and the message below, and a full clone probes as `v1.5.0-13214-g650864b74a` and vendors normally.

```
=== NO VERSION IN THE UPSTREAM CLONE ===
duckdb, cloned from <path>, has no versioning tag that
'git describe' can reach, so every commit vendored from it would carry
DUCKDB_VERSION "v0.0.0" and fail to install any extension.
A shallow clone, or one fetched without tags, is the usual cause:
  git -C <path> fetch --unshallow origin
  git -C <path> fetch --tags origin
Then rerun this script.
```

`.claude/skills/series-loop.md` already said tags are not optional in the setup section; it now names the failure they prevent.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ve6VgkfGyVYdHAvRXP2FoJ)_