### PR TITLE
fix(series): Report what stage 5 added, not what it set out to add

### DIFF
--- a/scripts/series-advance-test.sh
+++ b/scripts/series-advance-test.sh
@@ -195,6 +195,19 @@ bvendor fff1111 1.0.0.9000.1 f.cpp
 bvendor fff2222 1.0.0.9000.2 g.cpp
 git branch solo-build-base base-seed
 
+# --- a buffer commit whose content already reached -dev (claim 12) ----------
+# Stage 3 sends a patch/ entry down both paths on purpose, so the replay drops
+# it (`--empty=drop`) and the stage adds nothing. The subject on the -dev side
+# is not a vendor one, so the anchor looks past it to the seed and the buffer
+# still reads as one commit ahead -- which is what makes the drop reachable.
+git checkout -q -b dup-dev base-seed
+bvendor fff3333 1.0.0.9000.1 i.cpp
+git commit -q --amend -m 'chore: Carry the same content by another route'
+git branch dup-green base-seed
+git checkout -q -b dup-build base-seed
+bvendor fff3333 1.0.0.9000.1 i.cpp
+git branch dup-build-base base-seed
+
 # The store stub: stage 5 refuses over a `failure` and reads `missing` for
 # anything absent, which is what a freshly pushed commit looks like.
 git checkout -q --orphan rcc2
@@ -204,7 +217,8 @@ git commit -q --allow-empty -m 'chore: empty store'
 git checkout -q main
 git push -q origin main base-seed base-build base-dev base-green base-build-base \
   base-fwd-build base-fwd-dev base-fwd-green base-fwd-build-base \
-  solo-build solo-dev solo-green solo-build-base rcc2
+  solo-build solo-dev solo-green solo-build-base \
+  dup-build dup-dev dup-green dup-build-base rcc2
 git fetch -q origin
 
 run() { set +e; scripts/series-advance.sh "$@" 2>&1; echo "EXIT=$?"; set -e; }
@@ -371,6 +385,16 @@ is "replayed onto the base's own tip, not the buffer's" \
   "$(git rev-parse "$F^")" "$(git rev-parse origin/base-green)"
 is "and the counter rose once for it" \
   "$(git show "$F:DESCRIPTION" | sed -n 's/^Version: //p')" 1.0.0.9000.6
+
+# --- claim 12: a replay that drops every commit says so -----------------------
+echo
+echo "== a buffer commit whose content already reached -dev"
+before=$(git rev-parse origin/dup-dev)
+out=$(run dup)
+hasnt "does not report an empty buffer" "$out" 'buffer empty'
+has   "reports nothing added"           "$out" "dev -> $(git rev-parse --short "$before") (+0)"
+git fetch -q origin
+is "and leaves dev where it was" "$(git rev-parse origin/dup-dev)" "$before"
 
 echo
 echo "$pass passed, $fail failed"

--- a/scripts/series-advance.sh
+++ b/scripts/series-advance.sh
@@ -462,6 +462,13 @@ if [ "$ahead" -eq 0 ]; then
 fi
 n=$((ahead < chunk ? ahead : chunk))
 
+# What -dev is at before this stage writes anything, so the closing line can
+# report what the stage actually added rather than what it set out to add. The
+# replay drops a buffer commit whose content reached -dev by another route
+# (`--empty=drop` below), so the two differ, and `git push` moves the
+# remote-tracking ref this resolves -- read it once, here.
+dev_before=$(git rev-parse "$dev")
+
 # Which commits in this chunk have a test-side fix waiting on the base series.
 # Computed before anything is written, because it decides the route: a plain ref
 # move cannot carry content, so one carry in the chunk makes the whole chunk a
@@ -629,4 +636,4 @@ else
   rm -f "$STATE"
   git push "$remote" "$next:refs/heads/$S-dev"
 fi
-echo "dev -> $(git rev-parse --short "$next") (+$n)"
+echo "dev -> $(git rev-parse --short "$next") (+$(git rev-list --count "$dev_before..$next"))"


### PR DESCRIPTION
`scripts/series-advance.sh` closed with `(+$n)` — the chunk size it computed *before* replaying, not what the replay produced. The replay drops a buffer commit whose content reached `-dev` by another route (`--empty=drop`), so the two numbers differ, and a run that added nothing still claimed a commit.

Observed on `v1.4-andium` in today's series-loop firing, where the buffer's `chore: Auto-update from GitHub Actions` commit replayed to empty:

```
green unchanged at 97017f595
dropping f52ed130b0955dc140c46476156d52744635ebd7 chore: Auto-update from GitHub Actions -- patch contents already upstream
Everything up-to-date
dev -> 97017f595 (+1)
```

`dev` did not move — `Everything up-to-date` says so one line earlier. That closing line is the only thing a firing reads to learn whether the stage pushed anything, so a wrong count there reads as ref motion that never happened.

## The fix

Count `$dev_before..$next` instead. `dev_before` is read once, next to where the chunk size is computed, because `git push` moves the remote-tracking ref that `$dev` would otherwise resolve to by the time the line prints.

The ref-move fast path is unaffected: it takes the nth buffer commit by position, so its delta was always exactly `n`.

## Test

`scripts/series-advance-test.sh` gains a twelfth claim — a series whose single buffered commit has already reached `-dev` under a non-vendor subject, which is the shape stage 3 creates on purpose when it sends a `patch/` entry down both paths. The anchor looks past that subject to the seed, so the buffer still reads as one commit ahead and the drop is reachable.

Against `main`'s script the new claim fails (`missing: dev -> f793be1 (+0)`); with the fix the suite is 57 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VEKNYxsPR7mPquar5dQ1Ng

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEKNYxsPR7mPquar5dQ1Ng)_