### PR TITLE
perf(revdepx): Compile the dev binary through ccache

### DIFF
--- a/.github/workflows/revdep4.yaml
+++ b/.github/workflows/revdep4.yaml
@@ -412,6 +412,23 @@ jobs:
           restore-keys: |
             revdepx-pak-build-
 
+      # The compiler cache, which is what keeps this job from recompiling the
+      # whole vendored engine every run. Everything in it was produced by the
+      # base image's toolchain, so the key carries that image's recipe hash
+      # and the R version naming it: a change to either is a different
+      # compiler, and ccache would miss on every object regardless. The run id
+      # makes the key unique, because actions/cache never overwrites a key
+      # that already exists and the cache would otherwise be saved once and
+      # never again; restore-keys then takes the newest cache the same
+      # toolchain left behind.
+      - name: Cache the compiler cache
+        uses: actions/cache@v5
+        with:
+          path: ${{ runner.temp }}/ccache
+          key: revdepx-ccache-${{ env.REVDEPX_R_VERSION_INPUT }}-${{ hashFiles('.github/workflows/revdepx/base-image.sh') }}-${{ github.run_id }}
+          restore-keys: |
+            revdepx-ccache-${{ env.REVDEPX_R_VERSION_INPUT }}-${{ hashFiles('.github/workflows/revdepx/base-image.sh') }}-
+
       # Inside the base container, because the binary must load under the
       # container's R (the pinned oldrel), and a binary built by the runner's
       # newer R would not.
@@ -420,22 +437,35 @@ jobs:
           BASE_IMAGE: ${{ needs.base.outputs.image }}
         run: |
           set -eu
-          mkdir -p "${RUNNER_TEMP}/pkg" "${RUNNER_TEMP}/pak-cache"
+          mkdir -p "${RUNNER_TEMP}/pkg" "${RUNNER_TEMP}/pak-cache" \
+            "${RUNNER_TEMP}/ccache"
+          # CCACHE_MAXSIZE is a budget, not an estimate: a repository gets
+          # 10 GB of Actions cache in total and the universe job's pak cache
+          # already spends more than two of them, so a compiler cache that
+          # grew without a ceiling would evict the very thing it shares the
+          # budget with. ccache compresses what it stores; raise this if the
+          # statistics in the build summary start reporting evictions.
           docker run --rm \
             -v "${GITHUB_WORKSPACE}:/revdepx/src" \
             -v "${RUNNER_TEMP}/pkg:/revdepx/pkg-out" \
             -v "${RUNNER_TEMP}/pak-cache:/root/.cache/R/pkgcache" \
+            -v "${RUNNER_TEMP}/ccache:/revdepx/ccache" \
             -w /revdepx/src \
             -e REVDEPX_BUILD_DEPS=1 \
             -e PKG_SYSREQS=true \
             -e OUT_DIR=/revdepx/pkg-out \
+            -e CCACHE_DIR=/revdepx/ccache \
+            -e CCACHE_MAXSIZE=2G \
             -e GITHUB_SHA \
             "${BASE_IMAGE}" \
             Rscript ./.github/workflows/revdepx/build.R
           # Root in the container wrote the pak cache, and its 600 lock
           # files defeat the cache post-step's tar ("Permission denied",
-          # save skipped). Hand the tree back to the runner user.
-          sudo chown -R "$(id -u):$(id -g)" "${RUNNER_TEMP}/pak-cache" || true
+          # save skipped). Hand the tree back to the runner user. The
+          # compiler cache is root-written for the same reason and needs the
+          # same handover.
+          sudo chown -R "$(id -u):$(id -g)" \
+            "${RUNNER_TEMP}/pak-cache" "${RUNNER_TEMP}/ccache" || true
         shell: bash
 
       - name: Upload the package binary

--- a/.github/workflows/revdepx/base-image.sh
+++ b/.github/workflows/revdepx/base-image.sh
@@ -20,6 +20,11 @@
 # (the same lesson revdep2 learnt on the host). Everything downstream (the
 # universe image, every check container) stands on this.
 #
+# ccache is the one entry no check needs. The build job compiles the whole
+# vendored engine on the critical path of every run, and it alone puts
+# /usr/lib/ccache on its PATH (revdepx/build.R): a check container carries
+# the binary and never invokes it.
+#
 # Usage:
 #   base-image.sh <r-version> <registry-image>   # ensure it exists, print ref
 #   base-image.sh --tag-only <r-version>         # print the tag; no docker
@@ -110,6 +115,7 @@ RUN apt-get update \\
       xvfb xauth xfonts-base \\
       libtcl8.6 libtk8.6 \\
       tidy curl file git locales unzip \\
+      ccache \\
     && rm -rf /var/lib/apt/lists/*
 # Rust, for the reverse dependencies that compile cargo crates -- run
 # 32260705703 left exactly six packages uninstallable, every one of them

--- a/.github/workflows/revdepx/build.R
+++ b/.github/workflows/revdepx/build.R
@@ -16,6 +16,10 @@
 #   OUT_DIR             - where tarball, binary and metadata land (default: pkg)
 #   REVDEPX_BUILD_DEPS  - if truthy, pak-install the package's own hard
 #                         dependencies (with system requirements) first
+#   CCACHE_DIR          - read by ccache itself, not by this script: where
+#                         the compiler cache lives. Point it at a mount the
+#                         caller persists between runs, or leave it unset
+#                         and every object is compiled from scratch
 
 source(file.path(
   dirname(sub("--file=", "", grep("^--file=", commandArgs(), value = TRUE))),
@@ -24,6 +28,75 @@ source(file.path(
 
 out_dir <- env_chr("OUT_DIR", "pkg")
 dir.create(out_dir, recursive = TRUE, showWarnings = FALSE)
+
+# Compile through ccache. This build is the whole vendored engine and it is
+# on the critical path of every run -- no shard starts before the binary
+# exists -- while between runs the engine moves by one vendor commit at a
+# time, which is exactly the shape a content-addressed compiler cache pays
+# off on.
+#
+# Debian's ccache package keeps one symlink per installed compiler under
+# /usr/lib/ccache, so putting that directory first on PATH routes every
+# `gcc`/`g++` the build resolves through ccache and touches neither R's
+# Makeconf nor ~/.R/Makevars. Prefixing the compiler in Makevars instead is
+# the alternative, and it is the one that bit us before: R-devel took the
+# first word of `CC = ccache gcc` and ran a bare `ccache`, which died with
+# "invalid option -- 'E'" (.github/workflows/install/action.yml says more).
+#
+# Where the cache lives is CCACHE_DIR's business, and the caller's: with a
+# persisted mount this is minutes off every run, with nothing mounted it is
+# the container's own directory, thrown away with the container. Correct
+# either way -- a cold cache only ever costs the hashing.
+ccache_bin_dir <- "/usr/lib/ccache"
+use_ccache <- dir.exists(ccache_bin_dir) && nzchar(Sys.which("ccache"))
+if (use_ccache) {
+  Sys.setenv(
+    PATH = paste(ccache_bin_dir, Sys.getenv("PATH"), sep = .Platform$path.sep)
+  )
+  # Zeroed so the statistics printed at the end describe this build alone,
+  # not every build the restored cache has ever served.
+  system2("ccache", "--zero-stats", stdout = FALSE, stderr = FALSE)
+  cache_dir <- Sys.getenv("CCACHE_DIR")
+  inform(
+    "Compiling through ccache, cache in ",
+    if (nzchar(cache_dir)) {
+      cache_dir
+    } else {
+      "the container's own directory (not persisted)"
+    }
+  )
+} else {
+  inform("ccache is not installed in this image; compiling without it")
+}
+
+# ccache's own words rather than a hit rate parsed out of them: the format of
+# `--show-stats` has changed more than once between ccache versions, and a
+# mis-parse would report a healthy cache as a cold one -- the exact thing this
+# is here to notice.
+ccache_stats <- function() {
+  out <- tryCatch(
+    suppressWarnings(system2(
+      "ccache",
+      "--show-stats",
+      stdout = TRUE,
+      stderr = TRUE
+    )),
+    error = function(e) character()
+  )
+  if (length(out) == 0) {
+    return(character())
+  }
+  c(
+    "",
+    "<details><summary>ccache statistics</summary>",
+    "",
+    "```",
+    out,
+    "```",
+    "",
+    "</details>"
+  )
+}
 
 if (env_flag("REVDEPX_BUILD_DEPS")) {
   # The image's baked repo may be a frozen P3M snapshot (rocker pins the last
@@ -137,8 +210,14 @@ write_json(
 )
 inform("Binary: ", binary)
 
+# What the cache actually did, in the log and in the run summary: a hit rate
+# is the only way to notice that a key stopped matching and every run has
+# quietly gone back to compiling the engine from scratch.
+ccache_summary <- if (use_ccache) ccache_stats() else character()
+
 append_summary(c(
   "## revdepx build",
   "",
-  sprintf("Built `%s` %s: `%s`.", package, dev_version, binary)
+  sprintf("Built `%s` %s: `%s`.", package, dev_version, binary),
+  ccache_summary
 ))


### PR DESCRIPTION
The `build` job compiles the whole vendored engine, and it sits on the critical path of every `revdep4` run — no shard starts before the binary exists. Run 34677973468 spent 48 minutes there against a 90-minute timeout, and every earlier run paid the same from scratch: the only thing the job persisted was pak's *package* cache, never compiler output.

Between runs the engine moves by one vendor commit at a time, which is the shape a content-addressed compiler cache pays off on. So this installs `ccache` in the base image, mounts a runner directory as `CCACHE_DIR`, and persists it with `actions/cache`.

**The compilers are reached by PATH, not by `~/.R/Makevars`.** Debian's ccache package keeps one symlink per installed compiler under `/usr/lib/ccache`, so prepending that directory routes every `gcc`/`g++` the build resolves, touching neither R's `Makeconf` nor any `Makevars`. Prefixing the compiler in `Makevars` is the alternative, and it is the one that bit us before: R-devel took the first word of `CC = ccache gcc` and ran a bare `ccache`, which died with `invalid option -- 'E'`. `.github/workflows/install/action.yml` carries that story.

**Only the build job puts `/usr/lib/ccache` on its PATH.** A check container inherits the binary from the base image and never invokes it, so no reverse dependency's own compile changes behaviour or timing.

**Verified end to end** rather than assumed: with `/usr/lib/ccache` prepended and no `Makevars` in play, `R CMD INSTALL` of a small C package compiles as a bare `gcc ... -c hello.c -o hello.o` and ccache records one miss; re-running after deleting the object records a direct hit (1/1).

### Costs, stated plainly

`CCACHE_MAXSIZE` is 2G deliberately: a repository gets 10 GB of Actions cache in total and the universe job's pak cache already spends more than two of them, so an uncapped compiler cache would evict the very thing it shares the budget with.

Editing `base-image.sh` rolls the base image tag, by design. That costs one base-image rebuild and — because the universe image reuses its donor only when the donor stands on the same base — one cold universe build on the first run after this lands. Steady state after that.

### Not in scope

The shard checks compile each reverse dependency twice (old half, then new half) with nothing shared between them. ccache is now present in the image for that too, but wiring it into `check-half.sh` is a separate change with its own correctness story, and its payoff is unmeasured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019uQbmeLGpgaAd5iAULGbDf

---
_Generated by [Claude Code](https://claude.ai/code/session_011111gzMorCmNxr7sHKWR3L)_