### PR TITLE
fix(connections): Warn rather than fail when a reused instance drops settings

### DIFF
--- a/R/Driver.R
+++ b/R/Driver.R
@@ -108,7 +108,8 @@ driver_registry <- new.env(parent = emptyenv())
 #'
 #' Because the instance is created once per database file,
 #' `config`, `read_only`, `home`, and `shared_home` take effect only at creation.
-#' A call that reuses an existing instance cannot apply them, and fails rather than dropping them.
+#' A call that reuses an existing instance cannot apply them, and warns rather than dropping them silently.
+#' The warning is classed `duckdb_instance_settings_ignored`, so it can be caught or suppressed on purpose.
 #' Passing `dbdir` to `dbConnect()` fails too when the driver owns a database file of its own,
 #' because the connection would go to `dbdir` while the driver kept its own database open.
 #' To apply different values to a file-based database --
@@ -423,6 +424,14 @@ check_tz <- function(timezone) {
 # the driver's own values, and repeating a setting the instance already has is
 # not a collision. Explained in handbook/usage/connections/README.md;
 # duckdb/duckdb-r#2560 asks for the noise, duckdb/duckdb-r#126 for the removal.
+#
+# A warning, not an error. It began as an error, and a reverse-dependency run
+# against 353 packages priced that choice: `datacaged` and `Rduckhts` both stop
+# where 1.5.5 ran, on calls that pass `read_only` to a database they opened
+# earlier. The setting was silently dropped before and is still dropped now --
+# what the error bought was the telling, and a warning tells just as loudly
+# without ending the script. `duckdb_instance_settings_ignored` classes it, so
+# a caller who has read the message once can silence it deliberately.
 warn_instance_settings_ignored <- function(
   drv,
   read_only,
@@ -449,7 +458,7 @@ warn_instance_settings_ignored <- function(
     return(invisible())
   }
 
-  abort(
+  warn(
     c(
       paste0(
         paste0("`", ignored, "`", collapse = ", "),
@@ -460,6 +469,7 @@ warn_instance_settings_ignored <- function(
       "These settings take effect only when the instance is created.",
       "Release it with `duckdb_shutdown()` first, or pass them to the `duckdb()` call that creates it."
     ),
+    class = "duckdb_instance_settings_ignored",
     call = call
   )
 }

--- a/R/dbConnect__duckdb_driver.R
+++ b/R/dbConnect__duckdb_driver.R
@@ -11,7 +11,7 @@
 #' @param read_only Set to `TRUE` for read-only operation.
 #'   For file-based databases, this is only applied when the database file is opened for the first time.
 #'   Subsequent connections (via the same `drv` object or a `drv` object pointing to the same path)
-#'   cannot apply it, and fail rather than ignoring it.
+#'   cannot apply it, and warn rather than ignoring it silently.
 #' @param timezone_out The time zone in which plain `TIMESTAMP` columns
 #'   (without time zone) are returned to R, defaults to `"UTC"`.
 #'   If you want to display datetime values in the local timezone,
@@ -25,7 +25,7 @@
 #' @param config Named list with DuckDB configuration flags, see
 #'   <https://duckdb.org/docs/configuration/overview#configuration-reference> for the possible options.
 #'   These flags are only applied when the database object is instantiated.
-#'   Subsequent connections cannot apply them, and fail rather than ignoring them.
+#'   Subsequent connections cannot apply them, and warn rather than ignoring them silently.
 #' @param bigint How 64-bit integers should be returned. There are two options: `"numeric"` and `"integer64"`.
 #'   If `"numeric"` is selected, bigint integers will be treated as double/numeric.
 #'   If `"integer64"` is selected, bigint integers will be set to bit64 encoding.

--- a/R/rlang.R
+++ b/R/rlang.R
@@ -34,6 +34,26 @@ abort <- function(message = NULL, ..., class = NULL, call = NULL) {
   stop(paste(message, collapse = "\n"), call. = FALSE)
 }
 
+# `rlang::warn()`. How this package raises the diagnostics that are not fatal.
+#
+# The base fallback keeps the message vector joined with newlines, the bulleted
+# layout being rlang's, and drops the calling function the way `abort()` does.
+#
+# Unlike `abort()` it honours `class`, via `warningCondition()`. The class is
+# not decoration: `duckdb_instance_settings_ignored` is documented as the
+# handle for catching or suppressing that warning on purpose, and a contract
+# that held only where rlang happens to be installed would not be one. `call`
+# stays accepted and ignored, so a call site need not know which
+# implementation it is talking to.
+warn <- function(message = NULL, ..., class = NULL, call = NULL) {
+  warning(warningCondition(
+    paste(message, collapse = "\n"),
+    class = class,
+    call = NULL
+  ))
+  invisible()
+}
+
 # `rlang::check_dots_empty0()`.
 check_dots_empty0 <- function(...) {
   if (...length() > 0L) {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -26,6 +26,7 @@
     rapi_error <<- rapi_error_rlang
     check_dots_empty0 <<- rlang::check_dots_empty0
     inform <<- rlang::inform
+    warn <<- rlang::warn
     arg_match <<- rlang::arg_match
   } else {
     rethrow_restore()

--- a/handbook/usage/connections/README.md
+++ b/handbook/usage/connections/README.md
@@ -37,28 +37,36 @@ The load-bearing facts:
   release the instance with `duckdb_shutdown()` first;
   a setting the engine also accepts after startup, `memory_limit`
   and `threads` among them, can be `SET` on the connection instead.
-* **Each of those losses is now an error**
+* **Each of those losses warns**
   ([#2560](https://github.com/duckdb/duckdb-r/issues/2560)),
+  under the class `duckdb_instance_settings_ignored`,
   and taking the arguments out of `dbConnect()` altogether remains
   [#126](https://github.com/duckdb/duckdb-r/issues/126).
-  A setting is refused when it *differs* from the instance's, not
+  A setting is reported when it *differs* from the instance's, not
   merely when it is passed: `dbConnect()` forwards the driver's own
   values, so repeating one is no collision.
-  A `dbdir` that would displace the driver's is refused only when the
-  driver owns a file — `dbConnect(duckdb(), "my.db")` displaces a
-  throwaway in-memory database and is the documented idiom.
+  A `dbdir` that would displace the driver's is a different case and
+  still an error, and only when the driver owns a file —
+  `dbConnect(duckdb(), "my.db")` displaces a throwaway in-memory
+  database and is the documented idiom.
   The way through, either way, is `duckdb_shutdown()`.
-* **Why an error and not a warning.**
-  The trade is a script that used to run and now stops, against a
-  setting the caller believed had applied.
-  The second is the worse failure and the harder one to notice —
+* **Why a warning and not an error.**
+  It was an error first.
+  The reasoning was that a setting the caller believed had applied is
+  the worse failure and the harder one to notice —
   a database opened writable when `read_only = TRUE` was asked for
-  reads as success until something writes — and
-  [tidy design](https://design.tidyverse.org/) settles which way that
-  goes.
-  The cost is bounded by comparing values rather than counting
-  arguments: the calls that break are the ones that were already not
-  doing what they said.
+  reads as success until something writes.
+  A reverse-dependency run over 353 packages then priced the other
+  side of that trade: `datacaged` and `Rduckhts` stop where 1.5.5 ran,
+  on calls that hand `read_only` to a database they opened earlier.
+  A warning keeps the telling, which is what #2560 asked for, and
+  drops the part that ends somebody else's script.
+  The setting is no more applied than it was before —
+  the caller now reads about it and carries on.
+  Silence is still the thing being fixed, and the cost stays bounded
+  by comparing values rather than counting arguments:
+  the calls that warn are the ones that were already not doing what
+  they said.
 * **A `dbdir` an extension answers is not normalized.**
   `md:` (MotherDuck), `ducklake:` and their kind name a replacement
   open, not a file, so they pass through untouched; normalizing one

--- a/man/duckdb.Rd
+++ b/man/duckdb.Rd
@@ -52,7 +52,7 @@ data is kept in RAM.}
 \item{read_only}{Set to \code{TRUE} for read-only operation.
 For file-based databases, this is only applied when the database file is opened for the first time.
 Subsequent connections (via the same \code{drv} object or a \code{drv} object pointing to the same path)
-cannot apply it, and fail rather than ignoring it.}
+cannot apply it, and warn rather than ignoring it silently.}
 
 \item{bigint}{How 64-bit integers should be returned. There are two options: \code{"numeric"} and \code{"integer64"}.
 If \code{"numeric"} is selected, bigint integers will be treated as double/numeric.
@@ -61,7 +61,7 @@ If \code{"integer64"} is selected, bigint integers will be set to bit64 encoding
 \item{config}{Named list with DuckDB configuration flags, see
 \url{https://duckdb.org/docs/configuration/overview#configuration-reference} for the possible options.
 These flags are only applied when the database object is instantiated.
-Subsequent connections cannot apply them, and fail rather than ignoring them.}
+Subsequent connections cannot apply them, and warn rather than ignoring them silently.}
 
 \item{...}{These dots are for future extensions and must be empty.}
 
@@ -211,7 +211,8 @@ every \code{duckdb()} call creates a fresh, isolated instance.
 
 Because the instance is created once per database file,
 \code{config}, \code{read_only}, \code{home}, and \code{shared_home} take effect only at creation.
-A call that reuses an existing instance cannot apply them, and fails rather than dropping them.
+A call that reuses an existing instance cannot apply them, and warns rather than dropping them silently.
+The warning is classed \code{duckdb_instance_settings_ignored}, so it can be caught or suppressed on purpose.
 Passing \code{dbdir} to \code{dbConnect()} fails too when the driver owns a database file of its own,
 because the connection would go to \code{dbdir} while the driver kept its own database open.
 To apply different values to a file-based database --

--- a/tests/testthat/test-instance-settings.R
+++ b/tests/testthat/test-instance-settings.R
@@ -10,8 +10,8 @@ test_that("reusing an instance is silent when nothing collides", {
   withr::defer(dbDisconnect(con))
 
   # Same settings again.
-  expect_no_error(duckdb(path))
-  expect_no_error(dbDisconnect(dbConnect(drv)))
+  expect_no_warning(duckdb(path))
+  expect_no_warning(dbDisconnect(dbConnect(drv)))
 })
 
 test_that("a differing `bigint` is not a collision", {
@@ -39,9 +39,25 @@ test_that("a `read_only` that the instance cannot honor is reported", {
   con <- dbConnect(drv)
   withr::defer(dbDisconnect(con))
 
-  expect_error(duckdb(path, read_only = TRUE), "read_only")
-  # Refused, not applied: the writable instance is untouched and still reachable.
-  expect_identical(duckdb(path)@database_ref, drv@database_ref)
+  expect_warning(reused <- duckdb(path, read_only = TRUE), "read_only")
+  # Dropped, not applied, and the call still returns the instance it found:
+  # the warning says what was lost without ending the caller's script.
+  expect_identical(reused@database_ref, drv@database_ref)
+  expect_false(reused@read_only)
+})
+
+test_that("the warning is classed, so it can be silenced deliberately", {
+  path <- file.path(withr::local_tempdir(), "db.duckdb")
+
+  drv <- duckdb(path)
+  withr::defer(duckdb_shutdown(drv))
+  con <- dbConnect(drv)
+  withr::defer(dbDisconnect(con))
+
+  expect_warning(
+    duckdb(path, read_only = TRUE),
+    class = "duckdb_instance_settings_ignored"
+  )
 })
 
 test_that("a `config` entry that the instance cannot honor is reported", {
@@ -52,9 +68,10 @@ test_that("a `config` entry that the instance cannot honor is reported", {
   con <- dbConnect(drv)
   withr::defer(dbDisconnect(con))
 
-  # Repeating what the instance already has is not a collision.
-  expect_no_error(duckdb(path, config = list(default_order = "DESC")))
-  expect_error(
+  # Repeating what the instance already has is not a collision, and so is not
+  # a warning either -- `dbConnect()` forwards the driver's own values.
+  expect_no_warning(duckdb(path, config = list(default_order = "DESC")))
+  expect_warning(
     duckdb(path, config = list(default_order = "ASC")),
     "config$default_order",
     fixed = TRUE
@@ -69,7 +86,8 @@ test_that("storage arguments are reported when the instance already exists", {
   con <- dbConnect(drv)
   withr::defer(dbDisconnect(con))
 
-  expect_error(duckdb(path, shared_home = FALSE), "shared_home")
+  expect_warning(reused <- duckdb(path, shared_home = FALSE), "shared_home")
+  expect_identical(reused@database_ref, drv@database_ref)
 })
 
 test_that("a `dbdir` that overrides a file driver's own is reported", {


### PR DESCRIPTION
Since #2641, `duckdb()` refuses to reuse a cached instance when the call passes `read_only`, a `config` entry, or a storage argument that differs from the one the instance was created with. A reverse-dependency run over 353 packages priced that choice: `datacaged` and `Rduckhts` both stop where 1.5.5 ran, each on a `read_only` handed to a database it had opened earlier.

The setting was silently dropped before #2641 and is still dropped now. What the error bought was the telling, and a warning tells just as loudly without ending somebody else's script. So `warn_instance_settings_ignored()` warns — which is what its name said all along — and `duckdb()` returns the instance it found.

The warning is classed `duckdb_instance_settings_ignored`, so a caller who has read it once can silence it deliberately. The class holds on both paths: `R/rlang.R` gains a `warn()` fallback that honours `class` through `warningCondition()`, because a contract that held only where rlang happens to be installed would not be one.

The `dbdir` override that `dbConnect()` refuses is a separate case and stays an error. It displaces the driver's own database rather than dropping a setting, and it broke no reverse dependency.

`handbook/usage/connections/README.md` argued for the error; that section now carries this reasoning instead.

Alternative approach in #2693; these are mutually exclusive, only one should merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016xj5YaYaSnxsdxTibchhKn