### PR TITLE
feat(series-cutover): Name the package versions before and after the swap

### DIFF
--- a/.claude/skills/series-forward.md
+++ b/.claude/skills/series-forward.md
@@ -270,6 +270,23 @@ without it the coverage gate degrades to a warning,
 and a warning is not what should authorize
 retiring the lineage consumers are reading.
 
+The report names the package on both sides —
+`Package:` once, and `Version:` for each of the four refs,
+before and after —
+so the confirmation is given with the version
+consumers will be offered on screen.
+A version that would go **backwards** is warned about, not refused:
+the replay renumbers the fifth component
+as a counter of its own chain,
+which starts well below the one the base series accumulated,
+and the fourth component usually covers it
+because the forward is seeded on a newer `main`.
+Where it does not, r-universe has no upgrade to offer
+until the new chain climbs past the old one's counter —
+a cost rather than a corruption,
+and whether it is worth paying is the judgement
+the typed confirmation already asks for.
+
 It swaps all four refs in a single `git push --atomic`
 with a per-ref lease,
 so consumers never observe a half-replaced series,

--- a/scripts/series-converge.sh
+++ b/scripts/series-converge.sh
@@ -30,7 +30,10 @@
 #   * `DESCRIPTION` -- but only its `Version:` line. The replay renumbers the
 #     fifth component as a counter of its own chain, so the versions differ by
 #     construction. Anything else in that file is a real difference, and the
-#     file is diffed line-wise to tell the two apart.
+#     file is diffed line-wise to tell the two apart. Both versions are named
+#     where the difference is explained: "renumbered" accounts for a counter
+#     that restarted, and for nothing that happened to the four components
+#     above it.
 #   * `NEWS.md` -- the release paperwork a `fledge:` commit carries, and stage 4
 #     never ports a VERSION commit: `main`'s R-client counter is not a series'
 #     (.claude/skills/series-loop.md). So the two branches hold whatever their
@@ -163,6 +166,11 @@ def_expected() {
   echo "src/$pkg-win.def R_init_${pkg//./_}"
 }
 
+# The version a branch declares, for naming the two the explanation covers.
+desc_version() {
+  git show "$1:DESCRIPTION" 2>/dev/null | sed -n 's/^Version: *//p' | head -n 1 || true
+}
+
 # True when each branch's Windows export list is the one its own package needs,
 # and the two differ by the flavor rename and nothing else.
 #
@@ -231,7 +239,9 @@ while IFS=$'\t' read -r add del f; do
       if [ -n "$other" ]; then
         unexplained+=("$f|$add/$del|differs beyond its Version: line")
       else
-        explained+=("$f|$add/$del|version counter, renumbered by the replay")
+        renumbered="version counter, renumbered by the replay:"
+        renumbered="$renumbered $(desc_version "$dev") -> $(desc_version "$fwd")"
+        explained+=("$f|$add/$del|$renumbered")
       fi
       ;;
     NEWS.md)

--- a/scripts/series-cutover.sh
+++ b/scripts/series-cutover.sh
@@ -17,6 +17,12 @@
 # A base series ref that does not exist yet is created rather than swapped:
 # a series that started as -fwd has no counterpart to replace.
 #
+# The report names the package on both sides -- `Package:` once, and `Version:`
+# for each of the four refs, before and after -- because the swap moves both:
+# the forward regenerates its own flavor commits, and the replay renumbers the
+# fifth component as a counter of its own chain. A version that goes backwards
+# is the one cost of the swap that nothing else on screen shows.
+#
 # Usage: series-cutover.sh <series> [remote] [upstream-clone]
 #   series-cutover.sh main origin ../duckdb
 #
@@ -56,6 +62,36 @@ vendored_sha() {
     fi
   fi
   echo "$sha"
+}
+
+# One field of a branch's DESCRIPTION, empty when the ref or the field is not
+# there. Both fields this script reads are per-branch: the flavor rename writes
+# `Package:`, and the replay renumbers the fifth component of `Version:`.
+#
+# A missing ref is ordinary here -- a series opened as `-fwd` has no base refs
+# at all -- so `git show`'s failure is swallowed rather than left to `pipefail`,
+# which would otherwise make an empty answer end the run.
+desc_field() {
+  git show "$1:DESCRIPTION" 2>/dev/null | sed -n "s/^$2: *//p" | head -n 1 || true
+}
+
+# Compare two dotted numeric versions componentwise, printing -1, 0 or 1.
+# `sort -V` would be one line, but it is GNU-only in practice and this script
+# runs where the system tools are BSD's too (scripts/flavor.sh says the same of
+# `sed`). A missing component reads as 0, so 1.5.5.9020 sorts below
+# 1.5.5.9020.1 rather than beside it.
+version_cmp() {
+  awk -v a="$1" -v b="$2" '
+    BEGIN {
+      na = split(a, x, "."); nb = split(b, y, ".")
+      n = na > nb ? na : nb
+      for (i = 1; i <= n; i++) {
+        u = (i <= na) ? x[i] + 0 : 0
+        v = (i <= nb) ? y[i] + 0 : 0
+        if (u != v) { print (u < v) ? -1 : 1; exit }
+      }
+      print 0
+    }'
 }
 
 for r in build dev green build-base; do
@@ -120,6 +156,23 @@ if [ "$rc" -eq 1 ]; then
 fi
 echo
 
+# The package the swap publishes, named on both sides. `Package:` and
+# `Version:` are what a consumer installs, and the swap moves both: the name
+# because the forward regenerates its own flavor commits, the version because
+# the replay renumbers the fifth component as a counter of its own chain. So
+# each ref is shown with the version it carries before and after, and a name
+# that changes is called out rather than left to be read off four lines.
+old_pkg=$(desc_field "refs/remotes/$remote/$S-dev" Package)
+new_pkg=$(desc_field "refs/remotes/$remote/$S-fwd-dev" Package)
+if [ -z "$old_pkg" ] || [ "$old_pkg" = "$new_pkg" ]; then
+  echo "package: ${new_pkg:-<none>}"
+else
+  echo "package: $old_pkg -> $new_pkg"
+  echo "  ^ the swap renames the package. A series and its forward are flavored"
+  echo "    the same; a name that moved means the forward was seeded with"
+  echo "    another flavor, and the swap would publish a different package."
+fi
+
 leases=()
 refspecs=()
 echo "refs to swap:"
@@ -133,13 +186,44 @@ for r in build dev green build-base; do
   leases+=("--force-with-lease=refs/heads/$S-$r:$cur")
   refspecs+=("$new:refs/heads/$S-$r")
   short=${cur:0:7}
-  printf '  %-20s %s -> %s\n' "$S-$r" "${short:-<new>}" "${new:0:7}"
+  oldv=$(desc_field "refs/remotes/$remote/$S-$r" Version)
+  newv=$(desc_field "refs/remotes/$remote/$S-fwd-$r" Version)
+  printf '  %-26s %-7s %-16s ->  %-7s %s\n' \
+    "$S-$r" "${short:-<new>}" "${oldv:--}" "${new:0:7}" "${newv:--}"
+done
+
+# A version that does not move forward -- back, or not at all -- is the swap's
+# one cost that nothing else on screen shows. `<S>-dev` is what r-universe builds, so its version is the
+# one consumers are offered -- and the replay's renumbering starts the fifth
+# component well below what the base series accumulated. Usually the fourth
+# component covers it, because the forward is seeded on a newer `main` whose
+# version has moved on since; where it does not, r-universe has nothing to
+# offer as an upgrade until the new chain's counter climbs past the old one's.
+# That is a cost rather than a corruption, and whether it is worth paying is a
+# judgement, so this names it and leaves the decision with the confirmation.
+for r in dev green; do
+  oldv=$(desc_field "refs/remotes/$remote/$S-$r" Version)
+  newv=$(desc_field "refs/remotes/$remote/$S-fwd-$r" Version)
+  [ -n "$oldv" ] && [ -n "$newv" ] || continue
+  case "$(version_cmp "$oldv" "$newv")" in
+    -1) continue ;;
+    # Equal is the same problem wearing the other face: two different trees
+    # published under one version, so whoever already has it never sees the
+    # replacement at all.
+    0) echo "Warning: $S-$r keeps version $oldv across the swap." ;;
+    1) echo "Warning: $S-$r would go from $oldv back to $newv." ;;
+  esac
+  if [ "$r" = dev ]; then
+    echo "  r-universe publishes from this ref and has no upgrade to offer"
+    echo "  until the forward chain's counter passes $oldv."
+  fi
 done
 
 # The gate above says the swap is allowed; this asks whether it is wanted. It
-# comes last so the operator confirms with the coverage lines and the four ref
-# moves on screen, and it takes the series name rather than a keystroke because
-# the mistake worth catching is cutting over the wrong series.
+# comes last so the operator confirms with the coverage lines, the package
+# versions and the four ref moves on screen, and it takes the series name
+# rather than a keystroke because the mistake worth catching is cutting over
+# the wrong series.
 printf 'Replace series %s with %s-fwd-*? Type the series name to confirm: ' "$S" "$S"
 read -r confirm
 [ "$confirm" = "$S" ] || { echo "Aborted; nothing was pushed."; exit 1; }

--- a/scripts/series-cutover.sh
+++ b/scripts/series-cutover.sh
@@ -75,23 +75,29 @@ desc_field() {
   git show "$1:DESCRIPTION" 2>/dev/null | sed -n "s/^$2: *//p" | head -n 1 || true
 }
 
-# Compare two dotted numeric versions componentwise, printing -1, 0 or 1.
-# `sort -V` would be one line, but it is GNU-only in practice and this script
-# runs where the system tools are BSD's too (scripts/flavor.sh says the same of
-# `sed`). A missing component reads as 0, so 1.5.5.9020 sorts below
-# 1.5.5.9020.1 rather than beside it.
+# GNU sort, wherever it is called: on Linux that is `sort`, on macOS it is
+# `gsort` and the system `sort` is BSD's. Prefer `gsort`, then verify -- the
+# same choice, and the same reason, scripts/flavor.sh makes for `sed`. Empty
+# when neither is GNU, which is a comparison not made rather than a wrong one.
+if command -v gsort >/dev/null 2>&1; then
+  gnu_sort=gsort
+else
+  gnu_sort=sort
+fi
+case "$("$gnu_sort" --version 2>/dev/null || true)" in
+  *"GNU coreutils"*) ;;
+  *) gnu_sort= ;;
+esac
+
+# Where two dotted versions sort against each other, as -1, 0 or 1. `sort -V`
+# compares them component by component and numerically, so 1.5.5.9013.36 sorts
+# below 1.5.5.9020.12 rather than by string order, and a missing component
+# ranks below a present one: 1.5.5.9020 below 1.5.5.9020.1.
 version_cmp() {
-  awk -v a="$1" -v b="$2" '
-    BEGIN {
-      na = split(a, x, "."); nb = split(b, y, ".")
-      n = na > nb ? na : nb
-      for (i = 1; i <= n; i++) {
-        u = (i <= na) ? x[i] + 0 : 0
-        v = (i <= nb) ? y[i] + 0 : 0
-        if (u != v) { print (u < v) ? -1 : 1; exit }
-      }
-      print 0
-    }'
+  local sorted
+  [ "$1" != "$2" ] || { printf '%s\n' 0; return; }
+  sorted=$(printf '%s\n%s\n' "$1" "$2" | "$gnu_sort" -V)
+  if [ "${sorted%%$'\n'*}" = "$1" ]; then printf '%s\n' -1; else printf '%s\n' 1; fi
 }
 
 for r in build dev green build-base; do
@@ -193,31 +199,43 @@ for r in build dev green build-base; do
 done
 
 # A version that does not move forward -- back, or not at all -- is the swap's
-# one cost that nothing else on screen shows. `<S>-dev` is what r-universe builds, so its version is the
-# one consumers are offered -- and the replay's renumbering starts the fifth
-# component well below what the base series accumulated. Usually the fourth
-# component covers it, because the forward is seeded on a newer `main` whose
-# version has moved on since; where it does not, r-universe has nothing to
-# offer as an upgrade until the new chain's counter climbs past the old one's.
-# That is a cost rather than a corruption, and whether it is worth paying is a
-# judgement, so this names it and leaves the decision with the confirmation.
-for r in dev green; do
-  oldv=$(desc_field "refs/remotes/$remote/$S-$r" Version)
-  newv=$(desc_field "refs/remotes/$remote/$S-fwd-$r" Version)
-  [ -n "$oldv" ] && [ -n "$newv" ] || continue
-  case "$(version_cmp "$oldv" "$newv")" in
-    -1) continue ;;
-    # Equal is the same problem wearing the other face: two different trees
-    # published under one version, so whoever already has it never sees the
-    # replacement at all.
-    0) echo "Warning: $S-$r keeps version $oldv across the swap." ;;
-    1) echo "Warning: $S-$r would go from $oldv back to $newv." ;;
-  esac
-  if [ "$r" = dev ]; then
-    echo "  r-universe publishes from this ref and has no upgrade to offer"
-    echo "  until the forward chain's counter passes $oldv."
-  fi
-done
+# one cost that nothing else on screen shows. `<S>-dev` is what r-universe
+# builds, so its version is the one consumers are offered, and the replay's
+# renumbering starts the fifth component well below what the base series
+# accumulated. Usually the fourth component covers it, because the forward is
+# seeded on a newer `main` whose version has moved on since; where it does not,
+# r-universe has nothing to offer as an upgrade until the new chain's counter
+# climbs past the old one's. That is a cost rather than a corruption, and
+# whether it is worth paying is a judgement, so this names it and leaves the
+# decision with the confirmation.
+#
+# Without a GNU sort the versions are still printed and simply not compared:
+# the swap is not worth blocking over a missing coreutils, and a comparison
+# made with the wrong tool would read as a clean bill.
+if [ -z "$gnu_sort" ]; then
+  echo "Note: no GNU sort here, so the versions above were not compared."
+  echo "  Read them: a $S-dev version that does not move forward is an upgrade"
+  echo "  r-universe cannot offer. Install GNU coreutils as 'gsort' -- on"
+  echo "  macOS, 'brew install coreutils'."
+else
+  for r in dev green; do
+    oldv=$(desc_field "refs/remotes/$remote/$S-$r" Version)
+    newv=$(desc_field "refs/remotes/$remote/$S-fwd-$r" Version)
+    [ -n "$oldv" ] && [ -n "$newv" ] || continue
+    case "$(version_cmp "$oldv" "$newv")" in
+      -1) continue ;;
+      # Equal is the same problem wearing the other face: two different trees
+      # published under one version, so whoever already has it never sees the
+      # replacement at all.
+      0) echo "Warning: $S-$r keeps version $oldv across the swap." ;;
+      1) echo "Warning: $S-$r would go from $oldv back to $newv." ;;
+    esac
+    if [ "$r" = dev ]; then
+      echo "  r-universe publishes from this ref and has no upgrade to offer"
+      echo "  until the forward chain's counter passes $oldv."
+    fi
+  done
+fi
 
 # The gate above says the swap is allowed; this asks whether it is wanted. It
 # comes last so the operator confirms with the coverage lines, the package


### PR DESCRIPTION
The swap report named the two greens' vendored upstream SHAs and the four ref moves, and nothing about the package a consumer installs. The swap moves both halves of that: the forward regenerates its own flavor commits, so `Package:` can differ, and the replay renumbers `Version:`'s fifth component as a counter of its own chain, which starts well below the one the base series accumulated.

So `scripts/series-cutover.sh` now names the package once and each ref's version before and after, and reads the comparison rather than leaving it to the eye: a `-dev` or `-green` version that would go backwards — or not move at all, which publishes two different trees under one version — is warned about by name. It warns rather than refuses. r-universe publishes from `-dev`, so the cost is an upgrade nobody is offered until the new chain's counter climbs past the old one's; that is a cost and not a corruption, and the typed confirmation is already where that judgement sits.

The comparison is `sort -V` from GNU coreutils, found the way `scripts/flavor.sh` finds GNU `sed`: prefer the `g`-prefixed binary, since on macOS the GNU tool installs as `gsort` and the system `sort` is BSD's, then verify it really is GNU. Where neither is, the versions are still printed and simply not compared, under a note that says so — the swap is not worth blocking over a missing coreutils, and a comparison made with the wrong tool would read as a clean bill.

`scripts/series-converge.sh` explained a differing `DESCRIPTION` as a renumbered counter without saying which two versions. It names them now, so "renumbered" accounts for the counter that restarted and for nothing that happened to the four components above it. Against the live `v1.5-variegata` forwarding it reads:

```
DESCRIPTION    1/1    version counter, renumbered by the replay: 1.5.5.9020.36 -> 1.5.5.9020.0
```

`scripts/rcc-cutover.sh` is the other cutover script and gains nothing here: it cuts over a verdict store, which holds no package.

Two things came out of exercising the report. `desc_field()` swallows `git show`'s failure, because a series opened directly as `-fwd` has no base refs at all and `pipefail` would otherwise end the run on an empty answer. And `.claude/skills/series-forward.md` records what the report now shows, including that a backwards version is warned about rather than refused.

Exercised against scratch series covering the ordinary swap, the create-rather-than-swap path, a renamed package, and backwards, equal and forward versions, with the GNU-sort lookup driven through a shimmed BSD `sort` both with and without a `gsort` beside it; and the converge line against the live refs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5mEiAXb2E7TVuEuHyXnJF