### PR TITLE
fix(vendor): Say how a retired patch reaches the vendor commit

### DIFF
--- a/scripts/vendor-one.sh
+++ b/scripts/vendor-one.sh
@@ -264,7 +264,14 @@ while [ $commits_vendored -lt $num_commits ]; do
         echo "uncommitted, and the upstream clone is kept."
         echo "Rebase $f against them, keeping the rebased patch outside the tree,"
         echo "then 'git checkout -- .', put it back, and rerun this script."
-        echo "Delete it only after confirming its change is genuinely upstream."
+        echo "Delete it only after confirming its change is genuinely upstream --"
+        echo "the effect it had, however upstream reached it, not this diff."
+        echo "A deletion has to ride in the vendor commit for ${commit}, and this"
+        echo "script refuses to start on a dirty tree, so land it in three steps:"
+        echo "  git checkout -- . && git rm $f && git commit -m 'tmp: retire patch'"
+        echo "  $0 --commits 1 <upstream>"
+        echo "  git reset --soft HEAD~2 && git commit   # keep the vendor message,"
+        echo "                                          # add an 'R-side fix' section"
         exit 4
       fi
     done


### PR DESCRIPTION
`vendor-one.sh`'s `PATCH BROKEN` refusal already allows deleting the entry "after confirming its change is genuinely upstream", but stops there. Two things a firing then has to work out for itself:

- **How the deletion lands.** It has to ride *inside* the vendor commit for the breaking upstream SHA — the same shape the reverses-cleanly branch produces by itself twenty lines above. But the script refuses to restart on a dirty tree (`Error: working directory not clean`), so a staged `git rm` blocks the very rerun the message asks for. The way through is a temp commit, a one-commit rerun, and a soft reset that folds the two.
- **What "genuinely upstream" is measured on.** The effect the entry had, however upstream reached it — not the diff surviving verbatim. An entry whose effect upstream achieved by different means reads, on a literal test, as "not upstream", which is the reading that keeps a dead patch alive.

This adds both to the refusal text. No behaviour change.

### Evidence

Today's firing hit it on `patch/0012-httplib-rand.patch`, on `main-build` and `main-fwd-build` alike. Upstream duckdb/duckdb@8c813ca6 (duckdb/duckdb#25091) bumps httplib 0.27.0 → 0.53.1 and rewrites `httplib.hpp` wholesale, so the patch neither applied nor reversed. It existed to replace `std::rand()` in `detail::random_string()` with R's `unif_rand()`, because `R CMD check --as-cran` flags a system RNG entry point in compiled code; the rewritten `random_string()` seeds a `std::mt19937` from `std::random_device` and no `std::rand` or `srand` call remains anywhere under `src/duckdb/`. So retiring it was right and re-rooting was not available — and the firing still spent a rerun learning that the staged deletion would be refused.

The retirement is on `krlmlr/duckdb-r@main-dev` and `main-fwd-dev`, in the commit for `duckdb/duckdb@8c813ca6`, with the reasoning in its `R-side fix` section.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BAZzD2pU1xemUqAsqjGzXH)_