### PR TITLE
fix(patch): Three vendored fixes for the clang23 and R-devel flavors

### DIFF
--- a/patch/0039-Undef-GROUPING-before-the-keyword-table.patch
+++ b/patch/0039-Undef-GROUPING-before-the-keyword-table.patch
@@ -1,0 +1,53 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kirill =?UTF-8?q?M=C3=BCller?= <kirill@cynkra.com>
+Date: Sat, 12 Sep 2026 12:00:00 +0200
+Subject: [PATCH] Undef GROUPING before the keyword table
+
+glibc's <langinfo.h> defines GROUPING as a macro under _GNU_SOURCE, and
+kwlist.hpp spells the bison token names bare. Whether that collides is
+decided by include order, and src_backend_parser_parser.cpp is the one
+translation unit where the order goes wrong: parser/gramparse.hpp brings
+in parser/gram.hpp and its `#define GROUPING 439`, and the next include,
+parser/parser.hpp, reaches <vector> -- which under libc++ with
+_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23 pulls <locale>, its
+__locale_dir/support/linux.h, and so <langinfo.h>. The token code is
+silently replaced by the nl_item 65538 before the table is parsed.
+
+The redefinition itself is never reported, because it happens inside a
+system header. What is reported is the consequence: 65538 does not fit
+the int16_t field it initializes, so the aggregate initializer becomes a
+-Wc++11-narrowing error and the package fails to install on CRAN's
+clang23 flavor. A compiler that let it through would give a parser that
+mis-scans "grouping".
+
+gram.hpp declares every token as an `enum yytokentype` enumerator as
+well as a macro, so dropping the macro leaves the same value behind.
+Undoing it here, at the one place the bare token names are used as
+values, is the seam that does not move -- the include order that
+poisons the name belongs to a system header, not to this tree, and the
+next standard-library reshuffle can poison it from a different
+direction.
+---
+diff --git a/src/duckdb/third_party/libpg_query/include/parser/kwlist.hpp b/src/duckdb/third_party/libpg_query/include/parser/kwlist.hpp
+index 77689d9..064ffca 100644
+--- a/src/duckdb/third_party/libpg_query/include/parser/kwlist.hpp
++++ b/src/duckdb/third_party/libpg_query/include/parser/kwlist.hpp
+@@ -1,3 +1,18 @@
++// glibc's <langinfo.h> defines GROUPING as a macro under _GNU_SOURCE,
++// and the table below spells the bison token names bare.
++// A translation unit that reaches <langinfo.h> after parser/gram.hpp
++// -- which is what libc++ does when <vector> keeps its transitive includes --
++// therefore expands GROUPING to the nl_item 65538 instead of the token code 439.
++// 65538 does not fit the int16_t field it initializes,
++// so the aggregate initializer below is a hard -Wc++11-narrowing error;
++// on a compiler that lets it through it would be a silently wrong parser.
++//
++// gram.hpp declares every token as an `enum yytokentype` enumerator as well as a macro,
++// so dropping the macro leaves the same value behind.
++// Undoing it here, at the one place the bare token names are used as values,
++// is the seam that does not move:
++// the include order that poisons the name belongs to a system header, not to this tree.
++#undef GROUPING
+ 
+ namespace duckdb_libpgquery {
+ #define PG_KEYWORD(a,b,c) {a,b,c},

--- a/patch/0040-Use-the-second-elem-column-ref-in-list-comprehensions.patch
+++ b/patch/0040-Use-the-second-elem-column-ref-in-list-comprehensions.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kirill =?UTF-8?q?M=C3=BCller?= <kirill@cynkra.com>
+Date: Sat, 12 Sep 2026 12:00:00 +0200
+Subject: [PATCH] Use the second elem column ref in list comprehensions
+
+The list-comprehension-with-filter rule in select.y builds two column
+references to the lambda parameter "elem", one for the filter lambda and
+one for the result lambda, and then hands the filter's node to both
+struct_extract calls. The second reference is left unused, which is what
+-Wunused-variable reports on CRAN's clang23 flavor.
+
+The value is the same either way -- both are makeColumnRef("elem") at
+the same location -- so this is not a wrong parse today. It does make
+one PGNode reachable from two places in a tree the rest of the parser
+walks as a tree, which is worth not relying on.
+
+This file is generated from grammar/statements/select.y, which the
+vendored tree does not carry; the fix belongs upstream in the grammar,
+and this patch drops out once it lands there. v1.4-andium does not have
+the rule at all.
+---
+diff --git a/src/duckdb/third_party/libpg_query/src_backend_parser_gram.cpp b/src/duckdb/third_party/libpg_query/src_backend_parser_gram.cpp
+index eb18ae1..20f6787 100644
+--- a/src/duckdb/third_party/libpg_query/src_backend_parser_gram.cpp
++++ b/src/duckdb/third_party/libpg_query/src_backend_parser_gram.cpp
+@@ -29734,7 +29734,7 @@ yyreduce:
+ 					/* Construct second apply */
+ 					PGNode *elem_column_ref_result = makeColumnRef(pstrdup("elem"), NIL, (yylsp[(1) - (9)]), yyscanner);
+ 					PGNode *result_column_name = makeStringConst("result", (yylsp[(1) - (9)]));
+-					PGFuncCall *result_extract = makeFuncCall(SystemFuncName("struct_extract"), list_make2(elem_column_ref_filter, result_column_name), (yylsp[(1) - (9)]));
++					PGFuncCall *result_extract = makeFuncCall(SystemFuncName("struct_extract"), list_make2(elem_column_ref_result, result_column_name), (yylsp[(1) - (9)]));
+ 
+ 					PGLambdaFunction *lambda_apply_2 = makeNode(PGLambdaFunction);
+ 					lambda_apply_2->lhs = list_make1(makeString("elem"));

--- a/patch/0041-Give-the-ART-delete-helpers-the-shape-of-the-insert-helpers.patch
+++ b/patch/0041-Give-the-ART-delete-helpers-the-shape-of-the-insert-helpers.patch
@@ -1,0 +1,163 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kirill =?UTF-8?q?M=C3=BCller?= <kirill@cynkra.com>
+Date: Sat, 12 Sep 2026 12:00:00 +0200
+Subject: [PATCH] Give the ART delete helpers the shape of the insert helpers
+
+GCC 14.3 under Rtools45 reports -Wdangling-pointer twice in
+ub_src_execution_index_art.cpp, both against optional_ptr.hpp:52 -- the
+`return ptr` in optional_ptr::operator-> -- reached by this chain:
+
+    optional_ptr<FixedSizeBuffer>::operator->()
+      inlined from SegmentHandle::~SegmentHandle()   (buffer_ptr->readers--)
+      inlined from NodeHandle<...>::~NodeHandle()
+      inlined from Node15Leaf::DeleteByte()          base_leaf.cpp:144
+    note: 'n15_handle' declared here                 base_leaf.cpp:139
+
+and the same for `handle` in Node16::DeleteChild, base_node.cpp:143.
+
+Both locals are initialized from DeleteByteInternal / DeleteChildInternal,
+which are the only two helpers in the ART that return a NodeHandle -- a
+buffer pin -- by value. The callee names its own local `handle` and
+returns it, so NRVO puts it in the caller's slot; the caller's
+initialization from that prvalue is elided in turn. One storage, two
+declared locals, and a destructor that loads `buffer_ptr` out of it: GCC
+takes the load in ~SegmentHandle for a read of storage whose lifetime it
+has already ended.
+
+Their insert twins do not have this shape. InsertByteInternal and
+InsertChildInternal take the node by reference and return void, and the
+caller is the one that holds the handle:
+
+    NodeHandle<Node16> handle(art, node);
+    auto &n = handle.Get();
+    InsertChildInternal(n, byte, child);
+
+This gives the delete pair the same shape. No pin crosses a return in the
+ART any more, the two paths read alike, and the four call sites keep the
+inner block they already had.
+
+The pin covers the same region as before: it used to start inside the
+helper and end when the caller's inner block closed, and now it starts at
+the top of that block and ends in the same place -- Node::FreeTree in
+DeleteChildInternal still runs under it.
+---
+diff --git a/src/duckdb/src/execution/index/art/base_leaf.cpp b/src/duckdb/src/execution/index/art/base_leaf.cpp
+index fce383d..13b6911 100644
+--- a/src/duckdb/src/execution/index/art/base_leaf.cpp
++++ b/src/duckdb/src/execution/index/art/base_leaf.cpp
+@@ -30,10 +30,7 @@ void BaseLeaf<CAPACITY, TYPE>::InsertByteInternal(BaseLeaf &n, const uint8_t byt
+ }
+ 
+ template <uint8_t CAPACITY, NType TYPE>
+-NodeHandle<BaseLeaf<CAPACITY, TYPE>> BaseLeaf<CAPACITY, TYPE>::DeleteByteInternal(ART &art, Node &node,
+-                                                                                  const uint8_t byte) {
+-	NodeHandle<BaseLeaf<CAPACITY, TYPE>> handle(art, node);
+-	auto &n = handle.Get();
++void BaseLeaf<CAPACITY, TYPE>::DeleteByteInternal(BaseLeaf &n, const uint8_t byte) {
+ 	uint8_t child_pos = 0;
+ 
+ 	for (; child_pos < n.count; child_pos++) {
+@@ -47,7 +44,6 @@ NodeHandle<BaseLeaf<CAPACITY, TYPE>> BaseLeaf<CAPACITY, TYPE>::DeleteByteInterna
+ 	for (uint8_t i = child_pos; i < n.count; i++) {
+ 		n.key[i] = n.key[i + 1];
+ 	}
+-	return handle;
+ }
+ 
+ //===--------------------------------------------------------------------===//
+@@ -73,8 +69,9 @@ void Node7Leaf::InsertByte(ART &art, Node &node, const uint8_t byte) {
+ void Node7Leaf::DeleteByte(ART &art, Node &node, Node &prefix, const uint8_t byte, const ARTKey &row_id) {
+ 	idx_t remainder;
+ 	{
+-		auto n7_handle = DeleteByteInternal(art, node, byte);
++		NodeHandle<Node7Leaf> n7_handle(art, node);
+ 		auto &n7 = n7_handle.Get();
++		DeleteByteInternal(n7, byte);
+ 
+ 		if (n7.count != 1) {
+ 			return;
+@@ -136,8 +133,9 @@ void Node15Leaf::InsertByte(ART &art, Node &node, const uint8_t byte) {
+ 
+ void Node15Leaf::DeleteByte(ART &art, Node &node, const uint8_t byte) {
+ 	{
+-		auto n15_handle = DeleteByteInternal(art, node, byte);
++		NodeHandle<Node15Leaf> n15_handle(art, node);
+ 		auto &n15 = n15_handle.Get();
++		DeleteByteInternal(n15, byte);
+ 		if (n15.count >= Node7Leaf::CAPACITY) {
+ 			return;
+ 		}
+diff --git a/src/duckdb/src/execution/index/art/base_node.cpp b/src/duckdb/src/execution/index/art/base_node.cpp
+index a59297c..94754ed 100644
+--- a/src/duckdb/src/execution/index/art/base_node.cpp
++++ b/src/duckdb/src/execution/index/art/base_node.cpp
+@@ -30,11 +30,7 @@ void BaseNode<CAPACITY, TYPE>::InsertChildInternal(BaseNode &n, const uint8_t by
+ }
+ 
+ template <uint8_t CAPACITY, NType TYPE>
+-NodeHandle<BaseNode<CAPACITY, TYPE>> BaseNode<CAPACITY, TYPE>::DeleteChildInternal(ART &art, Node &node,
+-                                                                                   const uint8_t byte) {
+-	NodeHandle<BaseNode<CAPACITY, TYPE>> handle(art, node);
+-	auto &n = handle.Get();
+-
++void BaseNode<CAPACITY, TYPE>::DeleteChildInternal(ART &art, BaseNode &n, const uint8_t byte) {
+ 	uint8_t child_pos = 0;
+ 	for (; child_pos < n.count; child_pos++) {
+ 		if (n.key[child_pos] == byte) {
+@@ -51,8 +47,6 @@ NodeHandle<BaseNode<CAPACITY, TYPE>> BaseNode<CAPACITY, TYPE>::DeleteChildIntern
+ 		n.key[i] = n.key[i + 1];
+ 		n.children[i] = n.children[i + 1];
+ 	}
+-
+-	return handle;
+ }
+ 
+ //===--------------------------------------------------------------------===//
+@@ -81,8 +75,9 @@ void Node4::DeleteChild(ART &art, Node &node, Node &parent, const uint8_t byte,
+ 	uint8_t remaining_byte;
+ 
+ 	{
+-		auto handle = DeleteChildInternal(art, node, byte);
++		NodeHandle<Node4> handle(art, node);
+ 		auto &n = handle.Get();
++		DeleteChildInternal(art, n, byte);
+ 
+ 		if (n.count != 1) {
+ 			return;
+@@ -140,8 +135,9 @@ void Node16::InsertChild(ART &art, Node &node, const uint8_t byte, const Node ch
+ 
+ void Node16::DeleteChild(ART &art, Node &node, const uint8_t byte) {
+ 	{
+-		auto handle = DeleteChildInternal(art, node, byte);
++		NodeHandle<Node16> handle(art, node);
+ 		auto &n = handle.Get();
++		DeleteChildInternal(art, n, byte);
+ 		if (n.count >= Node4::CAPACITY) {
+ 			return;
+ 		}
+diff --git a/src/duckdb/src/include/duckdb/execution/index/art/base_leaf.hpp b/src/duckdb/src/include/duckdb/execution/index/art/base_leaf.hpp
+index 797c184..5991790 100644
+--- a/src/duckdb/src/include/duckdb/execution/index/art/base_leaf.hpp
++++ b/src/duckdb/src/include/duckdb/execution/index/art/base_leaf.hpp
+@@ -72,7 +72,7 @@ public:
+ 
+ private:
+ 	static void InsertByteInternal(BaseLeaf &n, const uint8_t byte);
+-	static NodeHandle<BaseLeaf> DeleteByteInternal(ART &art, Node &node, const uint8_t byte);
++	static void DeleteByteInternal(BaseLeaf &n, const uint8_t byte);
+ };
+ 
+ //! Node7Leaf holds up to seven sorted bytes.
+diff --git a/src/duckdb/src/include/duckdb/execution/index/art/base_node.hpp b/src/duckdb/src/include/duckdb/execution/index/art/base_node.hpp
+index ba24307..f4448a5 100644
+--- a/src/duckdb/src/include/duckdb/execution/index/art/base_node.hpp
++++ b/src/duckdb/src/include/duckdb/execution/index/art/base_node.hpp
+@@ -117,7 +117,7 @@ public:
+ 
+ private:
+ 	static void InsertChildInternal(BaseNode &n, const uint8_t byte, const Node child);
+-	static NodeHandle<BaseNode> DeleteChildInternal(ART &art, Node &node, const uint8_t byte);
++	static void DeleteChildInternal(ART &art, BaseNode &n, const uint8_t byte);
+ };
+ 
+ //! Node4 holds up to four children sorted by their key byte.

--- a/src/duckdb/src/execution/index/art/base_leaf.cpp
+++ b/src/duckdb/src/execution/index/art/base_leaf.cpp
@@ -30,10 +30,7 @@ void BaseLeaf<CAPACITY, TYPE>::InsertByteInternal(BaseLeaf &n, const uint8_t byt
 }
 
 template <uint8_t CAPACITY, NType TYPE>
-NodeHandle<BaseLeaf<CAPACITY, TYPE>> BaseLeaf<CAPACITY, TYPE>::DeleteByteInternal(ART &art, Node &node,
-                                                                                  const uint8_t byte) {
-	NodeHandle<BaseLeaf<CAPACITY, TYPE>> handle(art, node);
-	auto &n = handle.Get();
+void BaseLeaf<CAPACITY, TYPE>::DeleteByteInternal(BaseLeaf &n, const uint8_t byte) {
 	uint8_t child_pos = 0;
 
 	for (; child_pos < n.count; child_pos++) {
@@ -47,7 +44,6 @@ NodeHandle<BaseLeaf<CAPACITY, TYPE>> BaseLeaf<CAPACITY, TYPE>::DeleteByteInterna
 	for (uint8_t i = child_pos; i < n.count; i++) {
 		n.key[i] = n.key[i + 1];
 	}
-	return handle;
 }
 
 //===--------------------------------------------------------------------===//
@@ -73,8 +69,9 @@ void Node7Leaf::InsertByte(ART &art, Node &node, const uint8_t byte) {
 void Node7Leaf::DeleteByte(ART &art, Node &node, Node &prefix, const uint8_t byte, const ARTKey &row_id) {
 	idx_t remainder;
 	{
-		auto n7_handle = DeleteByteInternal(art, node, byte);
+		NodeHandle<Node7Leaf> n7_handle(art, node);
 		auto &n7 = n7_handle.Get();
+		DeleteByteInternal(n7, byte);
 
 		if (n7.count != 1) {
 			return;
@@ -136,8 +133,9 @@ void Node15Leaf::InsertByte(ART &art, Node &node, const uint8_t byte) {
 
 void Node15Leaf::DeleteByte(ART &art, Node &node, const uint8_t byte) {
 	{
-		auto n15_handle = DeleteByteInternal(art, node, byte);
+		NodeHandle<Node15Leaf> n15_handle(art, node);
 		auto &n15 = n15_handle.Get();
+		DeleteByteInternal(n15, byte);
 		if (n15.count >= Node7Leaf::CAPACITY) {
 			return;
 		}

--- a/src/duckdb/src/execution/index/art/base_node.cpp
+++ b/src/duckdb/src/execution/index/art/base_node.cpp
@@ -30,11 +30,7 @@ void BaseNode<CAPACITY, TYPE>::InsertChildInternal(BaseNode &n, const uint8_t by
 }
 
 template <uint8_t CAPACITY, NType TYPE>
-NodeHandle<BaseNode<CAPACITY, TYPE>> BaseNode<CAPACITY, TYPE>::DeleteChildInternal(ART &art, Node &node,
-                                                                                   const uint8_t byte) {
-	NodeHandle<BaseNode<CAPACITY, TYPE>> handle(art, node);
-	auto &n = handle.Get();
-
+void BaseNode<CAPACITY, TYPE>::DeleteChildInternal(ART &art, BaseNode &n, const uint8_t byte) {
 	uint8_t child_pos = 0;
 	for (; child_pos < n.count; child_pos++) {
 		if (n.key[child_pos] == byte) {
@@ -51,8 +47,6 @@ NodeHandle<BaseNode<CAPACITY, TYPE>> BaseNode<CAPACITY, TYPE>::DeleteChildIntern
 		n.key[i] = n.key[i + 1];
 		n.children[i] = n.children[i + 1];
 	}
-
-	return handle;
 }
 
 //===--------------------------------------------------------------------===//
@@ -81,8 +75,9 @@ void Node4::DeleteChild(ART &art, Node &node, Node &parent, const uint8_t byte, 
 	uint8_t remaining_byte;
 
 	{
-		auto handle = DeleteChildInternal(art, node, byte);
+		NodeHandle<Node4> handle(art, node);
 		auto &n = handle.Get();
+		DeleteChildInternal(art, n, byte);
 
 		if (n.count != 1) {
 			return;
@@ -140,8 +135,9 @@ void Node16::InsertChild(ART &art, Node &node, const uint8_t byte, const Node ch
 
 void Node16::DeleteChild(ART &art, Node &node, const uint8_t byte) {
 	{
-		auto handle = DeleteChildInternal(art, node, byte);
+		NodeHandle<Node16> handle(art, node);
 		auto &n = handle.Get();
+		DeleteChildInternal(art, n, byte);
 		if (n.count >= Node4::CAPACITY) {
 			return;
 		}

--- a/src/duckdb/src/include/duckdb/execution/index/art/base_leaf.hpp
+++ b/src/duckdb/src/include/duckdb/execution/index/art/base_leaf.hpp
@@ -72,7 +72,7 @@ public:
 
 private:
 	static void InsertByteInternal(BaseLeaf &n, const uint8_t byte);
-	static NodeHandle<BaseLeaf> DeleteByteInternal(ART &art, Node &node, const uint8_t byte);
+	static void DeleteByteInternal(BaseLeaf &n, const uint8_t byte);
 };
 
 //! Node7Leaf holds up to seven sorted bytes.

--- a/src/duckdb/src/include/duckdb/execution/index/art/base_node.hpp
+++ b/src/duckdb/src/include/duckdb/execution/index/art/base_node.hpp
@@ -117,7 +117,7 @@ public:
 
 private:
 	static void InsertChildInternal(BaseNode &n, const uint8_t byte, const Node child);
-	static NodeHandle<BaseNode> DeleteChildInternal(ART &art, Node &node, const uint8_t byte);
+	static void DeleteChildInternal(ART &art, BaseNode &n, const uint8_t byte);
 };
 
 //! Node4 holds up to four children sorted by their key byte.

--- a/src/duckdb/third_party/libpg_query/include/parser/kwlist.hpp
+++ b/src/duckdb/third_party/libpg_query/include/parser/kwlist.hpp
@@ -1,3 +1,18 @@
+// glibc's <langinfo.h> defines GROUPING as a macro under _GNU_SOURCE,
+// and the table below spells the bison token names bare.
+// A translation unit that reaches <langinfo.h> after parser/gram.hpp
+// -- which is what libc++ does when <vector> keeps its transitive includes --
+// therefore expands GROUPING to the nl_item 65538 instead of the token code 439.
+// 65538 does not fit the int16_t field it initializes,
+// so the aggregate initializer below is a hard -Wc++11-narrowing error;
+// on a compiler that lets it through it would be a silently wrong parser.
+//
+// gram.hpp declares every token as an `enum yytokentype` enumerator as well as a macro,
+// so dropping the macro leaves the same value behind.
+// Undoing it here, at the one place the bare token names are used as values,
+// is the seam that does not move:
+// the include order that poisons the name belongs to a system header, not to this tree.
+#undef GROUPING
 
 namespace duckdb_libpgquery {
 #define PG_KEYWORD(a,b,c) {a,b,c},

--- a/src/duckdb/third_party/libpg_query/src_backend_parser_gram.cpp
+++ b/src/duckdb/third_party/libpg_query/src_backend_parser_gram.cpp
@@ -29734,7 +29734,7 @@ yyreduce:
 					/* Construct second apply */
 					PGNode *elem_column_ref_result = makeColumnRef(pstrdup("elem"), NIL, (yylsp[(1) - (9)]), yyscanner);
 					PGNode *result_column_name = makeStringConst("result", (yylsp[(1) - (9)]));
-					PGFuncCall *result_extract = makeFuncCall(SystemFuncName("struct_extract"), list_make2(elem_column_ref_filter, result_column_name), (yylsp[(1) - (9)]));
+					PGFuncCall *result_extract = makeFuncCall(SystemFuncName("struct_extract"), list_make2(elem_column_ref_result, result_column_name), (yylsp[(1) - (9)]));
 
 					PGLambdaFunction *lambda_apply_2 = makeNode(PGLambdaFunction);
 					lambda_apply_2->lhs = list_make1(makeString("elem"));


### PR DESCRIPTION
Three patches under `patch/`, each applied to `src/duckdb/` as well, each worth sending on to `duckdb/duckdb` separately.

## 1. `GROUPING` narrowing error — installation failure on CRAN's clang23 flavor (`patch/0039`)

```
kwlist.hpp:167:24: error: constant expression evaluates to 65538 which cannot be narrowed
  to type 'int16_t' [-Wc++11-narrowing]
  167 | PG_KEYWORD("grouping", GROUPING, COL_NAME_KEYWORD)
/usr/include/langinfo.h:562:20: note: expanded from macro 'GROUPING'
```

Not a clang 23 bug — an include-order collision that clang 23 is merely the first CRAN flavor to hit. glibc's `<langinfo.h>` defines `GROUPING` as a macro under `_GNU_SOURCE`, and `kwlist.hpp` spells the bison token names bare. In `src_backend_parser_parser.cpp` the order goes wrong: `parser/gramparse.hpp` brings in `parser/gram.hpp` and its `#define GROUPING 439`, and the next include, `parser/parser.hpp`, reaches `<vector>` — which under libc++ with `-D_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM23` pulls `<locale>`, its `__locale_dir/locale_base_api.h`, and so `<langinfo.h>`. The nl_item 65538 replaces the token code before the table is parsed, and does not fit the `int16_t` field it initializes.

The redefinition itself is never reported, because it happens inside a system header — which is why the log shows the consequence and not the cause. `src_common_keywords.cpp` includes the same table and compiles, because it has no standard header between `gramparse.hpp` and `kwlist.hpp`.

`gram.hpp` declares every token as an `enum yytokentype` enumerator as well as a macro, so `#undef GROUPING` before the table leaves the same value behind. Verified under the poisoned include order: `static_assert(GROUPING == 439)` holds and the table entry is 439. `GROUPING` is the only one of the 513 token names that collides with `<langinfo.h>`.

Reproduced byte-for-byte with stock clang 18 and glibc 2.39 by forcing `<langinfo.h>` into that position — the compiler is not the variable, the include order is.

Affects `duckdb` and `duckdb.1.5.dev` (v1.5-variegata) and `duckdb.1.4` / `duckdb.1.4.dev` (v1.4-andium). Not `duckdb.dev`: `main` has no `third_party/libpg_query` at all.

## 2. Unused `elem_column_ref_result` (`patch/0040`)

The list-comprehension-with-filter rule in `select.y` builds two column references to the lambda parameter `elem`, one for the filter lambda and one for the result lambda, and hands the filter's node to both `struct_extract` calls. Same parse today — both are `makeColumnRef("elem")` at the same location — but it leaves one `PGNode` reachable from two places in a tree the rest of the parser walks as a tree.

The generated `gram.cpp` is patched here because the vendored tree does not carry the grammar; the fix belongs upstream in `select.y`. `v1.4-andium` does not have the rule.

## 3. `-Wdangling-pointer` in the ART delete path (`patch/0041`)

GCC 14.3 under Rtools45 reports it twice in `ub_src_execution_index_art.cpp`, both against `optional_ptr.hpp:52` — the `return ptr` in `optional_ptr::operator->` — reached by:

```
optional_ptr<FixedSizeBuffer>::operator->()
  inlined from SegmentHandle::~SegmentHandle()   (buffer_ptr->readers--)
  inlined from NodeHandle<...>::~NodeHandle()
  inlined from Node15Leaf::DeleteByte()          base_leaf.cpp:144
note: 'n15_handle' declared here                 base_leaf.cpp:139
```

and the same for `handle` in `Node16::DeleteChild`, `base_node.cpp:143`.

Both locals are initialized from `DeleteByteInternal` / `DeleteChildInternal`, the only two helpers in the ART that return a `NodeHandle` — a buffer pin — by value. The callee names its own local `handle` and returns it, so NRVO puts it in the caller's slot, and the caller's initialization from that prvalue is elided in turn. One storage, two declared locals, and a destructor that loads `buffer_ptr` out of it: GCC takes the load in `~SegmentHandle` for a read of storage whose lifetime it has already ended.

Their insert twins do not have this shape. `InsertByteInternal` and `InsertChildInternal` take the node by reference and return void, and the caller is the one that holds the handle:

```cpp
NodeHandle<Node16> handle(art, node);
auto &n = handle.Get();
InsertChildInternal(n, byte, child);
```

This gives the delete pair the same shape. No pin crosses a return in the ART any more, the two paths read alike, and the four call sites keep the inner block they already had. The pin covers the same region as before: it used to start inside the helper and end when the caller's inner block closed, and now it starts at the top of that block and ends in the same place — `Node::FreeTree` in `DeleteChildInternal` still runs under it.

**Caveat worth a reviewer's eye:** the warning itself does not reproduce outside Rtools45, and no Linux-hosted mingw GCC 14.3 is installable from the archives reachable here, so the fix is verified as a no-op-in-behaviour simplification rather than by watching the diagnostic disappear. Clean before and after under GCC 13, 14.3 and 15 on Linux, clang 18, and a mingw-w64 GCC 13.2 cross-compile of the same unit. A re-run of `scripts/warnings.sh` on Rtools45 is what would confirm it.

## Checks

- `DUCKDB_R_WARNINGS_CXX=g++-15 scripts/warnings.sh vendored --all`: `vendored: clean` (341 translation units).
- `R CMD INSTALL`: exit 0, no compiler warnings.
- `testthat::test_local()`: green; skips only for absent optional packages.
- ART exercise on the installed package, since patch 3 moves real code: 200k-row primary key plus a secondary index, point lookups on both, duplicate-key rejection, 66,667 deletes (the shrink paths `DeleteByteInternal` and `ShrinkNode15Leaf` live on), 10,000 re-inserts onto the shrunk tree (the grow paths), `CHECKPOINT`, reopen read-only, re-verify.
- Full vendored sweep under `clang++-20 -stdlib=libc++ -D_LIBCPP_KEEP_TRANSITIVE_INCLUDES_LLVM20 -Wall -pedantic`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TntdcUzuGEQg1tXYecDDQ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01NUXS8PnVmaFbNcMveEvvcb)_