### PR TITLE
fix(connections): Warn instead of failing for the two callers that break

### DIFF
--- a/R/Driver.R
+++ b/R/Driver.R
@@ -417,12 +417,55 @@ check_tz <- function(timezone) {
   timezone
 }
 
+# The CRAN packages that call `duckdb()` with instance settings for a database
+# they opened earlier, and so would stop at the error below.
+#
+# A reverse-dependency run over 353 packages found exactly these two. They get
+# the warning instead; every other caller gets the error. The list is meant to
+# be deleted, not extended: each entry goes when that package stops passing
+# settings to a reused instance, and a third package discovered later is a
+# reason to reconsider erroring at all rather than to add a line here.
+#
+# Two things this list does not do. It does not help a user's own script, or
+# any package not on it, doing exactly what these two do. And it makes the
+# behaviour depend on who is calling, so the same line errors from a script and
+# warns from inside `datacaged` -- which is a thing to remember when a report
+# does not reproduce.
+INSTANCE_SETTINGS_WARN_ONLY <- c("datacaged", "Rduckhts")
+
+# The package whose code called us, or NULL from a script or the console.
+# `find_caller()` in R/dbSendQuery__duckdb_connection_character.R walks the
+# stack the same way for a different purpose; this one wants the name. DBI is
+# skipped with our own namespace because `dbConnect()` sits between the caller
+# and here.
+calling_package <- function() {
+  frames <- sys.frames()
+  skip <- c(get_package_name(), "DBI", "base", "methods")
+
+  for (i in rev(seq_along(frames))) {
+    env <- topenv(frames[[i]])
+    if (!isNamespace(env)) {
+      next
+    }
+    name <- environmentName(env)
+    if (name %in% skip) {
+      next
+    }
+    return(name)
+  }
+
+  NULL
+}
+
 # `config`, `read_only` and the storage arguments describe the database
 # *instance*, so a call that finds one in the registry cannot apply them. They
 # are compared rather than merely counted as supplied: `dbConnect()` forwards
 # the driver's own values, and repeating a setting the instance already has is
 # not a collision. Explained in handbook/usage/connections/README.md;
 # duckdb/duckdb-r#2560 asks for the noise, duckdb/duckdb-r#126 for the removal.
+#
+# An error, except for the callers named in INSTANCE_SETTINGS_WARN_ONLY, who
+# get the same words as a warning and carry on.
 warn_instance_settings_ignored <- function(
   drv,
   read_only,
@@ -449,19 +492,23 @@ warn_instance_settings_ignored <- function(
     return(invisible())
   }
 
-  abort(
-    c(
-      paste0(
-        paste0("`", ignored, "`", collapse = ", "),
-        " can't be applied to the database instance for `",
-        drv@dbdir,
-        "`, which already exists."
-      ),
-      "These settings take effect only when the instance is created.",
-      "Release it with `duckdb_shutdown()` first, or pass them to the `duckdb()` call that creates it."
+  message <- c(
+    paste0(
+      paste0("`", ignored, "`", collapse = ", "),
+      " can't be applied to the database instance for `",
+      drv@dbdir,
+      "`, which already exists."
     ),
-    call = call
+    "These settings take effect only when the instance is created.",
+    "Release it with `duckdb_shutdown()` first, or pass them to the `duckdb()` call that creates it."
   )
+
+  if (isTRUE(calling_package() %in% INSTANCE_SETTINGS_WARN_ONLY)) {
+    warn(message, class = "duckdb_instance_settings_ignored", call = call)
+    return(invisible())
+  }
+
+  abort(message, call = call)
 }
 
 # A `dbdir` an extension answers rather than the filesystem -- `md:` for

--- a/R/rlang.R
+++ b/R/rlang.R
@@ -34,6 +34,26 @@ abort <- function(message = NULL, ..., class = NULL, call = NULL) {
   stop(paste(message, collapse = "\n"), call. = FALSE)
 }
 
+# `rlang::warn()`. How this package raises the diagnostics that are not fatal.
+#
+# The base fallback keeps the message vector joined with newlines, the bulleted
+# layout being rlang's, and drops the calling function the way `abort()` does.
+#
+# Unlike `abort()` it honours `class`, via `warningCondition()`. The class is
+# not decoration: `duckdb_instance_settings_ignored` is documented as the
+# handle for catching or suppressing that warning on purpose, and a contract
+# that held only where rlang happens to be installed would not be one. `call`
+# stays accepted and ignored, so a call site need not know which
+# implementation it is talking to.
+warn <- function(message = NULL, ..., class = NULL, call = NULL) {
+  warning(warningCondition(
+    paste(message, collapse = "\n"),
+    class = class,
+    call = NULL
+  ))
+  invisible()
+}
+
 # `rlang::check_dots_empty0()`.
 check_dots_empty0 <- function(...) {
   if (...length() > 0L) {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -26,6 +26,7 @@
     rapi_error <<- rapi_error_rlang
     check_dots_empty0 <<- rlang::check_dots_empty0
     inform <<- rlang::inform
+    warn <<- rlang::warn
     arg_match <<- rlang::arg_match
   } else {
     rethrow_restore()

--- a/handbook/usage/connections/README.md
+++ b/handbook/usage/connections/README.md
@@ -59,6 +59,22 @@ The load-bearing facts:
   The cost is bounded by comparing values rather than counting
   arguments: the calls that break are the ones that were already not
   doing what they said.
+* **Two callers get the warning instead**
+  — `datacaged` and `Rduckhts`, named in
+  `INSTANCE_SETTINGS_WARN_ONLY` in [`R/Driver.R`](/R/Driver.R).
+  A reverse-dependency run over 353 packages found exactly those two
+  stopping where 1.5.5 ran, each on a `read_only` handed to a database
+  it had opened earlier.
+  The list is meant to be deleted rather than extended:
+  an entry goes when that package stops passing settings to a reused
+  instance, and a third package found later is a reason to reconsider
+  erroring at all, not to add a line.
+  Two things it does not do.
+  It does not help a user's own script, or any package not named,
+  doing exactly what those two do.
+  And it makes the behaviour depend on the caller, so the same line
+  errors from a script and warns from inside `datacaged` —
+  worth remembering when a report does not reproduce.
 * **A `dbdir` an extension answers is not normalized.**
   `md:` (MotherDuck), `ducklake:` and their kind name a replacement
   open, not a file, so they pass through untouched; normalizing one

--- a/tests/testthat/test-instance-settings.R
+++ b/tests/testthat/test-instance-settings.R
@@ -44,6 +44,53 @@ test_that("a `read_only` that the instance cannot honor is reported", {
   expect_identical(duckdb(path)@database_ref, drv@database_ref)
 })
 
+test_that("a caller on the warn-only list gets a warning and its driver back", {
+  # The list exists because `datacaged` and `Rduckhts` pass settings to a
+  # database they opened earlier, and erroring stops them where 1.5.5 ran.
+  # `calling_package()` is mocked rather than staged: building a package
+  # namespace inside a test to be found by a stack walk would test testthat.
+  path <- file.path(withr::local_tempdir(), "db.duckdb")
+
+  drv <- duckdb(path)
+  withr::defer(duckdb_shutdown(drv))
+  con <- dbConnect(drv)
+  withr::defer(dbDisconnect(con))
+
+  local_mocked_bindings(calling_package = function() "datacaged")
+
+  expect_warning(
+    reused <- duckdb(path, read_only = TRUE),
+    class = "duckdb_instance_settings_ignored"
+  )
+  # Warned, not applied, and the call still returns the instance it found.
+  expect_identical(reused@database_ref, drv@database_ref)
+  expect_false(reused@read_only)
+})
+
+test_that("a caller that is not on the list still gets the error", {
+  path <- file.path(withr::local_tempdir(), "db.duckdb")
+
+  drv <- duckdb(path)
+  withr::defer(duckdb_shutdown(drv))
+  con <- dbConnect(drv)
+  withr::defer(dbDisconnect(con))
+
+  local_mocked_bindings(calling_package = function() "someotherpkg")
+  expect_error(duckdb(path, read_only = TRUE), "read_only")
+
+  # And a call from a script, which is where `calling_package()` finds nothing.
+  local_mocked_bindings(calling_package = function() NULL)
+  expect_error(duckdb(path, read_only = TRUE), "read_only")
+})
+
+test_that("`calling_package()` names the namespace a call came from", {
+  expect_null(calling_package())
+
+  from_utils <- function() calling_package()
+  environment(from_utils) <- asNamespace("utils")
+  expect_identical(from_utils(), "utils")
+})
+
 test_that("a `config` entry that the instance cannot honor is reported", {
   path <- file.path(withr::local_tempdir(), "db.duckdb")
 


### PR DESCRIPTION
An alternative to the blanket dial-back: keep the error #2641 introduced, and hand the same words to `datacaged` and `Rduckhts` as a warning. Those are the two packages a reverse-dependency run over 353 packages found stopping where 1.5.5 ran, each on a `read_only` passed to a database it had opened earlier.

`calling_package()` walks the stack for the innermost namespace that is neither ours nor DBI's, the way `find_caller()` already does for `dbSendQuery()`. A call from a script finds nothing and gets the error.

`INSTANCE_SETTINGS_WARN_ONLY` is meant to be deleted rather than extended: an entry goes when that package stops passing settings to a reused instance, and a third package found later is a reason to reconsider erroring at all rather than to add a line.

**Two limits, stated in the code and the handbook rather than discovered later.** The list does nothing for a user's own script, or any package not on it, doing exactly what these two do. And it makes behaviour depend on the caller, so the same line errors from a script and warns from inside `datacaged` — worth remembering when a report does not reproduce.

The user-facing documentation still says the call fails. A carve-out for two named packages is a concession, not a promise to keep.

Alternative approach in #2692; these are mutually exclusive, only one should merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016xj5YaYaSnxsdxTibchhKn