### PR TITLE
fix(series): Stop counting a buffer commit stage 5 would drop as empty

### DIFF
--- a/scripts/series-check.sh
+++ b/scripts/series-check.sh
@@ -86,6 +86,38 @@ vendored_sha() {
   echo "$sha"
 }
 
+# How many commits of a buffer range are still work for stage 5.
+#
+# series-advance.sh replays them with `cherry-pick --empty=drop`, so a commit
+# whose every path `-dev` already carries at that commit's post-image produces
+# nothing and is dropped. Counting one leaves the series reading ADVANCE for
+# ever: the firing runs the advance, is told `dev -> … (+0)`, and reads the
+# same verdict again next time. Only a new vendor commit on the buffer would
+# clear it, by moving the anchor past the whole run.
+#
+# Observed on v1.4-andium since 2026-08-06 (f52ed130b). A buffer takes no ports
+# by design, so its `.github/` predates the removal of the `v*.*-*` push filter
+# from R-CMD-check.yaml, and a series ref move still triggers `rcc` there; its
+# auto-update step committed a `Config/roxygen2/version` bump onto `-build`
+# that `-dev` already carried.
+#
+# The comparison is by content and not by patch-id: `git cherry` reports such a
+# commit as unmerged, because the same post-image was reached on `-dev` by a
+# different diff.
+consumable_count() { # <range> <dev> -> commits of <range> that are not no-ops on <dev>
+  local range=$1 dev=$2 n=0 c f
+  while IFS= read -r c; do
+    while IFS= read -r -d '' f; do
+      if [ "$(git rev-parse -q --verify "$c:$f" || true)" \
+        != "$(git rev-parse -q --verify "$dev:$f" || true)" ]; then
+        n=$((n + 1))
+        break
+      fi
+    done < <(git diff-tree --no-commit-id --name-only -r -z "$c")
+  done < <(git rev-list "$range")
+  echo "$n"
+}
+
 # The store's record for a commit: one small blob, published by the matrix leg
 # seconds after it decided the commit. One read for every question below, so they
 # cannot disagree about which verdict they are describing — which they could
@@ -240,15 +272,17 @@ for S in "${series[@]}"; do
   # the buffer counts from -dev's consumption anchor on -build: the -dev tip
   # while it sits on -build's line, otherwise the -build commit equivalent to
   # -dev's newest vendor commit — the identical rule, and the identical reasons,
-  # as the anchor in scripts/series-advance.sh.
+  # as the anchor in scripts/series-advance.sh. It counts what that stage would
+  # actually mint, which is why a commit it would drop as empty is not buffered
+  # work (consumable_count above).
   mb=$(git merge-base "$dev" "$build")
   if [ "$mb" = "$(git rev-parse "$dev")" ]; then
-    buffered=$(git rev-list --count "$dev..$build")
+    buffered=$(consumable_count "$dev..$build" "$dev")
   else
     dev_up=$(vendored_sha "$dev")
     anchor=$(git log --format='%H %s' "$build" | grep -m 1 "duckdb@${dev_up:-NONE}" | cut -d' ' -f1 || true)
     if [ -n "$anchor" ]; then
-      buffered=$(git rev-list --count "$anchor..$build")
+      buffered=$(consumable_count "$anchor..$build" "$dev")
     else
       buffered="?"
     fi


### PR DESCRIPTION
`series-check.sh` counts every commit in the buffer range. `series-advance.sh` replays them with `cherry-pick --empty=drop`, so a commit whose every path `-dev` already carries at that commit's post-image produces nothing and is dropped. The two disagree, and the disagreement does not settle: the firing reads `ADVANCE`, runs the advance, is told `dev -> … (+0)`, and reads `ADVANCE` again next firing. Only a new vendor commit on the buffer clears it, by moving the anchor past the whole run.

## The commit that has been doing this

`v1.4-andium` has read `ADVANCE` since 2026-08-06, on `f52ed130b`:

```
=== v1.4-andium: 0 in flight, 1 buffered, green=9aabbe331 dev=9aabbe331
  ADVANCE
```

and the advance that verdict asks for says

```
green unchanged at 9aabbe331
dropping f52ed130b0955dc140c46476156d52744635ebd7 chore: Auto-update from GitHub Actions -- patch contents already upstream
dev -> 9aabbe331 (+0)
```

Upstream `v1.4-andium` last moved on 2026-07-07, so nothing was going to clear it on its own.

Where the commit came from is worth recording, because it is not a one-off. A buffer takes no ports by design, so `v1.4-andium-build`'s `.github/` still carries the `v*.*-*` push filter that `main`'s `R-CMD-check.yaml` has since dropped. That pattern matches every `v1.4-andium-*` series ref, so a ref move triggers `rcc` from the buffer's own tree, and its auto-update step commits a `Config/roxygen2/version` bump back onto the ref. It happened again on 2026-09-04, on `v1.4-andium-build-base` this time — run `33918111854`, head branch `v1.4-andium-build-base` — producing `842165b3c`, a second sibling of `f52ed130b` with an identical tree. That is the sibling pair `.claude/skills/series-loop.md` records under stage 3 as having happened once; it has now happened twice, and this is what wrote it. Nothing on `main` can reach those buffers, so the loop has to read the situation correctly rather than be spared it.

## The fix

`consumable_count <range> <dev>` counts only the commits stage 5 would actually mint, and the buffer count uses it on both of its branches.

The comparison is by content and not by patch-id: `git cherry` reports `f52ed130b` as unmerged (`+ f52ed130b…`), because `-dev` reached the same post-image by a different diff. So a patch-id test would not have caught it.

## Checked

Against the six live series, `main`'s copy of the script:

- `v1.4-andium` goes from `1 buffered` / `ADVANCE` to `0 buffered` / `IDLE`.
- The other five series' counts and verdicts are unchanged, as are all three `CUTOVER` lines.
- Run time goes from 1.5 s to 2.4 s over all six.
- A five-commit range of real vendor commits still counts 5.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FqjecFkTtJTy8FoMbtXH26

---
_Generated by [Claude Code](https://claude.ai/code/session_01FqjecFkTtJTy8FoMbtXH26)_