### PR TITLE
fix(flavor): Refresh the README.Rmd hunk the patch no longer matched

### DIFF
--- a/scripts/flavor.patch
+++ b/scripts/flavor.patch
@@ -43,7 +43,7 @@ index df1f52e..19f0527 100644
 -```
 -
 -For Linux or older R versions, installing the package from source may take up to an hour.
--Consider the [Posit Public Package Manager](https://p3m.dev/) for binary installs (see the next section).
+-Consider the [Posit Public Package Manager](https://p3m.dev/) or [r-universe](https://duckdb.r-universe.dev) for binary installs (see the next sections).
 -
 -## Installation from the Posit Public Package Manager
 -


### PR DESCRIPTION
`scripts/flavor.patch` removes the CRAN and Posit sections from `README.Rmd`, and one of the lines it removes has since been reworded: the binary-install pointer now names r-universe alongside the Posit Public Package Manager. A removal whose text has moved cannot match, and this is not a fuzz case — `patch` rejects the hunk outright, `scripts/flavor.sh` restores the tree and stops, and no series can be seeded or forwarded while that holds (`.claude/skills/series-open.md` step 2, `.claude/skills/series-forward.md` step 1).

Only the context of the removal is refreshed here; the rename the patch drives is untouched. `patch -p1 --dry-run` now reports every hunk applying, the `README.Rmd` one without fuzz, and `scripts/flavor.sh 1.5.dev` runs through to both of its commits on today's `main`.

Found while regenerating the seed for `v1.5-variegata-fwd`, which carries the same one-line fix below its flavor commits because the seed could not be made without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5mEiAXb2E7TVuEuHyXnJF

---
_Generated by [Claude Code](https://claude.ai/code/session_01FnfhSQZocUsAQEyZzUyRx8)_